### PR TITLE
fix: explicit-word detection, batch toggle, and syllable marking (#62)

### DIFF
--- a/src/stores/project.explicit.test.ts
+++ b/src/stores/project.explicit.test.ts
@@ -258,6 +258,149 @@ describe("toggleWordExplicit · history", () => {
   });
 });
 
+describe("toggleWordExplicit · syllable expansion (issue #62)", () => {
+  it("marks every syllable of a multi-syllable word when one syllable is targeted", () => {
+    seedSingleLine({
+      id: "L1",
+      text: "I fu|cking love it",
+      agentId: "v1",
+      words: [
+        { text: "I ", begin: 0, end: 0.3 },
+        { text: "fu", begin: 0.3, end: 0.4 },
+        { text: "cking ", begin: 0.4, end: 0.6 },
+        { text: "love ", begin: 0.6, end: 0.8 },
+        { text: "it", begin: 0.8, end: 1 },
+      ],
+    });
+    useProjectStore.getState().toggleWordExplicit("L1", "words", [1]);
+    const words = useProjectStore.getState().lines[0].words!;
+    expect(words[1].explicit).toBe(true);
+    expect(words[2].explicit).toBe(true);
+    expect(words[0].explicit).toBeUndefined();
+    expect(words[3].explicit).toBeUndefined();
+  });
+
+  it("unmarks every syllable of a multi-syllable word when all are marked", () => {
+    seedSingleLine({
+      id: "L1",
+      text: "fu|cking",
+      agentId: "v1",
+      words: [
+        { text: "fu", begin: 0, end: 0.5, explicit: true },
+        { text: "cking", begin: 0.5, end: 1, explicit: true },
+      ],
+    });
+    useProjectStore.getState().toggleWordExplicit("L1", "words", [1]);
+    const words = useProjectStore.getState().lines[0].words!;
+    expect(words[0].explicit).toBeUndefined();
+    expect(words[1].explicit).toBeUndefined();
+  });
+
+  it("expansion propagates to every syllable on linked siblings", () => {
+    const group: LinkGroup = { id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 };
+    useProjectStore.getState().setGroups([group]);
+    useProjectStore.getState().setLines([
+      {
+        id: "A",
+        text: "fu|cking yeah",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 0,
+        templateLineIdx: 0,
+        words: [
+          { text: "fu", begin: 0, end: 0.2 },
+          { text: "cking ", begin: 0.2, end: 0.5 },
+          { text: "yeah", begin: 0.5, end: 1 },
+        ],
+      },
+      {
+        id: "B",
+        text: "fu|cking yeah",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 1,
+        templateLineIdx: 0,
+        words: [
+          { text: "fu", begin: 30, end: 30.2 },
+          { text: "cking ", begin: 30.2, end: 30.5 },
+          { text: "yeah", begin: 30.5, end: 31 },
+        ],
+      },
+    ]);
+    useProjectStore.getState().toggleWordExplicit("A", "words", [0]);
+    const lines = useProjectStore.getState().lines;
+    expect(lines[0].words![0].explicit).toBe(true);
+    expect(lines[0].words![1].explicit).toBe(true);
+    expect(lines[1].words![0].explicit).toBe(true);
+    expect(lines[1].words![1].explicit).toBe(true);
+  });
+});
+
+describe("markWordsExplicit · syllable + batch (issue #62)", () => {
+  it("expands a single syllable target to the whole word", () => {
+    seedSingleLine({
+      id: "L1",
+      text: "fu|cking yeah",
+      agentId: "v1",
+      words: [
+        { text: "fu", begin: 0, end: 0.2 },
+        { text: "cking ", begin: 0.2, end: 0.5 },
+        { text: "yeah", begin: 0.5, end: 1 },
+      ],
+    });
+    useProjectStore.getState().markWordsExplicit([{ lineId: "L1", field: "words", wordIndex: 0 }], true);
+    const words = useProjectStore.getState().lines[0].words!;
+    expect(words[0].explicit).toBe(true);
+    expect(words[1].explicit).toBe(true);
+    expect(words[2].explicit).toBeUndefined();
+  });
+
+  it("preserves a previously-set explicit flag on another word when batch-marking across linked siblings", () => {
+    const group: LinkGroup = { id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 };
+    useProjectStore.getState().setGroups([group]);
+    useProjectStore.getState().setLines([
+      {
+        id: "A",
+        text: "fuck this shit",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 0,
+        templateLineIdx: 0,
+        words: [
+          { text: "fuck ", begin: 0, end: 0.3 },
+          { text: "this ", begin: 0.3, end: 0.6 },
+          { text: "shit", begin: 0.6, end: 1, explicit: true },
+        ],
+      },
+      {
+        id: "B",
+        text: "fuck this shit",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 1,
+        templateLineIdx: 0,
+        words: [
+          { text: "fuck ", begin: 30, end: 30.3 },
+          { text: "this ", begin: 30.3, end: 30.6 },
+          { text: "shit", begin: 30.6, end: 31, explicit: true },
+        ],
+      },
+    ]);
+    useProjectStore.getState().markWordsExplicit(
+      [
+        { lineId: "A", field: "words", wordIndex: 0 },
+        { lineId: "B", field: "words", wordIndex: 0 },
+      ],
+      true,
+    );
+    const lines = useProjectStore.getState().lines;
+    expect(lines[0].words![0].explicit).toBe(true);
+    expect(lines[0].words![2].explicit).toBe(true);
+    expect(lines[1].words![0].explicit).toBe(true);
+    expect(lines[1].words![2].explicit).toBe(true);
+  });
+});
+
 describe("markWordsExplicit · batch action", () => {
   it("applies multiple targets in a single history entry so one undo reverts them all", () => {
     useProjectStore.getState().setLines([

--- a/src/stores/project.ts
+++ b/src/stores/project.ts
@@ -1,6 +1,7 @@
 import { useAudioStore } from "@/stores/audio";
 import { useSettingsStore } from "@/stores/settings";
 import { GROUP_COLORS, pickNextGroupColor } from "@/utils/group-colors";
+import { expandToSyllableGroup } from "@/utils/syllable-groups";
 import { applySiblingWords } from "@/utils/word-diff";
 import { addTrailingSpaceIfMissing, resolveOverlapsForward, trimTrailingSpaceFromLast } from "@/utils/word-spaces";
 import { create } from "zustand";
@@ -779,7 +780,9 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
     const currentWords = target[field];
     if (!currentWords || currentWords.length === 0) return;
 
-    const indexSet = new Set(wordIndices.filter((i) => i >= 0 && i < currentWords.length));
+    const filtered = wordIndices.filter((i) => i >= 0 && i < currentWords.length);
+    const expanded = expandToSyllableGroup(currentWords, filtered).filter((i) => i < currentWords.length);
+    const indexSet = new Set(expanded);
     if (indexSet.size === 0) return;
 
     const allMarked = Array.from(indexSet).every((i) => currentWords[i].explicit === true);
@@ -802,7 +805,10 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
       let changed = false;
       const linesById = new Map<string, LyricLine>();
       for (const l of lines) linesById.set(l.id, l);
-      for (const target of targets) {
+
+      const expandedTargets = expandTargetsToSyllableGroups(targets, linesById);
+
+      for (const target of expandedTargets) {
         const line = linesById.get(target.lineId);
         if (!line) continue;
         const currentWords = line[target.field];
@@ -850,6 +856,27 @@ const useProjectStore = create<ProjectState & ProjectActions>((set, get) => ({
 
   clearDismissedExplicitSuggestions: () => set({ dismissedExplicitSuggestions: [], isDirty: true }),
 }));
+
+function expandTargetsToSyllableGroups(
+  targets: { lineId: string; field: "words" | "backgroundWords"; wordIndex: number }[],
+  linesById: Map<string, LyricLine>,
+): { lineId: string; field: "words" | "backgroundWords"; wordIndex: number }[] {
+  const byLineField = new Map<string, { lineId: string; field: "words" | "backgroundWords"; indices: number[] }>();
+  for (const t of targets) {
+    const key = `${t.lineId}:${t.field}`;
+    const existing = byLineField.get(key);
+    if (existing) existing.indices.push(t.wordIndex);
+    else byLineField.set(key, { lineId: t.lineId, field: t.field, indices: [t.wordIndex] });
+  }
+  const out: { lineId: string; field: "words" | "backgroundWords"; wordIndex: number }[] = [];
+  for (const group of byLineField.values()) {
+    const line = linesById.get(group.lineId);
+    const currentWords = line?.[group.field];
+    const expanded = currentWords ? expandToSyllableGroup(currentWords, group.indices) : group.indices;
+    for (const idx of expanded) out.push({ lineId: group.lineId, field: group.field, wordIndex: idx });
+  }
+  return out;
+}
 
 function applyExplicitTargetToLines(
   lines: LyricLine[],

--- a/src/utils/explicit-detection.test.ts
+++ b/src/utils/explicit-detection.test.ts
@@ -15,12 +15,12 @@ function lineWithText(id: string, text: string, words?: LyricLine["words"]): Lyr
 }
 
 describe("findExplicitWords", () => {
-  it("detects a basic profanity in main lyric text and returns the wordIndex", () => {
+  it("detects a basic profanity in main lyric text and returns the word indices", () => {
     const result = findExplicitWords([lineWithText("L1", "I fuck you")]);
     expect(result).toHaveLength(1);
     expect(result[0].lineId).toBe("L1");
     expect(result[0].field).toBe("words");
-    expect(result[0].wordIndex).toBe(1);
+    expect(result[0].wordIndices).toEqual([1]);
   });
 
   it("returns no suggestions for clean lyrics", () => {
@@ -49,13 +49,13 @@ describe("findExplicitWords", () => {
     const result = findExplicitWords([line]);
     expect(result).toHaveLength(1);
     expect(result[0].field).toBe("backgroundWords");
-    expect(result[0].wordIndex).toBe(1);
+    expect(result[0].wordIndices).toEqual([1]);
   });
 
   it("handles leetspeak via the recommended transformers", () => {
     const result = findExplicitWords([lineWithText("L1", "I sh1t on this")]);
     expect(result.length).toBeGreaterThanOrEqual(1);
-    expect(result.some((s) => s.wordIndex === 1)).toBe(true);
+    expect(result.some((s) => s.wordIndices[0] === 1)).toBe(true);
   });
 
   it("produces a stable fingerprint for the same word in the same line", () => {
@@ -66,7 +66,7 @@ describe("findExplicitWords", () => {
 
   it("deduplicates multiple matches that land on the same word", () => {
     const result = findExplicitWords([lineWithText("L1", "shithead and stuff")]);
-    const onWord0 = result.filter((r) => r.wordIndex === 0);
+    const onWord0 = result.filter((r) => r.wordIndices[0] === 0);
     expect(onWord0.length).toBeLessThanOrEqual(1);
   });
 
@@ -87,6 +87,68 @@ describe("findExplicitWords", () => {
       lineWithText("C", "fuck this"),
     ]);
     expect(result[0].lineIndex).toBe(2);
+  });
+
+  it("emits a wordIndices array (single element) for non-split words", () => {
+    const result = findExplicitWords([lineWithText("L1", "I fuck you")]);
+    expect(result).toHaveLength(1);
+    expect(result[0].wordIndices).toEqual([1]);
+  });
+});
+
+describe("findExplicitWords · syllable-split words", () => {
+  it("does NOT flag a syllable-split clean word that looks profane in fragments", () => {
+    const result = findExplicitWords([lineWithText("L1", "I fu|cking love it")]);
+    expect(result).toHaveLength(1);
+    expect(result[0].word).toBe("fucking");
+    expect(result[0].wordIndices).toEqual([1, 2]);
+    expect(result[0].lineId).toBe("L1");
+  });
+
+  it("flags the full word when profanity is detected in any syllable (fuc|king)", () => {
+    const result = findExplicitWords([lineWithText("L1", "I fuc|king love it")]);
+    expect(result).toHaveLength(1);
+    expect(result[0].word).toBe("fucking");
+    expect(result[0].wordIndices).toEqual([1, 2]);
+  });
+
+  it("flags every syllable of a syllable-split asshole", () => {
+    const result = findExplicitWords([lineWithText("L1", "ass|hole alert")]);
+    expect(result).toHaveLength(1);
+    expect(result[0].word).toBe("asshole");
+    expect(result[0].wordIndices).toEqual([0, 1]);
+  });
+
+  it("does NOT flag 'as|sass|in' because the whole word 'assassin' is whitelisted", () => {
+    const result = findExplicitWords([lineWithText("L1", "the as|sass|in attacks")]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("skips a syllable-split word when all of its syllables are already marked", () => {
+    const result = findExplicitWords([
+      lineWithText("L1", "I fu|cking love it", [
+        { text: "I ", begin: 0, end: 0.3 },
+        { text: "fu", begin: 0.3, end: 0.4, explicit: true },
+        { text: "cking ", begin: 0.4, end: 0.6, explicit: true },
+        { text: "love ", begin: 0.6, end: 0.8 },
+        { text: "it", begin: 0.8, end: 1 },
+      ]),
+    ]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("emits a suggestion when at least one syllable of a profane word is unmarked", () => {
+    const result = findExplicitWords([
+      lineWithText("L1", "I fu|cking love it", [
+        { text: "I ", begin: 0, end: 0.3 },
+        { text: "fu", begin: 0.3, end: 0.4, explicit: true },
+        { text: "cking ", begin: 0.4, end: 0.6 },
+        { text: "love ", begin: 0.6, end: 0.8 },
+        { text: "it", begin: 0.8, end: 1 },
+      ]),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].wordIndices).toEqual([1, 2]);
   });
 });
 
@@ -173,7 +235,7 @@ describe("findExplicitWords · linked instances", () => {
   it("toggling via the representative lineId is enough; propagation handles siblings", () => {
     const result = findExplicitWords(linkedChorusLines(), choruses);
     expect(result[0].lineId).toBe("C1");
-    expect(result[0].wordIndex).toBe(1);
+    expect(result[0].wordIndices).toEqual([1]);
     expect(result[0].field).toBe("words");
   });
 });

--- a/src/utils/explicit-detection.ts
+++ b/src/utils/explicit-detection.ts
@@ -21,7 +21,7 @@ interface ExplicitSuggestion {
   lineId: string;
   lineIndex: number;
   field: "words" | "backgroundWords";
-  wordIndex: number;
+  wordIndices: number[];
   word: string;
   fingerprint: string;
   linked?: LinkedInfo;
@@ -31,7 +31,7 @@ interface RawHit {
   line: LyricLine;
   lineIndex: number;
   field: "words" | "backgroundWords";
-  wordIndex: number;
+  wordIndices: number[];
   word: string;
 }
 
@@ -51,32 +51,49 @@ function getMatcher(): RegExpMatcher {
 // -- Word-range mapping --------------------------------------------------------
 
 interface WordRange {
-  index: number;
   start: number;
   end: number;
   text: string;
+  syllableIndices: number[];
 }
 
 function buildWordRanges(text: string): { canonical: string; ranges: WordRange[] } {
-  const { parts } = splitIntoWordsWithMeta(text);
+  const { parts, trailingSpace } = splitIntoWordsWithMeta(text);
+  if (parts.length === 0) return { canonical: "", ranges: [] };
+
   const ranges: WordRange[] = [];
   const pieces: string[] = [];
   let offset = 0;
+  let syllableBuffer: number[] = [];
+  let textBuffer = "";
+
   for (let i = 0; i < parts.length; i++) {
+    syllableBuffer.push(i);
+    textBuffer += parts[i];
+    const finishesWord = trailingSpace[i] || i === parts.length - 1;
+    if (!finishesWord) continue;
+
     const start = offset;
-    const part = parts[i];
-    pieces.push(part);
-    const end = start + part.length;
-    ranges.push({ index: i, start, end, text: part });
-    offset = end + 1;
-    if (i < parts.length - 1) pieces.push(" ");
+    const end = start + textBuffer.length;
+    pieces.push(textBuffer);
+    ranges.push({ start, end, text: textBuffer, syllableIndices: syllableBuffer });
+
+    if (i < parts.length - 1) {
+      pieces.push(" ");
+      offset = end + 1;
+    } else {
+      offset = end;
+    }
+    syllableBuffer = [];
+    textBuffer = "";
   }
+
   return { canonical: pieces.join(""), ranges };
 }
 
-function wordIndexForOffset(ranges: WordRange[], startIndex: number): number | null {
+function rangeForOffset(ranges: WordRange[], startIndex: number): WordRange | null {
   for (const r of ranges) {
-    if (startIndex >= r.start && startIndex < r.end) return r.index;
+    if (startIndex >= r.start && startIndex < r.end) return r;
   }
   return null;
 }
@@ -120,19 +137,20 @@ function scanField(
   const { canonical, ranges } = buildWordRanges(source);
   if (canonical.length === 0) return;
   const matches = matcher.getAllMatches(canonical, true);
-  const seenIndices = new Set<number>();
+  const seenStart = new Set<number>();
   for (const m of matches) {
-    const wordIndex = wordIndexForOffset(ranges, m.startIndex);
-    if (wordIndex === null) continue;
-    if (seenIndices.has(wordIndex)) continue;
-    if (alreadyMarked.has(wordIndex)) continue;
-    seenIndices.add(wordIndex);
+    const range = rangeForOffset(ranges, m.startIndex);
+    if (!range) continue;
+    if (seenStart.has(range.start)) continue;
+    const allMarked = range.syllableIndices.every((idx) => alreadyMarked.has(idx));
+    if (allMarked) continue;
+    seenStart.add(range.start);
     out.push({
       line,
       lineIndex,
       field,
-      wordIndex,
-      word: ranges[wordIndex].text,
+      wordIndices: range.syllableIndices,
+      word: range.text,
     });
   }
 }
@@ -177,7 +195,7 @@ function findExplicitWords(lines: LyricLine[], groups: LinkGroup[] = []): Explic
       hit.line.groupId as string,
       hit.line.templateLineIdx as number,
       hit.field,
-      hit.wordIndex,
+      hit.wordIndices[0],
       hit.word,
     );
     const bucket = linkedBuckets.get(key);
@@ -194,9 +212,9 @@ function findExplicitWords(lines: LyricLine[], groups: LinkGroup[] = []): Explic
         lineId: hit.line.id,
         lineIndex: hit.lineIndex,
         field: hit.field,
-        wordIndex: hit.wordIndex,
+        wordIndices: hit.wordIndices,
         word: hit.word,
-        fingerprint: standaloneFingerprint(hit.line.id, hit.field, hit.wordIndex, hit.word),
+        fingerprint: standaloneFingerprint(hit.line.id, hit.field, hit.wordIndices[0], hit.word),
       });
       continue;
     }
@@ -207,7 +225,7 @@ function findExplicitWords(lines: LyricLine[], groups: LinkGroup[] = []): Explic
       lineId: representative.line.id,
       lineIndex: representative.lineIndex,
       field: representative.field,
-      wordIndex: representative.wordIndex,
+      wordIndices: representative.wordIndices,
       word: representative.word,
       fingerprint,
       linked: {
@@ -228,9 +246,9 @@ function findExplicitWords(lines: LyricLine[], groups: LinkGroup[] = []): Explic
       lineId: hit.line.id,
       lineIndex: hit.lineIndex,
       field: hit.field,
-      wordIndex: hit.wordIndex,
+      wordIndices: hit.wordIndices,
       word: hit.word,
-      fingerprint: standaloneFingerprint(hit.line.id, hit.field, hit.wordIndex, hit.word),
+      fingerprint: standaloneFingerprint(hit.line.id, hit.field, hit.wordIndices[0], hit.word),
     });
   }
 

--- a/src/utils/explicit-snippet.test.ts
+++ b/src/utils/explicit-snippet.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 
 describe("getExplicitSnippet", () => {
   it("returns the full source when it fits under max", () => {
-    const result = getExplicitSnippet("I fuck you", 1, 80);
+    const result = getExplicitSnippet("I fuck you", [1], 80);
     expect(result).not.toBeNull();
     expect(result?.before).toBe("I ");
     expect(result?.word).toBe("fuck");
@@ -19,7 +19,7 @@ describe("getExplicitSnippet", () => {
     const source =
       "this is a very long lyric line that goes on and on and contains the word fuck buried way past any reasonable truncation boundary and continues for a while after";
     const wordIndex = source.split(/\s+/).indexOf("fuck");
-    const result = getExplicitSnippet(source, wordIndex, 60);
+    const result = getExplicitSnippet(source, [wordIndex], 60);
     expect(result).not.toBeNull();
     expect(result?.word).toBe("fuck");
     const total = result!.before.length + result!.word.length + result!.after.length;
@@ -30,7 +30,7 @@ describe("getExplicitSnippet", () => {
 
   it("no leading ellipsis when word is near the start", () => {
     const source = "fuck this entire long sentence that keeps on going forever and ever beyond reason";
-    const result = getExplicitSnippet(source, 0, 40);
+    const result = getExplicitSnippet(source, [0], 40);
     expect(result?.leadingEllipsis).toBe(false);
     expect(result?.word).toBe("fuck");
     expect(result?.trailingEllipsis).toBe(true);
@@ -39,21 +39,33 @@ describe("getExplicitSnippet", () => {
   it("no trailing ellipsis when word is near the end", () => {
     const source = "this is a long opening that runs and runs and finally ends with shit";
     const wordIndex = source.split(/\s+/).indexOf("shit");
-    const result = getExplicitSnippet(source, wordIndex, 40);
+    const result = getExplicitSnippet(source, [wordIndex], 40);
     expect(result?.trailingEllipsis).toBe(false);
     expect(result?.word).toBe("shit");
     expect(result?.leadingEllipsis).toBe(true);
   });
 
-  it("returns null when wordIndex is out of range", () => {
-    expect(getExplicitSnippet("hello world", 5, 80)).toBeNull();
-    expect(getExplicitSnippet("hello world", -1, 80)).toBeNull();
+  it("returns null when any wordIndex is out of range", () => {
+    expect(getExplicitSnippet("hello world", [5], 80)).toBeNull();
+    expect(getExplicitSnippet("hello world", [-1], 80)).toBeNull();
+  });
+
+  it("returns null for an empty index list", () => {
+    expect(getExplicitSnippet("hello world", [], 80)).toBeNull();
   });
 
   it("handles punctuation attached to the word", () => {
     const source = "you ain't really doin' this shit, like who you doin' it with?";
     const wordIndex = source.split(/\s+/).indexOf("shit,");
-    const result = getExplicitSnippet(source, wordIndex, 80);
+    const result = getExplicitSnippet(source, [wordIndex], 80);
     expect(result?.word).toBe("shit,");
+  });
+
+  it("spans every syllable of a syllable-split word", () => {
+    const result = getExplicitSnippet("I fu|cking love it", [1, 2], 80);
+    expect(result).not.toBeNull();
+    expect(result?.before).toBe("I ");
+    expect(result?.word).toBe("fu|cking");
+    expect(result?.after).toBe(" love it");
   });
 });

--- a/src/utils/explicit-snippet.ts
+++ b/src/utils/explicit-snippet.ts
@@ -12,22 +12,29 @@ interface ExplicitSnippet {
 
 // -- Helpers -------------------------------------------------------------------
 
-function findWordCharRange(source: string, wordIndex: number): { start: number; end: number } | null {
+function findWordCharRange(source: string, wordIndices: number[]): { start: number; end: number } | null {
+  if (wordIndices.length === 0) return null;
   const { parts } = splitIntoWordsWithMeta(source);
-  if (wordIndex < 0 || wordIndex >= parts.length) return null;
+  const minIndex = Math.min(...wordIndices);
+  const maxIndex = Math.max(...wordIndices);
+  if (minIndex < 0 || maxIndex >= parts.length) return null;
   let cursor = 0;
+  let start = -1;
+  let end = -1;
   for (let i = 0; i < parts.length; i++) {
-    const start = source.indexOf(parts[i], cursor);
-    if (start === -1) return null;
-    const end = start + parts[i].length;
-    if (i === wordIndex) return { start, end };
-    cursor = end;
+    const partStart = source.indexOf(parts[i], cursor);
+    if (partStart === -1) return null;
+    const partEnd = partStart + parts[i].length;
+    if (i === minIndex) start = partStart;
+    if (i === maxIndex) end = partEnd;
+    cursor = partEnd;
   }
-  return null;
+  if (start === -1 || end === -1) return null;
+  return { start, end };
 }
 
-function getExplicitSnippet(source: string, wordIndex: number, max: number): ExplicitSnippet | null {
-  const range = findWordCharRange(source, wordIndex);
+function getExplicitSnippet(source: string, wordIndices: number[], max: number): ExplicitSnippet | null {
+  const range = findWordCharRange(source, wordIndices);
   if (!range) return null;
   const { start, end } = range;
   const wordLen = end - start;

--- a/src/utils/syllable-groups.ts
+++ b/src/utils/syllable-groups.ts
@@ -51,7 +51,20 @@ function getSyllablePositions(words: WordTiming[]): SyllablePosition[] {
   return positions;
 }
 
+function expandToSyllableGroup(words: WordTiming[], indices: number[]): number[] {
+  if (indices.length === 0) return [];
+  const groups = computeSyllableGroups(words);
+  if (groups.length === 0) return Array.from(new Set(indices)).sort((a, b) => a - b);
+  const expanded = new Set<number>(indices);
+  for (const i of indices) {
+    const group = groups.find((g) => i >= g.startIndex && i <= g.endIndex);
+    if (!group) continue;
+    for (let k = group.startIndex; k <= group.endIndex; k++) expanded.add(k);
+  }
+  return Array.from(expanded).sort((a, b) => a - b);
+}
+
 // -- Exports ------------------------------------------------------------------
 
-export { computeSyllableGroups, getSyllablePositions };
+export { computeSyllableGroups, expandToSyllableGroup, getSyllablePositions };
 export type { SyllablePosition };

--- a/src/views/timeline/explicit-selection-toggle.test.ts
+++ b/src/views/timeline/explicit-selection-toggle.test.ts
@@ -1,10 +1,10 @@
 /**
  * @vitest-environment node
  */
-import type { LyricLine } from "@/stores/project";
+import { type LinkGroup, type LyricLine, useProjectStore } from "@/stores/project";
 import { resolveExplicitSelectionToggle } from "@/views/timeline/explicit-selection-toggle";
 import type { WordSelection } from "@/views/timeline/timeline-store";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 function sel(lineId: string, wordIndex: number, type: "word" | "bg" = "word"): WordSelection {
   return { lineId, lineIndex: 0, wordIndex, type };
@@ -131,5 +131,59 @@ describe("resolveExplicitSelectionToggle", () => {
   it("returns an empty target list for an empty selection", () => {
     const result = resolveExplicitSelectionToggle([], []);
     expect(result.targets).toEqual([]);
+  });
+});
+
+describe("resolveExplicitSelectionToggle → markWordsExplicit (keyboard flow, issue #62 Bug 2)", () => {
+  beforeEach(() => {
+    useProjectStore.getState().reset();
+    useProjectStore.getState().clearHistory();
+  });
+
+  function seedLinkedChorus(explicit = false) {
+    const group: LinkGroup = { id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 };
+    useProjectStore.getState().setGroups([group]);
+    useProjectStore.getState().setLines(
+      [0, 1, 2].map((idx) => ({
+        id: `inst-${idx}`,
+        text: "fuck this",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: idx,
+        templateLineIdx: 0,
+        words: [
+          { text: "fuck ", begin: idx * 30, end: idx * 30 + 0.5, ...(explicit ? { explicit: true as const } : {}) },
+          { text: "this", begin: idx * 30 + 0.5, end: idx * 30 + 1 },
+        ],
+      })),
+    );
+  }
+
+  function runToggle(): void {
+    const selection: WordSelection[] = [sel("inst-0", 0), sel("inst-1", 0), sel("inst-2", 0)];
+    const { targets, value } = resolveExplicitSelectionToggle(useProjectStore.getState().lines, selection);
+    useProjectStore.getState().markWordsExplicit(targets, value);
+  }
+
+  it("marks the word across every linked instance instead of flip-flopping", () => {
+    seedLinkedChorus();
+    runToggle();
+    const lines = useProjectStore.getState().lines;
+    expect(lines.every((l) => l.words?.[0].explicit === true)).toBe(true);
+  });
+
+  it("reverts the whole batch with a single undo", () => {
+    seedLinkedChorus();
+    runToggle();
+    useProjectStore.getState().undo();
+    const lines = useProjectStore.getState().lines;
+    expect(lines.every((l) => l.words?.[0].explicit === undefined)).toBe(true);
+  });
+
+  it("unmarks the batch when every selected word is already explicit", () => {
+    seedLinkedChorus(true);
+    runToggle();
+    const lines = useProjectStore.getState().lines;
+    expect(lines.every((l) => l.words?.[0].explicit === undefined)).toBe(true);
   });
 });

--- a/src/views/timeline/explicit-selection-toggle.test.ts
+++ b/src/views/timeline/explicit-selection-toggle.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @vitest-environment node
+ */
+import type { LyricLine } from "@/stores/project";
+import { resolveExplicitSelectionToggle } from "@/views/timeline/explicit-selection-toggle";
+import type { WordSelection } from "@/views/timeline/timeline-store";
+import { describe, expect, it } from "vitest";
+
+function sel(lineId: string, wordIndex: number, type: "word" | "bg" = "word"): WordSelection {
+  return { lineId, lineIndex: 0, wordIndex, type };
+}
+
+describe("resolveExplicitSelectionToggle", () => {
+  it("marks the whole word when a partially-marked syllable group is selected via one syllable", () => {
+    const lines: LyricLine[] = [
+      {
+        id: "L1",
+        text: "fu|cking yeah",
+        agentId: "v1",
+        words: [
+          { text: "fu", begin: 0, end: 0.2, explicit: true },
+          { text: "cking ", begin: 0.2, end: 0.5 },
+          { text: "yeah", begin: 0.5, end: 1 },
+        ],
+      },
+    ];
+    const result = resolveExplicitSelectionToggle(lines, [sel("L1", 0)]);
+    expect(result.value).toBe(true);
+    expect(result.targets.map((t) => t.wordIndex).sort((a, b) => a - b)).toEqual([0, 1]);
+  });
+
+  it("unmarks when every syllable of the selected word is already marked", () => {
+    const lines: LyricLine[] = [
+      {
+        id: "L1",
+        text: "fu|cking yeah",
+        agentId: "v1",
+        words: [
+          { text: "fu", begin: 0, end: 0.2, explicit: true },
+          { text: "cking ", begin: 0.2, end: 0.5, explicit: true },
+          { text: "yeah", begin: 0.5, end: 1 },
+        ],
+      },
+    ];
+    const result = resolveExplicitSelectionToggle(lines, [sel("L1", 1)]);
+    expect(result.value).toBe(false);
+    expect(result.targets.map((t) => t.wordIndex).sort((a, b) => a - b)).toEqual([0, 1]);
+  });
+
+  it("marks when the selected word is fully unmarked", () => {
+    const lines: LyricLine[] = [
+      {
+        id: "L1",
+        text: "fuck this",
+        agentId: "v1",
+        words: [
+          { text: "fuck ", begin: 0, end: 0.5 },
+          { text: "this", begin: 0.5, end: 1 },
+        ],
+      },
+    ];
+    const result = resolveExplicitSelectionToggle(lines, [sel("L1", 0)]);
+    expect(result.value).toBe(true);
+    expect(result.targets).toEqual([{ lineId: "L1", field: "words", wordIndex: 0 }]);
+  });
+
+  it("treats a multi-line selection as marked-only-if every expanded index is marked", () => {
+    const lines: LyricLine[] = [
+      {
+        id: "A",
+        text: "fuck this",
+        agentId: "v1",
+        words: [
+          { text: "fuck ", begin: 0, end: 0.5, explicit: true },
+          { text: "this", begin: 0.5, end: 1 },
+        ],
+      },
+      {
+        id: "B",
+        text: "shit happens",
+        agentId: "v1",
+        words: [
+          { text: "shit ", begin: 1, end: 1.5 },
+          { text: "happens", begin: 1.5, end: 2 },
+        ],
+      },
+    ];
+    const result = resolveExplicitSelectionToggle(lines, [sel("A", 0), sel("B", 0)]);
+    expect(result.value).toBe(true);
+    expect(result.targets).toEqual([
+      { lineId: "A", field: "words", wordIndex: 0 },
+      { lineId: "B", field: "words", wordIndex: 0 },
+    ]);
+  });
+
+  it("maps a bg-type selection to the backgroundWords field", () => {
+    const lines: LyricLine[] = [
+      {
+        id: "L1",
+        text: "main",
+        agentId: "v1",
+        words: [{ text: "main", begin: 0, end: 1 }],
+        backgroundText: "oh shit",
+        backgroundWords: [
+          { text: "oh ", begin: 1, end: 1.25 },
+          { text: "shit", begin: 1.25, end: 1.5 },
+        ],
+      },
+    ];
+    const result = resolveExplicitSelectionToggle(lines, [sel("L1", 1, "bg")]);
+    expect(result.value).toBe(true);
+    expect(result.targets).toEqual([{ lineId: "L1", field: "backgroundWords", wordIndex: 1 }]);
+  });
+
+  it("drops out-of-range and unknown-line selections", () => {
+    const lines: LyricLine[] = [
+      {
+        id: "L1",
+        text: "fuck this",
+        agentId: "v1",
+        words: [
+          { text: "fuck ", begin: 0, end: 0.5 },
+          { text: "this", begin: 0.5, end: 1 },
+        ],
+      },
+    ];
+    const result = resolveExplicitSelectionToggle(lines, [sel("L1", 9), sel("ghost", 0), sel("L1", 0)]);
+    expect(result.targets).toEqual([{ lineId: "L1", field: "words", wordIndex: 0 }]);
+  });
+
+  it("returns an empty target list for an empty selection", () => {
+    const result = resolveExplicitSelectionToggle([], []);
+    expect(result.targets).toEqual([]);
+  });
+});

--- a/src/views/timeline/explicit-selection-toggle.ts
+++ b/src/views/timeline/explicit-selection-toggle.ts
@@ -50,4 +50,3 @@ function resolveExplicitSelectionToggle(lines: LyricLine[], selection: WordSelec
 // -- Exports -------------------------------------------------------------------
 
 export { resolveExplicitSelectionToggle };
-export type { ExplicitTarget };

--- a/src/views/timeline/explicit-selection-toggle.ts
+++ b/src/views/timeline/explicit-selection-toggle.ts
@@ -1,0 +1,53 @@
+import type { LyricLine } from "@/stores/project";
+import { expandToSyllableGroup } from "@/utils/syllable-groups";
+import type { WordSelection } from "@/views/timeline/timeline-store";
+
+// -- Types ---------------------------------------------------------------------
+
+interface ExplicitTarget {
+  lineId: string;
+  field: "words" | "backgroundWords";
+  wordIndex: number;
+}
+
+interface ExplicitToggleResolution {
+  targets: ExplicitTarget[];
+  value: boolean;
+}
+
+// -- Functions -----------------------------------------------------------------
+
+function resolveExplicitSelectionToggle(lines: LyricLine[], selection: WordSelection[]): ExplicitToggleResolution {
+  const linesById = new Map(lines.map((l) => [l.id, l]));
+  const groups = new Map<string, { lineId: string; field: "words" | "backgroundWords"; indices: number[] }>();
+
+  for (const w of selection) {
+    const field: "words" | "backgroundWords" = w.type === "word" ? "words" : "backgroundWords";
+    const wordsArr = linesById.get(w.lineId)?.[field];
+    if (!wordsArr || w.wordIndex < 0 || w.wordIndex >= wordsArr.length) continue;
+    const key = `${w.lineId}:${field}`;
+    const existing = groups.get(key);
+    if (existing) existing.indices.push(w.wordIndex);
+    else groups.set(key, { lineId: w.lineId, field, indices: [w.wordIndex] });
+  }
+
+  const targets: ExplicitTarget[] = [];
+  let allMarked = true;
+
+  for (const group of groups.values()) {
+    const wordsArr = linesById.get(group.lineId)?.[group.field];
+    if (!wordsArr) continue;
+    const expanded = expandToSyllableGroup(wordsArr, group.indices).filter((i) => i >= 0 && i < wordsArr.length);
+    for (const idx of expanded) {
+      targets.push({ lineId: group.lineId, field: group.field, wordIndex: idx });
+      if (wordsArr[idx].explicit !== true) allMarked = false;
+    }
+  }
+
+  return { targets, value: !allMarked };
+}
+
+// -- Exports -------------------------------------------------------------------
+
+export { resolveExplicitSelectionToggle };
+export type { ExplicitTarget };

--- a/src/views/timeline/explicit-suggestions-banner.browser.test.tsx
+++ b/src/views/timeline/explicit-suggestions-banner.browser.test.tsx
@@ -10,4 +10,97 @@ describe("ExplicitSuggestionsBanner", () => {
     const screen = await render(<ExplicitSuggestionsBanner />);
     expect(screen.container.textContent ?? "").toBe("");
   });
+
+  it("marks the word explicit when the single-suggestion 'Mark explicit' button is clicked", async () => {
+    useProjectStore.setState({
+      lines: [
+        createLine({
+          id: "L1",
+          text: "fuck this",
+          words: [
+            { text: "fuck ", begin: 0, end: 0.5 },
+            { text: "this", begin: 0.5, end: 1 },
+          ],
+        }),
+      ],
+    });
+    const screen = await render(<ExplicitSuggestionsBanner />);
+    expect(screen.container.textContent ?? "").toContain("Possibly explicit word");
+
+    await screen.getByRole("button", { name: /mark explicit/i }).click();
+    expect(useProjectStore.getState().lines[0].words?.[0].explicit).toBe(true);
+  });
+
+  it("opens the review modal for multiple suggestions", async () => {
+    useProjectStore.setState({
+      lines: [createLine({ id: "L1", text: "fuck this" }), createLine({ id: "L2", text: "oh shit" })],
+    });
+    const screen = await render(<ExplicitSuggestionsBanner />);
+    expect(screen.container.textContent ?? "").toContain("Found 2");
+
+    await screen.getByRole("button", { name: /review 2/i }).click();
+    await expect.element(screen.getByRole("button", { name: /mark all/i })).toBeInTheDocument();
+  });
+
+  it("marks every suggestion when 'Mark all' is clicked in the modal", async () => {
+    useProjectStore.setState({
+      lines: [
+        createLine({
+          id: "L1",
+          text: "fuck this",
+          words: [
+            { text: "fuck ", begin: 0, end: 0.5 },
+            { text: "this", begin: 0.5, end: 1 },
+          ],
+        }),
+        createLine({
+          id: "L2",
+          text: "oh shit",
+          words: [
+            { text: "oh ", begin: 1, end: 1.5 },
+            { text: "shit", begin: 1.5, end: 2 },
+          ],
+        }),
+      ],
+    });
+    const screen = await render(<ExplicitSuggestionsBanner />);
+
+    await screen.getByRole("button", { name: /review 2/i }).click();
+    await screen.getByRole("button", { name: /mark all/i }).click();
+
+    const lines = useProjectStore.getState().lines;
+    expect(lines[0].words?.[0].explicit).toBe(true);
+    expect(lines[1].words?.[1].explicit).toBe(true);
+  });
+
+  it("dismissing the single suggestion hides the banner", async () => {
+    useProjectStore.setState({
+      lines: [
+        createLine({
+          id: "L1",
+          text: "fuck this",
+          words: [
+            { text: "fuck ", begin: 0, end: 0.5 },
+            { text: "this", begin: 0.5, end: 1 },
+          ],
+        }),
+      ],
+    });
+    const screen = await render(<ExplicitSuggestionsBanner />);
+
+    await screen.getByRole("button", { name: "Dismiss suggestion" }).click();
+
+    expect(useProjectStore.getState().dismissedExplicitSuggestions).toHaveLength(1);
+    await expect.poll(() => screen.container.textContent ?? "").toBe("");
+  });
+
+  it("highlights the whole word in the modal snippet for a syllable-split profanity", async () => {
+    useProjectStore.setState({
+      lines: [createLine({ id: "L1", text: "I fu|cking love it" }), createLine({ id: "L2", text: "oh shit" })],
+    });
+    const screen = await render(<ExplicitSuggestionsBanner />);
+
+    await screen.getByRole("button", { name: /review 2/i }).click();
+    await expect.element(screen.getByText("fu|cking", { exact: true })).toBeInTheDocument();
+  });
 });

--- a/src/views/timeline/explicit-suggestions-banner.tsx
+++ b/src/views/timeline/explicit-suggestions-banner.tsx
@@ -30,7 +30,7 @@ const ExplicitSuggestionsBanner: React.FC = () => {
   if (visible.length === 0) return null;
 
   const acceptOne = (s: ExplicitSuggestion) => {
-    toggleWordExplicit(s.lineId, s.field, [s.wordIndex]);
+    toggleWordExplicit(s.lineId, s.field, s.wordIndices);
   };
 
   const dismissOne = (s: ExplicitSuggestion) => dismissExplicitSuggestion(s.fingerprint);
@@ -41,7 +41,7 @@ const ExplicitSuggestionsBanner: React.FC = () => {
 
   const acceptAll = () => {
     markWordsExplicit(
-      visible.map((s) => ({ lineId: s.lineId, field: s.field, wordIndex: s.wordIndex })),
+      visible.flatMap((s) => s.wordIndices.map((wordIndex) => ({ lineId: s.lineId, field: s.field, wordIndex }))),
       true,
     );
   };
@@ -161,7 +161,7 @@ const ExplicitSuggestionsModal: React.FC<ExplicitSuggestionsModalProps> = ({
                       {s.linked ? <LinkedPill linked={s.linked} /> : null}
                     </span>
                     <span className="text-xs text-composer-text-muted truncate">
-                      {formatLineLocation(s)} · <SnippetPreview source={source} wordIndex={s.wordIndex} />
+                      {formatLineLocation(s)} · <SnippetPreview source={source} wordIndices={s.wordIndices} />
                     </span>
                   </div>
                   <div className="flex items-center gap-1 shrink-0">
@@ -208,10 +208,10 @@ function truncate(s: string, max: number): string {
   return `${s.slice(0, max - 1).trim()}…`;
 }
 
-const SnippetPreview: React.FC<{ source: string; wordIndex: number }> = ({ source, wordIndex }) => {
+const SnippetPreview: React.FC<{ source: string; wordIndices: number[] }> = ({ source, wordIndices }) => {
   const trimmed = source.trim();
   if (trimmed.length === 0) return <span>(empty line)</span>;
-  const snippet = getExplicitSnippet(source, wordIndex, MODAL_LINE_MAX);
+  const snippet = getExplicitSnippet(source, wordIndices, MODAL_LINE_MAX);
   if (!snippet) return <span>{truncate(trimmed, MODAL_LINE_MAX)}</span>;
   return (
     <span>

--- a/src/views/timeline/use-timeline-keyboard.ts
+++ b/src/views/timeline/use-timeline-keyboard.ts
@@ -10,6 +10,7 @@ import { convertLineToWord } from "@/utils/sync-helpers";
 import { findMatchingShortcut } from "@/utils/shortcut-matcher";
 import { copyInstanceToClipboardAndPreview } from "@/views/timeline/copy-instance-to-clipboard";
 import { decideAddInstancePlacement } from "@/views/timeline/decide-add-instance-placement";
+import { resolveExplicitSelectionToggle } from "@/views/timeline/explicit-selection-toggle";
 import { GROUP_HEADER_HEIGHT } from "@/views/timeline/group-header-row";
 import { createGroupFromSelection, fillSelectionGaps, instanceToTemplate } from "@/views/timeline/group-ops";
 import { scrollToInstanceHeader } from "@/views/timeline/scroll-helpers";
@@ -677,18 +678,9 @@ function useTimelineKeyboard(
           const { selectedWords: explicitSel } = useTimelineStore.getState();
           if (explicitSel.length === 0) break;
           e.preventDefault();
-          const grouped = new Map<string, { lineId: string; field: "words" | "backgroundWords"; indices: number[] }>();
-          for (const w of explicitSel) {
-            const field: "words" | "backgroundWords" = w.type === "word" ? "words" : "backgroundWords";
-            const key = `${w.lineId}:${field}`;
-            const existing = grouped.get(key);
-            if (existing) existing.indices.push(w.wordIndex);
-            else grouped.set(key, { lineId: w.lineId, field, indices: [w.wordIndex] });
-          }
-          const toggle = useProjectStore.getState().toggleWordExplicit;
-          for (const group of grouped.values()) {
-            toggle(group.lineId, group.field, group.indices);
-          }
+          const { targets, value } = resolveExplicitSelectionToggle(useProjectStore.getState().lines, explicitSel);
+          if (targets.length === 0) break;
+          useProjectStore.getState().markWordsExplicit(targets, value);
           break;
         }
         case "timeline.shiftInstanceToPlayhead": {


### PR DESCRIPTION
## Overview

- Fix issue #62 explicit-word bugs: substring false positives, unreliable batch-marking from a timeline selection, and only part of a syllable-split word getting marked.