### PR TITLE
fix: prevent sparse word arrays after sync cursor drift (#44)

### DIFF
--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -4,6 +4,8 @@ import { useProjectStore } from "@/stores/project";
 import type { LyricLine, WordTiming } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import {
+  commitHeldWord,
+  commitTappedWord,
   getNudgeAmount,
   type SyncState,
   createInitialBgWords,
@@ -67,22 +69,7 @@ function useSyncHandlers({
     const existingWords = line.words ?? [];
 
     if (existingWords.length > 0) {
-      const updatedWords = [...existingWords];
-      if (wordIndex === 0) {
-        updatedWords.length = 1;
-        updatedWords[0] = { ...updatedWords[0], text: textWithSpace, begin: currentTime, end: fallbackEnd };
-      } else {
-        updatedWords.length = wordIndex;
-        updatedWords[wordIndex - 1] = {
-          ...updatedWords[wordIndex - 1],
-          end: currentTime,
-        };
-        updatedWords.push({
-          text: textWithSpace,
-          begin: currentTime,
-          end: fallbackEnd,
-        });
-      }
+      const updatedWords = commitTappedWord(existingWords, wordIndex, textWithSpace, currentTime, fallbackEnd);
       updateLineWithHistory(line.id, { words: updatedWords });
     } else {
       const updates: Partial<LyricLine> = {
@@ -181,18 +168,7 @@ function useSyncHandlers({
     const existingWords = line.words ?? [];
 
     if (existingWords.length > 0) {
-      const updatedWords = [...existingWords];
-      if (wordIndex === 0) {
-        updatedWords.length = 1;
-        updatedWords[0] = { ...updatedWords[0], text: textWithSpace, begin: currentTime };
-      } else {
-        updatedWords.length = wordIndex;
-        updatedWords.push({
-          text: textWithSpace,
-          begin: currentTime,
-          end: currentTime,
-        });
-      }
+      const updatedWords = commitHeldWord(existingWords, wordIndex, textWithSpace, currentTime);
       updateLineWithHistory(line.id, { words: updatedWords });
     } else {
       const updates: Partial<LyricLine> = {

--- a/src/utils/sync-helpers.test.ts
+++ b/src/utils/sync-helpers.test.ts
@@ -1,0 +1,118 @@
+import type { WordTiming } from "@/stores/project";
+import { commitHeldWord, commitTappedWord } from "@/utils/sync-helpers";
+import { describe, expect, it } from "vitest";
+
+// -- commitTappedWord ---------------------------------------------------------
+
+describe("commitTappedWord", () => {
+  it("returns a single new word when there are no existing words", () => {
+    const result = commitTappedWord([], 0, "hello", 5, 6);
+    expect(result).toEqual([{ text: "hello", begin: 5, end: 6 }]);
+  });
+
+  it("returns a single new word when there are no existing words and wordIndex is non-zero", () => {
+    const result = commitTappedWord([], 2, "hello", 5, 6);
+    expect(result).toEqual([{ text: "hello", begin: 5, end: 6 }]);
+  });
+
+  it("replaces the first word when wordIndex is 0", () => {
+    const existing: WordTiming[] = [
+      { text: "one ", begin: 0, end: 1 },
+      { text: "two", begin: 1, end: 2 },
+    ];
+    const result = commitTappedWord(existing, 0, "ONE", 5, 6);
+    expect(result).toEqual([{ text: "ONE", begin: 5, end: 6 }]);
+  });
+
+  it("re-syncs from the middle: truncates and closes the prior word at begin", () => {
+    const existing: WordTiming[] = [
+      { text: "one ", begin: 0, end: 1 },
+      { text: "two ", begin: 1, end: 2 },
+      { text: "three", begin: 2, end: 3 },
+    ];
+    const result = commitTappedWord(existing, 1, "TWO", 5, 6);
+    expect(result).toEqual([
+      { text: "one ", begin: 0, end: 5 },
+      { text: "TWO", begin: 5, end: 6 },
+    ]);
+  });
+
+  it("forward tap at the end: closes the prior word and appends", () => {
+    const existing: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }];
+    const result = commitTappedWord(existing, 1, "two", 5, 6);
+    expect(result).toEqual([
+      { text: "one ", begin: 0, end: 5 },
+      { text: "two", begin: 5, end: 6 },
+    ]);
+  });
+
+  it("drifted cursor (wordIndex past existing length) clamps to length and appends without holes", () => {
+    const existing: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }];
+    const result = commitTappedWord(existing, 4, "two", 5, 6);
+    expect(result).toHaveLength(2);
+    for (const w of result) {
+      expect(typeof w.text).toBe("string");
+      expect(typeof w.begin).toBe("number");
+      expect(typeof w.end).toBe("number");
+    }
+    expect(result[0]).toEqual({ text: "one ", begin: 0, end: 5 });
+    expect(result[1]).toEqual({ text: "two", begin: 5, end: 6 });
+  });
+
+  it("drifted cursor result has no sparse holes", () => {
+    const existing: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }];
+    const result = commitTappedWord(existing, 5, "next", 10, 11);
+    expect(Object.keys(result).length).toBe(result.length);
+    for (let i = 0; i < result.length; i++) {
+      expect(result[i]).toBeDefined();
+    }
+  });
+});
+
+// -- commitHeldWord -----------------------------------------------------------
+
+describe("commitHeldWord", () => {
+  it("returns a single new word when there are no existing words", () => {
+    const result = commitHeldWord([], 0, "hello", 5);
+    expect(result).toEqual([{ text: "hello", begin: 5, end: 5 }]);
+  });
+
+  it("replaces the first word's text and begin but preserves its end when wordIndex is 0", () => {
+    const existing: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }];
+    const result = commitHeldWord(existing, 0, "ONE", 5);
+    expect(result).toEqual([{ text: "ONE", begin: 5, end: 1 }]);
+  });
+
+  it("truncates to wordIndex and appends a held word", () => {
+    const existing: WordTiming[] = [
+      { text: "one ", begin: 0, end: 1 },
+      { text: "two ", begin: 1, end: 2 },
+      { text: "three", begin: 2, end: 3 },
+    ];
+    const result = commitHeldWord(existing, 1, "TWO", 5);
+    expect(result).toEqual([
+      { text: "one ", begin: 0, end: 1 },
+      { text: "TWO", begin: 5, end: 5 },
+    ]);
+  });
+
+  it("forward hold at the end: appends a held word without closing prior word's end", () => {
+    const existing: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }];
+    const result = commitHeldWord(existing, 1, "two", 5);
+    expect(result).toEqual([
+      { text: "one ", begin: 0, end: 1 },
+      { text: "two", begin: 5, end: 5 },
+    ]);
+  });
+
+  it("drifted cursor (wordIndex past existing length) clamps and appends without holes", () => {
+    const existing: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }];
+    const result = commitHeldWord(existing, 4, "two", 5);
+    expect(result).toHaveLength(2);
+    for (const w of result) {
+      expect(typeof w.text).toBe("string");
+    }
+    expect(result[0]).toEqual({ text: "one ", begin: 0, end: 1 });
+    expect(result[1]).toEqual({ text: "two", begin: 5, end: 5 });
+  });
+});

