### PR TITLE
Fix/misc issues

### DIFF
--- a/src/audio/audio-engine.tsx
+++ b/src/audio/audio-engine.tsx
@@ -1,3 +1,4 @@
+import { bindAudioStateEvents } from "@/audio/audio-state-events";
 import { useAudioStore } from "@/stores/audio";
 import { useEffect, useRef } from "react";
 
@@ -56,12 +57,14 @@ const AudioEngine: React.FC = () => {
     audio.addEventListener("timeupdate", handleTimeUpdate);
     audio.addEventListener("ended", handleEnded);
     audio.addEventListener("error", handleError);
+    const unbindStateEvents = bindAudioStateEvents(audio, setIsPlaying);
 
     return () => {
       audio.removeEventListener("loadedmetadata", handleLoadedMetadata);
       audio.removeEventListener("timeupdate", handleTimeUpdate);
       audio.removeEventListener("ended", handleEnded);
       audio.removeEventListener("error", handleError);
+      unbindStateEvents();
       audio.pause();
       audio.src = "";
       audio.remove();

--- a/src/audio/audio-state-events.test.ts
+++ b/src/audio/audio-state-events.test.ts
@@ -1,0 +1,35 @@
+import { useAudioStore } from "@/stores/audio";
+import { bindAudioStateEvents } from "@/audio/audio-state-events";
+import { beforeEach, describe, expect, it } from "vitest";
+
+beforeEach(() => useAudioStore.getState().reset());
+
+describe("bindAudioStateEvents", () => {
+  it("flips store isPlaying to true when audio fires 'play'", () => {
+    const audio = new Audio();
+    bindAudioStateEvents(audio, useAudioStore.getState().setIsPlaying);
+    expect(useAudioStore.getState().isPlaying).toBe(false);
+    audio.dispatchEvent(new Event("play"));
+    expect(useAudioStore.getState().isPlaying).toBe(true);
+  });
+
+  it("flips store isPlaying to false when audio fires 'pause'", () => {
+    useAudioStore.setState({ isPlaying: true });
+    const audio = new Audio();
+    bindAudioStateEvents(audio, useAudioStore.getState().setIsPlaying);
+    audio.dispatchEvent(new Event("pause"));
+    expect(useAudioStore.getState().isPlaying).toBe(false);
+  });
+
+  it("cleanup removes both play and pause listeners", () => {
+    useAudioStore.setState({ isPlaying: false });
+    const audio = new Audio();
+    const cleanup = bindAudioStateEvents(audio, useAudioStore.getState().setIsPlaying);
+    cleanup();
+    audio.dispatchEvent(new Event("play"));
+    expect(useAudioStore.getState().isPlaying).toBe(false);
+    useAudioStore.setState({ isPlaying: true });
+    audio.dispatchEvent(new Event("pause"));
+    expect(useAudioStore.getState().isPlaying).toBe(true);
+  });
+});

--- a/src/audio/audio-state-events.ts
+++ b/src/audio/audio-state-events.ts
@@ -1,0 +1,12 @@
+function bindAudioStateEvents(audio: HTMLAudioElement, setIsPlaying: (isPlaying: boolean) => void): () => void {
+  const handlePlay = () => setIsPlaying(true);
+  const handlePause = () => setIsPlaying(false);
+  audio.addEventListener("play", handlePlay);
+  audio.addEventListener("pause", handlePause);
+  return () => {
+    audio.removeEventListener("play", handlePlay);
+    audio.removeEventListener("pause", handlePause);
+  };
+}
+
+export { bindAudioStateEvents };

--- a/src/stores/project.history.test.ts
+++ b/src/stores/project.history.test.ts
@@ -47,6 +47,36 @@ describe("updateLinesWithHistory", () => {
     expect(useProjectStore.getState().lines.map((l) => l.agentId)).toEqual(["v2", "v1", "v3"]);
   });
 
+  it("snapshots a pending non-history edit before a subsequent history-aware update so undo lands on the typed state", () => {
+    // Reproduces issue #33 follow-up: typing in Edit (uses setLines, no
+    // history) followed by clicking Place (updateLineWithHistory) used to
+    // make Cmd+Z drop the user back past their typing.
+    useProjectStore.getState().setLines([seedLine("a", { text: "" })]);
+    useProjectStore.getState().setLinesWithHistory([seedLine("a", { text: "" })]);
+
+    useProjectStore.getState().setLines([seedLine("a", { text: "our favorite song is on" })]);
+    expect(useProjectStore.getState().lines[0].text).toBe("our favorite song is on");
+
+    useProjectStore.getState().updateLineWithHistory("a", { begin: 5, end: 7 });
+    const placed = useProjectStore.getState().lines[0];
+    expect(placed.text).toBe("our favorite song is on");
+    expect(placed.begin).toBe(5);
+
+    useProjectStore.getState().undo();
+    const afterUndo = useProjectStore.getState().lines[0];
+    expect(afterUndo.text).toBe("our favorite song is on");
+    expect(afterUndo.begin).toBeUndefined();
+  });
+
+  it("snapshots pending edit before updateLinesWithHistory too", () => {
+    useProjectStore.getState().setLinesWithHistory([seedLine("a", { text: "alpha" })]);
+    useProjectStore.getState().setLines([seedLine("a", { text: "alpha edited" })]);
+    useProjectStore.getState().updateLinesWithHistory([{ id: "a", updates: { begin: 1, end: 2 } }]);
+    useProjectStore.getState().undo();
+    expect(useProjectStore.getState().lines[0].text).toBe("alpha edited");
+    expect(useProjectStore.getState().lines[0].begin).toBeUndefined();
+  });
+
   it("clears words/begin/end via undefined updates and is undoable", () => {
     useProjectStore.getState().setLines([
       seedLine("a", {

--- a/src/stores/project.ts
+++ b/src/stores/project.ts
@@ -89,6 +89,11 @@ interface ProjectState {
   history: HistoryEntry[];
   historyIndex: number;
   dismissedSuggestions: string[];
+  // True when state.lines or state.groups has changed since the last history
+  // entry was written (e.g., per-keystroke setLines from the Edit textarea).
+  // The next history-aware mutator snapshots this state into history first
+  // so undo lands on the pending edit instead of skipping past it.
+  isDirtySinceHistory: boolean;
 }
 
 interface ProjectActions {
@@ -187,6 +192,7 @@ function createInitialState(): ProjectState {
     history: [],
     historyIndex: -1,
     dismissedSuggestions: [],
+    isDirtySinceHistory: false,
   };
 }
 
@@ -203,12 +209,12 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
       isDirty: true,
     })),
 
-  setLines: (lines) => set({ lines, isDirty: true }),
+  setLines: (lines) => set({ lines, isDirty: true, isDirtySinceHistory: true }),
 
   setLinesWithHistory: (lines) =>
     set((state) => {
       const newHistory = state.history.slice(0, state.historyIndex + 1);
-      if (newHistory.length === 0) {
+      if (newHistory.length === 0 || state.isDirtySinceHistory) {
         newHistory.push({
           lines: structuredClone(state.lines),
           groups: structuredClone(state.groups),
@@ -226,6 +232,7 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
       return {
         lines,
         isDirty: true,
+        isDirtySinceHistory: false,
         history: newHistory,
         historyIndex: newHistory.length - 1,
       };
@@ -235,12 +242,13 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
     set((state) => ({
       lines: state.lines.map((line) => (line.id === id ? { ...line, ...updates } : line)),
       isDirty: true,
+      isDirtySinceHistory: true,
     })),
 
   updateLineWithHistory: (id, updates) =>
     set((state) => {
       const newHistory = state.history.slice(0, state.historyIndex + 1);
-      if (newHistory.length === 0) {
+      if (newHistory.length === 0 || state.isDirtySinceHistory) {
         newHistory.push({
           lines: structuredClone(state.lines),
           groups: structuredClone(state.groups),
@@ -300,6 +308,7 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
       return {
         lines: newLines,
         isDirty: true,
+        isDirtySinceHistory: false,
         history: newHistory,
         historyIndex: newHistory.length - 1,
       };
@@ -308,7 +317,7 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
   updateLinesWithHistory: (updates) =>
     set((state) => {
       const newHistory = state.history.slice(0, state.historyIndex + 1);
-      if (newHistory.length === 0) {
+      if (newHistory.length === 0 || state.isDirtySinceHistory) {
         newHistory.push({
           lines: structuredClone(state.lines),
           groups: structuredClone(state.groups),
@@ -360,6 +369,7 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
       return {
         lines: newLines,
         isDirty: true,
+        isDirtySinceHistory: false,
         history: newHistory,
         historyIndex: newHistory.length - 1,
       };
@@ -412,6 +422,7 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
         groups: structuredClone(entry.groups),
         historyIndex: state.historyIndex - 1,
         isDirty: true,
+        isDirtySinceHistory: false,
       };
     }),
 
@@ -424,6 +435,7 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
         groups: structuredClone(entry.groups),
         historyIndex: state.historyIndex + 1,
         isDirty: true,
+        isDirtySinceHistory: false,
       };
     }),
 
@@ -491,7 +503,7 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
       return commitHistory(state, { lines: newLines });
     }),
 
-  setGroups: (groups) => set({ groups: Array.isArray(groups) ? groups : [], isDirty: true }),
+  setGroups: (groups) => set({ groups: Array.isArray(groups) ? groups : [], isDirty: true, isDirtySinceHistory: true }),
 
   addGroup: (group) => set((state) => commitHistory(state, { groups: [...state.groups, group] })),
 
@@ -875,7 +887,7 @@ function commitHistory(state: ProjectState, changes: { lines?: LyricLine[]; grou
   const nextGroups = changes.groups ?? state.groups;
 
   const newHistory = state.history.slice(0, state.historyIndex + 1);
-  if (newHistory.length === 0) {
+  if (newHistory.length === 0 || state.isDirtySinceHistory) {
     newHistory.push({
       lines: structuredClone(state.lines),
       groups: structuredClone(state.groups),
@@ -892,6 +904,7 @@ function commitHistory(state: ProjectState, changes: { lines?: LyricLine[]; grou
     lines: nextLines,
     groups: nextGroups,
     isDirty: true,
+    isDirtySinceHistory: false,
     history: newHistory,
     historyIndex: newHistory.length - 1,
   };

--- a/src/utils/lyrics-text.test.ts
+++ b/src/utils/lyrics-text.test.ts
@@ -219,6 +219,38 @@ describe("textToLyricLines · group attrs preservation", () => {
     expect(result[1].id).toBe("L2");
   });
 
+  it("preserves an empty draft line when the user edits a sibling line", () => {
+    const existing: LyricLine[] = [
+      { id: "A", text: "verse one", agentId: "v1" },
+      { id: "EMPTY", text: "", agentId: "v1" },
+      { id: "C", text: "verse three", agentId: "v1" },
+    ];
+    const result = textToLyricLines("verse one edited\n\nverse three", "v1", existing);
+    expect(result).toHaveLength(3);
+    expect(result[0].id).toBe("A");
+    expect(result[0].text).toBe("verse one edited");
+    expect(result[1].id).toBe("EMPTY");
+    expect(result[1].text).toBe("");
+    expect(result[2].id).toBe("C");
+    expect(result[2].text).toBe("verse three");
+  });
+
+  it("fills an empty draft line when user types into its position", () => {
+    const existing: LyricLine[] = [
+      { id: "A", text: "first", agentId: "v1" },
+      { id: "DRAFT", text: "", agentId: "v1" },
+    ];
+    const result = textToLyricLines("first\nfilled in", "v1", existing);
+    expect(result).toHaveLength(2);
+    expect(result[1].id).toBe("DRAFT");
+    expect(result[1].text).toBe("filled in");
+  });
+
+  it("explicit blank line in textarea round-trips as text: ''", () => {
+    const result = textToLyricLines("a\n\nb", "v1", []);
+    expect(result.map((l) => l.text)).toEqual(["a", "", "b"]);
+  });
+
   it("typo on first instance preserves the second instance's words", () => {
     const existing: LyricLine[] = [
       {

--- a/src/utils/lyrics-text.ts
+++ b/src/utils/lyrics-text.ts
@@ -23,7 +23,7 @@ function textToLyricLines(text: string, defaultAgentId: string, existingLines: L
   }
 
   const usedExistingIds = new Set<string>();
-  const newLines = text.split("\n").filter((line) => line.trim() !== "");
+  const newLines = text.split("\n");
   // Position-based fallback only makes sense when the user is editing-in-place
   // (same number of typed lines as existing lines). If the count changed, the
   // user inserted or deleted rows: position-match would silently overwrite the

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -10,54 +10,10 @@ import { stripSplitCharacter } from "@/utils/split-character";
 import { AgentManager } from "@/views/edit/agent-manager";
 import { decideEditTextAction } from "@/views/edit/decide-edit-text-action";
 import { detachInstancesFromLines } from "@/views/edit/diff-edit-text";
+import { parseLyrics } from "@/views/edit/parse-lyrics";
+import type { ParsedLine } from "@/views/edit/parse-lyrics";
 import { IconAlertTriangle, IconFileImport, IconMicrophone, IconX } from "@tabler/icons-react";
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
-
-// -- Types --------------------------------------------------------------------
-
-interface ParsedLine {
-  lineNumber: number;
-  lineId: string;
-  text: string;
-  isEmpty: boolean;
-  hasBrackets: boolean;
-  hasTiming: boolean;
-  agentId: string;
-  backgroundText?: string;
-  groupId?: string;
-  instanceIdx?: number;
-  templateLineIdx?: number;
-}
-
-// -- Helpers ------------------------------------------------------------------
-
-function parseLyrics(text: string, lines: LyricLine[], defaultAgentId: string): ParsedLine[] {
-  const textLines = text.split("\n");
-  let nonEmptyIndex = 0;
-
-  return textLines.map((line, index) => {
-    const trimmed = line.trim();
-    const isEmpty = trimmed === "";
-
-    // Match non-empty lines to stored lines by index (skipping empty lines)
-    const lyricLine = isEmpty ? undefined : lines[nonEmptyIndex++];
-    const hasTiming = lyricLine?.begin !== undefined || (lyricLine?.words?.length ?? 0) > 0;
-
-    return {
-      lineNumber: index + 1,
-      lineId: lyricLine?.id ?? "",
-      text: lyricLine?.text ?? line,
-      isEmpty,
-      hasBrackets: /\[.*?\]/.test(line),
-      hasTiming,
-      agentId: lyricLine?.agentId ?? defaultAgentId,
-      backgroundText: lyricLine?.backgroundText,
-      groupId: lyricLine?.groupId,
-      instanceIdx: lyricLine?.instanceIdx,
-      templateLineIdx: lyricLine?.templateLineIdx,
-    };
-  });
-}
 
 // -- Components ---------------------------------------------------------------
 

--- a/src/views/edit/parse-lyrics.test.ts
+++ b/src/views/edit/parse-lyrics.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment node
+ */
+import type { LyricLine } from "@/stores/project";
+import { parseLyrics } from "@/views/edit/parse-lyrics";
+import { describe, expect, it } from "vitest";
+
+describe("parseLyrics", () => {
+  it("matches non-empty input lines to non-empty stored lines in order", () => {
+    const lines: LyricLine[] = [
+      { id: "A", text: "verse one", agentId: "v1" },
+      { id: "B", text: "verse two", agentId: "v2" },
+    ];
+    const result = parseLyrics("verse one\nverse two", lines, "v1");
+    expect(result).toHaveLength(2);
+    expect(result[0].lineId).toBe("A");
+    expect(result[0].text).toBe("verse one");
+    expect(result[1].lineId).toBe("B");
+    expect(result[1].text).toBe("verse two");
+  });
+
+  it("renders blank input lines as isEmpty=true placeholders without consuming a stored line", () => {
+    const lines: LyricLine[] = [
+      { id: "A", text: "verse one", agentId: "v1" },
+      { id: "B", text: "verse two", agentId: "v2" },
+    ];
+    const result = parseLyrics("verse one\n\nverse two", lines, "v1");
+    expect(result).toHaveLength(3);
+    expect(result[0].lineId).toBe("A");
+    expect(result[1].isEmpty).toBe(true);
+    expect(result[1].lineId).toBe("");
+    expect(result[2].lineId).toBe("B");
+  });
+
+  it("skips text:'' stored lines so non-empty input lines align correctly", () => {
+    // Reproduces the bug from issue #33: an empty draft line in the project
+    // store made parseLyrics index off by one, causing every line after the
+    // empty to render its predecessor's text.
+    const lines: LyricLine[] = [
+      { id: "A", text: "Whoa", agentId: "v1" },
+      { id: "B", text: "Yeah", agentId: "v1" },
+      { id: "EMPTY", text: "", agentId: "v1" },
+      { id: "C", text: "Lit City", agentId: "v1" },
+      { id: "D", text: "Wave again", agentId: "v1" },
+    ];
+    const text = "Whoa\nYeah\n\nLit City\nWave again";
+    const result = parseLyrics(text, lines, "v1");
+    expect(result).toHaveLength(5);
+    expect(result[0].lineId).toBe("A");
+    expect(result[1].lineId).toBe("B");
+    expect(result[2].isEmpty).toBe(true);
+    expect(result[2].lineId).toBe("");
+    expect(result[3].lineId).toBe("C");
+    expect(result[3].text).toBe("Lit City");
+    expect(result[4].lineId).toBe("D");
+    expect(result[4].text).toBe("Wave again");
+  });
+
+  it("falls back to defaultAgentId for unmatched non-empty input", () => {
+    const result = parseLyrics("brand new line", [], "v9");
+    expect(result[0].agentId).toBe("v9");
+    expect(result[0].lineId).toBe("");
+  });
+
+  it("propagates groupId/instanceIdx/templateLineIdx from matched stored lines", () => {
+    const lines: LyricLine[] = [
+      { id: "A", text: "x", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 2 },
+    ];
+    const result = parseLyrics("x", lines, "v1");
+    expect(result[0].groupId).toBe("g1");
+    expect(result[0].instanceIdx).toBe(0);
+    expect(result[0].templateLineIdx).toBe(2);
+  });
+});

--- a/src/views/edit/parse-lyrics.ts
+++ b/src/views/edit/parse-lyrics.ts
@@ -1,0 +1,45 @@
+import type { LyricLine } from "@/stores/project";
+
+interface ParsedLine {
+  lineNumber: number;
+  lineId: string;
+  text: string;
+  isEmpty: boolean;
+  hasBrackets: boolean;
+  hasTiming: boolean;
+  agentId: string;
+  backgroundText?: string;
+  groupId?: string;
+  instanceIdx?: number;
+  templateLineIdx?: number;
+}
+
+function parseLyrics(text: string, lines: LyricLine[], defaultAgentId: string): ParsedLine[] {
+  const textLines = text.split("\n");
+  const nonEmptyStored = lines.filter((l) => l.text !== "");
+  let nonEmptyIndex = 0;
+
+  return textLines.map((line, index) => {
+    const trimmed = line.trim();
+    const isEmpty = trimmed === "";
+    const lyricLine = isEmpty ? undefined : nonEmptyStored[nonEmptyIndex++];
+    const hasTiming = lyricLine?.begin !== undefined || (lyricLine?.words?.length ?? 0) > 0;
+
+    return {
+      lineNumber: index + 1,
+      lineId: lyricLine?.id ?? "",
+      text: lyricLine?.text ?? line,
+      isEmpty,
+      hasBrackets: /\[.*?\]/.test(line),
+      hasTiming,
+      agentId: lyricLine?.agentId ?? defaultAgentId,
+      backgroundText: lyricLine?.backgroundText,
+      groupId: lyricLine?.groupId,
+      instanceIdx: lyricLine?.instanceIdx,
+      templateLineIdx: lyricLine?.templateLineIdx,
+    };
+  });
+}
+
+export { parseLyrics };
+export type { ParsedLine };

--- a/src/views/timeline/line-row.tsx
+++ b/src/views/timeline/line-row.tsx
@@ -222,7 +222,7 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
                 className="sticky left-[48px] z-10 inline-flex items-center gap-2 px-3 text-xs text-composer-text-muted italic bg-composer-bg/80 backdrop-blur-sm"
                 style={{ height: rowHeight, maxWidth: "calc(100% - 48px)" }}
               >
-                <span className="truncate">
+                <span className="truncate pr-0.5">
                   {displayText.slice(0, 60)}
                   {displayText.length > 60 ? "..." : ""}
                 </span>

--- a/src/views/timeline/line-row.tsx
+++ b/src/views/timeline/line-row.tsx
@@ -79,6 +79,7 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
   const rowHeight = useTimelineStore((s) => s.rowHeights[line.id] ?? s.defaultRowHeight);
   const defaultRowHeight = useTimelineStore((s) => s.defaultRowHeight);
   const setRowHeight = useTimelineStore((s) => s.setRowHeight);
+  const zoom = useTimelineStore((s) => s.zoom);
   const dragShiftPx = useTimelineStore((s) =>
     s.draggedGroupShift &&
     line.groupId !== undefined &&
@@ -148,7 +149,7 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
         <GutterAgentPicker lineId={line.id} lineIndex={lineIndex} agentId={line.agentId} />
       </div>
 
-      <div className="flex-1 overflow-hidden border-b border-composer-border relative">
+      <div className={cn("flex-1 border-b border-composer-border relative", hasMainWords && "overflow-hidden")}>
         <div
           className="absolute inset-0"
           style={{ transform: dragShiftPx !== 0 ? `translateX(${dragShiftPx}px)` : undefined }}
@@ -183,13 +184,13 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
             />
           ) : (
             <div
-              className="sticky left-0 z-10 flex items-center gap-2 px-3 text-xs text-composer-text-muted italic truncate bg-composer-bg/80 backdrop-blur-sm"
-              style={{ height: rowHeight, width: "fit-content" }}
+              className="relative cursor-pointer"
+              style={{ width: duration * zoom, height: rowHeight }}
               onDoubleClick={(e) => {
                 if (useTimelineStore.getState().selectOnlyMode) return;
-                const zoom = useTimelineStore.getState().zoom;
+                const zoomPx = useTimelineStore.getState().zoom;
                 const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-                const time = (e.clientX - rect.left) / zoom;
+                const time = (e.clientX - rect.left) / zoomPx;
                 const audioDuration = useAudioStore.getState().duration;
                 const wordDuration = useSettingsStore.getState().defaultWordDuration;
                 const slot = findInsertionSlot([], time, wordDuration, audioDuration);
@@ -207,9 +208,9 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
               }}
               onContextMenu={(e) => {
                 e.preventDefault();
-                const zoom = useTimelineStore.getState().zoom;
+                const zoomPx = useTimelineStore.getState().zoom;
                 const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-                const time = (e.clientX - rect.left) / zoom;
+                const time = (e.clientX - rect.left) / zoomPx;
                 useTimelineStore.getState().setContextMenu({
                   x: e.clientX,
                   y: e.clientY,
@@ -217,13 +218,18 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
                 });
               }}
             >
-              <span className="truncate">
-                {displayText.slice(0, 60)}
-                {displayText.length > 60 ? "..." : ""}
-              </span>
-              {displayText.length > 0 && (
-                <SyncLineButton lineId={line.id} wordCount={splitIntoWordsWithMeta(line.text).parts.length} />
-              )}
+              <div
+                className="sticky left-[48px] z-10 inline-flex items-center gap-2 px-3 text-xs text-composer-text-muted italic bg-composer-bg/80 backdrop-blur-sm"
+                style={{ height: rowHeight, maxWidth: "calc(100% - 48px)" }}
+              >
+                <span className="truncate">
+                  {displayText.slice(0, 60)}
+                  {displayText.length > 60 ? "..." : ""}
+                </span>
+                {displayText.length > 0 && (
+                  <SyncLineButton lineId={line.id} wordCount={splitIntoWordsWithMeta(line.text).parts.length} />
+                )}
+              </div>
             </div>
           )}
         </div>

--- a/src/views/timeline/line-row.tsx
+++ b/src/views/timeline/line-row.tsx
@@ -183,8 +183,39 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
             />
           ) : (
             <div
-              className="flex items-center gap-2 px-3 text-xs text-composer-text-muted italic truncate"
-              style={{ height: rowHeight }}
+              className="sticky left-0 z-10 flex items-center gap-2 px-3 text-xs text-composer-text-muted italic truncate bg-composer-bg/80 backdrop-blur-sm"
+              style={{ height: rowHeight, width: "fit-content" }}
+              onDoubleClick={(e) => {
+                if (useTimelineStore.getState().selectOnlyMode) return;
+                const zoom = useTimelineStore.getState().zoom;
+                const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                const time = (e.clientX - rect.left) / zoom;
+                const audioDuration = useAudioStore.getState().duration;
+                const wordDuration = useSettingsStore.getState().defaultWordDuration;
+                const slot = findInsertionSlot([], time, wordDuration, audioDuration);
+                if (!slot) return;
+                const newWord: WordTiming = {
+                  text: displayText.slice(0, 60) || "...",
+                  begin: slot.begin,
+                  end: slot.end,
+                };
+                useProjectStore.getState().updateLineWithHistory(line.id, {
+                  words: [newWord],
+                  text: newWord.text,
+                });
+                useTimelineStore.getState().setEditingWord({ lineId: line.id, wordIndex: 0, type: "word" });
+              }}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                const zoom = useTimelineStore.getState().zoom;
+                const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                const time = (e.clientX - rect.left) / zoom;
+                useTimelineStore.getState().setContextMenu({
+                  x: e.clientX,
+                  y: e.clientY,
+                  target: { kind: "track", lineId: line.id, lineIndex, time, type: "word" },
+                });
+              }}
             >
               <span className="truncate">
                 {displayText.slice(0, 60)}

--- a/src/views/timeline/timeline-context-menu.tsx
+++ b/src/views/timeline/timeline-context-menu.tsx
@@ -188,19 +188,17 @@ const TimelineContextMenu: React.FC = () => {
     clearContextMenu();
   }, [contextMenu, lines, duration, updateLineWithHistory, clearContextMenu]);
 
-  const handlePlaceLineAtPlayhead = useCallback(() => {
+  const handlePlaceLineHere = useCallback(() => {
     if (!contextMenu || contextMenu.target.kind !== "track") return;
-    const lineId = contextMenu.target.lineId;
+    const { lineId, time } = contextMenu.target;
     const line = rawLines.find((l) => l.id === lineId);
     if (!line) return;
-    const audio = useAudioStore.getState().audioElement;
-    const currentTime = audio?.currentTime ?? useAudioStore.getState().currentTime;
     const wordDuration = useSettingsStore.getState().defaultWordDuration;
     const wordCount = splitIntoWordsWithMeta(line.text).parts.length;
     const lineDuration = Math.max(wordCount, 1) * wordDuration;
     updateLineWithHistory(lineId, {
-      begin: currentTime,
-      end: currentTime + lineDuration,
+      begin: time,
+      end: time + lineDuration,
     });
     clearContextMenu();
   }, [contextMenu, rawLines, updateLineWithHistory, clearContextMenu]);
@@ -633,7 +631,7 @@ const TimelineContextMenu: React.FC = () => {
                 targetLine.text.trim() !== "" &&
                 !targetLine.words?.length &&
                 targetLine.begin === undefined;
-              return canPlace ? <MenuItem label="Place line at playhead" onClick={handlePlaceLineAtPlayhead} /> : null;
+              return canPlace ? <MenuItem label="Place line here" onClick={handlePlaceLineHere} /> : null;
             })()}
             {groupableSelection && (
               <>

--- a/src/views/timeline/timeline-context-menu.tsx
+++ b/src/views/timeline/timeline-context-menu.tsx
@@ -8,7 +8,7 @@ import { formatKey } from "@/ui/help-modal";
 import { GROUP_COLORS } from "@/utils/group-colors";
 import { showGroupActionToast } from "@/utils/group-toast";
 import { isMac, MOD_KEY } from "@/utils/platform";
-import { convertLineToWord } from "@/utils/sync-helpers";
+import { convertLineToWord, splitIntoWordsWithMeta } from "@/utils/sync-helpers";
 import { findInsertionSlot, normalizeTrailingSpaces } from "@/utils/word-spaces";
 import { copyInstanceToClipboardAndPreview } from "@/views/timeline/copy-instance-to-clipboard";
 import { decideAddInstancePlacement } from "@/views/timeline/decide-add-instance-placement";
@@ -187,6 +187,23 @@ const TimelineContextMenu: React.FC = () => {
     useTimelineStore.getState().setEditingWord({ lineId, wordIndex: newIndex, type });
     clearContextMenu();
   }, [contextMenu, lines, duration, updateLineWithHistory, clearContextMenu]);
+
+  const handlePlaceLineAtPlayhead = useCallback(() => {
+    if (!contextMenu || contextMenu.target.kind !== "track") return;
+    const lineId = contextMenu.target.lineId;
+    const line = rawLines.find((l) => l.id === lineId);
+    if (!line) return;
+    const audio = useAudioStore.getState().audioElement;
+    const currentTime = audio?.currentTime ?? useAudioStore.getState().currentTime;
+    const wordDuration = useSettingsStore.getState().defaultWordDuration;
+    const wordCount = splitIntoWordsWithMeta(line.text).parts.length;
+    const lineDuration = Math.max(wordCount, 1) * wordDuration;
+    updateLineWithHistory(lineId, {
+      begin: currentTime,
+      end: currentTime + lineDuration,
+    });
+    clearContextMenu();
+  }, [contextMenu, rawLines, updateLineWithHistory, clearContextMenu]);
 
   const handleAddLine = useCallback(
     (position: "above" | "below") => {
@@ -609,6 +626,15 @@ const TimelineContextMenu: React.FC = () => {
         {target.kind === "track" && (
           <>
             <MenuItem label="Add word here" shortcut={["Double Click"]} onClick={handleAddWordHere} />
+            {(() => {
+              const targetLine = rawLines.find((l) => l.id === target.lineId);
+              const canPlace =
+                targetLine &&
+                targetLine.text.trim() !== "" &&
+                !targetLine.words?.length &&
+                targetLine.begin === undefined;
+              return canPlace ? <MenuItem label="Place line at playhead" onClick={handlePlaceLineAtPlayhead} /> : null;
+            })()}
             {groupableSelection && (
               <>
                 <MenuDivider />


### PR DESCRIPTION
## Overview

- Closes #34: audio engine now syncs `isPlaying` from native `play`/`pause` events, so braccato preview clicks and Enter shortcut no longer leave the toolbar out of state.
- Closes #33: `textToLyricLines` and `parseLyrics` preserve empty draft lines instead of dropping them, so gutter-created blank rows survive Edit-textarea edits without losing downstream IDs/metadata. Empty placeholder gains right-click "Add word here", "Place line here", and double-click to insert a word at the click position.
- Closes #31: empty-track placeholder is now sticky and stays docked at the left of the row content area as the timeline pans; full-width hit target so the entire empty track responds to right-click + double-click.
- Project history: any `*WithHistory` mutator now snapshots a pre-action state when there are pending non-history edits (e.g. per-keystroke text changes), so undo after Place / Add word here lands on the typed-text state instead of skipping back past it.