### PR TITLE
fix: various bugs

### DIFF
--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -301,16 +301,18 @@ function useSyncHandlers({
   const handleTap = granularity === "word" ? handleTapWord : handleTapLine;
 
   const handleReset = useCallback(() => {
-    for (const line of lines) {
-      updateLine(line.id, {
+    const updates = lines.map((line) => ({
+      id: line.id,
+      updates: {
         words: undefined,
         begin: undefined,
         end: undefined,
         backgroundWords: undefined,
-      });
-    }
+      },
+    }));
+    useProjectStore.getState().updateLinesWithHistory(updates);
     setSyncState({ position: { lineIndex: 0, wordIndex: 0 }, isActive: false });
-  }, [lines, updateLine, setSyncState]);
+  }, [lines, setSyncState]);
 
   const handleStartSync = useCallback(() => {
     setSyncState({ position: { lineIndex: 0, wordIndex: 0 }, isActive: true });

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -3,10 +3,7 @@ import { create } from "zustand";
 
 // -- Types --------------------------------------------------------------------
 
-type AudioSource =
-  | { type: "file"; file: File }
-  | { type: "youtube"; videoId: string; file?: File }
-  | null;
+type AudioSource = { type: "file"; file: File } | { type: "youtube"; videoId: string; file?: File } | null;
 
 interface AudioState {
   source: AudioSource;

--- a/src/stores/project.history.test.ts
+++ b/src/stores/project.history.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment node
+ */
+import { type LyricLine, useProjectStore } from "@/stores/project";
+import { beforeEach, describe, expect, it } from "vitest";
+
+function seedLine(id: string, overrides: Partial<LyricLine> = {}): LyricLine {
+  return { id, text: "hello world", agentId: "v1", ...overrides };
+}
+
+beforeEach(() => {
+  useProjectStore.getState().reset();
+  useProjectStore.getState().clearHistory();
+});
+
+// -- setLinesWithHistory and updateLinesWithHistory ----------------------------
+
+describe("setLinesWithHistory", () => {
+  it("pushes a history entry that undo restores", () => {
+    useProjectStore.getState().setLines([seedLine("a"), seedLine("b")]);
+    const before = useProjectStore.getState().lines;
+
+    useProjectStore.getState().setLinesWithHistory([seedLine("a", { agentId: "v2" }), seedLine("b")]);
+    expect(useProjectStore.getState().lines[0].agentId).toBe("v2");
+    expect(useProjectStore.getState().canUndo()).toBe(true);
+
+    useProjectStore.getState().undo();
+    expect(useProjectStore.getState().lines).toEqual(before);
+  });
+});
+
+describe("updateLinesWithHistory", () => {
+  it("merges multiple line updates into one history step", () => {
+    useProjectStore.getState().setLines([seedLine("a"), seedLine("b"), seedLine("c")]);
+
+    useProjectStore.getState().updateLinesWithHistory([
+      { id: "a", updates: { agentId: "v2" } },
+      { id: "c", updates: { agentId: "v3" } },
+    ]);
+
+    expect(useProjectStore.getState().lines.map((l) => l.agentId)).toEqual(["v2", "v1", "v3"]);
+
+    useProjectStore.getState().undo();
+    expect(useProjectStore.getState().lines.map((l) => l.agentId)).toEqual(["v1", "v1", "v1"]);
+
+    useProjectStore.getState().redo();
+    expect(useProjectStore.getState().lines.map((l) => l.agentId)).toEqual(["v2", "v1", "v3"]);
+  });
+
+  it("clears words/begin/end via undefined updates and is undoable", () => {
+    useProjectStore.getState().setLines([
+      seedLine("a", {
+        words: [{ text: "hi", begin: 0, end: 1 }],
+        begin: 0,
+        end: 1,
+        backgroundWords: [{ text: "ah", begin: 0, end: 0.5 }],
+        backgroundText: "ah",
+      }),
+    ]);
+
+    useProjectStore.getState().updateLinesWithHistory([
+      {
+        id: "a",
+        updates: { words: undefined, begin: undefined, end: undefined, backgroundWords: undefined },
+      },
+    ]);
+
+    const cleared = useProjectStore.getState().lines[0];
+    expect(cleared.words).toBeUndefined();
+    expect(cleared.begin).toBeUndefined();
+    expect(cleared.backgroundWords).toBeUndefined();
+
+    useProjectStore.getState().undo();
+    const restored = useProjectStore.getState().lines[0];
+    expect(restored.words).toEqual([{ text: "hi", begin: 0, end: 1 }]);
+    expect(restored.begin).toBe(0);
+    expect(restored.backgroundWords).toEqual([{ text: "ah", begin: 0, end: 0.5 }]);
+  });
+});

--- a/src/stores/project.move.test.ts
+++ b/src/stores/project.move.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @vitest-environment node
+ */
+import { type LyricLine, useProjectStore } from "@/stores/project";
+import { beforeEach, describe, expect, it } from "vitest";
+
+const DURATION = 30;
+
+function seedLine(overrides: Partial<LyricLine> = {}): LyricLine {
+  return {
+    id: "line-1",
+    text: "hello world goodbye",
+    agentId: "v1",
+    words: [
+      { text: "hello ", begin: 0, end: 1 },
+      { text: "world ", begin: 1, end: 2 },
+      { text: "goodbye", begin: 2, end: 3 },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useProjectStore.getState().reset();
+  useProjectStore.getState().clearHistory();
+});
+
+// -- moveWordToBg --------------------------------------------------------------
+
+describe("moveWordToBg", () => {
+  it("moves a single word and applies timeDelta", () => {
+    useProjectStore.getState().setLines([seedLine()]);
+
+    useProjectStore.getState().moveWordToBg("line-1", [2], 5, DURATION);
+
+    const line = useProjectStore.getState().lines[0];
+    expect(line.words?.map((w) => w.text)).toEqual(["hello ", "world"]);
+    expect(line.backgroundWords).toHaveLength(1);
+    expect(line.backgroundWords?.[0]).toEqual({ text: "goodbye", begin: 7, end: 8 });
+    expect(line.backgroundText).toBe("goodbye");
+  });
+
+  it("trims trailing space from the new last main word", () => {
+    useProjectStore.getState().setLines([seedLine()]);
+
+    useProjectStore.getState().moveWordToBg("line-1", [2], 5, DURATION);
+
+    const line = useProjectStore.getState().lines[0];
+    expect(line.words?.[1].text).toBe("world");
+  });
+
+  it("moves multiple selected words at once", () => {
+    useProjectStore.getState().setLines([seedLine()]);
+
+    useProjectStore.getState().moveWordToBg("line-1", [0, 2], 0, DURATION);
+
+    const line = useProjectStore.getState().lines[0];
+    expect(line.words?.map((w) => w.text)).toEqual(["world"]);
+    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["hello ", "goodbye"]);
+    expect(line.backgroundText).toBe("hello goodbye");
+  });
+
+  it("adds a trailing space to the previous last bg word when a new word lands at the end", () => {
+    useProjectStore.getState().setLines([
+      seedLine({
+        backgroundWords: [
+          { text: "ah", begin: 0, end: 0.5 },
+          { text: "ooh", begin: 0.5, end: 1 },
+        ],
+        backgroundText: "ahooh",
+      }),
+    ]);
+
+    useProjectStore.getState().moveWordToBg("line-1", [2], 7, DURATION);
+
+    const line = useProjectStore.getState().lines[0];
+    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["ah ", "ooh ", "goodbye"]);
+    expect(line.backgroundText).toBe("ah ooh goodbye");
+  });
+
+  it("resolves overlap when moved word collides with an existing bg word", () => {
+    useProjectStore.getState().setLines([
+      seedLine({
+        backgroundWords: [{ text: "yeah", begin: 5, end: 6 }],
+        backgroundText: "yeah",
+      }),
+    ]);
+
+    useProjectStore.getState().moveWordToBg("line-1", [2], 3, DURATION);
+
+    const line = useProjectStore.getState().lines[0];
+    const bg = line.backgroundWords;
+    if (!bg) throw new Error("backgroundWords missing");
+    expect(bg).toHaveLength(2);
+    for (let i = 1; i < bg.length; i++) {
+      expect(bg[i].begin).toBeGreaterThanOrEqual(bg[i - 1].end);
+    }
+  });
+});
+
+// -- moveWordFromBg ------------------------------------------------------------
+
+describe("moveWordFromBg", () => {
+  it("moves a single bg word back to main and applies timeDelta", () => {
+    useProjectStore.getState().setLines([
+      seedLine({
+        backgroundWords: [{ text: "ooh", begin: 10, end: 11 }],
+        backgroundText: "ooh",
+      }),
+    ]);
+
+    useProjectStore.getState().moveWordFromBg("line-1", [0], -7, DURATION);
+
+    const line = useProjectStore.getState().lines[0];
+    expect(line.backgroundWords).toBeUndefined();
+    expect(line.backgroundText).toBeUndefined();
+    expect(line.words?.find((w) => w.text.trimEnd() === "ooh")).toBeTruthy();
+    const ooh = line.words?.find((w) => w.text.trimEnd() === "ooh");
+    expect(ooh?.begin).toBe(3);
+    expect(ooh?.end).toBe(4);
+  });
+
+  it("clears bg fields only when no bg words remain", () => {
+    useProjectStore.getState().setLines([
+      seedLine({
+        backgroundWords: [
+          { text: "ah ", begin: 5, end: 6 },
+          { text: "ooh", begin: 6, end: 7 },
+        ],
+        backgroundText: "ahooh",
+      }),
+    ]);
+
+    useProjectStore.getState().moveWordFromBg("line-1", [1], 3, DURATION);
+
+    const line = useProjectStore.getState().lines[0];
+    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["ah"]);
+    expect(line.backgroundText).toBe("ah");
+  });
+
+  it("moves multiple selected bg words at once", () => {
+    useProjectStore.getState().setLines([
+      seedLine({
+        words: [],
+        backgroundWords: [
+          { text: "ah ", begin: 5, end: 6 },
+          { text: "ooh ", begin: 6, end: 7 },
+          { text: "yeah", begin: 7, end: 8 },
+        ],
+        backgroundText: "ah ooh yeah",
+      }),
+    ]);
+
+    useProjectStore.getState().moveWordFromBg("line-1", [0, 2], 0, DURATION);
+
+    const line = useProjectStore.getState().lines[0];
+    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["ooh"]);
+    expect(line.words?.map((w) => w.text)).toEqual(["ah ", "yeah"]);
+  });
+});