--- a/src/utils/sync-helpers.ts
+++ b/src/utils/sync-helpers.ts
@@ -203,9 +203,39 @@ function createBgWordsFromLine(line: { begin?: number; end?: number; words?: Wor
   return createInitialBgWords(line.backgroundText, (timing.begin + timing.end) / 2, timing.end);
 }
 
+// -- Tap and hold commit ------------------------------------------------------
+
+function commitTappedWord(
+  existingWords: WordTiming[],
+  wordIndex: number,
+  text: string,
+  begin: number,
+  end: number,
+): WordTiming[] {
+  if (existingWords.length === 0) return [{ text, begin, end }];
+  if (wordIndex === 0) return [{ ...existingWords[0], text, begin, end }];
+  const keepCount = Math.min(wordIndex, existingWords.length);
+  const result = existingWords.slice(0, keepCount);
+  const lastIdx = result.length - 1;
+  result[lastIdx] = { ...result[lastIdx], end: begin };
+  result.push({ text, begin, end });
+  return result;
+}
+
+function commitHeldWord(existingWords: WordTiming[], wordIndex: number, text: string, begin: number): WordTiming[] {
+  if (existingWords.length === 0) return [{ text, begin, end: begin }];
+  if (wordIndex === 0) return [{ ...existingWords[0], text, begin }];
+  const keepCount = Math.min(wordIndex, existingWords.length);
+  const result = existingWords.slice(0, keepCount);
+  result.push({ text, begin, end: begin });
+  return result;
+}
+
 // -- Exports ------------------------------------------------------------------
 
 export {
+  commitHeldWord,
+  commitTappedWord,
   createBgWordsFromLine,
   createInitialBgWords,
   distributeWordsInLine,

--- a/src/utils/word-patch.test.ts
+++ b/src/utils/word-patch.test.ts
@@ -1,0 +1,93 @@
+import type { WordTiming } from "@/stores/project";
+import { applyWordPatch } from "@/utils/word-patch";
+import { describe, expect, it } from "vitest";
+
+// -- Raw-pattern bug demonstration --------------------------------------------
+
+describe("raw spread-and-assign pattern (unsafe, motivates the helper)", () => {
+  it("produces a textless entry and a sparse hole when wordIndex is out of bounds", () => {
+    const words: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }];
+    const wordIndex = 3;
+    const result = [...words];
+    result[wordIndex] = { ...result[wordIndex], begin: 5, end: 6 };
+
+    expect(result).toHaveLength(4);
+    expect(result[wordIndex]).toEqual({ begin: 5, end: 6 });
+    expect("text" in (result[wordIndex] as object)).toBe(false);
+    expect(Object.hasOwn(result, 1)).toBe(false);
+    expect(Object.hasOwn(result, 2)).toBe(false);
+  });
+});
+
+// -- applyWordPatch -----------------------------------------------------------
+
+describe("applyWordPatch", () => {
+  it("patches a word in range", () => {
+    const words: WordTiming[] = [
+      { text: "one ", begin: 0, end: 1 },
+      { text: "two", begin: 1, end: 2 },
+    ];
+    const result = applyWordPatch(words, 1, { begin: 1.5, end: 2.5 });
+    expect(result).toEqual([
+      { text: "one ", begin: 0, end: 1 },
+      { text: "two", begin: 1.5, end: 2.5 },
+    ]);
+  });
+
+  it("patches the adjacent word too when provided", () => {
+    const words: WordTiming[] = [
+      { text: "one ", begin: 0, end: 1 },
+      { text: "two", begin: 1, end: 2 },
+    ];
+    const result = applyWordPatch(words, 0, { end: 1.5 }, { index: 1, updates: { begin: 1.5 } });
+    expect(result).toEqual([
+      { text: "one ", begin: 0, end: 1.5 },
+      { text: "two", begin: 1.5, end: 2 },
+    ]);
+  });
+
+  it("returns the same reference shape but a new array (input unchanged)", () => {
+    const words: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }];
+    const result = applyWordPatch(words, 0, { begin: 0.5 });
+    expect(result).not.toBe(words);
+    expect(words[0]).toEqual({ text: "one ", begin: 0, end: 1 });
+  });
+
+  it("returns null when wordIndex is out of bounds (stale index after undo)", () => {
+    const words: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }];
+    expect(applyWordPatch(words, 3, { begin: 5, end: 6 })).toBeNull();
+  });
+
+  it("returns null when wordIndex equals the array length", () => {
+    const words: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }];
+    expect(applyWordPatch(words, 1, { begin: 5, end: 6 })).toBeNull();
+  });
+
+  it("returns null when wordIndex is negative", () => {
+    const words: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }];
+    expect(applyWordPatch(words, -1, { begin: 5, end: 6 })).toBeNull();
+  });
+
+  it("returns null when the adjacent index is out of bounds", () => {
+    const words: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }];
+    expect(applyWordPatch(words, 0, { begin: 0.5 }, { index: 5, updates: { begin: 1 } })).toBeNull();
+  });
+
+  it("returns null when the adjacent index is negative", () => {
+    const words: WordTiming[] = [
+      { text: "one ", begin: 0, end: 1 },
+      { text: "two", begin: 1, end: 2 },
+    ];
+    expect(applyWordPatch(words, 0, { end: 1.5 }, { index: -1, updates: { begin: 1.5 } })).toBeNull();
+  });
+
+  it("returns null when given an empty array", () => {
+    expect(applyWordPatch([], 0, { begin: 0, end: 1 })).toBeNull();
+  });
+
+  it("preserves text on the patched entry", () => {
+    const words: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }];
+    const result = applyWordPatch(words, 0, { begin: 5, end: 6 });
+    expect(result?.[0].text).toBe("one ");
+  });
+});

