### PR TITLE
refactor: deduplicate shared utilities and fix TTML granularity

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,7 @@
     "zustand": "^5.0.0"
   },
   "pnpm": {
-    "ignoredBuiltDependencies": [
-      "@biomejs/biome",
-      "esbuild"
-    ],
+    "ignoredBuiltDependencies": ["@biomejs/biome", "esbuild"],
     "overrides": {
       "@braccato/parsers": "^0.1.1"
     }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
     "zustand": "^5.0.0"
   },
   "pnpm": {
-    "ignoredBuiltDependencies": ["@biomejs/biome", "esbuild"],
+    "ignoredBuiltDependencies": [
+      "@biomejs/biome",
+      "esbuild"
+    ],
     "overrides": {
       "@braccato/parsers": "^0.1.1"
     }
@@ -47,6 +50,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "jsdom": "^29.0.1",
     "tailwindcss": "^4.0.0",
     "typescript": "~5.7.0",
     "vite": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.0
         version: 4.7.0(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1
       tailwindcss:
         specifier: ^4.0.0
         version: 4.1.18
@@ -101,9 +104,20 @@ importers:
         version: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)
+        version: 4.0.16(@types/node@25.0.3)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.30.2)
 
 packages:
+
+  '@asamuzakjp/css-color@5.0.1':
+    resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    resolution: {integrity: sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -246,6 +260,46 @@ packages:
 
   '@braccato/parsers@0.1.1':
     resolution: {integrity: sha512-S4LlT8vTMNiXvVUC5iaQiLvu8KUNZn7oAI0LRaQ0W75THlX/pTSEp3EoB3UBzI2F0k3ARvxL9qNuxpd3+WHmeQ==}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.1':
+    resolution: {integrity: sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -424,6 +478,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -784,6 +847,9 @@ packages:
     resolution: {integrity: sha512-WhtvB2NG2wjr04+h77sg3klAIwrgOqnjS49GGudnUPGFFgg7G17y7Qecqp+2Dr5kUDxNRBca0SK7cG8JwzkWDQ==}
     hasBin: true
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -803,8 +869,16 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -814,6 +888,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -828,6 +905,10 @@ packages:
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -883,12 +964,28 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@29.0.1:
+    resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -979,11 +1076,18 @@ packages:
   lit@3.3.2:
     resolution: {integrity: sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==}
 
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   motion-dom@12.24.11:
     resolution: {integrity: sha512-DlWOmsXMJrV8lzZyd+LKjG2CXULUs++bkq8GZ2Sr0R0RRhs30K2wtY+LKiTjhmJU3W61HK+rB0GLz6XmPvTA1A==}
@@ -1028,6 +1132,9 @@ packages:
   overlayscrollbars@2.14.0:
     resolution: {integrity: sha512-RjV0pqc79kYhQLC3vTcLRb5GLpI1n6qh0Oua3g+bGH4EgNOJHVBGP7u0zZtxoAa0dkHlAqTTSYRb9MMmxNLjig==}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -1046,6 +1153,10 @@ packages:
     resolution: {integrity: sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==}
     peerDependencies:
       react: '>=16.0.0'
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
@@ -1066,10 +1177,18 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1096,6 +1215,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
@@ -1125,6 +1247,21 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.27:
+    resolution: {integrity: sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==}
+
+  tldts@7.0.27:
+    resolution: {integrity: sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1135,6 +1272,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.24.5:
+    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
+    engines: {node: '>=20.18.1'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1216,13 +1357,36 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   wavesurfer.js@7.12.1:
     resolution: {integrity: sha512-NswPjVHxk0Q1F/VMRemCPUzSojjuHHisQrBqQiRXg7MVbe3f5vQ6r0rTTXA/a/neC/4hnOEC4YpXca4LpH0SUg==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1246,6 +1410,24 @@ packages:
         optional: true
 
 snapshots:
+
+  '@asamuzakjp/css-color@5.0.1':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -1401,6 +1583,34 @@ snapshots:
 
   '@braccato/parsers@0.1.1': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.1(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@dnd-kit/accessibility@3.1.1(react@19.2.3)':
     dependencies:
       react: 19.2.3
@@ -1503,6 +1713,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.12':
     optional: true
+
+  '@exodus/bytes@1.15.0': {}
 
   '@floating-ui/core@1.7.3':
     dependencies:
@@ -1814,6 +2026,10 @@ snapshots:
 
   baseline-browser-mapping@2.9.13: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.9.13
@@ -1830,11 +2046,25 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -1846,6 +2076,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@6.0.1: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -1906,9 +2138,43 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  is-potential-custom-element-name@1.0.1: {}
+
   jiti@2.6.1: {}
 
   js-tokens@4.0.0: {}
+
+  jsdom@29.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.0.1
+      '@asamuzakjp/dom-selector': 7.0.4
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.1(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.5
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -1979,6 +2245,8 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.2
 
+  lru-cache@11.2.7: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -1986,6 +2254,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
 
   motion-dom@12.24.11:
     dependencies:
@@ -2016,6 +2286,10 @@ snapshots:
 
   overlayscrollbars@2.14.0: {}
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -2034,6 +2308,8 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.3
 
+  punycode@2.3.1: {}
+
   react-dom@19.2.3(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -2047,6 +2323,8 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
 
   react@19.2.3: {}
+
+  require-from-string@2.0.2: {}
 
   rollup@4.59.0:
     dependencies:
@@ -2079,6 +2357,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -2095,6 +2377,8 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tabbable@6.4.0: {}
 
@@ -2115,11 +2399,27 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tldts-core@7.0.27: {}
+
+  tldts@7.0.27:
+    dependencies:
+      tldts-core: 7.0.27
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.27
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
   tslib@2.8.1: {}
 
   typescript@5.7.3: {}
 
   undici-types@7.16.0: {}
+
+  undici@7.24.5: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -2141,7 +2441,7 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
 
-  vitest@4.0.16(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2):
+  vitest@4.0.16(@types/node@25.0.3)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.30.2):
     dependencies:
       '@vitest/expect': 4.0.16
       '@vitest/mocker': 4.0.16(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2))
@@ -2165,6 +2465,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.3
+      jsdom: 29.0.1
     transitivePeerDependencies:
       - jiti
       - less
@@ -2178,12 +2479,32 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   wavesurfer.js@7.12.1: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/src/audio/audio-player.tsx
+++ b/src/audio/audio-player.tsx
@@ -2,17 +2,9 @@ import { useAudioStore } from "@/stores/audio";
 import { Button } from "@/ui/button";
 import { Popover } from "@/ui/popover";
 import { Slider } from "@/ui/slider";
+import { formatTime } from "@/utils/format-time";
 import { IconPlayerPauseFilled, IconPlayerPlayFilled, IconVolume, IconVolume2, IconVolume3 } from "@tabler/icons-react";
 import { useCallback } from "react";
-
-// -- Helpers ------------------------------------------------------------------
-
-function formatTime(seconds: number): string {
-  if (!Number.isFinite(seconds)) return "0:00";
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
-  return `${mins}:${secs.toString().padStart(2, "0")}`;
-}
 
 // -- Components ---------------------------------------------------------------
 
@@ -24,7 +16,7 @@ const PlayButton: React.FC<{ isPlaying: boolean; onClick: () => void }> = ({ isP
 
 const TimeDisplay: React.FC<{ current: number; duration: number }> = ({ current, duration }) => (
   <span className="font-mono text-sm select-text text-composer-text-secondary tabular-nums">
-    {formatTime(current)} / {formatTime(duration)}
+    {formatTime(current, 0)} / {formatTime(duration, 0)}
   </span>
 );
 
@@ -174,4 +166,4 @@ const AudioPlayer: React.FC = () => {
 
 // -- Exports ------------------------------------------------------------------
 
-export { AudioPlayer, formatTime };
+export { AudioPlayer };

--- a/src/ui/empty-state.tsx
+++ b/src/ui/empty-state.tsx
@@ -1,0 +1,19 @@
+// -- Interfaces ----------------------------------------------------------------
+
+interface EmptyStateProps {
+  message: string;
+  hint: string;
+}
+
+// -- Components ----------------------------------------------------------------
+
+const EmptyState: React.FC<EmptyStateProps> = ({ message, hint }) => (
+  <div className="flex flex-col items-center justify-center flex-1 gap-2 text-center">
+    <p className="text-lg text-composer-text-secondary">{message}</p>
+    <p className="text-sm text-composer-text-muted">{hint}</p>
+  </div>
+);
+
+// -- Exports -------------------------------------------------------------------
+
+export { EmptyState };

--- a/src/ui/empty-state.tsx
+++ b/src/ui/empty-state.tsx
@@ -3,14 +3,16 @@
 interface EmptyStateProps {
   message: string;
   hint: string;
+  action?: React.ReactNode;
 }
 
 // -- Components ----------------------------------------------------------------
 
-const EmptyState: React.FC<EmptyStateProps> = ({ message, hint }) => (
+const EmptyState: React.FC<EmptyStateProps> = ({ message, hint, action }) => (
   <div className="flex flex-col items-center justify-center flex-1 gap-2 text-center">
     <p className="text-lg text-composer-text-secondary">{message}</p>
     <p className="text-sm text-composer-text-muted">{hint}</p>
+    {action}
   </div>
 );
 

--- a/src/ui/help-sections.tsx
+++ b/src/ui/help-sections.tsx
@@ -5,6 +5,7 @@ import { isMac } from "@/utils/platform";
 // -- Constants ----------------------------------------------------------------
 
 const MOD_KEY = isMac ? "Cmd" : "Ctrl";
+const ALT_KEY = isMac ? "Option" : "Alt";
 
 const PROSE = "text-sm text-composer-text-secondary leading-relaxed";
 const HEADING = "text-sm font-medium";
@@ -311,8 +312,23 @@ const TimelineSection: React.FC = () => (
           {MOD_KEY} + C / X / V work as expected. When you paste, a ghost preview appears. Click to place the pasted
           words.
         </li>
-        <li>Alt + drag selected words to duplicate them.</li>
+        <li>{ALT_KEY} + drag selected words to duplicate them.</li>
         <li>Press Delete or Backspace to remove selected words.</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 className={HEADING}>Boundary dragging</h4>
+      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
+        <li>
+          Syllables of the same word have <strong>conjoined boundaries</strong> by default. Dragging the boundary between
+          them moves both sides together, preventing gaps.
+        </li>
+        <li>
+          Hold <strong>{ALT_KEY}</strong> while dragging to flip the mode: syllable boundaries become independent (gaps
+          allowed), and separate word boundaries become conjoined.
+        </li>
+        <li>You can toggle {ALT_KEY} mid-drag to switch modes on the fly.</li>
       </ul>
     </div>
 

--- a/src/utils/format-time.ts
+++ b/src/utils/format-time.ts
@@ -1,0 +1,15 @@
+function formatTime(seconds: number, precision: 0 | 2 | 3 = 3): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return precision === 0 ? "0:00" : `0:00.${"0".repeat(precision)}`;
+  }
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  const base = `${mins}:${secs.toString().padStart(2, "0")}`;
+  if (precision === 0) return base;
+  const fraction = Math.floor((seconds % 1) * 10 ** precision);
+  return `${base}.${fraction.toString().padStart(precision, "0")}`;
+}
+
+// -- Exports -------------------------------------------------------------------
+
+export { formatTime };

--- a/src/utils/sync-helpers.ts
+++ b/src/utils/sync-helpers.ts
@@ -182,9 +182,9 @@ function createInitialBgWords(backgroundText: string, begin: number, end?: numbe
   return distributeWordsInLine(backgroundText, begin, resolvedEnd);
 }
 
-function createBgWordsFromLine(
-  line: { begin?: number; end?: number; words?: WordTiming[]; backgroundText?: string },
-): WordTiming[] | null {
+function createBgWordsFromLine(line: { begin?: number; end?: number; words?: WordTiming[]; backgroundText?: string }):
+  | WordTiming[]
+  | null {
   if (!line.backgroundText) return null;
   const timing = getLineTiming(line);
   if (!timing) return null;

--- a/src/utils/sync-helpers.ts
+++ b/src/utils/sync-helpers.ts
@@ -1,5 +1,6 @@
 import type { WordTiming } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
+import { formatTime } from "@/utils/format-time";
 import { getSplitCharacter } from "@/utils/split-character";
 
 // -- Types --------------------------------------------------------------------
@@ -17,6 +18,12 @@ interface SyncState {
 interface LineTiming {
   begin: number;
   end: number;
+}
+
+interface LineTimingInput {
+  begin?: number;
+  end?: number;
+  words?: WordTiming[];
 }
 
 // -- Constants ----------------------------------------------------------------
@@ -52,13 +59,7 @@ function splitIntoWordsWithMeta(text: string): { parts: string[]; trailingSpace:
   return { parts, trailingSpace };
 }
 
-function formatTimeMs(seconds: number): string {
-  if (!Number.isFinite(seconds)) return "0:00.000";
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
-  const ms = Math.floor((seconds % 1) * 1000);
-  return `${mins}:${secs.toString().padStart(2, "0")}.${ms.toString().padStart(3, "0")}`;
-}
+const formatTimeMs = (seconds: number) => formatTime(seconds, 3);
 
 function parseTimeMs(str: string): number | null {
   const trimmed = str.trim();
@@ -80,11 +81,7 @@ function getSyncedWordCount(lines: { words?: WordTiming[] }[]): number {
   return lines.reduce((acc, line) => acc + (line.words?.length ?? 0), 0);
 }
 
-function getLineTiming(line: {
-  begin?: number;
-  end?: number;
-  words?: WordTiming[];
-}): LineTiming | null {
+function getLineTiming(line: LineTimingInput): LineTiming | null {
   if (line.words?.length) {
     const firstWord = line.words[0];
     const lastWord = line.words[line.words.length - 1];
@@ -96,7 +93,7 @@ function getLineTiming(line: {
   return null;
 }
 
-function getSyncedLineCount(lines: { begin?: number; end?: number; words?: WordTiming[] }[]): number {
+function getSyncedLineCount(lines: LineTimingInput[]): number {
   return lines.filter((line) => getLineTiming(line) !== null).length;
 }
 

--- a/src/utils/timing/bg-word-timing.ts
+++ b/src/utils/timing/bg-word-timing.ts
@@ -1,83 +1,13 @@
-import type { LyricLine } from "@/stores/project";
+import { createWordTimingOps } from "@/utils/timing/word-timing-ops";
 
-type UpdateLineWithHistory = (id: string, updates: Partial<LyricLine>) => void;
+const { nudgeBegin, setBegin, nudgeEnd, setEnd } = createWordTimingOps({
+  getWords: (line) => line.backgroundWords,
+  updateKey: "backgroundWords",
+});
 
-function nudgeBgWordBegin(
-  lines: LyricLine[],
-  lineIdx: number,
-  wordIdx: number,
-  delta: number,
-  updateLineWithHistory: UpdateLineWithHistory,
-) {
-  const line = lines[lineIdx];
-  if (!line?.backgroundWords?.[wordIdx]) return;
-
-  const updatedWords = [...line.backgroundWords];
-  const word = updatedWords[wordIdx];
-  const prevWord = updatedWords[wordIdx - 1];
-  const minBegin = prevWord?.end ?? 0;
-  const newBegin = Math.min(word.end, Math.max(minBegin, word.begin + delta));
-
-  updatedWords[wordIdx] = { ...word, begin: newBegin };
-  updateLineWithHistory(line.id, { backgroundWords: updatedWords });
-}
-
-function setBgWordBegin(
-  lines: LyricLine[],
-  lineIdx: number,
-  wordIdx: number,
-  newBegin: number,
-  updateLineWithHistory: UpdateLineWithHistory,
-) {
-  const line = lines[lineIdx];
-  if (!line?.backgroundWords?.[wordIdx]) return;
-
-  const updatedWords = [...line.backgroundWords];
-  const word = updatedWords[wordIdx];
-  const prevWord = updatedWords[wordIdx - 1];
-  const minBegin = prevWord?.end ?? 0;
-  const clampedBegin = Math.min(word.end, Math.max(minBegin, newBegin));
-  updatedWords[wordIdx] = { ...word, begin: clampedBegin };
-  updateLineWithHistory(line.id, { backgroundWords: updatedWords });
-}
-
-function nudgeBgWordEnd(
-  lines: LyricLine[],
-  lineIdx: number,
-  wordIdx: number,
-  delta: number,
-  updateLineWithHistory: UpdateLineWithHistory,
-) {
-  const line = lines[lineIdx];
-  if (!line?.backgroundWords?.[wordIdx]) return;
-
-  const updatedWords = [...line.backgroundWords];
-  const word = updatedWords[wordIdx];
-  const nextWord = updatedWords[wordIdx + 1];
-  const maxEnd = nextWord?.begin ?? Number.POSITIVE_INFINITY;
-  const newEnd = Math.min(maxEnd, Math.max(word.begin, word.end + delta));
-
-  updatedWords[wordIdx] = { ...word, end: newEnd };
-  updateLineWithHistory(line.id, { backgroundWords: updatedWords });
-}
-
-function setBgWordEnd(
-  lines: LyricLine[],
-  lineIdx: number,
-  wordIdx: number,
-  newEnd: number,
-  updateLineWithHistory: UpdateLineWithHistory,
-) {
-  const line = lines[lineIdx];
-  if (!line?.backgroundWords?.[wordIdx]) return;
-
-  const updatedWords = [...line.backgroundWords];
-  const word = updatedWords[wordIdx];
-  const nextWord = updatedWords[wordIdx + 1];
-  const maxEnd = nextWord?.begin ?? Number.POSITIVE_INFINITY;
-  const clampedEnd = Math.min(maxEnd, Math.max(word.begin, newEnd));
-  updatedWords[wordIdx] = { ...word, end: clampedEnd };
-  updateLineWithHistory(line.id, { backgroundWords: updatedWords });
-}
-
-export { nudgeBgWordBegin, setBgWordBegin, nudgeBgWordEnd, setBgWordEnd };
+export {
+  nudgeBegin as nudgeBgWordBegin,
+  setBegin as setBgWordBegin,
+  nudgeEnd as nudgeBgWordEnd,
+  setEnd as setBgWordEnd,
+};

--- a/src/utils/timing/word-timing-ops.ts
+++ b/src/utils/timing/word-timing-ops.ts
@@ -1,0 +1,105 @@
+import type { LyricLine, WordTiming } from "@/stores/project";
+
+// -- Types --------------------------------------------------------------------
+
+type UpdateLineWithHistory = (id: string, updates: Partial<LyricLine>) => void;
+
+interface WordFieldConfig {
+  getWords: (line: LyricLine) => WordTiming[] | undefined;
+  updateKey: "words" | "backgroundWords";
+}
+
+// -- Factory ------------------------------------------------------------------
+
+function createWordTimingOps(config: WordFieldConfig) {
+  const { getWords, updateKey } = config;
+
+  function nudgeBegin(
+    lines: LyricLine[],
+    lineIdx: number,
+    wordIdx: number,
+    delta: number,
+    updateLineWithHistory: UpdateLineWithHistory,
+  ) {
+    const line = lines[lineIdx];
+    const words = getWords(line);
+    if (!words?.[wordIdx]) return;
+
+    const updatedWords = [...words];
+    const word = updatedWords[wordIdx];
+    const prevWord = updatedWords[wordIdx - 1];
+    const minBegin = prevWord?.end ?? 0;
+    const newBegin = Math.min(word.end, Math.max(minBegin, word.begin + delta));
+
+    updatedWords[wordIdx] = { ...word, begin: newBegin };
+    updateLineWithHistory(line.id, { [updateKey]: updatedWords } as Partial<LyricLine>);
+  }
+
+  function setBegin(
+    lines: LyricLine[],
+    lineIdx: number,
+    wordIdx: number,
+    newBegin: number,
+    updateLineWithHistory: UpdateLineWithHistory,
+  ) {
+    const line = lines[lineIdx];
+    const words = getWords(line);
+    if (!words?.[wordIdx]) return;
+
+    const updatedWords = [...words];
+    const word = updatedWords[wordIdx];
+    const prevWord = updatedWords[wordIdx - 1];
+    const minBegin = prevWord?.end ?? 0;
+    const clampedBegin = Math.min(word.end, Math.max(minBegin, newBegin));
+    updatedWords[wordIdx] = { ...word, begin: clampedBegin };
+    updateLineWithHistory(line.id, { [updateKey]: updatedWords } as Partial<LyricLine>);
+  }
+
+  function nudgeEnd(
+    lines: LyricLine[],
+    lineIdx: number,
+    wordIdx: number,
+    delta: number,
+    updateLineWithHistory: UpdateLineWithHistory,
+  ) {
+    const line = lines[lineIdx];
+    const words = getWords(line);
+    if (!words?.[wordIdx]) return;
+
+    const updatedWords = [...words];
+    const word = updatedWords[wordIdx];
+    const nextWord = updatedWords[wordIdx + 1];
+    const maxEnd = nextWord?.begin ?? Number.POSITIVE_INFINITY;
+    const newEnd = Math.min(maxEnd, Math.max(word.begin, word.end + delta));
+
+    updatedWords[wordIdx] = { ...word, end: newEnd };
+    updateLineWithHistory(line.id, { [updateKey]: updatedWords } as Partial<LyricLine>);
+  }
+
+  function setEnd(
+    lines: LyricLine[],
+    lineIdx: number,
+    wordIdx: number,
+    newEnd: number,
+    updateLineWithHistory: UpdateLineWithHistory,
+  ) {
+    const line = lines[lineIdx];
+    const words = getWords(line);
+    if (!words?.[wordIdx]) return;
+
+    const updatedWords = [...words];
+    const word = updatedWords[wordIdx];
+    const nextWord = updatedWords[wordIdx + 1];
+    const maxEnd = nextWord?.begin ?? Number.POSITIVE_INFINITY;
+    const clampedEnd = Math.min(maxEnd, Math.max(word.begin, newEnd));
+    updatedWords[wordIdx] = { ...word, end: clampedEnd };
+    updateLineWithHistory(line.id, { [updateKey]: updatedWords } as Partial<LyricLine>);
+  }
+
+  return { nudgeBegin, setBegin, nudgeEnd, setEnd };
+}
+
+// -- Exports -------------------------------------------------------------------
+
+export { createWordTimingOps };
+export type { UpdateLineWithHistory };

--- a/src/utils/timing/word-timing-ops.ts
+++ b/src/utils/timing/word-timing-ops.ts
@@ -22,6 +22,7 @@ function createWordTimingOps(config: WordFieldConfig) {
     updateLineWithHistory: UpdateLineWithHistory,
   ) {
     const line = lines[lineIdx];
+    if (!line) return;
     const words = getWords(line);
     if (!words?.[wordIdx]) return;
 
@@ -43,6 +44,7 @@ function createWordTimingOps(config: WordFieldConfig) {
     updateLineWithHistory: UpdateLineWithHistory,
   ) {
     const line = lines[lineIdx];
+    if (!line) return;
     const words = getWords(line);
     if (!words?.[wordIdx]) return;
 
@@ -63,6 +65,7 @@ function createWordTimingOps(config: WordFieldConfig) {
     updateLineWithHistory: UpdateLineWithHistory,
   ) {
     const line = lines[lineIdx];
+    if (!line) return;
     const words = getWords(line);
     if (!words?.[wordIdx]) return;
 
@@ -84,6 +87,7 @@ function createWordTimingOps(config: WordFieldConfig) {
     updateLineWithHistory: UpdateLineWithHistory,
   ) {
     const line = lines[lineIdx];
+    if (!line) return;
     const words = getWords(line);
     if (!words?.[wordIdx]) return;
 
@@ -102,4 +106,3 @@ function createWordTimingOps(config: WordFieldConfig) {
 // -- Exports -------------------------------------------------------------------
 
 export { createWordTimingOps };
-export type { UpdateLineWithHistory };

--- a/src/utils/timing/word-timing.ts
+++ b/src/utils/timing/word-timing.ts
@@ -1,83 +1,13 @@
-import type { LyricLine } from "@/stores/project";
+import { createWordTimingOps } from "@/utils/timing/word-timing-ops";
 
-type UpdateLineWithHistory = (id: string, updates: Partial<LyricLine>) => void;
+const { nudgeBegin, setBegin, nudgeEnd, setEnd } = createWordTimingOps({
+  getWords: (line) => line.words,
+  updateKey: "words",
+});
 
-function nudgeWordBegin(
-  lines: LyricLine[],
-  lineIdx: number,
-  wordIdx: number,
-  delta: number,
-  updateLineWithHistory: UpdateLineWithHistory,
-) {
-  const line = lines[lineIdx];
-  if (!line?.words?.[wordIdx]) return;
-
-  const updatedWords = [...line.words];
-  const word = updatedWords[wordIdx];
-  const prevWord = updatedWords[wordIdx - 1];
-  const minBegin = prevWord?.end ?? 0;
-  const newBegin = Math.min(word.end, Math.max(minBegin, word.begin + delta));
-
-  updatedWords[wordIdx] = { ...word, begin: newBegin };
-  updateLineWithHistory(line.id, { words: updatedWords });
-}
-
-function setWordBegin(
-  lines: LyricLine[],
-  lineIdx: number,
-  wordIdx: number,
-  newBegin: number,
-  updateLineWithHistory: UpdateLineWithHistory,
-) {
-  const line = lines[lineIdx];
-  if (!line?.words?.[wordIdx]) return;
-
-  const updatedWords = [...line.words];
-  const word = updatedWords[wordIdx];
-  const prevWord = updatedWords[wordIdx - 1];
-  const minBegin = prevWord?.end ?? 0;
-  const clampedBegin = Math.min(word.end, Math.max(minBegin, newBegin));
-  updatedWords[wordIdx] = { ...word, begin: clampedBegin };
-  updateLineWithHistory(line.id, { words: updatedWords });
-}
-
-function nudgeWordEnd(
-  lines: LyricLine[],
-  lineIdx: number,
-  wordIdx: number,
-  delta: number,
-  updateLineWithHistory: UpdateLineWithHistory,
-) {
-  const line = lines[lineIdx];
-  if (!line?.words?.[wordIdx]) return;
-
-  const updatedWords = [...line.words];
-  const word = updatedWords[wordIdx];
-  const nextWord = updatedWords[wordIdx + 1];
-  const maxEnd = nextWord?.begin ?? Number.POSITIVE_INFINITY;
-  const newEnd = Math.min(maxEnd, Math.max(word.begin, word.end + delta));
-
-  updatedWords[wordIdx] = { ...word, end: newEnd };
-  updateLineWithHistory(line.id, { words: updatedWords });
-}
-
-function setWordEnd(
-  lines: LyricLine[],
-  lineIdx: number,
-  wordIdx: number,
-  newEnd: number,
-  updateLineWithHistory: UpdateLineWithHistory,
-) {
-  const line = lines[lineIdx];
-  if (!line?.words?.[wordIdx]) return;
-
-  const updatedWords = [...line.words];
-  const word = updatedWords[wordIdx];
-  const nextWord = updatedWords[wordIdx + 1];
-  const maxEnd = nextWord?.begin ?? Number.POSITIVE_INFINITY;
-  const clampedEnd = Math.min(maxEnd, Math.max(word.begin, newEnd));
-  updatedWords[wordIdx] = { ...word, end: clampedEnd };
-  updateLineWithHistory(line.id, { words: updatedWords });
-}
-
-export { nudgeWordBegin, setWordBegin, nudgeWordEnd, setWordEnd };
+export {
+  nudgeBegin as nudgeWordBegin,
+  setBegin as setWordBegin,
+  nudgeEnd as nudgeWordEnd,
+  setEnd as setWordEnd,
+};

--- a/src/utils/timing/word-timing.ts
+++ b/src/utils/timing/word-timing.ts
@@ -5,9 +5,4 @@ const { nudgeBegin, setBegin, nudgeEnd, setEnd } = createWordTimingOps({
   updateKey: "words",
 });
 
-export {
-  nudgeBegin as nudgeWordBegin,
-  setBegin as setWordBegin,
-  nudgeEnd as nudgeWordEnd,
-  setEnd as setWordEnd,
-};
+export { nudgeBegin as nudgeWordBegin, setBegin as setWordBegin, nudgeEnd as nudgeWordEnd, setEnd as setWordEnd };

--- a/src/utils/ttml.ts
+++ b/src/utils/ttml.ts
@@ -1,30 +1,12 @@
 import type { Agent, LyricLine, ProjectMetadata } from "@/stores/project";
+import { formatTime } from "@/utils/format-time";
 import { stripSplitCharacter } from "@/utils/split-character";
+import { getLineTiming } from "@/utils/sync-helpers";
 
 // -- Helpers ------------------------------------------------------------------
 
-function formatTime(seconds: number): string {
-  if (!Number.isFinite(seconds) || seconds < 0) return "0:00.000";
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
-  const ms = Math.floor((seconds % 1) * 1000);
-  return `${mins}:${secs.toString().padStart(2, "0")}.${ms.toString().padStart(3, "0")}`;
-}
-
 function escapeXml(str: string): string {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;");
-}
-
-function getLineTiming(line: LyricLine): { begin: number; end: number } | null {
-  if (line.words?.length) {
-    const firstWord = line.words[0];
-    const lastWord = line.words[line.words.length - 1];
-    return { begin: firstWord.begin, end: lastWord.end };
-  }
-  if (line.begin !== undefined && line.end !== undefined) {
-    return { begin: line.begin, end: line.end };
-  }
-  return null;
 }
 
 // -- Generator ----------------------------------------------------------------
@@ -42,11 +24,13 @@ function generateTTML({ metadata, agents, lines, granularity, minify = false, du
   const nl = minify ? "" : "\n";
   const ind = (n: number) => (minify ? "" : "  ".repeat(n));
 
+  const effectiveGranularity = granularity === "word" && lines.some((l) => l.words?.length) ? "word" : "line";
+
   const parts: string[] = [];
 
   // Root element with namespaces
   parts.push(
-    `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:composer="https://composer.boidu.dev/ttml" ttp:timeBase="media" xml:lang="${escapeXml(metadata.language || "en")}" composer:timing="${granularity === "word" ? "Word" : "Line"}">`,
+    `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:composer="https://composer.boidu.dev/ttml" ttp:timeBase="media" xml:lang="${escapeXml(metadata.language || "en")}" composer:timing="${effectiveGranularity === "word" ? "Word" : "Line"}">`,
   );
 
   // Head section
@@ -119,4 +103,4 @@ function generateTTML({ metadata, agents, lines, granularity, minify = false, du
 
 // -- Exports ------------------------------------------------------------------
 
-export { generateTTML, formatTime };
+export { generateTTML };

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -7,7 +7,7 @@ import { textToLyricLines } from "@/utils/lyrics-text";
 import { stripSplitCharacter } from "@/utils/split-character";
 import { AgentManager } from "@/views/edit/agent-manager";
 import { IconAlertTriangle, IconFileImport, IconMicrophone, IconX } from "@tabler/icons-react";
-import { useCallback, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 
 // -- Types --------------------------------------------------------------------
 
@@ -234,13 +234,25 @@ const EditPanel: React.FC = () => {
   const updateLine = useProjectStore((s) => s.updateLine);
   const addAgent = useProjectStore((s) => s.addAgent);
 
-  const [rawText, setRawText] = useState("");
+  const [rawText, setRawText] = useState(() =>
+    lines.length > 0 ? lines.map((l) => l.text).join("\n") : "",
+  );
+  const linesSetByUs = useRef<LyricLine[] | null>(null);
   const [importResult, setImportResult] = useState<{
     result: ParseResult;
     filename: string;
   } | null>(null);
   const [selectedLines, setSelectedLines] = useState<Set<number>>(new Set());
   const [lastSelectedLine, setLastSelectedLine] = useState<number | null>(null);
+
+  // Sync rawText when lines change externally (persistence restore, project import, etc.)
+  useEffect(() => {
+    if (linesSetByUs.current === lines) {
+      linesSetByUs.current = null;
+      return;
+    }
+    setRawText(lines.length > 0 ? lines.map((l) => l.text).join("\n") : "");
+  }, [lines]);
 
   const defaultAgentId = agents[0]?.id ?? "v1";
   const parsed = useMemo(() => parseLyrics(rawText, lines, defaultAgentId), [rawText, lines, defaultAgentId]);
@@ -290,6 +302,7 @@ const EditPanel: React.FC = () => {
       const selectedLineIds = parsed.filter((p) => selectedLines.has(p.lineNumber) && p.lineId).map((p) => p.lineId);
 
       const updatedLines = lines.map((line) => (selectedLineIds.includes(line.id) ? { ...line, agentId } : line));
+      linesSetByUs.current = updatedLines;
       setLines(updatedLines);
       setSelectedLines(new Set());
     },
@@ -306,6 +319,7 @@ const EditPanel: React.FC = () => {
       setRawText(text);
 
       const lyricLines = textToLyricLines(text, defaultAgentId, lines);
+      linesSetByUs.current = lyricLines;
       setLines(lyricLines);
       setImportResult(null);
     },
@@ -318,6 +332,7 @@ const EditPanel: React.FC = () => {
       const result = parseLyricsFile(file.name, content);
 
       if (result.lines.length > 0) {
+        linesSetByUs.current = result.lines;
         setLines(result.lines);
         setRawText(result.lines.map((l) => l.text).join("\n"));
 

--- a/src/views/export.tsx
+++ b/src/views/export.tsx
@@ -2,6 +2,8 @@ import { exportProjectToFile, importProjectFromFile, clearCurrentProject, cancel
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { Button } from "@/ui/button";
+import { EmptyState } from "@/ui/empty-state";
+import { getLineTiming } from "@/utils/sync-helpers";
 import { generateTTML } from "@/utils/ttml";
 import {
   IconCheck,
@@ -16,33 +18,7 @@ import {
 import { Highlight, themes } from "prism-react-renderer";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-// -- Helpers ------------------------------------------------------------------
-
-function getLineTiming(line: {
-  begin?: number;
-  end?: number;
-  words?: { begin: number; end: number }[];
-}) {
-  if (line.words?.length) {
-    return {
-      begin: line.words[0].begin,
-      end: line.words[line.words.length - 1].end,
-    };
-  }
-  if (line.begin !== undefined && line.end !== undefined) {
-    return { begin: line.begin, end: line.end };
-  }
-  return null;
-}
-
 // -- Components ---------------------------------------------------------------
-
-const EmptyState: React.FC<{ message: string; hint: string }> = ({ message, hint }) => (
-  <div className="flex flex-col items-center justify-center flex-1 gap-2 text-center">
-    <p className="text-lg text-composer-text-secondary">{message}</p>
-    <p className="text-sm text-composer-text-muted">{hint}</p>
-  </div>
-);
 
 const ExportPanel: React.FC = () => {
   const metadata = useProjectStore((s) => s.metadata);

--- a/src/views/export.tsx
+++ b/src/views/export.tsx
@@ -138,10 +138,26 @@ const ExportPanel: React.FC = () => {
     await clearCurrentProject();
   }, [reset]);
 
+  const importAction = (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json,.ttml-project.json"
+        onChange={handleImportProject}
+        className="hidden"
+      />
+      <Button hasIcon variant="secondary" onClick={() => fileInputRef.current?.click()} className="mt-2">
+        <IconFolderOpen className="w-4 h-4 text-composer-text opacity-50" />
+        Import Project
+      </Button>
+    </>
+  );
+
   if (lines.length === 0) {
     return (
       <div className="flex flex-col flex-1 p-4">
-        <EmptyState message="No lyrics to export" hint="Add lyrics in the Edit tab first" />
+        <EmptyState message="No lyrics to export" hint="Add lyrics in the Edit tab first" action={importAction} />
       </div>
     );
   }
@@ -149,7 +165,7 @@ const ExportPanel: React.FC = () => {
   if (!hasSyncedContent) {
     return (
       <div className="flex flex-col flex-1 p-4">
-        <EmptyState message="No synced content" hint="Sync lyrics in the Sync tab first" />
+        <EmptyState message="No synced content" hint="Sync lyrics in the Sync tab first" action={importAction} />
       </div>
     );
   }

--- a/src/views/preview.tsx
+++ b/src/views/preview.tsx
@@ -3,18 +3,12 @@ import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { generateTTML } from "@/utils/ttml";
 import { Button } from "@/ui/button";
+import { EmptyState } from "@/ui/empty-state";
 import { getLineTiming } from "@/views/timeline/utils";
 import { IconPlayerPauseFilled, IconPlayerPlayFilled } from "@tabler/icons-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 // -- Components ---------------------------------------------------------------
-
-const EmptyState: React.FC<{ message: string; hint: string }> = ({ message, hint }) => (
-  <div className="flex flex-col items-center justify-center flex-1 gap-2 text-center">
-    <p className="text-lg text-composer-text-secondary">{message}</p>
-    <p className="text-sm text-composer-text-muted">{hint}</p>
-  </div>
-);
 
 const PreviewPanel: React.FC = () => {
   const lines = useProjectStore((s) => s.lines);

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -4,6 +4,7 @@ import { useProjectStore } from "@/stores/project";
 import type { SyncMethod } from "@/stores/project";
 import { getEffectiveKeysArray } from "@/stores/shortcut-bindings";
 import { Button } from "@/ui/button";
+import { EmptyState } from "@/ui/empty-state";
 import { findMatchingShortcut } from "@/utils/shortcut-matcher";
 import {
   shimmerTransition,
@@ -30,13 +31,6 @@ import { motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 // -- Components ---------------------------------------------------------------
-
-const EmptyState: React.FC<{ message: string; hint: string }> = ({ message, hint }) => (
-  <div className="flex flex-col items-center justify-center flex-1 gap-2 text-center">
-    <p className="text-lg text-composer-text-secondary">{message}</p>
-    <p className="text-sm text-composer-text-muted">{hint}</p>
-  </div>
-);
 
 const SyncPanel: React.FC = () => {
   const lines = useProjectStore((s) => s.lines);

--- a/src/views/timeline/line-row.tsx
+++ b/src/views/timeline/line-row.tsx
@@ -17,8 +17,8 @@ interface LineRowProps {
   line: LyricLine;
   lineIndex: number;
   duration: number;
-  onUpdateWord: (wordIndex: number, updates: Partial<WordTiming>) => void;
-  onUpdateBgWord: (wordIndex: number, updates: Partial<WordTiming>) => void;
+  onUpdateWord: (wordIndex: number, updates: Partial<WordTiming>, adjacentIndex?: number, adjacentUpdates?: Partial<WordTiming>) => void;
+  onUpdateBgWord: (wordIndex: number, updates: Partial<WordTiming>, adjacentIndex?: number, adjacentUpdates?: Partial<WordTiming>) => void;
 }
 
 // -- Constants -----------------------------------------------------------------

--- a/src/views/timeline/timeline-playhead.tsx
+++ b/src/views/timeline/timeline-playhead.tsx
@@ -162,7 +162,11 @@ const TimelinePlayhead: React.FC<TimelinePlayheadProps> = ({ containerHeight, sc
   if (duration === 0) return null;
 
   return (
-    <div ref={containerRef} className="absolute inset-0 pointer-events-none overflow-hidden z-50" style={{ clipPath: `inset(0 0 0 ${GUTTER_WIDTH}px)` }}>
+    <div
+      ref={containerRef}
+      className="absolute inset-0 pointer-events-none overflow-hidden z-50"
+      style={{ clipPath: `inset(0 0 0 ${GUTTER_WIDTH}px)` }}
+    >
       <div
         ref={playheadRef}
         className="absolute top-0 left-0 w-0.5 bg-indigo-400 cursor-ew-resize pointer-events-auto expanded-hit-x-sm"

--- a/src/views/timeline/timeline-rows.tsx
+++ b/src/views/timeline/timeline-rows.tsx
@@ -30,7 +30,7 @@ const TimelineRows: React.FC<TimelineRowsProps> = ({ scrollContainerRef }) => {
   const effectiveLines = useMemo(() => getEffectiveLines(lines), [lines]);
 
   const handleUpdateWord = useCallback(
-    (lineId: string, wordIndex: number, updates: Partial<WordTiming>) => {
+    (lineId: string, wordIndex: number, updates: Partial<WordTiming>, adjacentIndex?: number, adjacentUpdates?: Partial<WordTiming>) => {
       const realLine = lines.find((l) => l.id === lineId);
       if (!realLine) return;
 
@@ -45,18 +45,24 @@ const TimelineRows: React.FC<TimelineRowsProps> = ({ scrollContainerRef }) => {
       if (!realLine.words) return;
       const updatedWords = [...realLine.words];
       updatedWords[wordIndex] = { ...updatedWords[wordIndex], ...updates };
+      if (adjacentIndex !== undefined && adjacentUpdates) {
+        updatedWords[adjacentIndex] = { ...updatedWords[adjacentIndex], ...adjacentUpdates };
+      }
       updateLineWithHistory(lineId, { words: updatedWords });
     },
     [lines, updateLineWithHistory],
   );
 
   const handleUpdateBgWord = useCallback(
-    (lineId: string, wordIndex: number, updates: Partial<WordTiming>) => {
+    (lineId: string, wordIndex: number, updates: Partial<WordTiming>, adjacentIndex?: number, adjacentUpdates?: Partial<WordTiming>) => {
       const line = lines.find((l) => l.id === lineId);
       if (!line?.backgroundWords) return;
 
       const updatedWords = [...line.backgroundWords];
       updatedWords[wordIndex] = { ...updatedWords[wordIndex], ...updates };
+      if (adjacentIndex !== undefined && adjacentUpdates) {
+        updatedWords[adjacentIndex] = { ...updatedWords[adjacentIndex], ...adjacentUpdates };
+      }
       updateLineWithHistory(lineId, { backgroundWords: updatedWords });
     },
     [lines, updateLineWithHistory],
@@ -90,8 +96,8 @@ const TimelineRows: React.FC<TimelineRowsProps> = ({ scrollContainerRef }) => {
             line={line}
             lineIndex={index}
             duration={duration}
-            onUpdateWord={(wordIndex, updates) => handleUpdateWord(line.id, wordIndex, updates)}
-            onUpdateBgWord={(wordIndex, updates) => handleUpdateBgWord(line.id, wordIndex, updates)}
+            onUpdateWord={(wordIndex, updates, adjacentIndex, adjacentUpdates) => handleUpdateWord(line.id, wordIndex, updates, adjacentIndex, adjacentUpdates)}
+            onUpdateBgWord={(wordIndex, updates, adjacentIndex, adjacentUpdates) => handleUpdateBgWord(line.id, wordIndex, updates, adjacentIndex, adjacentUpdates)}
           />
         )}
         style={{ height: "100%", width: "100%" }}

--- a/src/views/timeline/utils.test.ts
+++ b/src/views/timeline/utils.test.ts
@@ -127,6 +127,8 @@ describe("getLineTiming", () => {
       id: "1",
       text: "Hello",
       agentId: "v1",
+      begin: undefined,
+      end: undefined,
     };
 
     const timing = getLineTiming(line);

--- a/src/views/timeline/utils.ts
+++ b/src/views/timeline/utils.ts
@@ -1,6 +1,7 @@
 import type { LyricLine, WordTiming } from "@/stores/project";
+import { formatTime as formatTimeBase } from "@/utils/format-time";
 import { stripSplitCharacter } from "@/utils/split-character";
-import { distributeWordsInLine } from "@/utils/sync-helpers";
+import { distributeWordsInLine, getLineTiming } from "@/utils/sync-helpers";
 
 // -- Functions -----------------------------------------------------------------
 
@@ -24,22 +25,7 @@ function distributeLinesTiming<T extends { id: string; text: string }>(
   });
 }
 
-function getLineTiming(line: LyricLine): { begin: number; end: number } | null {
-  if (line.words?.length) {
-    return { begin: line.words[0].begin, end: line.words[line.words.length - 1].end };
-  }
-  if (line.begin !== undefined && line.end !== undefined) {
-    return { begin: line.begin, end: line.end };
-  }
-  return null;
-}
-
-function formatTime(seconds: number): string {
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
-  const ms = Math.floor((seconds % 1) * 100);
-  return `${mins}:${secs.toString().padStart(2, "0")}.${ms.toString().padStart(2, "0")}`;
-}
+const formatTime = (seconds: number) => formatTimeBase(seconds, 2);
 
 interface WordAtTimeResult {
   lineId: string;

--- a/src/views/timeline/word-block.tsx
+++ b/src/views/timeline/word-block.tsx
@@ -18,8 +18,11 @@ interface WordBlockProps {
   isDimmed: boolean;
   isSelected: boolean;
   syllablePosition?: SyllablePosition;
+  leftHighlighted?: boolean;
+  rightHighlighted?: boolean;
   onClick: (e: React.MouseEvent) => void;
   onResizeStart: (edge: "left" | "right", startX: number) => void;
+  onEdgeHover?: (edge: "left" | "right", hovering: boolean) => void;
   onDoubleClick?: (e: React.MouseEvent) => void;
   onContextMenu?: (e: React.MouseEvent) => void;
 }
@@ -47,8 +50,11 @@ const WordBlock: React.FC<WordBlockProps> = ({
   isDimmed,
   isSelected,
   syllablePosition = "none",
+  leftHighlighted,
+  rightHighlighted,
   onClick,
   onResizeStart,
+  onEdgeHover,
   onDoubleClick,
   onContextMenu,
 }) => {
@@ -113,18 +119,30 @@ const WordBlock: React.FC<WordBlockProps> = ({
     >
       <div
         data-edge="left"
-        className="absolute left-0 top-0 bottom-0 w-2 cursor-ew-resize hover:bg-white/10 z-10"
+        className={cn(
+          "absolute left-0 top-0 bottom-0 w-2 z-10 hover:bg-white/10",
+          syllablePosition === "middle" || syllablePosition === "last" ? "cursor-col-resize" : "cursor-ew-resize",
+          leftHighlighted && "bg-white/10",
+        )}
         onMouseDown={handleResizeStart}
         onPointerDown={(e) => e.stopPropagation()}
+        onMouseEnter={() => onEdgeHover?.("left", true)}
+        onMouseLeave={() => onEdgeHover?.("left", false)}
       />
 
       {showText && <span className="px-1 pointer-events-none truncate">{text}</span>}
 
       <div
         data-edge="right"
-        className="absolute right-0 top-0 bottom-0 w-2 cursor-ew-resize hover:bg-white/10 z-10"
+        className={cn(
+          "absolute right-0 top-0 bottom-0 w-2 z-10 hover:bg-white/10",
+          syllablePosition === "first" || syllablePosition === "middle" ? "cursor-col-resize" : "cursor-ew-resize",
+          rightHighlighted && "bg-white/10",
+        )}
         onMouseDown={handleResizeStart}
         onPointerDown={(e) => e.stopPropagation()}
+        onMouseEnter={() => onEdgeHover?.("right", true)}
+        onMouseLeave={() => onEdgeHover?.("right", false)}
       />
     </div>
   );

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -17,7 +17,7 @@ interface WordTrackProps {
   trackType: "word" | "bg";
   duration: number;
   height: number;
-  onUpdateWord: (index: number, updates: Partial<WordTiming>) => void;
+  onUpdateWord: (index: number, updates: Partial<WordTiming>, adjacentIndex?: number, adjacentUpdates?: Partial<WordTiming>) => void;
 }
 
 interface DragState {
@@ -25,7 +25,14 @@ interface DragState {
   edge: "left" | "right";
   begin: number;
   end: number;
+  adjacentWordIndex?: number;
+  adjacentBegin?: number;
+  adjacentEnd?: number;
 }
+
+// -- Constants -----------------------------------------------------------------
+
+const MIN_WORD_DURATION = 0.05;
 
 // -- Component -----------------------------------------------------------------
 
@@ -45,46 +52,89 @@ const WordTrack: React.FC<WordTrackProps> = ({
   const toggleSelection = useTimelineStore((s) => s.toggleSelection);
 
   const showSyllableIndicators = useSettingsStore((s) => s.showSyllableIndicators);
-  const syllablePositions = useMemo(
-    () => (showSyllableIndicators ? getSyllablePositions(words) : null),
-    [words, showSyllableIndicators],
-  );
+  const syllablePositions = useMemo(() => getSyllablePositions(words), [words]);
 
   const [dragState, setDragState] = useState<DragState | null>(null);
+  const [hoveredBoundary, setHoveredBoundary] = useState<number | null>(null);
+  const [altPressed, setAltPressed] = useState(false);
   const dragStateRef = useRef<DragState | null>(null);
+  const justResizedRef = useRef(false);
   const cleanupRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
+    return () => { cleanupRef.current?.(); };
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => setAltPressed(e.altKey);
+    document.addEventListener("keydown", onKey);
+    document.addEventListener("keyup", onKey);
     return () => {
-      cleanupRef.current?.();
+      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("keyup", onKey);
     };
   }, []);
 
   const handleResizeStart = useCallback(
     (wordIndex: number, edge: "left" | "right", startX: number) => {
       const word = words[wordIndex];
-      const initialState = { wordIndex, edge, begin: word.begin, end: word.end };
+      const initialState: DragState = { wordIndex, edge, begin: word.begin, end: word.end };
       dragStateRef.current = initialState;
       setDragState(initialState);
+
+      const isSyllableBoundary = (idx: number, side: "left" | "right"): boolean => {
+        const pos = syllablePositions[idx];
+        if (side === "right") return pos === "first" || pos === "middle";
+        return pos === "middle" || pos === "last";
+      };
 
       const handleMouseMove = (e: MouseEvent) => {
         const deltaX = e.clientX - startX;
         const deltaTime = deltaX / zoom;
         const originalWord = words[wordIndex];
+        const altHeld = e.altKey;
+
+        const isSyllable = isSyllableBoundary(wordIndex, edge);
+        const conjoined = altHeld ? !isSyllable : isSyllable;
 
         let newState: DragState;
+
         if (edge === "left") {
-          const newBegin = originalWord.begin + deltaTime;
-          const maxBegin = originalWord.end - 0.05;
-          const prevEnd = wordIndex > 0 ? words[wordIndex - 1].end : 0;
-          const clampedBegin = Math.max(prevEnd, Math.min(maxBegin, Math.max(0, newBegin)));
-          newState = { wordIndex, edge, begin: clampedBegin, end: originalWord.end };
+          if (conjoined && wordIndex > 0) {
+            const prevWord = words[wordIndex - 1];
+            const newBoundary = originalWord.begin + deltaTime;
+            const min = prevWord.begin + MIN_WORD_DURATION;
+            const max = originalWord.end - MIN_WORD_DURATION;
+            const clamped = Math.max(min, Math.min(max, Math.max(0, newBoundary)));
+            newState = {
+              wordIndex, edge, begin: clamped, end: originalWord.end,
+              adjacentWordIndex: wordIndex - 1, adjacentBegin: prevWord.begin, adjacentEnd: clamped,
+            };
+          } else {
+            const newBegin = originalWord.begin + deltaTime;
+            const maxBegin = originalWord.end - MIN_WORD_DURATION;
+            const prevEnd = wordIndex > 0 ? words[wordIndex - 1].end : 0;
+            const clampedBegin = Math.max(prevEnd, Math.min(maxBegin, Math.max(0, newBegin)));
+            newState = { wordIndex, edge, begin: clampedBegin, end: originalWord.end };
+          }
         } else {
-          const newEnd = originalWord.end + deltaTime;
-          const minEnd = originalWord.begin + 0.05;
-          const nextBegin = wordIndex < words.length - 1 ? words[wordIndex + 1].begin : duration;
-          const clampedEnd = Math.min(nextBegin, Math.max(minEnd, Math.min(duration, newEnd)));
-          newState = { wordIndex, edge, begin: originalWord.begin, end: clampedEnd };
+          if (conjoined && wordIndex < words.length - 1) {
+            const nextWord = words[wordIndex + 1];
+            const newBoundary = originalWord.end + deltaTime;
+            const min = originalWord.begin + MIN_WORD_DURATION;
+            const max = nextWord.end - MIN_WORD_DURATION;
+            const clamped = Math.max(min, Math.min(max, Math.min(duration, newBoundary)));
+            newState = {
+              wordIndex, edge, begin: originalWord.begin, end: clamped,
+              adjacentWordIndex: wordIndex + 1, adjacentBegin: clamped, adjacentEnd: nextWord.end,
+            };
+          } else {
+            const newEnd = originalWord.end + deltaTime;
+            const minEnd = originalWord.begin + MIN_WORD_DURATION;
+            const nextBegin = wordIndex < words.length - 1 ? words[wordIndex + 1].begin : duration;
+            const clampedEnd = Math.min(nextBegin, Math.max(minEnd, Math.min(duration, newEnd)));
+            newState = { wordIndex, edge, begin: originalWord.begin, end: clampedEnd };
+          }
         }
 
         dragStateRef.current = newState;
@@ -95,9 +145,15 @@ const WordTrack: React.FC<WordTrackProps> = ({
         const finalState = dragStateRef.current;
         dragStateRef.current = null;
         setDragState(null);
+        justResizedRef.current = true;
+        requestAnimationFrame(() => { justResizedRef.current = false; });
 
         if (finalState) {
-          if (edge === "left") {
+          if (finalState.adjacentWordIndex !== undefined) {
+            const mainUpdate = edge === "left" ? { begin: finalState.begin } : { end: finalState.end };
+            const adjUpdate = edge === "left" ? { end: finalState.adjacentEnd! } : { begin: finalState.adjacentBegin! };
+            onUpdateWord(wordIndex, mainUpdate, finalState.adjacentWordIndex, adjUpdate);
+          } else if (edge === "left") {
             onUpdateWord(wordIndex, { begin: finalState.begin });
           } else {
             onUpdateWord(wordIndex, { end: finalState.end });
@@ -117,25 +173,52 @@ const WordTrack: React.FC<WordTrackProps> = ({
       document.addEventListener("mousemove", handleMouseMove);
       document.addEventListener("mouseup", handleMouseUp);
     },
-    [words, zoom, duration, onUpdateWord],
+    [words, zoom, duration, onUpdateWord, syllablePositions],
   );
+
+  const isBoundaryConjoined = (boundaryIndex: number): boolean => {
+    if (boundaryIndex < 0 || boundaryIndex >= words.length - 1) return false;
+    const pos = syllablePositions[boundaryIndex];
+    const isSyllable = pos === "first" || pos === "middle";
+    return altPressed ? !isSyllable : isSyllable;
+  };
 
   const hasSelection = selectedWords.length > 0;
 
   const getDisplay = (wordIndex: number) => {
-    if (dragState && dragState.wordIndex === wordIndex) {
-      return { begin: dragState.begin, end: dragState.end };
+    if (dragState) {
+      if (dragState.wordIndex === wordIndex) {
+        return { begin: dragState.begin, end: dragState.end };
+      }
+      if (dragState.adjacentWordIndex === wordIndex) {
+        return { begin: dragState.adjacentBegin!, end: dragState.adjacentEnd! };
+      }
     }
     const word = words[wordIndex];
     return { begin: word.begin, end: word.end };
   };
+
+  const handleEdgeHover = useCallback(
+    (wordIndex: number, edge: "left" | "right", hovering: boolean) => {
+      if (!hovering) {
+        setHoveredBoundary(null);
+        return;
+      }
+      // Boundary index = the gap between words[i] and words[i+1]
+      // Right edge of word N → boundary N
+      // Left edge of word N → boundary N-1
+      setHoveredBoundary(edge === "right" ? wordIndex : wordIndex - 1);
+    },
+    [],
+  );
 
   const handleTrackClick = () => {
     setSelectedWords([]);
   };
 
   const handleSelect = (wordIndex: number, e: React.MouseEvent) => {
-    if (e.shiftKey && syllablePositions) {
+    if (justResizedRef.current) return;
+    if (e.shiftKey) {
       const pos = syllablePositions[wordIndex];
       if (pos !== "none") {
         const groups = computeSyllableGroups(words);
@@ -261,9 +344,12 @@ const WordTrack: React.FC<WordTrackProps> = ({
             zoom={zoom}
             isDimmed={hasSelection && !isWordSelected(selectedWords, lineId, wordIndex, trackType)}
             isSelected={isWordSelected(selectedWords, lineId, wordIndex, trackType)}
-            syllablePosition={syllablePositions?.[wordIndex] ?? "none"}
+            syllablePosition={showSyllableIndicators ? syllablePositions[wordIndex] : "none"}
+            leftHighlighted={hoveredBoundary === wordIndex - 1 && isBoundaryConjoined(wordIndex - 1)}
+            rightHighlighted={hoveredBoundary === wordIndex && isBoundaryConjoined(wordIndex)}
             onClick={(e) => handleSelect(wordIndex, e)}
             onResizeStart={(edge, startX) => handleResizeStart(wordIndex, edge, startX)}
+            onEdgeHover={(edge, hovering) => handleEdgeHover(wordIndex, edge, hovering)}
             onDoubleClick={() => handleWordDoubleClick(wordIndex)}
             onContextMenu={(e) => handleWordContextMenu(wordIndex, e)}
           />


### PR DESCRIPTION
## Overview

- Consolidated `getLineTiming` from 4 identical copies (sync-helpers, ttml, timeline/utils, export) into single source in `sync-helpers.ts`
- Unified 4 `formatTime` variants (0/2/3-digit precision) into `src/utils/format-time.ts` with a `precision` parameter
- Extracted identical `EmptyState` component from preview, export, and sync-panel into `src/ui/empty-state.tsx`
- Replaced near-identical `word-timing.ts` and `bg-word-timing.ts` (83 lines each) with a shared factory in `word-timing-ops.ts`
- Extracted inline `LineTimingInput` type from repeated inline type annotations in `sync-helpers.ts`
- Fixed TTML export writing `composer:timing="Word"` for line-synced-only songs by deriving effective granularity from actual data