--- a/src/stores/project.move.test.ts
+++ b/src/stores/project.move.test.ts
@@ -158,3 +158,55 @@ describe("moveWordFromBg", () => {
     expect(line.words?.map((w) => w.text)).toEqual(["ah ", "yeah"]);
   });
 });
+
+// -- history -------------------------------------------------------------------
+
+describe("cross-track moves and history", () => {
+  it("moveWordToBg is undoable", () => {
+    useProjectStore.getState().setLines([seedLine()]);
+    const before = useProjectStore.getState().lines[0];
+
+    useProjectStore.getState().moveWordToBg("line-1", [2], 5, DURATION);
+    expect(useProjectStore.getState().lines[0].backgroundWords).toBeTruthy();
+    expect(useProjectStore.getState().canUndo()).toBe(true);
+
+    useProjectStore.getState().undo();
+    const restored = useProjectStore.getState().lines[0];
+    expect(restored.words?.map((w) => w.text)).toEqual(before.words?.map((w) => w.text));
+    expect(restored.backgroundWords).toBeUndefined();
+  });
+
+  it("moveWordFromBg is undoable and redoable", () => {
+    useProjectStore.getState().setLines([
+      seedLine({
+        backgroundWords: [{ text: "ooh", begin: 10, end: 11 }],
+        backgroundText: "ooh",
+      }),
+    ]);
+
+    useProjectStore.getState().moveWordFromBg("line-1", [0], -7, DURATION);
+    const after = useProjectStore.getState().lines[0];
+    expect(after.backgroundWords).toBeUndefined();
+
+    useProjectStore.getState().undo();
+    const undone = useProjectStore.getState().lines[0];
+    expect(undone.backgroundWords).toEqual([{ text: "ooh", begin: 10, end: 11 }]);
+    expect(useProjectStore.getState().canRedo()).toBe(true);
+
+    useProjectStore.getState().redo();
+    const redone = useProjectStore.getState().lines[0];
+    expect(redone.backgroundWords).toBeUndefined();
+    expect(redone.words?.find((w) => w.text.trimEnd() === "ooh")).toBeTruthy();
+  });
+
+  it("does not push history when no words match the indices", () => {
+    useProjectStore.getState().setLines([seedLine()]);
+    const beforeIndex = useProjectStore.getState().historyIndex;
+
+    useProjectStore.getState().moveWordToBg("line-1", [], 0, DURATION);
+    expect(useProjectStore.getState().historyIndex).toBe(beforeIndex);
+
+    useProjectStore.getState().moveWordToBg("nonexistent", [0], 0, DURATION);
+    expect(useProjectStore.getState().historyIndex).toBe(beforeIndex);
+  });
+});