--- a/src/utils/word-patch.ts
+++ b/src/utils/word-patch.ts
@@ -1,0 +1,31 @@
+import type { WordTiming } from "@/stores/project";
+
+// -- Types --------------------------------------------------------------------
+
+interface AdjacentPatch {
+  index: number;
+  updates: Partial<WordTiming>;
+}
+
+// -- Functions ----------------------------------------------------------------
+
+function applyWordPatch(
+  words: WordTiming[],
+  wordIndex: number,
+  updates: Partial<WordTiming>,
+  adjacent?: AdjacentPatch,
+): WordTiming[] | null {
+  if (wordIndex < 0 || wordIndex >= words.length) return null;
+  if (adjacent && (adjacent.index < 0 || adjacent.index >= words.length)) return null;
+  const result = [...words];
+  result[wordIndex] = { ...result[wordIndex], ...updates };
+  if (adjacent) {
+    result[adjacent.index] = { ...result[adjacent.index], ...adjacent.updates };
+  }
+  return result;
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { applyWordPatch };
+export type { AdjacentPatch };

--- a/src/views/timeline/timeline-rows.tsx
+++ b/src/views/timeline/timeline-rows.tsx
@@ -1,6 +1,7 @@
 import { useAudioStore } from "@/stores/audio";
 import type { LyricLine } from "@/stores/project";
 import { type WordTiming, useProjectStore } from "@/stores/project";
+import { applyWordPatch } from "@/utils/word-patch";
 import { GROUP_HEADER_HEIGHT, GroupHeaderRow } from "@/views/timeline/group-header-row";
 import { LineRow } from "@/views/timeline/line-row";
 import { DEFAULT_ROW_HEIGHT, GUTTER_WIDTH, useTimelineStore } from "@/views/timeline/timeline-store";
@@ -94,11 +95,13 @@ const TimelineRows: React.FC<TimelineRowsProps> = ({ scrollContainerRef }) => {
       }
 
       if (!realLine.words) return;
-      const updatedWords = [...realLine.words];
-      updatedWords[wordIndex] = { ...updatedWords[wordIndex], ...updates };
-      if (adjacentIndex !== undefined && adjacentUpdates) {
-        updatedWords[adjacentIndex] = { ...updatedWords[adjacentIndex], ...adjacentUpdates };
-      }
+      const updatedWords = applyWordPatch(
+        realLine.words,
+        wordIndex,
+        updates,
+        adjacentIndex !== undefined && adjacentUpdates ? { index: adjacentIndex, updates: adjacentUpdates } : undefined,
+      );
+      if (!updatedWords) return;
       updateLineWithHistory(lineId, { words: updatedWords });
     },
     [lines, updateLineWithHistory],
