### PR TITLE
Fix/syllable breakage

### DIFF
--- a/src/stores/project.move.test.ts
+++ b/src/stores/project.move.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 import { type LyricLine, useProjectStore } from "@/stores/project";
+import { getSyllablePositions } from "@/utils/syllable-groups";
 import { beforeEach, describe, expect, it } from "vitest";
 
 const DURATION = 30;
@@ -60,7 +61,7 @@ describe("moveWordToBg", () => {
     expect(line.backgroundText).toBe("hello goodbye");
   });
 
-  it("adds a trailing space to the previous last bg word when a new word lands at the end", () => {
+  it("adds a trailing space to the previous last bg word when a new word lands at the end without breaking syllable bonds before it", () => {
     useProjectStore.getState().setLines([
       seedLine({
         backgroundWords: [
@@ -74,8 +75,8 @@ describe("moveWordToBg", () => {
     useProjectStore.getState().moveWordToBg("line-1", [2], 7, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["ah ", "ooh ", "goodbye"]);
-    expect(line.backgroundText).toBe("ah ooh goodbye");
+    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["ah", "ooh ", "goodbye"]);
+    expect(line.backgroundText).toBe("ahooh goodbye");
   });
 
   it("resolves overlap when moved word collides with an existing bg word", () => {
@@ -321,6 +322,100 @@ describe("moveWordToBg · linked propagation", () => {
     const x = useProjectStore.getState().lines.find((l) => l.id === "x");
     expect(x?.backgroundWords).toBeUndefined();
     expect(x?.words?.length).toBe(3);
+  });
+});
+
+// -- cross-track moves preserve syllable bonds --------------------------------
+
+describe("cross-track moves preserve syllable bonds", () => {
+  it("moveWordToBg keeps remaining split-word syllables bonded", () => {
+    useProjectStore.getState().setLines([
+      {
+        id: "line-1",
+        text: "hello every world",
+        agentId: "v1",
+        words: [
+          { text: "hello ", begin: 0, end: 1 },
+          { text: "ev", begin: 1, end: 1.2 },
+          { text: "er", begin: 1.2, end: 1.5 },
+          { text: "y ", begin: 1.5, end: 1.8 },
+          { text: "world", begin: 1.8, end: 2.5 },
+        ],
+      },
+    ]);
+
+    useProjectStore.getState().moveWordToBg("line-1", [4], 5, DURATION);
+
+    const line = useProjectStore.getState().lines[0];
+    expect(line.words?.map((w) => w.text)).toEqual(["hello ", "ev", "er", "y"]);
+    expect(getSyllablePositions(line.words ?? [])).toEqual(["none", "first", "middle", "last"]);
+  });
+
+  it("moveWordToBg keeps a whole syllable group bonded when all its indices move together", () => {
+    useProjectStore.getState().setLines([
+      {
+        id: "line-1",
+        text: "hello every world",
+        agentId: "v1",
+        words: [
+          { text: "hello ", begin: 0, end: 1 },
+          { text: "ev", begin: 1, end: 1.2 },
+          { text: "er", begin: 1.2, end: 1.5 },
+          { text: "y ", begin: 1.5, end: 1.8 },
+          { text: "world", begin: 1.8, end: 2.5 },
+        ],
+      },
+    ]);
+
+    useProjectStore.getState().moveWordToBg("line-1", [1, 2, 3], 5, DURATION);
+
+    const line = useProjectStore.getState().lines[0];
+    expect(line.words?.map((w) => w.text)).toEqual(["hello ", "world"]);
+    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["ev", "er", "y"]);
+    expect(getSyllablePositions(line.backgroundWords ?? [])).toEqual(["first", "middle", "last"]);
+  });
+
+  it("moveWordFromBg adds trailing space to previously-last main word when receiving a new tail", () => {
+    useProjectStore.getState().setLines([
+      {
+        id: "line-1",
+        text: "hello",
+        agentId: "v1",
+        words: [{ text: "hello", begin: 0, end: 1 }],
+        backgroundWords: [{ text: "world", begin: 2, end: 3 }],
+        backgroundText: "world",
+      },
+    ]);
+
+    useProjectStore.getState().moveWordFromBg("line-1", [0], 0, DURATION);
+
+    const line = useProjectStore.getState().lines[0];
+    expect(line.words?.map((w) => w.text)).toEqual(["hello ", "world"]);
+    expect(line.backgroundWords).toBeUndefined();
+  });
+
+  it("moveWordFromBg returns a syllable group from bg intact when the whole group flips", () => {
+    useProjectStore.getState().setLines([
+      {
+        id: "line-1",
+        text: "every",
+        agentId: "v1",
+        words: [],
+        backgroundWords: [
+          { text: "ev", begin: 5, end: 5.2 },
+          { text: "er", begin: 5.2, end: 5.5 },
+          { text: "y", begin: 5.5, end: 5.8 },
+        ],
+        backgroundText: "every",
+      },
+    ]);
+
+    useProjectStore.getState().moveWordFromBg("line-1", [0, 1, 2], -4, DURATION);
+
+    const line = useProjectStore.getState().lines[0];
+    expect(line.words?.map((w) => w.text)).toEqual(["ev", "er", "y"]);
+    expect(getSyllablePositions(line.words ?? [])).toEqual(["first", "middle", "last"]);
+    expect(line.backgroundWords).toBeUndefined();
   });
 });
 

--- a/src/stores/project.ts
+++ b/src/stores/project.ts
@@ -2,7 +2,11 @@ import { useAudioStore } from "@/stores/audio";
 import { useSettingsStore } from "@/stores/settings";
 import { GROUP_COLORS, pickNextGroupColor } from "@/utils/group-colors";
 import { applySiblingWords } from "@/utils/word-diff";
-import { normalizeTrailingSpaces, resolveOverlapsForward } from "@/utils/word-spaces";
+import {
+  addTrailingSpaceIfMissing,
+  resolveOverlapsForward,
+  trimTrailingSpaceFromLast,
+} from "@/utils/word-spaces";
 import { create } from "zustand";
 
 // -- Types --------------------------------------------------------------------
@@ -912,13 +916,12 @@ function applyMoveToBg(line: LyricLine, wordIndices: number[], timeDelta: number
 
   if (movedWords.length === 0) return null;
 
-  const remainingMain = normalizeTrailingSpaces(line.words.filter((_, i) => !indexSet.has(i)));
-  const mergedBg = normalizeTrailingSpaces(
-    resolveOverlapsForward(
-      [...(line.backgroundWords ?? []), ...movedWords].sort((a, b) => a.begin - b.begin),
-      duration,
-    ),
-  );
+  const remainingMain = trimTrailingSpaceFromLast(line.words.filter((_, i) => !indexSet.has(i)));
+
+  const prevBgLast = line.backgroundWords?.[line.backgroundWords.length - 1];
+  const sortedBg = [...(line.backgroundWords ?? []), ...movedWords].sort((a, b) => a.begin - b.begin);
+  const reconciledBg = prevBgLast ? addTrailingSpaceIfMissing(sortedBg, prevBgLast) : sortedBg;
+  const mergedBg = trimTrailingSpaceFromLast(resolveOverlapsForward(reconciledBg, duration));
 
   return {
     ...line,
@@ -947,13 +950,12 @@ function applyMoveFromBg(
 
   if (movedWords.length === 0) return null;
 
-  const remainingBg = normalizeTrailingSpaces(line.backgroundWords.filter((_, i) => !indexSet.has(i)));
-  const mergedMain = normalizeTrailingSpaces(
-    resolveOverlapsForward(
-      [...(line.words ?? []), ...movedWords].sort((a, b) => a.begin - b.begin),
-      duration,
-    ),
-  );
+  const remainingBg = trimTrailingSpaceFromLast(line.backgroundWords.filter((_, i) => !indexSet.has(i)));
+
+  const prevMainLast = line.words?.[line.words.length - 1];
+  const sortedMain = [...(line.words ?? []), ...movedWords].sort((a, b) => a.begin - b.begin);
+  const reconciledMain = prevMainLast ? addTrailingSpaceIfMissing(sortedMain, prevMainLast) : sortedMain;
+  const mergedMain = trimTrailingSpaceFromLast(resolveOverlapsForward(reconciledMain, duration));
 
   const hasBg = remainingBg.length > 0;
   return {

--- a/src/stores/project.ts
+++ b/src/stores/project.ts
@@ -2,11 +2,7 @@ import { useAudioStore } from "@/stores/audio";
 import { useSettingsStore } from "@/stores/settings";
 import { GROUP_COLORS, pickNextGroupColor } from "@/utils/group-colors";
 import { applySiblingWords } from "@/utils/word-diff";
-import {
-  addTrailingSpaceIfMissing,
-  resolveOverlapsForward,
-  trimTrailingSpaceFromLast,
-} from "@/utils/word-spaces";
+import { addTrailingSpaceIfMissing, resolveOverlapsForward, trimTrailingSpaceFromLast } from "@/utils/word-spaces";
 import { create } from "zustand";
 
 // -- Types --------------------------------------------------------------------

--- a/src/utils/word-spaces.test.ts
+++ b/src/utils/word-spaces.test.ts
@@ -2,51 +2,105 @@
  * @vitest-environment node
  */
 import type { WordTiming } from "@/stores/project";
-import { findInsertionSlot, normalizeTrailingSpaces, resolveOverlapsForward } from "@/utils/word-spaces";
+import {
+  addTrailingSpaceIfMissing,
+  findInsertionSlot,
+  resolveOverlapsForward,
+  trimTrailingSpaceFromLast,
+} from "@/utils/word-spaces";
 import { describe, expect, it } from "vitest";
 
-// -- normalizeTrailingSpaces ---------------------------------------------------
+// -- trimTrailingSpaceFromLast -------------------------------------------------
 
-describe("normalizeTrailingSpaces", () => {
+describe("trimTrailingSpaceFromLast", () => {
   it("returns empty array as-is", () => {
-    expect(normalizeTrailingSpaces([])).toEqual([]);
+    expect(trimTrailingSpaceFromLast([])).toEqual([]);
   });
 
   it("trims trailing space from the last word", () => {
-    const result = normalizeTrailingSpaces([{ text: "hello ", begin: 0, end: 1 }]);
+    const result = trimTrailingSpaceFromLast([{ text: "hello ", begin: 0, end: 1 }]);
     expect(result[0].text).toBe("hello");
   });
 
   it("leaves a single word without trailing space alone", () => {
-    const result = normalizeTrailingSpaces([{ text: "hello", begin: 0, end: 1 }]);
+    const result = trimTrailingSpaceFromLast([{ text: "hello", begin: 0, end: 1 }]);
     expect(result[0].text).toBe("hello");
   });
 
-  it("adds trailing space to non-last words missing one", () => {
-    const result = normalizeTrailingSpaces([
+  it("preserves missing trailing space on non-last words so syllable bonds survive", () => {
+    const result = trimTrailingSpaceFromLast([
       { text: "he", begin: 0, end: 0.5 },
       { text: "llo", begin: 0.5, end: 1 },
     ]);
-    expect(result[0].text).toBe("he ");
+    expect(result[0].text).toBe("he");
     expect(result[1].text).toBe("llo");
   });
 
-  it("preserves intentional trailing spaces on non-last words", () => {
-    const result = normalizeTrailingSpaces([
-      { text: "hello ", begin: 0, end: 1 },
-      { text: "world", begin: 1, end: 2 },
-    ]);
-    expect(result[0].text).toBe("hello ");
-    expect(result[1].text).toBe("world");
-  });
-
   it("trims a trailing space that drifted onto the last word", () => {
-    const result = normalizeTrailingSpaces([
+    const result = trimTrailingSpaceFromLast([
       { text: "hello ", begin: 0, end: 1 },
       { text: "world ", begin: 1, end: 2 },
     ]);
     expect(result[0].text).toBe("hello ");
     expect(result[1].text).toBe("world");
+  });
+
+  it("preserves the trailing-space pattern of every non-last syllable in a group", () => {
+    const result = trimTrailingSpaceFromLast([
+      { text: "ev", begin: 0, end: 0.2 },
+      { text: "er", begin: 0.2, end: 0.4 },
+      { text: "y ", begin: 0.4, end: 0.6 },
+      { text: "world", begin: 0.6, end: 1 },
+    ]);
+    expect(result.map((w) => w.text)).toEqual(["ev", "er", "y ", "world"]);
+  });
+});
+
+// -- addTrailingSpaceIfMissing -------------------------------------------------
+
+describe("addTrailingSpaceIfMissing", () => {
+  it("adds a trailing space to a non-last word that lacks one", () => {
+    const a = { text: "hello", begin: 0, end: 1 };
+    const b = { text: "world", begin: 1, end: 2 };
+    const result = addTrailingSpaceIfMissing([a, b], a);
+    expect(result[0].text).toBe("hello ");
+    expect(result[1]).toBe(b);
+  });
+
+  it("is a no-op when the target already has a trailing space", () => {
+    const a = { text: "hello ", begin: 0, end: 1 };
+    const b = { text: "world", begin: 1, end: 2 };
+    const input = [a, b];
+    const result = addTrailingSpaceIfMissing(input, a);
+    expect(result).toBe(input);
+    expect(result[0]).toBe(a);
+  });
+
+  it("is a no-op when the target is the array's last entry", () => {
+    const a = { text: "hello", begin: 0, end: 1 };
+    const b = { text: "world", begin: 1, end: 2 };
+    const input = [a, b];
+    const result = addTrailingSpaceIfMissing(input, b);
+    expect(result).toBe(input);
+    expect(result[1].text).toBe("world");
+  });
+
+  it("is a no-op when the target reference is not in the array", () => {
+    const a = { text: "hello", begin: 0, end: 1 };
+    const b = { text: "world", begin: 1, end: 2 };
+    const stranger = { text: "stranger", begin: 5, end: 6 };
+    const input = [a, b];
+    const result = addTrailingSpaceIfMissing(input, stranger);
+    expect(result).toBe(input);
+  });
+
+  it("does not mutate the input array or its entries", () => {
+    const a = { text: "hello", begin: 0, end: 1 };
+    const b = { text: "world", begin: 1, end: 2 };
+    const input = [a, b];
+    addTrailingSpaceIfMissing(input, a);
+    expect(a.text).toBe("hello");
+    expect(input[0]).toBe(a);
   });
 });
 

--- a/src/utils/word-spaces.ts
+++ b/src/utils/word-spaces.ts
@@ -6,15 +6,22 @@ const DEFAULT_MIN_WORD_DURATION = 0.05;
 
 // -- Functions -----------------------------------------------------------------
 
-function normalizeTrailingSpaces(words: WordTiming[]): WordTiming[] {
+function trimTrailingSpaceFromLast(words: WordTiming[]): WordTiming[] {
   if (words.length === 0) return words;
-  return words.map((word, i) => {
-    const isLast = i === words.length - 1;
-    const hasSpace = word.text.endsWith(" ");
-    if (isLast && hasSpace) return { ...word, text: word.text.trimEnd() };
-    if (!isLast && !hasSpace) return { ...word, text: `${word.text} ` };
-    return word;
-  });
+  const last = words[words.length - 1];
+  if (!last.text.endsWith(" ")) return words;
+  const next = words.slice();
+  next[next.length - 1] = { ...last, text: last.text.trimEnd() };
+  return next;
+}
+
+function addTrailingSpaceIfMissing(words: WordTiming[], target: WordTiming): WordTiming[] {
+  if (target.text.endsWith(" ")) return words;
+  const idx = words.indexOf(target);
+  if (idx < 0 || idx === words.length - 1) return words;
+  const next = words.slice();
+  next[idx] = { ...target, text: `${target.text} ` };
+  return next;
 }
 
 function resolveOverlapsForward(words: WordTiming[], duration: number): WordTiming[] {
@@ -83,4 +90,4 @@ function findInsertionSlot(
 
 // -- Exports -------------------------------------------------------------------
 
-export { normalizeTrailingSpaces, resolveOverlapsForward, findInsertionSlot };
+export { trimTrailingSpaceFromLast, addTrailingSpaceIfMissing, resolveOverlapsForward, findInsertionSlot };

--- a/src/views/timeline/timeline-context-menu.tsx
+++ b/src/views/timeline/timeline-context-menu.tsx
@@ -9,7 +9,7 @@ import { GROUP_COLORS } from "@/utils/group-colors";
 import { showGroupActionToast } from "@/utils/group-toast";
 import { isMac, MOD_KEY } from "@/utils/platform";
 import { convertLineToWord, splitIntoWordsWithMeta } from "@/utils/sync-helpers";
-import { findInsertionSlot, normalizeTrailingSpaces } from "@/utils/word-spaces";
+import { addTrailingSpaceIfMissing, findInsertionSlot, trimTrailingSpaceFromLast } from "@/utils/word-spaces";
 import { copyInstanceToClipboardAndPreview } from "@/views/timeline/copy-instance-to-clipboard";
 import { decideAddInstancePlacement } from "@/views/timeline/decide-add-instance-placement";
 import { createGroupFromSelection, fillSelectionGaps, instanceToTemplate } from "@/views/timeline/group-ops";
@@ -201,10 +201,13 @@ const TimelineContextMenu: React.FC = () => {
       return;
     }
 
-    const newWord: WordTiming = { text: "...", begin: slot.begin, end: slot.end };
-    const sorted = [...(existingWords ?? []), newWord].sort((a, b) => a.begin - b.begin);
+    const newWord: WordTiming = { text: "... ", begin: slot.begin, end: slot.end };
+    const existing = existingWords ?? [];
+    const prevLast = existing[existing.length - 1];
+    const sorted = [...existing, newWord].sort((a, b) => a.begin - b.begin);
     const newIndex = sorted.indexOf(newWord);
-    const words = normalizeTrailingSpaces(sorted);
+    const reconciled = prevLast ? addTrailingSpaceIfMissing(sorted, prevLast) : sorted;
+    const words = trimTrailingSpaceFromLast(reconciled);
 
     if (type === "word") {
       updateLineWithHistory(lineId, { words });

--- a/src/views/timeline/use-timeline-dnd.ts
+++ b/src/views/timeline/use-timeline-dnd.ts
@@ -1,6 +1,6 @@
 import { useAudioStore } from "@/stores/audio";
 import { type LyricLine, useProjectStore } from "@/stores/project";
-import { normalizeTrailingSpaces } from "@/utils/word-spaces";
+import { addTrailingSpaceIfMissing, trimTrailingSpaceFromLast } from "@/utils/word-spaces";
 import { wouldDropCrossInstance } from "@/views/timeline/dnd-group-guard";
 import { type WordSelection, isWordSelected, useTimelineStore } from "@/views/timeline/timeline-store";
 import { type DragEndEvent, type DragStartEvent, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
@@ -95,7 +95,10 @@ function handleAltDuplicate(event: DragEndEvent, lines: LyricLine[], zoom: numbe
       const existing = line.words ?? [];
       const hasOverlap = wordDups.some((dup) => existing.some((w) => dup.begin < w.end && dup.end > w.begin));
       if (!hasOverlap) {
-        lineUpdates.words = normalizeTrailingSpaces([...existing, ...wordDups].sort((a, b) => a.begin - b.begin));
+        const prevLast = existing[existing.length - 1];
+        const sorted = [...existing, ...wordDups].sort((a, b) => a.begin - b.begin);
+        const reconciled = prevLast ? addTrailingSpaceIfMissing(sorted, prevLast) : sorted;
+        lineUpdates.words = trimTrailingSpaceFromLast(reconciled);
       }
     }
 
@@ -103,7 +106,10 @@ function handleAltDuplicate(event: DragEndEvent, lines: LyricLine[], zoom: numbe
       const existing = line.backgroundWords ?? [];
       const hasOverlap = bgDups.some((dup) => existing.some((w) => dup.begin < w.end && dup.end > w.begin));
       if (!hasOverlap) {
-        const merged = normalizeTrailingSpaces([...existing, ...bgDups].sort((a, b) => a.begin - b.begin));
+        const prevLast = existing[existing.length - 1];
+        const sorted = [...existing, ...bgDups].sort((a, b) => a.begin - b.begin);
+        const reconciled = prevLast ? addTrailingSpaceIfMissing(sorted, prevLast) : sorted;
+        const merged = trimTrailingSpaceFromLast(reconciled);
         lineUpdates.backgroundWords = merged;
         lineUpdates.backgroundText = merged.map((w) => w.text).join("");
       }
@@ -253,7 +259,7 @@ function useTimelineDnd(lines: LyricLine[]) {
               words[words.length - 1] = { ...last, begin: last.begin - overflow, end: duration };
             }
 
-            const normalized = normalizeTrailingSpaces(words);
+            const normalized = trimTrailingSpaceFromLast(words);
             lineUpdates[trackKey] = normalized;
             if (trackKey === "backgroundWords") {
               lineUpdates.backgroundText = normalized.map((w) => w.text).join("");
@@ -295,7 +301,7 @@ function useTimelineDnd(lines: LyricLine[]) {
           words[words.length - 1] = { ...lastWord, begin: lastWord.begin - overflow, end: duration };
         }
 
-        const normalized = normalizeTrailingSpaces(words);
+        const normalized = trimTrailingSpaceFromLast(words);
         if (activeData.trackType === "word") {
           updateLineWithHistory(activeData.lineId, { words: normalized });
         } else {

--- a/src/views/timeline/word-track.browser.test.tsx
+++ b/src/views/timeline/word-track.browser.test.tsx
@@ -4,10 +4,7 @@ import { useProjectStore } from "@/stores/project";
 import { createLine, createWord } from "@/test/factories";
 import { render } from "@/test/render";
 
-const WORDS = [
-  createWord({ text: "hello ", begin: 0, end: 1 }),
-  createWord({ text: "world", begin: 1, end: 2 }),
-];
+const WORDS = [createWord({ text: "hello ", begin: 0, end: 1 }), createWord({ text: "world", begin: 1, end: 2 })];
 
 const SYLLABLE_GROUP_WORDS = [
   createWord({ text: "hello ", begin: 0, end: 1 }),

--- a/src/views/timeline/word-track.browser.test.tsx
+++ b/src/views/timeline/word-track.browser.test.tsx
@@ -9,6 +9,22 @@ const WORDS = [
   createWord({ text: "world", begin: 1, end: 2 }),
 ];
 
+const SYLLABLE_GROUP_WORDS = [
+  createWord({ text: "hello ", begin: 0, end: 1 }),
+  createWord({ text: "ev", begin: 1, end: 1.2 }),
+  createWord({ text: "er", begin: 1.2, end: 1.5 }),
+  createWord({ text: "y ", begin: 1.5, end: 1.8 }),
+  createWord({ text: "world", begin: 1.8, end: 2.5 }),
+];
+
+const SYLLABLE_GROUP_WORDS_SHIFTED = [
+  createWord({ text: "hello ", begin: 0, end: 1 }),
+  createWord({ text: "ev", begin: 1.4, end: 1.6 }),
+  createWord({ text: "er", begin: 1.6, end: 1.9 }),
+  createWord({ text: "y ", begin: 1.9, end: 2.2 }),
+  createWord({ text: "world", begin: 2.2, end: 2.9 }),
+];
+
 describe("WordTrack", () => {
   it("renders one WordBlock per word", async () => {
     const line = createLine({ words: WORDS });
@@ -27,6 +43,46 @@ describe("WordTrack", () => {
       { dndContext: true },
     );
     expect(screen.container.querySelectorAll("[data-word-block]").length).toBe(WORDS.length);
+  });
+
+  it("exposes data-syllable-position=first/middle/last for a split word in the middle of the row", async () => {
+    const line = createLine({ words: SYLLABLE_GROUP_WORDS });
+    useProjectStore.setState({ lines: [line] });
+    const screen = await render(
+      <WordTrack
+        lineId={line.id}
+        lineIndex={0}
+        words={SYLLABLE_GROUP_WORDS}
+        color="#a3c9ff"
+        trackType="word"
+        duration={3}
+        height={32}
+        onUpdateWord={() => {}}
+      />,
+      { dndContext: true },
+    );
+    const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
+    expect(blocks.map((b) => b.dataset.syllablePosition)).toEqual(["none", "first", "middle", "last", "none"]);
+  });
+
+  it("preserves data-syllable-position after a timing-only update (regression for issue #56)", async () => {
+    const line = createLine({ words: SYLLABLE_GROUP_WORDS });
+    useProjectStore.setState({ lines: [line] });
+    const screen = await render(
+      <WordTrack
+        lineId={line.id}
+        lineIndex={0}
+        words={SYLLABLE_GROUP_WORDS_SHIFTED}
+        color="#a3c9ff"
+        trackType="word"
+        duration={3}
+        height={32}
+        onUpdateWord={() => {}}
+      />,
+      { dndContext: true },
+    );
+    const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
+    expect(blocks.map((b) => b.dataset.syllablePosition)).toEqual(["none", "first", "middle", "last", "none"]);
   });
 
   it("sizes the track container to duration × zoom", async () => {

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -3,7 +3,7 @@ import type { WordTiming } from "@/stores/project";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import { computeSyllableGroups, getSyllablePositions } from "@/utils/syllable-groups";
-import { findInsertionSlot, normalizeTrailingSpaces } from "@/utils/word-spaces";
+import { addTrailingSpaceIfMissing, findInsertionSlot, trimTrailingSpaceFromLast } from "@/utils/word-spaces";
 import { selfKey } from "@/views/timeline/snap";
 import { isWordSelected, useTimelineStore } from "@/views/timeline/timeline-store";
 import { useSnapBypass } from "@/views/timeline/use-snap-bypass";
@@ -339,10 +339,12 @@ const WordTrack: React.FC<WordTrackProps> = ({
     const slot = findInsertionSlot(words, time, wordDuration, audioDuration);
     if (!slot) return;
 
-    const newWord: WordTiming = { text: "...", begin: slot.begin, end: slot.end };
+    const newWord: WordTiming = { text: "... ", begin: slot.begin, end: slot.end };
+    const prevLast = words[words.length - 1];
     const sorted = [...words, newWord].sort((a, b) => a.begin - b.begin);
     const newIndex = sorted.indexOf(newWord);
-    const newWords = normalizeTrailingSpaces(sorted);
+    const reconciled = prevLast ? addTrailingSpaceIfMissing(sorted, prevLast) : sorted;
+    const newWords = trimTrailingSpaceFromLast(reconciled);
 
     const updateLineWithHistory = useProjectStore.getState().updateLineWithHistory;
     if (trackType === "word") {


### PR DESCRIPTION
## Overview

- Replace `normalizeTrailingSpaces` with two helpers (`trimTrailingSpaceFromLast`, `addTrailingSpaceIfMissing`) so trailing-space changes only touch the array tail or one explicitly-referenced word, not every non-last entry.
- Update all 10 call sites that previously normalized after a structural rewrite: DnD single/multi move, Alt+drag duplicate (main + bg), double-click insert, context-menu insert, `applyMoveToBg`, `applyMoveFromBg`. Pure timing moves now only trim the tail; insert/duplicate/cross-track snapshot the previous-last word and add a trailing space only if it gets displaced.
- Fixes #56: a word split into syllables was losing its conjoined rendering on every move because `normalizeTrailingSpaces` unconditionally added a space to every non-last word, which is the exact signal encoding syllable membership.