--- a/src/stores/project.ts
+++ b/src/stores/project.ts
@@ -325,8 +325,9 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
   clearHistory: () => set({ history: [], historyIndex: -1 }),
 
   moveWordToBg: (lineId, wordIndices, timeDelta, duration) =>
-    set((state) => ({
-      lines: state.lines.map((line) => {
+    set((state) => {
+      let mutated = false;
+      const newLines = state.lines.map((line) => {
         if (line.id !== lineId || !line.words || wordIndices.length === 0) return line;
 
         const indexSet = new Set(wordIndices);
@@ -349,19 +350,23 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
           ),
         );
 
+        mutated = true;
         return {
           ...line,
           words: remainingMain,
           backgroundWords: mergedBg,
           backgroundText: mergedBg.map((w) => w.text).join(""),
         };
-      }),
-      isDirty: true,
-    })),
+      });
+
+      if (!mutated) return state;
+      return commitHistory(state, newLines);
+    }),
 
   moveWordFromBg: (lineId, wordIndices, timeDelta, duration) =>
-    set((state) => ({
-      lines: state.lines.map((line) => {
+    set((state) => {
+      let mutated = false;
+      const newLines = state.lines.map((line) => {
         if (line.id !== lineId || !line.backgroundWords || wordIndices.length === 0) return line;
 
         const indexSet = new Set(wordIndices);
@@ -385,16 +390,34 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
         );
 
         const hasBg = remainingBg.length > 0;
+        mutated = true;
         return {
           ...line,
           words: mergedMain,
           backgroundWords: hasBg ? remainingBg : undefined,
           backgroundText: hasBg ? remainingBg.map((w) => w.text).join("") : undefined,
         };
-      }),
-      isDirty: true,
-    })),
+      });
+
+      if (!mutated) return state;
+      return commitHistory(state, newLines);
+    }),
 }));
