### PR TITLE
fix: timeline + preview scroll jumping (#45, #43)

### DIFF
--- a/src/views/preview.tsx
+++ b/src/views/preview.tsx
@@ -95,7 +95,7 @@ const PreviewPanel: React.FC = () => {
         ref={braccatoRef}
         source="#composer-audio"
         src={blobUrl ?? undefined}
-        className="flex-1 mx-auto w-full max-w-3xl px-6"
+        className="flex-1 mx-auto w-full max-w-3xl px-6 [&::part(container)]:pb-[50cqh]"
         style={
           {
             "--braccato-font-family": "'Satoshi', sans-serif",

--- a/src/views/timeline/timeline-preview-sidebar-activity.test.ts
+++ b/src/views/timeline/timeline-preview-sidebar-activity.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from "vitest";
+import { getTimingState } from "./timeline-preview-sidebar-activity";
+
+describe("getTimingState", () => {
+  describe("regular timing (begin < end)", () => {
+    it("returns inactive before begin", () => {
+      expect(getTimingState(1, 2, 0.5)).toEqual({ isActive: false, isComplete: false, progress: 0 });
+    });
+
+    it("returns active at exactly begin", () => {
+      const state = getTimingState(1, 2, 1);
+      expect(state.isActive).toBe(true);
+      expect(state.isComplete).toBe(false);
+      expect(state.progress).toBeCloseTo(0);
+    });
+
+    it("returns active mid-word with linear progress", () => {
+      const state = getTimingState(1, 2, 1.5);
+      expect(state.isActive).toBe(true);
+      expect(state.isComplete).toBe(false);
+      expect(state.progress).toBeCloseTo(0.5);
+    });
+
+    it("returns complete at exactly end", () => {
+      expect(getTimingState(1, 2, 2)).toEqual({ isActive: false, isComplete: true, progress: 1 });
+    });
+
+    it("returns complete after end", () => {
+      expect(getTimingState(1, 2, 5)).toEqual({ isActive: false, isComplete: true, progress: 1 });
+    });
+  });
+
+  describe("zero-duration timing (begin === end)", () => {
+    it("returns inactive before begin", () => {
+      expect(getTimingState(1.5, 1.5, 1)).toEqual({ isActive: false, isComplete: false, progress: 0 });
+    });
+
+    it("returns complete at exactly begin", () => {
+      expect(getTimingState(1.5, 1.5, 1.5)).toEqual({ isActive: false, isComplete: true, progress: 1 });
+    });
+
+    it("does not stay active forever after begin (regression for #45)", () => {
+      const state = getTimingState(1.5, 1.5, 100);
+      expect(state.isActive).toBe(false);
+      expect(state.isComplete).toBe(true);
+      expect(state.progress).toBe(1);
+    });
+  });
+});

--- a/src/views/timeline/timeline-preview-sidebar-activity.ts
+++ b/src/views/timeline/timeline-preview-sidebar-activity.ts
@@ -1,0 +1,18 @@
+interface TimingState {
+  isActive: boolean;
+  isComplete: boolean;
+  progress: number;
+}
+
+function getTimingState(begin: number, end: number, currentTime: number): TimingState {
+  if (begin === end) {
+    if (currentTime >= begin) return { isActive: false, isComplete: true, progress: 1 };
+    return { isActive: false, isComplete: false, progress: 0 };
+  }
+  if (currentTime < begin) return { isActive: false, isComplete: false, progress: 0 };
+  if (currentTime >= end) return { isActive: false, isComplete: true, progress: 1 };
+  return { isActive: true, isComplete: false, progress: (currentTime - begin) / (end - begin) };
+}
+
+export { getTimingState };
+export type { TimingState };

--- a/src/views/timeline/timeline-preview-sidebar.tsx
+++ b/src/views/timeline/timeline-preview-sidebar.tsx
@@ -4,6 +4,7 @@ import type { LyricLine } from "@/stores/project";
 import { Scroll } from "@/ui/scroll";
 import { stripSplitCharacter } from "@/utils/split-character";
 import { splitIntoWords } from "@/utils/sync-helpers";
+import { getTimingState } from "@/views/timeline/timeline-preview-sidebar-activity";
 import { getLineTiming } from "@/views/timeline/utils";
 import { useEffect, useRef } from "react";
 
@@ -157,42 +158,27 @@ const TimelinePreviewSidebar: React.FC = () => {
       const currentTime = audioEl?.currentTime ?? useAudioStore.getState().currentTime;
       let currentLineIdx = -1;
 
-      // Update word progress
       const wordEls = container.querySelectorAll<HTMLElement>("[data-word-begin]");
       for (const el of wordEls) {
         const begin = Number.parseFloat(el.dataset.wordBegin ?? "0");
         const end = Number.parseFloat(el.dataset.wordEnd ?? "0");
-        const duration = end - begin;
         const lineIdx = Number.parseInt(el.dataset.lineIdx ?? "-1", 10);
 
-        const isOpen = end === begin;
-        const isWordActive = currentTime >= begin && (isOpen || currentTime < end);
-        const isComplete = end > begin && currentTime >= end;
-
-        let progress = 0;
-        if (isWordActive && duration > 0) {
-          progress = (currentTime - begin) / duration;
-        } else if (isComplete) {
-          progress = 1;
-        }
-
+        const { isActive, progress } = getTimingState(begin, end, currentTime);
         el.style.clipPath = `inset(0 ${(1 - progress) * 100}% 0 0)`;
 
-        if (isWordActive && lineIdx > currentLineIdx) {
+        if (isActive && lineIdx > currentLineIdx) {
           currentLineIdx = lineIdx;
         }
       }
 
-      // Update line opacity
       const lineEls = container.querySelectorAll<HTMLElement>("[data-line-begin]");
       for (const el of lineEls) {
         const begin = Number.parseFloat(el.dataset.lineBegin ?? "0");
         const end = Number.parseFloat(el.dataset.lineEnd ?? "0");
+        const { isActive, isComplete } = getTimingState(begin, end, currentTime);
 
-        const isComplete = end > begin && currentTime >= end;
-        const isLineActive = currentTime >= begin && (end === begin || currentTime < end);
-
-        if (isLineActive) {
+        if (isActive) {
           el.style.opacity = "1";
         } else if (isComplete) {
           el.style.opacity = "0.6";


### PR DESCRIPTION
## Overview

- Extract `getTimingState` helper so zero-duration words and lines are treated as instantly complete instead of eternally active, fixing the timeline preview sidebar jumping back to past lines with open-word timestamps (#45).
- Add `pb-[50cqh]` on braccato's `::part(container)` so the renderer has enough scrollable room past the last line, removing the end-of-song bobbing where the algorithm fought the browser's scroll clamp (#43).