@@ -115,11 +118,13 @@ const TimelineRows: React.FC<TimelineRowsProps> = ({ scrollContainerRef }) => {
       const line = lines.find((l) => l.id === lineId);
       if (!line?.backgroundWords) return;
 
-      const updatedWords = [...line.backgroundWords];
-      updatedWords[wordIndex] = { ...updatedWords[wordIndex], ...updates };
-      if (adjacentIndex !== undefined && adjacentUpdates) {
-        updatedWords[adjacentIndex] = { ...updatedWords[adjacentIndex], ...adjacentUpdates };
-      }
+      const updatedWords = applyWordPatch(
+        line.backgroundWords,
+        wordIndex,
+        updates,
+        adjacentIndex !== undefined && adjacentUpdates ? { index: adjacentIndex, updates: adjacentUpdates } : undefined,
+      );
+      if (!updatedWords) return;
       updateLineWithHistory(lineId, { backgroundWords: updatedWords });
     },
     [lines, updateLineWithHistory],

--- a/src/views/timeline/use-timeline-dnd.ts
+++ b/src/views/timeline/use-timeline-dnd.ts
@@ -273,6 +273,7 @@ function useTimelineDnd(lines: LyricLine[]) {
         if (!wordsArray) return;
 
         const wordIndex = activeData.wordIndex;
+        if (wordIndex < 0 || wordIndex >= wordsArray.length) return;
         const wordDuration = activeData.end - activeData.begin;
         const newBegin = Math.max(0, Math.min(duration - wordDuration, activeData.begin + timeDelta));
         const newEnd = newBegin + wordDuration;


### PR DESCRIPTION
## Overview

- Fixes #44 hard crash `TypeError: Cannot read properties of undefined (reading 'endsWith')` in `computeSyllableGroups`. Likely cause: `handleTapWord` / `handleHoldStart` did `updatedWords.length = wordIndex` then `{ ...updatedWords[wordIndex - 1], end: ... }`. When the sync cursor drifted past `line.words.length` (e.g. after Cmd+Z, which rewinds `line.words` but leaves `syncState.wordIndex` untouched), this produced sparse holes and a textless object that later crashed `.text.endsWith(" ")`.
- Extracts `commitTappedWord` / `commitHeldWord` into `src/utils/sync-helpers.ts` that clamp via `Math.min(wordIndex, existingWords.length)`. Drifted cursor now appends at the next available slot instead of creating malformed entries. Existing truncate-and-append (re-sync-from-middle) behavior is preserved.