+
+function commitHistory(state: ProjectState, newLines: LyricLine[]) {
+  const newHistory = state.history.slice(0, state.historyIndex + 1);
+  if (newHistory.length === 0) {
+    newHistory.push({ lines: JSON.parse(JSON.stringify(state.lines)), timestamp: Date.now() });
+  }
+  newHistory.push({ lines: JSON.parse(JSON.stringify(newLines)), timestamp: Date.now() });
+  if (newHistory.length > MAX_HISTORY_SIZE) newHistory.shift();
+  return {
+    lines: newLines,
+    isDirty: true,
+    history: newHistory,
+    historyIndex: newHistory.length - 1,
+  };
+}
 
 function getAgentColor(agentId: string): string {
   return AGENT_COLORS[agentId] ?? "#9ca3af"; // gray fallback

--- a/src/stores/project.ts
+++ b/src/stores/project.ts
@@ -1,5 +1,6 @@
 import { useAudioStore } from "@/stores/audio";
 import { useSettingsStore } from "@/stores/settings";
+import { normalizeTrailingSpaces, resolveOverlapsForward } from "@/utils/word-spaces";
 import { create } from "zustand";
 
 // -- Types --------------------------------------------------------------------
@@ -79,8 +80,8 @@ interface ProjectActions {
   canRedo: () => boolean;
   clearHistory: () => void;
   updateLinesWithHistory: (updates: Array<{ id: string; updates: Partial<LyricLine> }>) => void;
-  moveWordToBg: (lineId: string, wordIndex: number) => void;
-  moveWordFromBg: (lineId: string, wordIndex: number) => void;
+  moveWordToBg: (lineId: string, wordIndices: number[], timeDelta: number, duration: number) => void;
+  moveWordFromBg: (lineId: string, wordIndices: number[], timeDelta: number, duration: number) => void;
 }
 
 // -- Constants ----------------------------------------------------------------
@@ -323,40 +324,72 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
 
   clearHistory: () => set({ history: [], historyIndex: -1 }),
 
-  moveWordToBg: (lineId, wordIndex) =>
+  moveWordToBg: (lineId, wordIndices, timeDelta, duration) =>
     set((state) => ({
       lines: state.lines.map((line) => {
-        if (line.id !== lineId || !line.words) return line;
-        const word = line.words[wordIndex];
-        if (!word) return line;
-        const bgWords = [...(line.backgroundWords || []), word].sort((a, b) => a.begin - b.begin);
-        // Concatenate without adding spaces - trailing spaces are embedded in word.text
-        const bgText = bgWords.map((w) => w.text).join("");
+        if (line.id !== lineId || !line.words || wordIndices.length === 0) return line;
+
+        const indexSet = new Set(wordIndices);
+        const movedWords = line.words
+          .map((w, i) => ({ word: w, index: i }))
+          .filter(({ index }) => indexSet.has(index))
+          .map(({ word }) => {
+            const dur = word.end - word.begin;
+            const newBegin = Math.max(0, Math.min(duration - dur, word.begin + timeDelta));
+            return { ...word, begin: newBegin, end: newBegin + dur };
+          });
+
+        if (movedWords.length === 0) return line;
+
+        const remainingMain = normalizeTrailingSpaces(line.words.filter((_, i) => !indexSet.has(i)));
+        const mergedBg = normalizeTrailingSpaces(
+          resolveOverlapsForward(
+            [...(line.backgroundWords ?? []), ...movedWords].sort((a, b) => a.begin - b.begin),
+            duration,
+          ),
+        );
+
         return {
           ...line,
-          words: line.words.filter((_, i) => i !== wordIndex),
-          backgroundWords: bgWords,
-          backgroundText: bgText,
+          words: remainingMain,
+          backgroundWords: mergedBg,
+          backgroundText: mergedBg.map((w) => w.text).join(""),
         };
       }),
       isDirty: true,
     })),
 
-  moveWordFromBg: (lineId, wordIndex) =>
+  moveWordFromBg: (lineId, wordIndices, timeDelta, duration) =>
     set((state) => ({
       lines: state.lines.map((line) => {
-        if (line.id !== lineId || !line.backgroundWords) return line;
-        const word = line.backgroundWords[wordIndex];
-        if (!word) return line;
-        const mainWords = [...(line.words || []), word].sort((a, b) => a.begin - b.begin);
-        const remainingBgWords = line.backgroundWords.filter((_, i) => i !== wordIndex);
-        // Concatenate without adding spaces - trailing spaces are embedded in word.text
-        const bgText = remainingBgWords.length > 0 ? remainingBgWords.map((w) => w.text).join("") : undefined;
+        if (line.id !== lineId || !line.backgroundWords || wordIndices.length === 0) return line;
+
+        const indexSet = new Set(wordIndices);
+        const movedWords = line.backgroundWords
+          .map((w, i) => ({ word: w, index: i }))
+          .filter(({ index }) => indexSet.has(index))
+          .map(({ word }) => {
+            const dur = word.end - word.begin;
+            const newBegin = Math.max(0, Math.min(duration - dur, word.begin + timeDelta));
+            return { ...word, begin: newBegin, end: newBegin + dur };
+          });
+
+        if (movedWords.length === 0) return line;
+
+        const remainingBg = normalizeTrailingSpaces(line.backgroundWords.filter((_, i) => !indexSet.has(i)));
+        const mergedMain = normalizeTrailingSpaces(
+          resolveOverlapsForward(
+            [...(line.words ?? []), ...movedWords].sort((a, b) => a.begin - b.begin),
+            duration,
+          ),
+        );
+
+        const hasBg = remainingBg.length > 0;
         return {
           ...line,
-          backgroundWords: remainingBgWords.length > 0 ? remainingBgWords : undefined,
-          backgroundText: bgText,
-          words: mainWords,
+          words: mergedMain,
+          backgroundWords: hasBg ? remainingBg : undefined,
+          backgroundText: hasBg ? remainingBg.map((w) => w.text).join("") : undefined,
         };
       }),
       isDirty: true,

--- a/src/utils/word-spaces.test.ts
+++ b/src/utils/word-spaces.test.ts
@@ -1,0 +1,183 @@
+/**
+ * @vitest-environment node
+ */
+import type { WordTiming } from "@/stores/project";
+import { findInsertionSlot, normalizeTrailingSpaces, resolveOverlapsForward } from "@/utils/word-spaces";
+import { describe, expect, it } from "vitest";
+
+// -- normalizeTrailingSpaces ---------------------------------------------------
+
+describe("normalizeTrailingSpaces", () => {
+  it("returns empty array as-is", () => {
+    expect(normalizeTrailingSpaces([])).toEqual([]);
+  });
+
+  it("trims trailing space from the last word", () => {
+    const result = normalizeTrailingSpaces([{ text: "hello ", begin: 0, end: 1 }]);
+    expect(result[0].text).toBe("hello");
+  });
+
+  it("leaves a single word without trailing space alone", () => {
+    const result = normalizeTrailingSpaces([{ text: "hello", begin: 0, end: 1 }]);
+    expect(result[0].text).toBe("hello");
+  });
+
+  it("adds trailing space to non-last words missing one", () => {
+    const result = normalizeTrailingSpaces([
+      { text: "he", begin: 0, end: 0.5 },
+      { text: "llo", begin: 0.5, end: 1 },
+    ]);
+    expect(result[0].text).toBe("he ");
+    expect(result[1].text).toBe("llo");
+  });
+
+  it("preserves intentional trailing spaces on non-last words", () => {
+    const result = normalizeTrailingSpaces([
+      { text: "hello ", begin: 0, end: 1 },
+      { text: "world", begin: 1, end: 2 },
+    ]);
+    expect(result[0].text).toBe("hello ");
+    expect(result[1].text).toBe("world");
+  });
+
+  it("trims a trailing space that drifted onto the last word", () => {
+    const result = normalizeTrailingSpaces([
+      { text: "hello ", begin: 0, end: 1 },
+      { text: "world ", begin: 1, end: 2 },
+    ]);
+    expect(result[0].text).toBe("hello ");
+    expect(result[1].text).toBe("world");
+  });
+});
+
+// -- resolveOverlapsForward ----------------------------------------------------
+
+describe("resolveOverlapsForward", () => {
+  it("returns empty array as-is", () => {
+    expect(resolveOverlapsForward([], 10)).toEqual([]);
+  });
+
+  it("leaves non-overlapping words alone", () => {
+    const words: WordTiming[] = [
+      { text: "a", begin: 0, end: 1 },
+      { text: "b", begin: 2, end: 3 },
+    ];
+    expect(resolveOverlapsForward(words, 10)).toEqual(words);
+  });
+
+  it("pushes a single overlapping word forward", () => {
+    const result = resolveOverlapsForward(
+      [
+        { text: "a", begin: 0, end: 2 },
+        { text: "b", begin: 1, end: 3 },
+      ],
+      10,
+    );
+    expect(result[0]).toEqual({ text: "a", begin: 0, end: 2 });
+    expect(result[1]).toEqual({ text: "b", begin: 2, end: 4 });
+  });
+
+  it("cascades pushes through multiple overlaps", () => {
+    const result = resolveOverlapsForward(
+      [
+        { text: "a", begin: 0, end: 2 },
+        { text: "b", begin: 1, end: 3 },
+        { text: "c", begin: 2, end: 4 },
+      ],
+      20,
+    );
+    expect(result[1].begin).toBe(2);
+    expect(result[1].end).toBe(4);
+    expect(result[2].begin).toBe(4);
+    expect(result[2].end).toBe(6);
+  });
+
+  it("clamps the last word to duration while preserving its duration", () => {
+    const result = resolveOverlapsForward(
+      [
+        { text: "a", begin: 0, end: 1 },
+        { text: "b", begin: 8, end: 11 },
+      ],
+      10,
+    );
+    expect(result[1].end).toBe(10);
+    expect(result[1].begin).toBe(7);
+  });
+});
+
+// -- findInsertionSlot ---------------------------------------------------------
+
+describe("findInsertionSlot", () => {
+  it("centers a word in an empty track", () => {
+    const slot = findInsertionSlot([], 5, 1, 10);
+    expect(slot).toEqual({ begin: 4.5, end: 5.5 });
+  });
+
+  it("centers in an open gap between words", () => {
+    const words: WordTiming[] = [
+      { text: "a", begin: 0, end: 1 },
+      { text: "b", begin: 5, end: 6 },
+    ];
+    const slot = findInsertionSlot(words, 3, 1, 10);
+    expect(slot).toEqual({ begin: 2.5, end: 3.5 });
+  });
+
+  it("snaps right against the previous word when the click is near it", () => {
+    const words: WordTiming[] = [
+      { text: "a", begin: 0, end: 2 },
+      { text: "b", begin: 5, end: 6 },
+    ];
+    const slot = findInsertionSlot(words, 2.1, 1, 10);
+    expect(slot?.begin).toBe(2);
+    expect(slot?.end).toBe(3);
+  });
+
+  it("snaps left against the next word when the click is near it", () => {
+    const words: WordTiming[] = [
+      { text: "a", begin: 0, end: 1 },
+      { text: "b", begin: 5, end: 6 },
+    ];
+    const slot = findInsertionSlot(words, 4.9, 1, 10);
+    expect(slot?.end).toBe(5);
+    expect(slot?.begin).toBe(4);
+  });
+
+  it("shrinks the new word to the gap when desired duration does not fit", () => {
+    const words: WordTiming[] = [
+      { text: "a", begin: 0, end: 2 },
+      { text: "b", begin: 2.6, end: 5 },
+    ];
+    const slot = findInsertionSlot(words, 2.3, 1, 10);
+    expect(slot).toEqual({ begin: 2, end: 2.6 });
+  });
+
+  it("returns null when the gap is smaller than minDuration", () => {
+    const words: WordTiming[] = [
+      { text: "a", begin: 0, end: 2 },
+      { text: "b", begin: 2.02, end: 5 },
+    ];
+    expect(findInsertionSlot(words, 2.01, 1, 10, 0.05)).toBeNull();
+  });
+
+  it("snaps to the next gap when click lands inside an existing word", () => {
+    const words: WordTiming[] = [
+      { text: "a", begin: 0, end: 2 },
+      { text: "b", begin: 5, end: 6 },
+    ];
+    const slot = findInsertionSlot(words, 1, 1, 10);
+    expect(slot?.begin).toBe(2);
+    expect(slot?.end).toBeLessThanOrEqual(5);
+  });
+
+  it("clamps to audioDuration when click is past the last word", () => {
+    const words: WordTiming[] = [{ text: "a", begin: 0, end: 8 }];
+    const slot = findInsertionSlot(words, 9.9, 1, 10);
+    expect(slot?.end).toBe(10);
+    expect(slot?.begin).toBe(9);
+  });
+
+  it("returns null when there is no room past the last word", () => {
+    const words: WordTiming[] = [{ text: "a", begin: 0, end: 9.99 }];
+    expect(findInsertionSlot(words, 9.995, 1, 10, 0.05)).toBeNull();
+  });
+});

--- a/src/utils/word-spaces.ts
+++ b/src/utils/word-spaces.ts
@@ -1,0 +1,86 @@
+import type { WordTiming } from "@/stores/project";
+
+// -- Constants -----------------------------------------------------------------
+
+const DEFAULT_MIN_WORD_DURATION = 0.05;
+
+// -- Functions -----------------------------------------------------------------
+
+function normalizeTrailingSpaces(words: WordTiming[]): WordTiming[] {
+  if (words.length === 0) return words;
+  return words.map((word, i) => {
+    const isLast = i === words.length - 1;
+    const hasSpace = word.text.endsWith(" ");
+    if (isLast && hasSpace) return { ...word, text: word.text.trimEnd() };
+    if (!isLast && !hasSpace) return { ...word, text: `${word.text} ` };
+    return word;
+  });
+}
+
+function resolveOverlapsForward(words: WordTiming[], duration: number): WordTiming[] {
+  if (words.length === 0) return words;
+  const result = words.map((w) => ({ ...w }));
+  for (let i = 1; i < result.length; i++) {
+    if (result[i].begin < result[i - 1].end) {
+      const overlap = result[i - 1].end - result[i].begin;
+      result[i] = { ...result[i], begin: result[i].begin + overlap, end: result[i].end + overlap };
+    }
+  }
+  const last = result[result.length - 1];
+  if (last.end > duration) {
+    const overflow = last.end - duration;
+    result[result.length - 1] = { ...last, begin: Math.max(0, last.begin - overflow), end: duration };
+  }
+  return result;
+}
+
+function findInsertionSlot(
+  existingWords: WordTiming[],
+  preferredTime: number,
+  desiredDuration: number,
+  audioDuration: number,
+  minDuration: number = DEFAULT_MIN_WORD_DURATION,
+): { begin: number; end: number } | null {
+  const sorted = [...existingWords].sort((a, b) => a.begin - b.begin);
+
+  let gapStart = 0;
+  let gapEnd = audioDuration;
+
+  for (let i = 0; i < sorted.length; i++) {
+    const word = sorted[i];
+    if (preferredTime >= word.begin && preferredTime < word.end) {
+      gapStart = word.end;
+      const next = sorted[i + 1];
+      gapEnd = next ? next.begin : audioDuration;
+      break;
+    }
+    if (preferredTime < word.begin) {
+      gapEnd = word.begin;
+      break;
+    }
+    gapStart = word.end;
+    gapEnd = audioDuration;
+  }
+
+  const gapSize = gapEnd - gapStart;
+  if (gapSize < minDuration) return null;
+
+  const actualDuration = Math.min(desiredDuration, gapSize);
+  let begin = preferredTime - actualDuration / 2;
+  let end = begin + actualDuration;
+
+  if (begin < gapStart) {
+    begin = gapStart;
+    end = begin + actualDuration;
+  }
+  if (end > gapEnd) {
+    end = gapEnd;
+    begin = end - actualDuration;
+  }
+
+  return { begin, end };
+}
+
+// -- Exports -------------------------------------------------------------------
+
+export { normalizeTrailingSpaces, resolveOverlapsForward, findInsertionSlot };

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -291,12 +291,9 @@ const EditPanel: React.FC = () => {
   const bracketCount = useMemo(() => parsed.filter((p) => p.hasBrackets).length, [parsed]);
   const nonEmptyCount = useMemo(() => parsed.filter((p) => !p.isEmpty).length, [parsed]);
 
-  const handleAgentChange = useCallback(
-    (lineId: string, agentId: string) => {
-      updateLine(lineId, { agentId });
-    },
-    [updateLine],
-  );
+  const handleAgentChange = useCallback((lineId: string, agentId: string) => {
+    useProjectStore.getState().updateLineWithHistory(lineId, { agentId });
+  }, []);
 
   const handleBackgroundChange = useCallback(
     (lineId: string, text: string) => {
@@ -358,14 +355,14 @@ const EditPanel: React.FC = () => {
 
   const handleBulkAgentChange = useCallback(
     (agentId: string) => {
-      const selectedLineIds = parsed.filter((p) => selectedLines.has(p.lineNumber) && p.lineId).map((p) => p.lineId);
-
-      const updatedLines = lines.map((line) => (selectedLineIds.includes(line.id) ? { ...line, agentId } : line));
-      linesSetByUs.current = updatedLines;
-      setLines(updatedLines);
+      const selectedLineIds = new Set(
+        parsed.filter((p) => selectedLines.has(p.lineNumber) && p.lineId).map((p) => p.lineId),
+      );
+      const updates = [...selectedLineIds].map((id) => ({ id: id as string, updates: { agentId } }));
+      useProjectStore.getState().updateLinesWithHistory(updates);
       setSelectedLines(new Set());
     },
-    [parsed, selectedLines, lines, setLines],
+    [parsed, selectedLines],
   );
 
   const handleClearSelection = useCallback(() => {

--- a/src/views/edit/agent-manager.tsx
+++ b/src/views/edit/agent-manager.tsx
@@ -210,17 +210,16 @@ const AgentManager: React.FC = () => {
   const agents = useProjectStore((s) => s.agents);
   const removeAgent = useProjectStore((s) => s.removeAgent);
   const lines = useProjectStore((s) => s.lines);
-  const setLines = useProjectStore((s) => s.setLines);
+  const setLinesWithHistory = useProjectStore((s) => s.setLinesWithHistory);
 
   const handleRemoveAgent = useCallback(
     (agentId: string) => {
-      // Reassign lines with this agent to the first agent
       const fallbackId = agents.find((a) => a.id !== agentId)?.id ?? "v1";
       const updatedLines = lines.map((line) => (line.agentId === agentId ? { ...line, agentId: fallbackId } : line));
-      setLines(updatedLines);
+      setLinesWithHistory(updatedLines);
       removeAgent(agentId);
     },
-    [agents, lines, setLines, removeAgent],
+    [agents, lines, setLinesWithHistory, removeAgent],
   );
 
   return (

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -33,7 +33,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const SyncPanel: React.FC = () => {
   const lines = useProjectStore((s) => s.lines);
-  const setLines = useProjectStore((s) => s.setLines);
+  const setLinesWithHistory = useProjectStore((s) => s.setLinesWithHistory);
   const undo = useProjectStore((s) => s.undo);
   const redo = useProjectStore((s) => s.redo);
   const activeTab = useProjectStore((s) => s.activeTab);
@@ -160,12 +160,12 @@ const SyncPanel: React.FC = () => {
 
       if (newGranularity === "word" && hasLineTiming(lines)) {
         const convertedLines = lines.map((line) => convertLineToWord(line));
-        setLines(convertedLines);
+        setLinesWithHistory(convertedLines);
       }
 
       setGranularity(newGranularity);
     },
-    [granularity, lines, setLines, setGranularity],
+    [granularity, lines, setLinesWithHistory, setGranularity],
   );
 
   const playingLineIndex = useMemo(() => {

--- a/src/views/timeline/line-row.tsx
+++ b/src/views/timeline/line-row.tsx
@@ -4,6 +4,7 @@ import { useSettingsStore } from "@/stores/settings";
 import { cn } from "@/utils/cn";
 import { stripSplitCharacter } from "@/utils/split-character";
 import { splitIntoWordsWithMeta } from "@/utils/sync-helpers";
+import { findInsertionSlot } from "@/utils/word-spaces";
 import { GutterAgentPicker } from "@/views/timeline/gutter-agent-picker";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { WordTrack } from "@/views/timeline/word-track";
@@ -204,10 +205,13 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
               const time = (e.clientX - rect.left) / zoom;
               const audioDuration = useAudioStore.getState().duration;
               const wordDuration = useSettingsStore.getState().defaultWordDuration;
-              const begin = Math.max(0, time - wordDuration / 2);
-              const end = Math.min(audioDuration, time + wordDuration / 2);
-              const newWord: WordTiming = { text: "...", begin, end };
-              useProjectStore.getState().updateLineWithHistory(line.id, { backgroundWords: [newWord] });
+              const slot = findInsertionSlot([], time, wordDuration, audioDuration);
+              if (!slot) return;
+              const newWord: WordTiming = { text: "...", begin: slot.begin, end: slot.end };
+              useProjectStore.getState().updateLineWithHistory(line.id, {
+                backgroundWords: [newWord],
+                backgroundText: newWord.text,
+              });
               useTimelineStore.getState().setEditingWord({ lineId: line.id, wordIndex: 0, type: "bg" });
             }}
             onContextMenu={(e) => {

--- a/src/views/timeline/timeline-context-menu.tsx
+++ b/src/views/timeline/timeline-context-menu.tsx
@@ -6,6 +6,7 @@ import { useSettingsStore } from "@/stores/settings";
 import { formatKey } from "@/ui/help-modal";
 import { isMac } from "@/utils/platform";
 import { convertLineToWord } from "@/utils/sync-helpers";
+import { findInsertionSlot, normalizeTrailingSpaces } from "@/utils/word-spaces";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { getEffectiveLines, isLineSynced } from "@/views/timeline/utils";
 import { IconCommand } from "@tabler/icons-react";
@@ -129,30 +130,25 @@ const TimelineContextMenu: React.FC = () => {
     if (!line) return;
 
     const wordDuration = useSettingsStore.getState().defaultWordDuration;
-    const newWord: WordTiming = {
-      text: "...",
-      begin: Math.max(0, time - wordDuration / 2),
-      end: Math.min(duration, time + wordDuration / 2),
-    };
-
     const existingWords = type === "word" ? line.words : line.backgroundWords;
-    const words = [...(existingWords ?? []), newWord].sort((a, b) => a.begin - b.begin);
-    const newIndex = words.indexOf(newWord);
-
-    for (let i = 0; i < words.length; i++) {
-      const isLast = i === words.length - 1;
-      const hasSpace = words[i].text.endsWith(" ");
-      if (!isLast && !hasSpace) {
-        words[i] = { ...words[i], text: `${words[i].text} ` };
-      } else if (isLast && hasSpace) {
-        words[i] = { ...words[i], text: words[i].text.trimEnd() };
-      }
+    const slot = findInsertionSlot(existingWords ?? [], time, wordDuration, duration);
+    if (!slot) {
+      clearContextMenu();
+      return;
     }
+
+    const newWord: WordTiming = { text: "...", begin: slot.begin, end: slot.end };
+    const sorted = [...(existingWords ?? []), newWord].sort((a, b) => a.begin - b.begin);
+    const newIndex = sorted.indexOf(newWord);
+    const words = normalizeTrailingSpaces(sorted);
 
     if (type === "word") {
       updateLineWithHistory(lineId, { words });
     } else {
-      updateLineWithHistory(lineId, { backgroundWords: words });
+      updateLineWithHistory(lineId, {
+        backgroundWords: words,
+        backgroundText: words.map((w) => w.text).join(""),
+      });
     }
     useTimelineStore.getState().setEditingWord({ lineId, wordIndex: newIndex, type });
     clearContextMenu();

--- a/src/views/timeline/use-timeline-dnd.ts
+++ b/src/views/timeline/use-timeline-dnd.ts
@@ -1,5 +1,6 @@
 import { useAudioStore } from "@/stores/audio";
 import { type LyricLine, useProjectStore } from "@/stores/project";
+import { normalizeTrailingSpaces } from "@/utils/word-spaces";
 import { type WordSelection, isWordSelected, useTimelineStore } from "@/views/timeline/timeline-store";
 import { type DragEndEvent, type DragStartEvent, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { useCallback, useState } from "react";
@@ -92,7 +93,7 @@ function handleAltDuplicate(event: DragEndEvent, lines: LyricLine[], zoom: numbe
       const existing = line.words ?? [];
       const hasOverlap = wordDups.some((dup) => existing.some((w) => dup.begin < w.end && dup.end > w.begin));
       if (!hasOverlap) {
-        lineUpdates.words = [...existing, ...wordDups].sort((a, b) => a.begin - b.begin);
+        lineUpdates.words = normalizeTrailingSpaces([...existing, ...wordDups].sort((a, b) => a.begin - b.begin));
       }
     }
 
@@ -100,7 +101,7 @@ function handleAltDuplicate(event: DragEndEvent, lines: LyricLine[], zoom: numbe
       const existing = line.backgroundWords ?? [];
       const hasOverlap = bgDups.some((dup) => existing.some((w) => dup.begin < w.end && dup.end > w.begin));
       if (!hasOverlap) {
-        const merged = [...existing, ...bgDups].sort((a, b) => a.begin - b.begin);
+        const merged = normalizeTrailingSpaces([...existing, ...bgDups].sort((a, b) => a.begin - b.begin));
         lineUpdates.backgroundWords = merged;
         lineUpdates.backgroundText = merged.map((w) => w.text).join("");
       }
@@ -174,21 +175,27 @@ function useTimelineDnd(lines: LyricLine[]) {
       const movedDownToBg = delta.y > DRAG_TRACK_SWITCH_THRESHOLD;
       const movedUpToMain = delta.y < -DRAG_TRACK_SWITCH_THRESHOLD;
 
+      const { selectedWords } = useTimelineStore.getState();
+      const wordsToMove = resolveWordsToOperate(activeData, selectedWords);
+      const timeDelta = delta.x / zoom;
+
       if (dropId.startsWith("bg-drop-") && activeData.trackType === "word" && movedDownToBg) {
-        moveWordToBg(activeData.lineId, activeData.wordIndex);
+        const indices = wordsToMove
+          .filter((s) => s.lineId === activeData.lineId && s.type === "word")
+          .map((s) => s.wordIndex);
+        moveWordToBg(activeData.lineId, indices, timeDelta, duration);
         return;
       }
 
       if (dropId.startsWith("main-drop-") && activeData.trackType === "bg" && movedUpToMain) {
-        moveWordFromBg(activeData.lineId, activeData.wordIndex);
+        const indices = wordsToMove
+          .filter((s) => s.lineId === activeData.lineId && s.type === "bg")
+          .map((s) => s.wordIndex);
+        moveWordFromBg(activeData.lineId, indices, timeDelta, duration);
         return;
       }
 
       if (Math.abs(delta.x) < DRAG_X_MIN_THRESHOLD) return;
-
-      const { selectedWords } = useTimelineStore.getState();
-      const wordsToMove = resolveWordsToOperate(activeData, selectedWords);
-      const timeDelta = delta.x / zoom;
 
       if (wordsToMove.length > 1) {
         const grouped = groupSelectionsByLine(wordsToMove);
@@ -230,7 +237,11 @@ function useTimelineDnd(lines: LyricLine[]) {
               words[words.length - 1] = { ...last, begin: last.begin - overflow, end: duration };
             }
 
-            lineUpdates[trackKey] = words;
+            const normalized = normalizeTrailingSpaces(words);
+            lineUpdates[trackKey] = normalized;
+            if (trackKey === "backgroundWords") {
+              lineUpdates.backgroundText = normalized.map((w) => w.text).join("");
+            }
           }
 
           if (Object.keys(lineUpdates).length > 0) {
@@ -267,10 +278,14 @@ function useTimelineDnd(lines: LyricLine[]) {
           words[words.length - 1] = { ...lastWord, begin: lastWord.begin - overflow, end: duration };
         }
 
+        const normalized = normalizeTrailingSpaces(words);
         if (activeData.trackType === "word") {
-          updateLineWithHistory(activeData.lineId, { words });
+          updateLineWithHistory(activeData.lineId, { words: normalized });
         } else {
-          updateLineWithHistory(activeData.lineId, { backgroundWords: words });
+          updateLineWithHistory(activeData.lineId, {
+            backgroundWords: normalized,
+            backgroundText: normalized.map((w) => w.text).join(""),
+          });
         }
       }
     },

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -3,6 +3,7 @@ import type { WordTiming } from "@/stores/project";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import { computeSyllableGroups, getSyllablePositions } from "@/utils/syllable-groups";
+import { findInsertionSlot, normalizeTrailingSpaces } from "@/utils/word-spaces";
 import { isWordSelected, useTimelineStore } from "@/views/timeline/timeline-store";
 import { WordBlock } from "@/views/timeline/word-block";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -287,33 +288,22 @@ const WordTrack: React.FC<WordTrackProps> = ({
 
     const audioDuration = useAudioStore.getState().duration;
     const wordDuration = useSettingsStore.getState().defaultWordDuration;
-    const begin = Math.max(0, time - wordDuration / 2);
-    const end = Math.min(audioDuration, time + wordDuration / 2);
+    const slot = findInsertionSlot(words, time, wordDuration, audioDuration);
+    if (!slot) return;
 
-    // Check for overlap with existing words
-    for (const w of words) {
-      if (begin < w.end && end > w.begin) return;
-    }
-
-    const newWord: WordTiming = { text: "...", begin, end };
-    const newWords = [...words, newWord].sort((a, b) => a.begin - b.begin);
-    const newIndex = newWords.indexOf(newWord);
-
-    for (let i = 0; i < newWords.length; i++) {
-      const isLast = i === newWords.length - 1;
-      const hasSpace = newWords[i].text.endsWith(" ");
-      if (!isLast && !hasSpace) {
-        newWords[i] = { ...newWords[i], text: `${newWords[i].text} ` };
-      } else if (isLast && hasSpace) {
-        newWords[i] = { ...newWords[i], text: newWords[i].text.trimEnd() };
-      }
-    }
+    const newWord: WordTiming = { text: "...", begin: slot.begin, end: slot.end };
+    const sorted = [...words, newWord].sort((a, b) => a.begin - b.begin);
+    const newIndex = sorted.indexOf(newWord);
+    const newWords = normalizeTrailingSpaces(sorted);
 
     const updateLineWithHistory = useProjectStore.getState().updateLineWithHistory;
     if (trackType === "word") {
       updateLineWithHistory(lineId, { words: newWords });
     } else {
-      updateLineWithHistory(lineId, { backgroundWords: newWords });
+      updateLineWithHistory(lineId, {
+        backgroundWords: newWords,
+        backgroundText: newWords.map((w) => w.text).join(""),
+      });
     }
 
     useTimelineStore.getState().setEditingWord({ lineId, wordIndex: newIndex, type: trackType });


### PR DESCRIPTION
## Overview

- Cross-track drag now applies the drop offset and supports multi-selection (was hardcoded to single word at original time).
- Word inserts (drag, "Add word here", track double-click, alt-duplicate) now normalize trailing spaces so a new word at the end of a row no longer syllable-merges with the previous one; bg paths also keep `backgroundText` in sync with `backgroundWords`.
- New `findInsertionSlot` auto-shifts a new word into the nearest fitting gap, fixing right-click "Add word here" overlaps and double-click placement at the end of a line.