### PR TITLE
Add browser-side HTDemucs vocal separation via ONNX Runtime Web

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,9 @@
 VITE_COBALT_API_URL=https://cobalt.boidu.dev
 VITE_TURNSTILE_SITEKEY=
+
+# Base URL for the HTDemucs ONNX model used by browser-side vocal separation.
+# Cloudflare's static-asset limit is 25 MB and the model is ~85 MB (fp16),
+# so it is not bundled with the site. Host it on a public R2 bucket bound
+# to a custom domain. See README.md > "Vocal separation hosting" for setup.
+# Leave unset to hide the vocal separation feature.
+VITE_VOCAL_MODEL_BASE_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,7 @@ cspell.json
 # Playwright cache (test reports)
 playwright-report/
 test-results/
+
+# Built HTDemucs ONNX models (large; produced by scripts/build-htdemucs-onnx.sh)
+htdemucs-onnx-out/
+.wrangler

--- a/README.md
+++ b/README.md
@@ -90,6 +90,44 @@ pnpm lint:fix          # Format and lint
 pnpm typecheck         # Type check
 ```
 
+## Vocal separation hosting
+
+Composer ships an optional HTDemucs (Hybrid Transformer Demucs v4) vocal-separation feature that runs entirely in the browser via ONNX Runtime Web (WebGPU primary, WASM fallback). The model file is too large for Cloudflare Pages' 25 MB asset limit, so it is **not** bundled — instead it's served from a public Cloudflare R2 bucket. Egress from R2 is free, and serving via a custom domain keeps the file cached at Cloudflare's edge without going through a Worker.
+
+If `VITE_VOCAL_MODEL_BASE_URL` is unset, the vocal-separation dropdown is hidden entirely.
+
+### Where the model comes from
+
+HTDemucs is the **official Facebook AI Research model** (`facebookresearch/demucs`, the "Hybrid Transformer" variant published Nov 2022). The PyTorch weights are auto-downloaded from `dl.fbaipublicfiles.com` by the `demucs` Python package — you don't grab them manually. The two community ONNX export tools are:
+
+- **`sevagh/demucs.onnx`** — the most complete PyTorch → ONNX export pipeline; ships a forked `demucs` package that pulls STFT/iSTFT outside the graph so it exports cleanly. This is what the build script below uses.
+- **`gianlourbano/demucs-onnx`** — onnxruntime-web reference implementation; useful for cross-referencing the JS-side STFT/inference shape.
+
+### Build the ONNX models
+
+Two scripts in `scripts/` do the work:
+
+```bash
+# 1. Build fp32 + fp16 ONNX models. Outputs ./htdemucs-onnx-out/.
+#    Takes ~10–30 min on CPU and needs ~10 GB of free disk while building.
+./scripts/build-htdemucs-onnx.sh
+
+# 2. Upload to your R2 bucket (requires `wrangler login` first).
+./scripts/upload-htdemucs.sh composer-vocal-models
+```
+
+`build-htdemucs-onnx.sh` will clone `sevagh/demucs.onnx` into `/tmp/composer-htdemucs-build/`, spin up a Python venv, run the official converter, then quantize the fp32 export to fp16 via `onnxconverter-common`. It prints the model's input/output names + SHA-256 at the end — verify those against `src/audio/separation/worker.ts` and `src/audio/separation/model-registry.ts`.
+
+### One-time R2 setup
+
+1. Create a public R2 bucket (e.g. `composer-vocal-models`).
+2. Bind a custom domain to the bucket (e.g. `models.composer.boidu.dev`). **Avoid `r2.dev`** — it's rate-limited and intended for development.
+3. Add a Cloudflare page rule `Cache Everything` for that hostname so binary files are edge-cached.
+4. Add a CORS rule allowing your site origin(s).
+5. Set `VITE_VOCAL_MODEL_BASE_URL=https://models.composer.boidu.dev` at build time.
+
+Cost: free egress; ~$0.0015/month storage for the fp16 model.
+
 ## Tech stack
 
 React, TypeScript, Vite, TailwindCSS v4, Zustand, Vitest

--- a/package.json
+++ b/package.json
@@ -51,15 +51,13 @@
   "pnpm": {
     "ignoredBuiltDependencies": [
       "@biomejs/biome",
-      "esbuild"
+      "esbuild",
+      "protobufjs",
+      "sharp"
     ],
     "overrides": {
       "@braccato/parsers": "^0.1.2"
     },
-    "onlyBuiltDependencies": [
-      "protobufjs",
-      "sharp"
-    ],
     "peerDependencyRules": {
       "allowedVersions": {
         "react-helmet-async>react": "19",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.21.4",
+  "version": "1.22.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,13 @@
     "onlyBuiltDependencies": [
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "react-helmet-async>react": "19",
+        "react-helmet-async>react-dom": "19"
+      }
+    }
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,11 @@
     ],
     "overrides": {
       "@braccato/parsers": "^0.1.2"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "protobufjs",
+      "sharp"
+    ]
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "motion": "^12.24.12",
     "nanoid": "^5.1.11",
     "obscenity": "^0.4.6",
+    "onnxruntime-web": "^1.26.0",
     "overlayscrollbars": "^2.14.0",
     "overlayscrollbars-react": "^0.5.6",
     "prism-react-renderer": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,9 +120,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.6
         version: 4.1.6(@vitest/browser@4.1.6)(vitest@4.1.6)
-      jscpd:
-        specifier: ^4.2.3
-        version: 4.2.3
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1
@@ -335,10 +332,6 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
-
-  '@colors/colors@1.5.0':
-    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
-    engines: {node: '>=0.1.90'}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -774,21 +767,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@jscpd/badge-reporter@4.2.3':
-    resolution: {integrity: sha512-yNvbwWl/NwogHT5XrHyqXgF9yVZeLWA2QOhGqYTopvgi7LsSbDumpOqOcJMHP9Z4RalhMfahh+dVXFSI7tMcaA==}
-
-  '@jscpd/core@4.2.3':
-    resolution: {integrity: sha512-VQ2gH+tiI51ty3PBRD4HClNNgyX/VH9cs0dcFKuywxDzLQ64jYp7vhJPcqnyiVX9tVEIAa12sucRHQP/VHwugA==}
-
-  '@jscpd/finder@4.2.3':
-    resolution: {integrity: sha512-ZpjviFAg6zLojQHS+owvrn8DG1OY1d4835Je4LUKzbMurndmQDhvRRFDkN9V6xPn6gvRaMVkJHN2tyljsnUjWA==}
-
-  '@jscpd/html-reporter@4.2.3':
-    resolution: {integrity: sha512-kp1pqJXCKwyRu5mJK5IvXdFQEDHWQDb7svLFlbVXGI0dVH1y1XNl8mrIrSoRw+0AySxhDkuSyIlQOSDC2GRwQg==}
-
-  '@jscpd/tokenizer@4.2.3':
-    resolution: {integrity: sha512-RvjD7/hwqtcQC9MWOl31odTti6kGCFxZ77DKEhwyMn+r6oVEUFbXgcGvzn0GC/wuTl7f3j5MF9JNMeTneOFwYA==}
-
   '@lit-labs/ssr-dom-shim@1.5.1':
     resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
 
@@ -805,18 +783,6 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
-
-  '@nodelib/fs.scandir@2.1.5':
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.stat@2.0.5':
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.walk@1.2.8':
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
 
   '@oxc-parser/binding-android-arm-eabi@0.130.0':
     resolution: {integrity: sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw==}
@@ -1331,9 +1297,6 @@ packages:
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
 
-  '@types/sarif@2.1.7':
-    resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
-
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -1413,11 +1376,6 @@ packages:
       react: ^18.2.0 || ^19.0.0
       wavesurfer.js: '>=7.7.14'
 
-  acorn@7.4.1:
-    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1430,12 +1388,6 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
-  asap@2.0.6:
-    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
-
-  assert-never@1.4.0:
-    resolution: {integrity: sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1445,13 +1397,6 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  babel-walk@3.0.0-canary-5:
-    resolution: {integrity: sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==}
-    engines: {node: '>= 10.0.0'}
-
-  badgen@3.3.2:
-    resolution: {integrity: sha512-fbQwK9norfdzbdsoPwbLIAmgBXDGEme3jeIyqPAH7o6vp9lmuLHS7uXULvOiQ6XnMLkYNG4gDjILf74hgtTAug==}
 
   base64-js@0.0.8:
     resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
@@ -1464,29 +1409,13 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  blamer@1.0.7:
-    resolution: {integrity: sha512-GbBStl/EVlSWkiJQBZps3H1iARBrC7vt++Jb/TTmCNu/jZ04VW7tSN1nScbFXBUy1AN+jzeL7Zep9sbQxLhXKA==}
-    engines: {node: '>=8.9'}
-
-  braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
-
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
-
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
-
-  call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   camelize@1.0.1:
@@ -1498,13 +1427,6 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
-
-  character-parser@2.2.0:
-    resolution: {integrity: sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==}
-
-  cli-table3@0.6.5:
-    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
-    engines: {node: 10.* || >= 12.*}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1521,27 +1443,12 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  colors@1.4.0:
-    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
-    engines: {node: '>=0.1.90'}
-
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
-  commander@5.1.0:
-    resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
-    engines: {node: '>= 6'}
-
-  constantinople@4.0.1:
-    resolution: {integrity: sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==}
-
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
 
   css-background-parser@0.1.0:
     resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
@@ -1599,9 +1506,6 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  doctypes@1.1.0:
-    resolution: {integrity: sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==}
-
   driver.js@1.4.0:
     resolution: {integrity: sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==}
 
@@ -1618,9 +1522,6 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
@@ -1667,20 +1568,9 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
-  execa@4.1.0:
-    resolution: {integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==}
-    engines: {node: '>=10'}
-
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
-
-  fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
-
-  fastq@1.20.1:
-    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
@@ -1696,10 +1586,6 @@ packages:
 
   fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
-
-  fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -1757,16 +1643,8 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
-
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1817,10 +1695,6 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  human-signals@1.1.1:
-    resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
-    engines: {node: '>=8.12.0'}
-
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -1828,45 +1702,12 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
-  is-core-module@2.16.2:
-    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
-    engines: {node: '>= 0.4'}
-
-  is-expression@4.0.0:
-    resolution: {integrity: sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==}
-
-  is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
-
-  is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
-
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
-
-  is-promise@2.2.2:
-    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
-
-  is-regex@1.2.1:
-    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
-    engines: {node: '>= 0.4'}
-
-  is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
-
-  isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -1888,21 +1729,11 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  js-stringify@1.0.2:
-    resolution: {integrity: sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==}
-
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  jscpd-sarif-reporter@4.2.3:
-    resolution: {integrity: sha512-rM0LM5S0kdASLCtDsr1s51rJOPf8nubaxaWQUTWVVPda1UMPymXbELG+A3Rgpoa4D4QFUFfXqz60Jn/W+vlFtA==}
-
-  jscpd@4.2.3:
-    resolution: {integrity: sha512-/1BEga1E1cY56/sdQOzU/PFtnea+n1beqG8/Xx4HopG9c5rkUO8ptnu9En8Xf1ILGW6KSWidV4vLQTm2FGYvpw==}
-    hasBin: true
 
   jsdom@24.1.3:
     resolution: {integrity: sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==}
@@ -1934,9 +1765,6 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
-
-  jstransformer@1.0.0:
-    resolution: {integrity: sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==}
 
   knip@6.13.1:
     resolution: {integrity: sha512-hvSnb+YDpDWW1LXub4U0JFfkQhscwgInWuQOv99WTutPZavf1cEP3GwxzEzO2JJpGI9yATk6l0jPLY1V3fp1sQ==}
@@ -2052,26 +1880,12 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  markdown-table@2.0.0:
-    resolution: {integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==}
-
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
-
-  merge-stream@2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
-
-  merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
-
-  micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -2080,10 +1894,6 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
-
-  mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -2128,14 +1938,6 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  node-sarif-builder@3.4.0:
-    resolution: {integrity: sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==}
-    engines: {node: '>=20'}
-
-  npm-run-path@4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
-    engines: {node: '>=8'}
-
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
@@ -2149,13 +1951,6 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
-  onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
 
   overlayscrollbars-react@0.5.6:
     resolution: {integrity: sha512-E5To04bL5brn9GVCZ36SnfGanxa2I2MDkWoa4Cjo5wol7l+diAgi4DBc983V7l2nOk/OLJ6Feg4kySspQEGDBw==}
@@ -2193,22 +1988,11 @@ packages:
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
-  path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-
-  path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -2240,53 +2024,11 @@ packages:
     peerDependencies:
       react: '>=16.0.0'
 
-  promise@7.3.1:
-    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
-
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
-
-  pug-attrs@3.0.0:
-    resolution: {integrity: sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==}
-
-  pug-code-gen@3.0.4:
-    resolution: {integrity: sha512-6okWYIKdasTyXICyEtvobmTZAVX57JkzgzIi4iRJlin8kmhG+Xry2dsus+Mun/nGCn6F2U49haHI5mkELXB14g==}
-
-  pug-error@2.1.0:
-    resolution: {integrity: sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==}
-
-  pug-filters@4.0.0:
-    resolution: {integrity: sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==}
-
-  pug-lexer@5.0.1:
-    resolution: {integrity: sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==}
-
-  pug-linker@4.0.0:
-    resolution: {integrity: sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==}
-
-  pug-load@3.0.0:
-    resolution: {integrity: sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==}
-
-  pug-parser@6.0.0:
-    resolution: {integrity: sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==}
-
-  pug-runtime@3.0.1:
-    resolution: {integrity: sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==}
-
-  pug-strip-comments@2.0.0:
-    resolution: {integrity: sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==}
-
-  pug-walk@2.0.0:
-    resolution: {integrity: sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==}
-
-  pug@3.0.4:
-    resolution: {integrity: sha512-kFfq5mMzrS7+wrl5pLJzZEzemx34OQ0w4SARfhy/3yxTlhbstsudDwJzhf1hP02yHzbjoVMSXUj/Sz6RNfMyXg==}
-
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2294,9 +2036,6 @@ packages:
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
-
-  queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
@@ -2342,10 +2081,6 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
-  repeat-string@1.6.1:
-    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
-    engines: {node: '>=0.10'}
-
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -2360,15 +2095,6 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  resolve@1.22.12:
-    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
-    engines: {node: '>= 0.4'}
-    hasBin: true
-
-  reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -2379,9 +2105,6 @@ packages:
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
-
-  run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -2413,19 +2136,8 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-
-  signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -2445,9 +2157,6 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  spark-md5@3.0.2:
-    resolution: {integrity: sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==}
-
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2465,10 +2174,6 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strip-final-newline@2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
-    engines: {node: '>=6'}
-
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
@@ -2476,10 +2181,6 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
-
-  supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -2521,13 +2222,6 @@ packages:
   tldts@7.0.27:
     resolution: {integrity: sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==}
     hasBin: true
-
-  to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
-
-  token-stream@1.0.0:
-    resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -2713,10 +2407,6 @@ packages:
       jsdom:
         optional: true
 
-  void-elements@3.1.0:
-    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
-    engines: {node: '>=0.10.0'}
-
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -2757,26 +2447,14 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
-
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
-  with@7.0.2:
-    resolution: {integrity: sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==}
-    engines: {node: '>= 10.0.0'}
-
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
@@ -3041,9 +2719,6 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
-
-  '@colors/colors@1.5.0':
-    optional: true
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -3351,40 +3026,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@jscpd/badge-reporter@4.2.3':
-    dependencies:
-      badgen: 3.3.2
-      colors: 1.4.0
-      fs-extra: 11.3.4
-
-  '@jscpd/core@4.2.3':
-    dependencies:
-      eventemitter3: 5.0.4
-
-  '@jscpd/finder@4.2.3':
-    dependencies:
-      '@jscpd/core': 4.2.3
-      '@jscpd/tokenizer': 4.2.3
-      blamer: 1.0.7
-      bytes: 3.1.2
-      cli-table3: 0.6.5
-      colors: 1.4.0
-      fast-glob: 3.3.3
-      fs-extra: 11.3.4
-      markdown-table: 2.0.0
-      pug: 3.0.4
-
-  '@jscpd/html-reporter@4.2.3':
-    dependencies:
-      colors: 1.4.0
-      fs-extra: 11.3.4
-      pug: 3.0.4
-
-  '@jscpd/tokenizer@4.2.3':
-    dependencies:
-      '@jscpd/core': 4.2.3
-      spark-md5: 3.0.2
-
   '@lit-labs/ssr-dom-shim@1.5.1': {}
 
   '@lit/react@1.0.8(@types/react@19.2.7)':
@@ -3401,18 +3042,6 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
-
-  '@nodelib/fs.scandir@2.1.5':
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
-
-  '@nodelib/fs.stat@2.0.5': {}
-
-  '@nodelib/fs.walk@1.2.8':
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.20.1
 
   '@oxc-parser/binding-android-arm-eabi@0.130.0':
     optional: true
@@ -3766,8 +3395,6 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@types/sarif@2.1.7': {}
-
   '@types/trusted-types@2.0.7': {}
 
   '@uimaxbai/am-lyrics@1.5.4(@lit/react@1.0.8(@types/react@19.2.7))(react@19.2.3)':
@@ -3889,8 +3516,6 @@ snapshots:
       react: 19.2.3
       wavesurfer.js: 7.12.1
 
-  acorn@7.4.1: {}
-
   agent-base@7.1.4: {}
 
   ansi-regex@5.0.1: {}
@@ -3898,10 +3523,6 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
-
-  asap@2.0.6: {}
-
-  assert-never@1.4.0: {}
 
   assertion-error@2.0.1: {}
 
@@ -3913,12 +3534,6 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  babel-walk@3.0.0-canary-5:
-    dependencies:
-      '@babel/types': 7.29.0
-
-  badgen@3.3.2: {}
-
   base64-js@0.0.8: {}
 
   baseline-browser-mapping@2.9.13: {}
@@ -3926,15 +3541,6 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
-
-  blamer@1.0.7:
-    dependencies:
-      execa: 4.1.0
-      which: 2.0.2
-
-  braces@3.0.3:
-    dependencies:
-      fill-range: 7.1.1
 
   browserslist@4.28.1:
     dependencies:
@@ -3944,33 +3550,16 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
-  bytes@3.1.2: {}
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-
-  call-bound@1.0.4:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.0
 
   camelize@1.0.1: {}
 
   caniuse-lite@1.0.30001763: {}
 
   chai@6.2.2: {}
-
-  character-parser@2.2.0:
-    dependencies:
-      is-regex: 1.2.1
-
-  cli-table3@0.6.5:
-    dependencies:
-      string-width: 4.2.3
-    optionalDependencies:
-      '@colors/colors': 1.5.0
 
   cliui@8.0.1:
     dependencies:
@@ -3986,26 +3575,11 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  colors@1.4.0: {}
-
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
 
-  commander@5.1.0: {}
-
-  constantinople@4.0.1:
-    dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
-
   convert-source-map@2.0.0: {}
-
-  cross-spawn@7.0.6:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
 
   css-background-parser@0.1.0: {}
 
@@ -4055,8 +3629,6 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  doctypes@1.1.0: {}
-
   driver.js@1.4.0: {}
 
   dunder-proto@1.0.1:
@@ -4070,10 +3642,6 @@ snapshots:
   emoji-regex-xs@2.0.1: {}
 
   emoji-regex@8.0.0: {}
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
 
   enhanced-resolve@5.18.4:
     dependencies:
@@ -4138,31 +3706,7 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  execa@4.1.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      get-stream: 5.2.0
-      human-signals: 1.1.1
-      is-stream: 2.0.1
-      merge-stream: 2.0.0
-      npm-run-path: 4.0.1
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-      strip-final-newline: 2.0.0
-
   expect-type@1.3.0: {}
-
-  fast-glob@3.3.3:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
-  fastq@1.20.1:
-    dependencies:
-      reusify: 1.1.0
 
   fd-package-json@2.0.0:
     dependencies:
@@ -4173,10 +3717,6 @@ snapshots:
       picomatch: 4.0.4
 
   fflate@0.7.4: {}
-
-  fill-range@7.1.1:
-    dependencies:
-      to-regex-range: 5.0.1
 
   form-data@4.0.5:
     dependencies:
@@ -4235,17 +3775,9 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.4
-
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
 
   gopd@1.2.0: {}
 
@@ -4295,8 +3827,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  human-signals@1.1.1: {}
-
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -4305,39 +3835,9 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  is-core-module@2.16.2:
-    dependencies:
-      hasown: 2.0.3
-
-  is-expression@4.0.0:
-    dependencies:
-      acorn: 7.4.1
-      object-assign: 4.1.1
-
-  is-extglob@2.1.1: {}
-
   is-fullwidth-code-point@3.0.0: {}
 
-  is-glob@4.0.3:
-    dependencies:
-      is-extglob: 2.1.1
-
-  is-number@7.0.0: {}
-
   is-potential-custom-element-name@1.0.1: {}
-
-  is-promise@2.2.2: {}
-
-  is-regex@1.2.1:
-    dependencies:
-      call-bound: 1.0.4
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.3
-
-  is-stream@2.0.1: {}
-
-  isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -4356,29 +3856,9 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  js-stringify@1.0.2: {}
-
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  jscpd-sarif-reporter@4.2.3:
-    dependencies:
-      colors: 1.4.0
-      fs-extra: 11.3.4
-      node-sarif-builder: 3.4.0
-
-  jscpd@4.2.3:
-    dependencies:
-      '@jscpd/badge-reporter': 4.2.3
-      '@jscpd/core': 4.2.3
-      '@jscpd/finder': 4.2.3
-      '@jscpd/html-reporter': 4.2.3
-      '@jscpd/tokenizer': 4.2.3
-      colors: 1.4.0
-      commander: 5.1.0
-      fs-extra: 11.3.4
-      jscpd-sarif-reporter: 4.2.3
 
   jsdom@24.1.3:
     dependencies:
@@ -4443,11 +3923,6 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-
-  jstransformer@1.0.0:
-    dependencies:
-      is-promise: 2.2.2
-      promise: 7.3.1
 
   knip@6.13.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
@@ -4567,30 +4042,15 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  markdown-table@2.0.0:
-    dependencies:
-      repeat-string: 1.6.1
-
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.27.1: {}
-
-  merge-stream@2.0.0: {}
-
-  merge2@1.4.1: {}
-
-  micromatch@4.0.8:
-    dependencies:
-      braces: 3.0.3
-      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-
-  mimic-fn@2.1.0: {}
 
   minimist@1.2.8: {}
 
@@ -4618,15 +4078,6 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  node-sarif-builder@3.4.0:
-    dependencies:
-      '@types/sarif': 2.1.7
-      fs-extra: 11.3.4
-
-  npm-run-path@4.0.1:
-    dependencies:
-      path-key: 3.1.1
-
   nwsapi@2.2.23: {}
 
   object-assign@4.1.1: {}
@@ -4634,14 +4085,6 @@ snapshots:
   obscenity@0.4.6: {}
 
   obug@2.1.1: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
-
-  onetime@5.1.2:
-    dependencies:
-      mimic-fn: 2.1.0
 
   overlayscrollbars-react@0.5.6(overlayscrollbars@2.14.0)(react@19.2.3):
     dependencies:
@@ -4723,15 +4166,9 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
-  path-key@3.1.1: {}
-
-  path-parse@1.0.7: {}
-
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
-
-  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
@@ -4759,10 +4196,6 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.3
 
-  promise@7.3.1:
-    dependencies:
-      asap: 2.0.6
-
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4773,83 +4206,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  pug-attrs@3.0.0:
-    dependencies:
-      constantinople: 4.0.1
-      js-stringify: 1.0.2
-      pug-runtime: 3.0.1
-
-  pug-code-gen@3.0.4:
-    dependencies:
-      constantinople: 4.0.1
-      doctypes: 1.1.0
-      js-stringify: 1.0.2
-      pug-attrs: 3.0.0
-      pug-error: 2.1.0
-      pug-runtime: 3.0.1
-      void-elements: 3.1.0
-      with: 7.0.2
-
-  pug-error@2.1.0: {}
-
-  pug-filters@4.0.0:
-    dependencies:
-      constantinople: 4.0.1
-      jstransformer: 1.0.0
-      pug-error: 2.1.0
-      pug-walk: 2.0.0
-      resolve: 1.22.12
-
-  pug-lexer@5.0.1:
-    dependencies:
-      character-parser: 2.2.0
-      is-expression: 4.0.0
-      pug-error: 2.1.0
-
-  pug-linker@4.0.0:
-    dependencies:
-      pug-error: 2.1.0
-      pug-walk: 2.0.0
-
-  pug-load@3.0.0:
-    dependencies:
-      object-assign: 4.1.1
-      pug-walk: 2.0.0
-
-  pug-parser@6.0.0:
-    dependencies:
-      pug-error: 2.1.0
-      token-stream: 1.0.0
-
-  pug-runtime@3.0.1: {}
-
-  pug-strip-comments@2.0.0:
-    dependencies:
-      pug-error: 2.1.0
-
-  pug-walk@2.0.0: {}
-
-  pug@3.0.4:
-    dependencies:
-      pug-code-gen: 3.0.4
-      pug-filters: 4.0.0
-      pug-lexer: 5.0.1
-      pug-linker: 4.0.0
-      pug-load: 3.0.0
-      pug-parser: 6.0.0
-      pug-runtime: 3.0.1
-      pug-strip-comments: 2.0.0
-
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
   punycode@2.3.1: {}
 
   querystringify@2.2.0: {}
-
-  queue-microtask@1.2.3: {}
 
   react-dom@19.2.3(react@19.2.3):
     dependencies:
@@ -4891,8 +4250,6 @@ snapshots:
 
   react@19.2.3: {}
 
-  repeat-string@1.6.1: {}
-
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -4900,15 +4257,6 @@ snapshots:
   requires-port@1.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
-
-  resolve@1.22.12:
-    dependencies:
-      es-errors: 1.3.0
-      is-core-module: 2.16.2
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-
-  reusify@1.1.0: {}
 
   rollup@4.60.2:
     dependencies:
@@ -4944,10 +4292,6 @@ snapshots:
   rrweb-cssom@0.7.1: {}
 
   rrweb-cssom@0.8.0: {}
-
-  run-parallel@1.2.0:
-    dependencies:
-      queue-microtask: 1.2.3
 
   safer-buffer@2.1.2: {}
 
@@ -5009,15 +4353,7 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
-
   siginfo@2.0.0: {}
-
-  signal-exit@3.0.7: {}
 
   sirv@3.0.2:
     dependencies:
@@ -5033,8 +4369,6 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
 
   source-map-js@1.2.1: {}
-
-  spark-md5@3.0.2: {}
 
   stackback@0.0.2: {}
 
@@ -5052,15 +4386,11 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-final-newline@2.0.0: {}
-
   strip-json-comments@5.0.3: {}
 
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
-
-  supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
 
@@ -5090,12 +4420,6 @@ snapshots:
   tldts@7.0.27:
     dependencies:
       tldts-core: 7.0.27
-
-  to-regex-range@5.0.1:
-    dependencies:
-      is-number: 7.0.0
-
-  token-stream@1.0.0: {}
 
   totalist@3.0.1: {}
 
@@ -5222,8 +4546,6 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  void-elements@3.1.0: {}
-
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -5257,29 +4579,16 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
-
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  with@7.0.2:
-    dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
-      assert-never: 1.4.0
-      babel-walk: 3.0.0-canary-5
 
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  wrappy@1.0.2: {}
 
   ws@8.20.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       obscenity:
         specifier: ^0.4.6
         version: 0.4.6
+      onnxruntime-web:
+        specifier: ^1.26.0
+        version: 1.26.0
       overlayscrollbars:
         specifier: ^2.14.0
         version: 2.14.0
@@ -120,6 +123,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.6
         version: 4.1.6(@vitest/browser@4.1.6)(vitest@4.1.6)
+      jscpd:
+        specifier: ^4.2.3
+        version: 4.2.4
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1
@@ -289,24 +295,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@1.9.4':
     resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@1.9.4':
     resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@1.9.4':
     resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@1.9.4':
     resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
@@ -332,6 +342,10 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -644,89 +658,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -767,6 +797,21 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jscpd/badge-reporter@4.2.4':
+    resolution: {integrity: sha512-g5vu05u0lX9rcHA0k3CptLfpOiuMzxh5+mUe2iYRAznTwH3ks6JAVAf9aPi5mBFttMCRiJh2zSt3xnSadHtMGg==}
+
+  '@jscpd/core@4.2.4':
+    resolution: {integrity: sha512-9V9YzmmhYg9682kFqi+n0KGOhXNSoqxHbuIP3i/l/oSd6upBOnnSeBWDZMGOenQRQnyKEtCIbnS9YFz+3B+siQ==}
+
+  '@jscpd/finder@4.2.4':
+    resolution: {integrity: sha512-4LLEuAAmAraud/TAAlB5BByVdWfy7SYiPKacj5yEggpkNs0qsw2kiZ5EyU3LonB+/vntJJEDDpJMmvOeS58e0A==}
+
+  '@jscpd/html-reporter@4.2.4':
+    resolution: {integrity: sha512-6UljCTVGf7O+o6D6fs1zNBG+vR1PTn47W2mSgb5hzSrvNw60rLrVoAMZMnr/TeIEdd/OEgAu+icbdvvVBfnvJw==}
+
+  '@jscpd/tokenizer@4.2.4':
+    resolution: {integrity: sha512-nM4kGyDvpcevt8t0zOsMQ82ShSc65c3LIQUHClTYwraiOGOmWgUQyen+JIiFCNF8eDCGR2Qa5iI5XBfGWYQzIg==}
+
   '@lit-labs/ssr-dom-shim@1.5.1':
     resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
 
@@ -783,6 +828,18 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
   '@oxc-parser/binding-android-arm-eabi@0.130.0':
     resolution: {integrity: sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw==}
@@ -831,48 +888,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.130.0':
     resolution: {integrity: sha512-EiJ/gC0ljbcwVpycC8YWw6ggMbtsPX8XMOt0mPx0aqWeMsNR+L9m05Flbvd5T+GlivG+GkSWQL7tM9SRFpM/dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.130.0':
     resolution: {integrity: sha512-b+h/lsLLurp756dMGizNs5uPaJfyEdWrTcV5t8M609jWm1DEHB1StpRXCkyvwtkJx3m+qL5BNQ0dEKan/4yGFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.130.0':
     resolution: {integrity: sha512-O19Cil83XAyjEFfo8WhkMwY58ALqZ7ckjGL+25mjMIuF84urWBeANH0FC8B8BsSSygWU3/1aY3ADdDbp+wlBnw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.130.0':
     resolution: {integrity: sha512-BgXRVC0+83n3YzCscLQjj6nbyeBIVeZYPTI4fFMAE4WNm2+4RXhWp03IVizL7esIz36kgmT48aebk1iM+cs8sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.130.0':
     resolution: {integrity: sha512-6tJz0xvnGhsokE7N1WlUSBXibpYmT9xSJFS1Ce41Km/+8gQvdlW8MLhRv8PD0L7ix8vRG0FDDepp3jdOFzdVdw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.130.0':
     resolution: {integrity: sha512-9aCWj83dp3heTQGmGnZGdIWgxjZrr/7VQ0TGFHH5PKByxJKF2Hcr4qvaSUHhhGEa3MSsDjTL1YDP8RAgdL5/Cg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.130.0':
     resolution: {integrity: sha512-afXt87aZBqrUVli8TB/I8H1G50RDWcwirjWtXGXYqJ2ZqWEiErH7V72j3LUSDZaivmtu2OLX0KQ/mbhP81mr7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.130.0':
     resolution: {integrity: sha512-I0NCrZV/YZuCGWgqwNN/GO/iXlLF2z+Wgc7u+Aa9N4P51oYeIa0XT+zVBUne4csO9GqxskXgI4g8JzzWGRpfOw==}
@@ -945,41 +1010,49 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -1008,6 +1081,36 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@remix-run/router@1.23.2':
     resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
@@ -1054,66 +1157,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1199,24 +1315,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1297,6 +1417,9 @@ packages:
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
 
+  '@types/sarif@2.1.7':
+    resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -1376,6 +1499,11 @@ packages:
       react: ^18.2.0 || ^19.0.0
       wavesurfer.js: '>=7.7.14'
 
+  acorn@7.4.1:
+    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1388,6 +1516,12 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
+  assert-never@1.4.0:
+    resolution: {integrity: sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1397,6 +1531,13 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  babel-walk@3.0.0-canary-5:
+    resolution: {integrity: sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==}
+    engines: {node: '>= 10.0.0'}
+
+  badgen@3.3.2:
+    resolution: {integrity: sha512-fbQwK9norfdzbdsoPwbLIAmgBXDGEme3jeIyqPAH7o6vp9lmuLHS7uXULvOiQ6XnMLkYNG4gDjILf74hgtTAug==}
 
   base64-js@0.0.8:
     resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
@@ -1409,13 +1550,29 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  blamer@1.0.7:
+    resolution: {integrity: sha512-GbBStl/EVlSWkiJQBZps3H1iARBrC7vt++Jb/TTmCNu/jZ04VW7tSN1nScbFXBUy1AN+jzeL7Zep9sbQxLhXKA==}
+    engines: {node: '>=8.9'}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   camelize@1.0.1:
@@ -1427,6 +1584,13 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  character-parser@2.2.0:
+    resolution: {integrity: sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1443,12 +1607,27 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colors@1.4.0:
+    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
+    engines: {node: '>=0.1.90'}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  commander@5.1.0:
+    resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
+    engines: {node: '>= 6'}
+
+  constantinople@4.0.1:
+    resolution: {integrity: sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   css-background-parser@0.1.0:
     resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
@@ -1506,6 +1685,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  doctypes@1.1.0:
+    resolution: {integrity: sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==}
+
   driver.js@1.4.0:
     resolution: {integrity: sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==}
 
@@ -1522,6 +1704,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
@@ -1568,9 +1753,20 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  execa@4.1.0:
+    resolution: {integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==}
+    engines: {node: '>=10'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
@@ -1586,6 +1782,13 @@ packages:
 
   fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -1643,8 +1846,16 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1652,6 +1863,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1695,6 +1909,10 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  human-signals@1.1.1:
+    resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
+    engines: {node: '>=8.12.0'}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -1702,12 +1920,45 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-expression@4.0.0:
+    resolution: {integrity: sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@2.2.2:
+    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -1729,11 +1980,21 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  js-stringify@1.0.2:
+    resolution: {integrity: sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jscpd-sarif-reporter@4.2.4:
+    resolution: {integrity: sha512-JtX79kFSyAhqJh5TdLUcvtYJtJd1F8UW8b4Miaga+EIgUn2/nR0N2zWL9mH5cRXgbzLuQbbsw9kReUVIECApwQ==}
+
+  jscpd@4.2.4:
+    resolution: {integrity: sha512-PSo2U0G8OxULayGyQMv7T/0ZQ+c3PPltdMOz/57v9Xnmq5xSIhh4cnZ0oYZPKqejy10aFwAbMVxqAlo24+PQ3g==}
+    hasBin: true
 
   jsdom@24.1.3:
     resolution: {integrity: sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==}
@@ -1765,6 +2026,9 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jstransformer@1.0.0:
+    resolution: {integrity: sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==}
 
   knip@6.13.1:
     resolution: {integrity: sha512-hvSnb+YDpDWW1LXub4U0JFfkQhscwgInWuQOv99WTutPZavf1cEP3GwxzEzO2JJpGI9yATk6l0jPLY1V3fp1sQ==}
@@ -1809,24 +2073,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -1856,6 +2124,9 @@ packages:
   lit@3.3.2:
     resolution: {integrity: sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -1880,12 +2151,26 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  markdown-table@2.0.0:
+    resolution: {integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -1894,6 +2179,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -1938,6 +2227,14 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  node-sarif-builder@3.4.0:
+    resolution: {integrity: sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==}
+    engines: {node: '>=20'}
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
@@ -1951,6 +2248,19 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  onnxruntime-common@1.26.0:
+    resolution: {integrity: sha512-qVyMR4lcWgbkc4getFV+GQijsTnbg/siteoqcDwa3sI/LxbrMSNw4ePyvCq/ymdQaRomCA7YuWmhzsswxvymdw==}
+
+  onnxruntime-web@1.26.0:
+    resolution: {integrity: sha512-LbRr/8zZt2xilI2smrVQGGKINo0U46i8qJp+UXyMBGfqN7KjnH1BiwCwLwyNIVV4i9CKFv7Sf4PwLKWnT8/bEA==}
 
   overlayscrollbars-react@0.5.6:
     resolution: {integrity: sha512-E5To04bL5brn9GVCZ36SnfGanxa2I2MDkWoa4Cjo5wol7l+diAgi4DBc983V7l2nOk/OLJ6Feg4kySspQEGDBw==}
@@ -1988,15 +2298,29 @@ packages:
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
@@ -2024,11 +2348,57 @@ packages:
     peerDependencies:
       react: '>=16.0.0'
 
+  promise@7.3.1:
+    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protobufjs@7.6.1:
+    resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
+    engines: {node: '>=12.0.0'}
+
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
+  pug-attrs@3.0.0:
+    resolution: {integrity: sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==}
+
+  pug-code-gen@3.0.4:
+    resolution: {integrity: sha512-6okWYIKdasTyXICyEtvobmTZAVX57JkzgzIi4iRJlin8kmhG+Xry2dsus+Mun/nGCn6F2U49haHI5mkELXB14g==}
+
+  pug-error@2.1.0:
+    resolution: {integrity: sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==}
+
+  pug-filters@4.0.0:
+    resolution: {integrity: sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==}
+
+  pug-lexer@5.0.1:
+    resolution: {integrity: sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==}
+
+  pug-linker@4.0.0:
+    resolution: {integrity: sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==}
+
+  pug-load@3.0.0:
+    resolution: {integrity: sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==}
+
+  pug-parser@6.0.0:
+    resolution: {integrity: sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==}
+
+  pug-runtime@3.0.1:
+    resolution: {integrity: sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==}
+
+  pug-strip-comments@2.0.0:
+    resolution: {integrity: sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==}
+
+  pug-walk@2.0.0:
+    resolution: {integrity: sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==}
+
+  pug@3.0.4:
+    resolution: {integrity: sha512-kFfq5mMzrS7+wrl5pLJzZEzemx34OQ0w4SARfhy/3yxTlhbstsudDwJzhf1hP02yHzbjoVMSXUj/Sz6RNfMyXg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2036,6 +2406,9 @@ packages:
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
@@ -2081,6 +2454,10 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
+  repeat-string@1.6.1:
+    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
+    engines: {node: '>=0.10'}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -2095,6 +2472,15 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -2105,6 +2491,9 @@ packages:
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -2136,8 +2525,19 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -2157,6 +2557,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  spark-md5@3.0.2:
+    resolution: {integrity: sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2174,6 +2577,10 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
@@ -2181,6 +2588,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -2222,6 +2633,13 @@ packages:
   tldts@7.0.27:
     resolution: {integrity: sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==}
     hasBin: true
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  token-stream@1.0.0:
+    resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -2407,6 +2825,10 @@ packages:
       jsdom:
         optional: true
 
+  void-elements@3.1.0:
+    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    engines: {node: '>=0.10.0'}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -2447,14 +2869,26 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
+  with@7.0.2:
+    resolution: {integrity: sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==}
+    engines: {node: '>= 10.0.0'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
@@ -2719,6 +3153,9 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+
+  '@colors/colors@1.5.0':
+    optional: true
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -3026,6 +3463,40 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jscpd/badge-reporter@4.2.4':
+    dependencies:
+      badgen: 3.3.2
+      colors: 1.4.0
+      fs-extra: 11.3.4
+
+  '@jscpd/core@4.2.4':
+    dependencies:
+      eventemitter3: 5.0.4
+
+  '@jscpd/finder@4.2.4':
+    dependencies:
+      '@jscpd/core': 4.2.4
+      '@jscpd/tokenizer': 4.2.4
+      blamer: 1.0.7
+      bytes: 3.1.2
+      cli-table3: 0.6.5
+      colors: 1.4.0
+      fast-glob: 3.3.3
+      fs-extra: 11.3.4
+      markdown-table: 2.0.0
+      pug: 3.0.4
+
+  '@jscpd/html-reporter@4.2.4':
+    dependencies:
+      colors: 1.4.0
+      fs-extra: 11.3.4
+      pug: 3.0.4
+
+  '@jscpd/tokenizer@4.2.4':
+    dependencies:
+      '@jscpd/core': 4.2.4
+      spark-md5: 3.0.2
+
   '@lit-labs/ssr-dom-shim@1.5.1': {}
 
   '@lit/react@1.0.8(@types/react@19.2.7)':
@@ -3042,6 +3513,18 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
 
   '@oxc-parser/binding-android-arm-eabi@0.130.0':
     optional: true
@@ -3175,6 +3658,28 @@ snapshots:
     optional: true
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@remix-run/router@1.23.2': {}
 
@@ -3395,6 +3900,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/sarif@2.1.7': {}
+
   '@types/trusted-types@2.0.7': {}
 
   '@uimaxbai/am-lyrics@1.5.4(@lit/react@1.0.8(@types/react@19.2.7))(react@19.2.3)':
@@ -3516,6 +4023,8 @@ snapshots:
       react: 19.2.3
       wavesurfer.js: 7.12.1
 
+  acorn@7.4.1: {}
+
   agent-base@7.1.4: {}
 
   ansi-regex@5.0.1: {}
@@ -3523,6 +4032,10 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  asap@2.0.6: {}
+
+  assert-never@1.4.0: {}
 
   assertion-error@2.0.1: {}
 
@@ -3534,6 +4047,12 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  babel-walk@3.0.0-canary-5:
+    dependencies:
+      '@babel/types': 7.29.0
+
+  badgen@3.3.2: {}
+
   base64-js@0.0.8: {}
 
   baseline-browser-mapping@2.9.13: {}
@@ -3541,6 +4060,15 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  blamer@1.0.7:
+    dependencies:
+      execa: 4.1.0
+      which: 2.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
 
   browserslist@4.28.1:
     dependencies:
@@ -3550,16 +4078,33 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  bytes@3.1.2: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   camelize@1.0.1: {}
 
   caniuse-lite@1.0.30001763: {}
 
   chai@6.2.2: {}
+
+  character-parser@2.2.0:
+    dependencies:
+      is-regex: 1.2.1
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
 
   cliui@8.0.1:
     dependencies:
@@ -3575,11 +4120,26 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colors@1.4.0: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@5.1.0: {}
+
+  constantinople@4.0.1:
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
   convert-source-map@2.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   css-background-parser@0.1.0: {}
 
@@ -3629,6 +4189,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  doctypes@1.1.0: {}
+
   driver.js@1.4.0: {}
 
   dunder-proto@1.0.1:
@@ -3642,6 +4204,10 @@ snapshots:
   emoji-regex-xs@2.0.1: {}
 
   emoji-regex@8.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.18.4:
     dependencies:
@@ -3706,7 +4272,31 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  execa@4.1.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 5.2.0
+      human-signals: 1.1.1
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
   expect-type@1.3.0: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fd-package-json@2.0.0:
     dependencies:
@@ -3717,6 +4307,12 @@ snapshots:
       picomatch: 4.0.4
 
   fflate@0.7.4: {}
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  flatbuffers@25.9.23: {}
 
   form-data@4.0.5:
     dependencies:
@@ -3775,13 +4371,23 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  guid-typescript@1.0.9: {}
 
   has-flag@4.0.0: {}
 
@@ -3827,6 +4433,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-signals@1.1.1: {}
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -3835,9 +4443,39 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.3
+
+  is-expression@4.0.0:
+    dependencies:
+      acorn: 7.4.1
+      object-assign: 4.1.1
+
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@2.2.2: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  is-stream@2.0.1: {}
+
+  isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -3856,9 +4494,29 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  js-stringify@1.0.2: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
+
+  jscpd-sarif-reporter@4.2.4:
+    dependencies:
+      colors: 1.4.0
+      fs-extra: 11.3.4
+      node-sarif-builder: 3.4.0
+
+  jscpd@4.2.4:
+    dependencies:
+      '@jscpd/badge-reporter': 4.2.4
+      '@jscpd/core': 4.2.4
+      '@jscpd/finder': 4.2.4
+      '@jscpd/html-reporter': 4.2.4
+      '@jscpd/tokenizer': 4.2.4
+      colors: 1.4.0
+      commander: 5.1.0
+      fs-extra: 11.3.4
+      jscpd-sarif-reporter: 4.2.4
 
   jsdom@24.1.3:
     dependencies:
@@ -3923,6 +4581,11 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jstransformer@1.0.0:
+    dependencies:
+      is-promise: 2.2.2
+      promise: 7.3.1
 
   knip@6.13.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
@@ -4016,6 +4679,8 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.2
 
+  long@5.3.2: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -4042,15 +4707,30 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  markdown-table@2.0.0:
+    dependencies:
+      repeat-string: 1.6.1
+
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.27.1: {}
+
+  merge-stream@2.0.0: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mimic-fn@2.1.0: {}
 
   minimist@1.2.8: {}
 
@@ -4078,6 +4758,15 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  node-sarif-builder@3.4.0:
+    dependencies:
+      '@types/sarif': 2.1.7
+      fs-extra: 11.3.4
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   nwsapi@2.2.23: {}
 
   object-assign@4.1.1: {}
@@ -4085,6 +4774,25 @@ snapshots:
   obscenity@0.4.6: {}
 
   obug@2.1.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  onnxruntime-common@1.26.0: {}
+
+  onnxruntime-web@1.26.0:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.26.0
+      platform: 1.3.6
+      protobufjs: 7.6.1
 
   overlayscrollbars-react@0.5.6(overlayscrollbars@2.14.0)(react@19.2.3):
     dependencies:
@@ -4166,11 +4874,19 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.4: {}
+
+  platform@1.3.6: {}
 
   playwright-core@1.60.0: {}
 
@@ -4196,19 +4912,112 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.3
 
+  promise@7.3.1:
+    dependencies:
+      asap: 2.0.6
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  protobufjs@7.6.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 25.0.3
+      long: 5.3.2
+
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
 
+  pug-attrs@3.0.0:
+    dependencies:
+      constantinople: 4.0.1
+      js-stringify: 1.0.2
+      pug-runtime: 3.0.1
+
+  pug-code-gen@3.0.4:
+    dependencies:
+      constantinople: 4.0.1
+      doctypes: 1.1.0
+      js-stringify: 1.0.2
+      pug-attrs: 3.0.0
+      pug-error: 2.1.0
+      pug-runtime: 3.0.1
+      void-elements: 3.1.0
+      with: 7.0.2
+
+  pug-error@2.1.0: {}
+
+  pug-filters@4.0.0:
+    dependencies:
+      constantinople: 4.0.1
+      jstransformer: 1.0.0
+      pug-error: 2.1.0
+      pug-walk: 2.0.0
+      resolve: 1.22.12
+
+  pug-lexer@5.0.1:
+    dependencies:
+      character-parser: 2.2.0
+      is-expression: 4.0.0
+      pug-error: 2.1.0
+
+  pug-linker@4.0.0:
+    dependencies:
+      pug-error: 2.1.0
+      pug-walk: 2.0.0
+
+  pug-load@3.0.0:
+    dependencies:
+      object-assign: 4.1.1
+      pug-walk: 2.0.0
+
+  pug-parser@6.0.0:
+    dependencies:
+      pug-error: 2.1.0
+      token-stream: 1.0.0
+
+  pug-runtime@3.0.1: {}
+
+  pug-strip-comments@2.0.0:
+    dependencies:
+      pug-error: 2.1.0
+
+  pug-walk@2.0.0: {}
+
+  pug@3.0.4:
+    dependencies:
+      pug-code-gen: 3.0.4
+      pug-filters: 4.0.0
+      pug-lexer: 5.0.1
+      pug-linker: 4.0.0
+      pug-load: 3.0.0
+      pug-parser: 6.0.0
+      pug-runtime: 3.0.1
+      pug-strip-comments: 2.0.0
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   querystringify@2.2.0: {}
+
+  queue-microtask@1.2.3: {}
 
   react-dom@19.2.3(react@19.2.3):
     dependencies:
@@ -4250,6 +5059,8 @@ snapshots:
 
   react@19.2.3: {}
 
+  repeat-string@1.6.1: {}
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -4257,6 +5068,15 @@ snapshots:
   requires-port@1.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  reusify@1.1.0: {}
 
   rollup@4.60.2:
     dependencies:
@@ -4292,6 +5112,10 @@ snapshots:
   rrweb-cssom@0.7.1: {}
 
   rrweb-cssom@0.8.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   safer-buffer@2.1.2: {}
 
@@ -4353,7 +5177,15 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   sirv@3.0.2:
     dependencies:
@@ -4369,6 +5201,8 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
 
   source-map-js@1.2.1: {}
+
+  spark-md5@3.0.2: {}
 
   stackback@0.0.2: {}
 
@@ -4386,11 +5220,15 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-final-newline@2.0.0: {}
+
   strip-json-comments@5.0.3: {}
 
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
 
@@ -4420,6 +5258,12 @@ snapshots:
   tldts@7.0.27:
     dependencies:
       tldts-core: 7.0.27
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  token-stream@1.0.0: {}
 
   totalist@3.0.1: {}
 
@@ -4546,6 +5390,8 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  void-elements@3.1.0: {}
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -4579,16 +5425,29 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  with@7.0.2:
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      assert-never: 1.4.0
+      babel-walk: 3.0.0-canary-5
 
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
 
   ws@8.20.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  '@biomejs/biome': false
+  esbuild: false
+  protobufjs: false
+  sharp: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,0 @@
-allowBuilds:
-  '@biomejs/biome': false
-  esbuild: false
-  protobufjs: false
-  sharp: false

--- a/scripts/build-htdemucs-onnx.sh
+++ b/scripts/build-htdemucs-onnx.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# Build HTDemucs ONNX models for Composer's vocal separation feature.
+#
+# Pipeline:
+#   1. Clones github.com/sevagh/demucs.onnx (with its forked `demucs` submodule
+#      that exposes the spectrogram path as a standalone helper).
+#   2. Creates a Python venv with PyTorch + the forked demucs + onnx tooling.
+#   3. Downloads the official HTDemucs PyTorch weights via the `demucs` package.
+#      (The weights come from dl.fbaipublicfiles.com and are cached in
+#      ~/.cache/torch/hub/checkpoints/ — no manual download is required.)
+#   4. Exports htdemucs to ONNX (fp32).
+#   5. Quantizes the fp32 export to fp16 using onnxconverter-common.
+#   6. Prints SHA-256 hashes and the wrangler commands you can run to upload to
+#      your R2 bucket (see scripts/upload-htdemucs.sh for the same, automated).
+#
+# Usage:
+#   ./scripts/build-htdemucs-onnx.sh [output_dir]
+#
+# Requirements on the host:
+#   - python3 (3.10+ recommended)
+#   - git
+#   - ~6 GB free disk + ~10 GB while building
+#
+# Heads-up: ONNX export is heavy (>10 min on CPU). Run on a machine with RAM
+# headroom — the fp32 graph alone is ~600 MB.
+
+set -euo pipefail
+
+OUT_DIR="${1:-./htdemucs-onnx-out}"
+WORK_DIR="${WORK_DIR:-/tmp/composer-htdemucs-build}"
+DEMUCS_REPO="https://github.com/sevagh/demucs.onnx.git"
+DEMUCS_REPO_DIR="${WORK_DIR}/demucs.onnx"
+VENV_DIR="${WORK_DIR}/venv"
+
+mkdir -p "${OUT_DIR}" "${WORK_DIR}"
+
+echo "==> Cloning sevagh/demucs.onnx into ${DEMUCS_REPO_DIR}"
+# The repo's .gitmodules references SSH URLs for its C++ inference vendors
+# (ort-builder, libnyquist, etc.) which fail without a GitHub SSH key — and we
+# don't need those for the Python ONNX export anyway. We only need the
+# `demucs-for-onnx` submodule (the forked demucs package). Clone shallow first,
+# rewrite that one submodule URL to HTTPS, then init only that submodule.
+if [[ ! -d "${DEMUCS_REPO_DIR}" ]]; then
+  git clone "${DEMUCS_REPO}" "${DEMUCS_REPO_DIR}"
+else
+  (cd "${DEMUCS_REPO_DIR}" && git pull)
+fi
+
+# Selectively init only the demucs-for-onnx submodule, rewriting SSH -> HTTPS.
+(
+  cd "${DEMUCS_REPO_DIR}"
+  # Belt-and-suspenders: rewrite SSH GitHub URLs to HTTPS for this clone.
+  git config --local url."https://github.com/".insteadOf "git@github.com:"
+  git submodule init demucs-for-onnx
+  git submodule update --init --depth 1 demucs-for-onnx
+)
+
+echo "==> Creating Python venv at ${VENV_DIR}"
+python3 -m venv "${VENV_DIR}"
+# shellcheck disable=SC1091
+source "${VENV_DIR}/bin/activate"
+
+echo "==> Installing dependencies"
+pip install --upgrade pip
+pip install \
+  "torch>=2.1" \
+  "torchaudio>=2.1" \
+  onnx \
+  onnxruntime \
+  onnxconverter-common \
+  onnxscript \
+  numpy \
+  einops \
+  julius \
+  lameenc \
+  openunmix \
+  tqdm \
+  dora-search
+
+# The submodule at demucs-for-onnx/ is the forked demucs package that exposes
+# standalone_spec / standalone_magnitude needed by the converter.
+pip install -e "${DEMUCS_REPO_DIR}/demucs-for-onnx"
+
+echo "==> Exporting htdemucs to ONNX (fp32) — this can take 10+ minutes"
+FP32_DIR="${WORK_DIR}/fp32"
+mkdir -p "${FP32_DIR}"
+python "${DEMUCS_REPO_DIR}/scripts/convert-pth-to-onnx.py" "${FP32_DIR}"
+
+# The converter writes the graph to <model_name>.onnx and dumps weights to a
+# sidecar <model_name>.onnx.data (the model exceeds the 2 GB protobuf limit
+# when serialized inline, so PyTorch defaults to external data). We merge them
+# back into a single file per variant so the browser only needs one fetch.
+SRC_FP32="${FP32_DIR}/htdemucs.onnx"
+if [[ ! -f "${SRC_FP32}" ]]; then
+  echo "ERROR: expected ${SRC_FP32} but it does not exist. Conversion failed." >&2
+  exit 1
+fi
+
+echo "==> Merging external data + quantizing to fp16"
+export FP32_SRC="${SRC_FP32}"
+export OUT_DIR
+python - <<'PY'
+import os
+import onnx
+from onnxconverter_common import float16
+
+src = os.environ["FP32_SRC"]
+out_dir = os.environ["OUT_DIR"]
+
+print(f"loading {src} (auto-resolves external data sidecar)…")
+model = onnx.load(src)
+
+fp32_out = os.path.join(out_dir, "htdemucs_fp32.onnx")
+print(f"writing single-file fp32 -> {fp32_out}")
+onnx.save_model(model, fp32_out, save_as_external_data=False)
+print(f"  size: {os.path.getsize(fp32_out):,} bytes")
+
+print("converting to fp16…")
+fp16 = float16.convert_float_to_float16(
+    model,
+    keep_io_types=True,  # keep float32 I/O so the worker doesn't need to convert
+    disable_shape_infer=False,
+)
+fp16_out = os.path.join(out_dir, "htdemucs_fp16.onnx")
+print(f"writing single-file fp16 -> {fp16_out}")
+onnx.save_model(fp16, fp16_out, save_as_external_data=False)
+print(f"  size: {os.path.getsize(fp16_out):,} bytes")
+PY
+
+echo "==> Inspecting model I/O (verify these against src/audio/separation/worker.ts)"
+python - <<'PY'
+import os
+import onnx
+
+for variant in ("fp16", "fp32"):
+    path = os.path.join(os.environ["OUT_DIR"], f"htdemucs_{variant}.onnx")
+    print(f"\n-- {path} ({os.path.getsize(path):,} bytes) --")
+    m = onnx.load(path, load_external_data=False)
+    print("inputs:")
+    for inp in m.graph.input:
+        dims = [d.dim_value if d.dim_value > 0 else (d.dim_param or "?") for d in inp.type.tensor_type.shape.dim]
+        print(f"  {inp.name}: {dims}  elem_type={inp.type.tensor_type.elem_type}")
+    print("outputs:")
+    for out in m.graph.output:
+        dims = [d.dim_value if d.dim_value > 0 else (d.dim_param or "?") for d in out.type.tensor_type.shape.dim]
+        print(f"  {out.name}: {dims}  elem_type={out.type.tensor_type.elem_type}")
+PY
+
+echo "==> SHA-256"
+( cd "${OUT_DIR}" && sha256sum htdemucs_fp16.onnx htdemucs_fp32.onnx )
+
+echo ""
+echo "Done. Models are in ${OUT_DIR}/"
+echo ""
+echo "Model I/O contract (matches sevagh's export):"
+echo "  Inputs:  input  [1, 2, 343980]   stereo waveform @ 44.1 kHz, exactly 7.8s"
+echo "           x      [1, 4, 2048, 336] pre-computed magnitude spectrogram"
+echo "                                    (L_real, L_imag, R_real, R_imag stacked,"
+echo "                                     dropping the Nyquist bin)"
+echo "  Outputs: output  [1, 4, 4, 2048, 336] separated spectrograms (unused)"
+echo "           add_67  [1, 4, 2, 343980]    separated waveforms — what to read"
+echo "                                         Stem order: drums, bass, other, vocals"
+echo ""
+echo "Next steps:"
+echo "  1. Upload to R2:"
+echo "       ./scripts/upload-htdemucs.sh <BUCKET> ${OUT_DIR}"
+echo ""
+echo "  2. The worker in src/audio/separation/worker.ts currently passes only the"
+echo "     waveform tensor and reads the first output. To match this model it"
+echo "     needs to: pre-compute magspec from the input via the existing stft(),"
+echo "     pass two named inputs (\"input\" + \"x\"), and read the \"add_67\" output"
+echo "     at stem index 3 for vocals."

--- a/scripts/upload-htdemucs.sh
+++ b/scripts/upload-htdemucs.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Upload built HTDemucs ONNX models to a Cloudflare R2 bucket via wrangler.
+#
+# Usage:
+#   ./scripts/upload-htdemucs.sh <bucket-name> [models_dir]
+#
+# Example:
+#   ./scripts/upload-htdemucs.sh composer-vocal-models ./htdemucs-onnx-out
+#
+# Requires wrangler installed and authenticated against the right account:
+#   pnpm dlx wrangler login
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <bucket-name> [models_dir]" >&2
+  exit 1
+fi
+
+BUCKET="$1"
+MODELS_DIR="${2:-./htdemucs-onnx-out}"
+
+if [[ ! -d "${MODELS_DIR}" ]]; then
+  echo "ERROR: models dir ${MODELS_DIR} does not exist." >&2
+  echo "Run ./scripts/build-htdemucs-onnx.sh first." >&2
+  exit 1
+fi
+
+echo "==> applying CORS rules to ${BUCKET}"
+# AllowedOrigins:
+#   - production site
+#   - local Vite dev (5173) + preview (4173), both localhost and 127.0.0.1
+#   - any Cloudflare Workers/Pages preview deployment under boidushyabhattacharya.workers.dev
+# ExposeHeaders MUST include Content-Length so the in-browser download progress
+# bar can read the response size cross-origin (see src/audio/separation/model-cache.ts).
+CORS_FILE="$(mktemp -t r2-cors-XXXX.json)"
+trap 'rm -f "${CORS_FILE}"' EXIT
+cat > "${CORS_FILE}" <<'JSON'
+{
+  "rules": [
+    {
+      "allowed": {
+        "origins": [
+          "https://composer.boidu.dev",
+          "http://localhost:5173",
+          "http://127.0.0.1:5173",
+          "http://localhost:4173",
+          "http://127.0.0.1:4173",
+          "https://*.boidushyabhattacharya.workers.dev"
+        ],
+        "methods": ["GET", "HEAD"],
+        "headers": ["Range"]
+      },
+      "exposeHeaders": ["Content-Length", "Content-Type", "ETag"],
+      "maxAgeSeconds": 86400
+    }
+  ]
+}
+JSON
+pnpm dlx wrangler r2 bucket cors set "${BUCKET}" --file "${CORS_FILE}"
+
+for variant in fp16 fp32; do
+  file="${MODELS_DIR}/htdemucs_${variant}.onnx"
+  if [[ ! -f "${file}" ]]; then
+    echo "skip: ${file} not present"
+    continue
+  fi
+  echo "==> uploading htdemucs_${variant}.onnx ($(du -h "${file}" | cut -f1))"
+  pnpm dlx wrangler r2 object put --remote "${BUCKET}/htdemucs_${variant}.onnx" \
+    --file="${file}" \
+    --content-type=application/octet-stream \
+    --cache-control='public, max-age=31536000, immutable'
+done
+
+echo ""
+echo "Done. Verify the files are reachable via your bound custom domain, e.g.:"
+echo "  curl -I https://models.composer.boidu.dev/htdemucs_fp16.onnx"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { AudioEngine } from "@/audio/audio-engine";
 import { AudioPlayer } from "@/audio/audio-player";
+import { useAutoSeparate } from "@/hooks/useAutoSeparate";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { useGlobalShortcuts } from "@/hooks/useGlobalShortcuts";
 import { useImportFromHash } from "@/hooks/useImportFromHash";
@@ -64,6 +65,7 @@ const AppContent: React.FC = () => {
   useImportFromQuery();
   useImportFromYouTube();
   usePanicRecovery();
+  useAutoSeparate();
   useDocumentTitle();
 
   const setHelpOpenCb = useCallback((open: boolean) => setHelpOpen(open), []);

--- a/src/audio/audio-engine.browser.test.tsx
+++ b/src/audio/audio-engine.browser.test.tsx
@@ -155,4 +155,28 @@ describe("AudioEngine", () => {
       URL.revokeObjectURL(vocalsUrl);
     }
   });
+
+  it("switches from a separated track back to the original source", async () => {
+    await render(<AudioEngine />);
+    useAudioStore.setState({ source: { type: "file", file: createAudioFile() } });
+    await waitFor(() => useAudioStore.getState().audioElement !== null);
+    const audio = useAudioStore.getState().audioElement as HTMLAudioElement;
+    const originalUrl = audio.src;
+    const vocalsUrl = URL.createObjectURL(createAudioFile("vocals.wav"));
+
+    try {
+      useSeparationStore.setState({
+        currentStem: "vocals",
+        availableStems: ["original", "vocals"],
+        stemUrls: { vocals: vocalsUrl },
+      });
+      await waitFor(() => audio.src === vocalsUrl);
+
+      useSeparationStore.setState({ currentStem: "original" });
+      await waitFor(() => audio.src === originalUrl);
+      expect(audio.src).toBe(originalUrl);
+    } finally {
+      URL.revokeObjectURL(vocalsUrl);
+    }
+  });
 });

--- a/src/audio/audio-engine.browser.test.tsx
+++ b/src/audio/audio-engine.browser.test.tsx
@@ -156,6 +156,46 @@ describe("AudioEngine", () => {
     }
   });
 
+  it("switches to the instrumental separated track", async () => {
+    await render(<AudioEngine />);
+    useAudioStore.setState({ source: { type: "file", file: createAudioFile() } });
+    await waitFor(() => useAudioStore.getState().audioElement !== null);
+    const audio = useAudioStore.getState().audioElement as HTMLAudioElement;
+    const instrumentalUrl = URL.createObjectURL(createAudioFile("instrumental.wav"));
+
+    try {
+      useSeparationStore.setState({
+        currentStem: "instrumental",
+        availableStems: ["original", "vocals", "instrumental"],
+        stemUrls: { instrumental: instrumentalUrl },
+      });
+
+      await waitFor(() => audio.src === instrumentalUrl);
+      expect(audio.src).toBe(instrumentalUrl);
+    } finally {
+      URL.revokeObjectURL(instrumentalUrl);
+    }
+  });
+
+  it("applies a preselected instrumental track after the audio element is created", async () => {
+    const instrumentalUrl = URL.createObjectURL(createAudioFile("instrumental.wav"));
+
+    try {
+      useSeparationStore.setState({
+        currentStem: "instrumental",
+        availableStems: ["original", "vocals", "instrumental"],
+        stemUrls: { instrumental: instrumentalUrl },
+      });
+      await render(<AudioEngine />);
+      useAudioStore.setState({ source: { type: "file", file: createAudioFile() } });
+
+      await waitFor(() => useAudioStore.getState().audioElement?.src === instrumentalUrl);
+      expect(useAudioStore.getState().audioElement?.src).toBe(instrumentalUrl);
+    } finally {
+      URL.revokeObjectURL(instrumentalUrl);
+    }
+  });
+
   it("switches from a separated track back to the original source", async () => {
     await render(<AudioEngine />);
     useAudioStore.setState({ source: { type: "file", file: createAudioFile() } });

--- a/src/audio/audio-engine.browser.test.tsx
+++ b/src/audio/audio-engine.browser.test.tsx
@@ -1,5 +1,6 @@
 import { AudioEngine } from "@/audio/audio-engine";
 import { useAudioStore } from "@/stores/audio";
+import { useSeparationStore } from "@/stores/separation";
 import { createAudioFile, createMp3File } from "@/test/audio-fixtures";
 import { allowConsole } from "@/test/console-guard";
 import { render } from "@/test/render";
@@ -120,5 +121,38 @@ describe("AudioEngine", () => {
     expect(elements[0]).toBe(audio);
     const served = await (await fetch(audio.src)).arrayBuffer();
     expect(served.byteLength).toBe(wav.size);
+  });
+
+  it("preserves playbackRate when switching separated audio tracks", async () => {
+    await render(<AudioEngine />);
+    useAudioStore.setState({
+      source: { type: "file", file: createAudioFile() },
+      playbackRate: 1.5,
+      volume: 0.4,
+      isMuted: true,
+    });
+    await waitFor(() => useAudioStore.getState().audioElement !== null);
+    const audio = useAudioStore.getState().audioElement as HTMLAudioElement;
+    await waitFor(() => audio.playbackRate === 1.5);
+
+    audio.playbackRate = 1;
+    audio.volume = 1;
+    audio.muted = false;
+    const vocalsUrl = URL.createObjectURL(createAudioFile("vocals.wav"));
+
+    try {
+      useSeparationStore.setState({
+        currentStem: "vocals",
+        availableStems: ["original", "vocals"],
+        stemUrls: { vocals: vocalsUrl },
+      });
+
+      await waitFor(() => audio.src === vocalsUrl);
+      expect(audio.playbackRate).toBe(1.5);
+      expect(audio.volume).toBe(0.4);
+      expect(audio.muted).toBe(true);
+    } finally {
+      URL.revokeObjectURL(vocalsUrl);
+    }
   });
 });

--- a/src/audio/audio-engine.tsx
+++ b/src/audio/audio-engine.tsx
@@ -14,6 +14,7 @@ const SLOW_DECODE_MS = 800;
 
 const AudioEngine: React.FC = () => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const originalUrlRef = useRef<string | null>(null);
 
   const source = useAudioStore((s) => s.source);
   const isPlaying = useAudioStore((s) => s.isPlaying);
@@ -122,6 +123,7 @@ const AudioEngine: React.FC = () => {
       audio.style.display = "none";
       document.body.appendChild(audio);
       audioRef.current = audio;
+      originalUrlRef.current = objectUrl;
       registerAudioElement(audio);
       if (initialIsPlaying) audio.play().catch(() => undefined);
 
@@ -148,6 +150,7 @@ const AudioEngine: React.FC = () => {
         audio.src = "";
         audio.remove();
         if (audioRef.current === audio) audioRef.current = null;
+        if (originalUrlRef.current === objectUrl) originalUrlRef.current = null;
         URL.revokeObjectURL(objectUrl);
       };
     };
@@ -186,7 +189,7 @@ const AudioEngine: React.FC = () => {
     const audio = audioRef.current;
     if (!audio) return;
     const stemUrl = currentStem !== "original" ? stemUrls[currentStem] : null;
-    const targetUrl = stemUrl ?? objectUrlRef.current;
+    const targetUrl = stemUrl ?? originalUrlRef.current;
     if (!targetUrl || audio.src === targetUrl) return;
     const wasPlaying = !audio.paused;
     const time = audio.currentTime;

--- a/src/audio/audio-engine.tsx
+++ b/src/audio/audio-engine.tsx
@@ -21,6 +21,7 @@ const AudioEngine: React.FC = () => {
   const playbackRate = useAudioStore((s) => s.playbackRate);
   const volume = useAudioStore((s) => s.volume);
   const isMuted = useAudioStore((s) => s.isMuted);
+  const audioElement = useAudioStore((s) => s.audioElement);
   const setCurrentTime = useAudioStore((s) => s.setCurrentTime);
   const setDuration = useAudioStore((s) => s.setDuration);
   const setIsPlaying = useAudioStore((s) => s.setIsPlaying);
@@ -186,7 +187,7 @@ const AudioEngine: React.FC = () => {
   }, [playbackRate, volume, isMuted]);
 
   useEffect(() => {
-    const audio = audioRef.current;
+    const audio = audioElement;
     if (!audio) return;
     const stemUrl = currentStem !== "original" ? stemUrls[currentStem] : null;
     const targetUrl = stemUrl ?? originalUrlRef.current;
@@ -204,7 +205,7 @@ const AudioEngine: React.FC = () => {
     audio.volume = currentVolume;
     audio.muted = currentIsMuted;
     if (wasPlaying) audio.play().catch(() => {});
-  }, [currentStem, stemUrls]);
+  }, [currentStem, stemUrls, audioElement]);
 
   return null;
 };

--- a/src/audio/audio-engine.tsx
+++ b/src/audio/audio-engine.tsx
@@ -2,6 +2,7 @@ import { decodeMp3ToWav, isMp3File } from "@/audio/audio-decode";
 import { bindAudioStateEvents } from "@/audio/audio-state-events";
 import { scrubPreview } from "@/audio/scrub-preview";
 import { useAudioStore } from "@/stores/audio";
+import { useSeparationStore } from "@/stores/separation";
 import { useEffect, useRef } from "react";
 
 // -- Constants -----------------------------------------------------------------
@@ -24,6 +25,9 @@ const AudioEngine: React.FC = () => {
   const setIsPlaying = useAudioStore((s) => s.setIsPlaying);
   const setIsLoading = useAudioStore((s) => s.setIsLoading);
   const registerAudioElement = useAudioStore((s) => s.registerAudioElement);
+
+  const currentStem = useSeparationStore((s) => s.currentStem);
+  const stemUrls = useSeparationStore((s) => s.stemUrls);
 
   useEffect(() => {
     if (!source) {
@@ -177,6 +181,27 @@ const AudioEngine: React.FC = () => {
     audio.volume = volume;
     audio.muted = isMuted;
   }, [playbackRate, volume, isMuted]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const stemUrl = currentStem !== "original" ? stemUrls[currentStem] : null;
+    const targetUrl = stemUrl ?? objectUrlRef.current;
+    if (!targetUrl || audio.src === targetUrl) return;
+    const wasPlaying = !audio.paused;
+    const time = audio.currentTime;
+    const {
+      playbackRate: currentPlaybackRate,
+      volume: currentVolume,
+      isMuted: currentIsMuted,
+    } = useAudioStore.getState();
+    audio.src = targetUrl;
+    audio.currentTime = time;
+    audio.playbackRate = currentPlaybackRate;
+    audio.volume = currentVolume;
+    audio.muted = currentIsMuted;
+    if (wasPlaying) audio.play().catch(() => {});
+  }, [currentStem, stemUrls]);
 
   return null;
 };

--- a/src/audio/audio-player.tsx
+++ b/src/audio/audio-player.tsx
@@ -2,6 +2,7 @@ import { useAudioStore } from "@/stores/audio";
 import { Button } from "@/ui/button";
 import { Popover } from "@/ui/popover";
 import { Slider } from "@/ui/slider";
+import { VocalSeparationDropdown } from "@/ui/vocal-separation-dropdown";
 import { formatTime } from "@/utils/format-time";
 import { IconPlayerPauseFilled, IconPlayerPlayFilled, IconVolume, IconVolume2, IconVolume3 } from "@tabler/icons-react";
 import { useCallback } from "react";
@@ -160,6 +161,7 @@ const AudioPlayer: React.FC = () => {
       <TimeDisplay current={currentTime} duration={duration} />
       <VolumeControl volume={volume} isMuted={isMuted} onChangeVolume={setVolume} onToggleMute={toggleMute} />
       <PlaybackRateControl rate={playbackRate} onChangeRate={setPlaybackRate} />
+      <VocalSeparationDropdown />
     </div>
   );
 };

--- a/src/audio/separation/audio-codec.ts
+++ b/src/audio/separation/audio-codec.ts
@@ -1,0 +1,115 @@
+const TARGET_SAMPLE_RATE = 44_100;
+const TARGET_CHANNELS = 2;
+
+interface DecodedAudio {
+  channels: Float32Array[];
+  sampleRate: number;
+  numFrames: number;
+}
+
+async function decodeFileToFloat32(file: File | Blob): Promise<DecodedAudio> {
+  const buf = await file.arrayBuffer();
+  const ctx = new OfflineAudioContext(TARGET_CHANNELS, 1, TARGET_SAMPLE_RATE);
+  const decoded = await ctx.decodeAudioData(buf);
+
+  if (decoded.sampleRate === TARGET_SAMPLE_RATE && decoded.numberOfChannels === TARGET_CHANNELS) {
+    const channels: Float32Array[] = [];
+    for (let c = 0; c < TARGET_CHANNELS; c++) {
+      const out = new Float32Array(decoded.length);
+      decoded.copyFromChannel(out, c);
+      channels.push(out);
+    }
+    return { channels, sampleRate: TARGET_SAMPLE_RATE, numFrames: decoded.length };
+  }
+
+  const durationSec = decoded.length / decoded.sampleRate;
+  const targetFrames = Math.ceil(durationSec * TARGET_SAMPLE_RATE);
+  const resampleCtx = new OfflineAudioContext(TARGET_CHANNELS, targetFrames, TARGET_SAMPLE_RATE);
+  const source = resampleCtx.createBufferSource();
+
+  if (decoded.numberOfChannels === 1) {
+    const stereoBuffer = resampleCtx.createBuffer(TARGET_CHANNELS, decoded.length, decoded.sampleRate);
+    const mono = decoded.getChannelData(0);
+    stereoBuffer.copyToChannel(mono, 0);
+    stereoBuffer.copyToChannel(mono, 1);
+    source.buffer = stereoBuffer;
+  } else {
+    source.buffer = decoded;
+  }
+  source.connect(resampleCtx.destination);
+  source.start();
+  const rendered = await resampleCtx.startRendering();
+
+  const channels: Float32Array[] = [];
+  for (let c = 0; c < TARGET_CHANNELS; c++) {
+    const out = new Float32Array(rendered.length);
+    rendered.copyFromChannel(out, c);
+    channels.push(out);
+  }
+  return { channels, sampleRate: TARGET_SAMPLE_RATE, numFrames: rendered.length };
+}
+
+function floatChannelsToWavBlob(channels: Float32Array[], sampleRate: number): Blob {
+  const numChannels = channels.length;
+  const numFrames = channels[0]?.length ?? 0;
+  const bytesPerSample = 2;
+  const blockAlign = numChannels * bytesPerSample;
+  const byteRate = sampleRate * blockAlign;
+  const dataSize = numFrames * blockAlign;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  let offset = 0;
+  function writeString(s: string) {
+    for (let i = 0; i < s.length; i++) view.setUint8(offset + i, s.charCodeAt(i));
+    offset += s.length;
+  }
+  function writeUint32(v: number) {
+    view.setUint32(offset, v, true);
+    offset += 4;
+  }
+  function writeUint16(v: number) {
+    view.setUint16(offset, v, true);
+    offset += 2;
+  }
+
+  writeString("RIFF");
+  writeUint32(36 + dataSize);
+  writeString("WAVE");
+  writeString("fmt ");
+  writeUint32(16);
+  writeUint16(1);
+  writeUint16(numChannels);
+  writeUint32(sampleRate);
+  writeUint32(byteRate);
+  writeUint16(blockAlign);
+  writeUint16(16);
+  writeString("data");
+  writeUint32(dataSize);
+
+  for (let frame = 0; frame < numFrames; frame++) {
+    for (let c = 0; c < numChannels; c++) {
+      const sample = Math.max(-1, Math.min(1, channels[c][frame]));
+      view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+      offset += 2;
+    }
+  }
+
+  return new Blob([buffer], { type: "audio/wav" });
+}
+
+async function sha256Hex(bytes: ArrayBuffer | Uint8Array): Promise<string> {
+  const data = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function hashFile(file: File | Blob): Promise<string> {
+  const buf = await file.arrayBuffer();
+  return sha256Hex(buf);
+}
+
+export { TARGET_SAMPLE_RATE, TARGET_CHANNELS, decodeFileToFloat32, floatChannelsToWavBlob, sha256Hex, hashFile };
+export type { DecodedAudio };

--- a/src/audio/separation/chunker.test.ts
+++ b/src/audio/separation/chunker.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { iterateChunks, chunkCount, stitchChunks, SEGMENT_SAMPLES, STRIDE_SAMPLES } from "@/audio/separation/chunker";
+
+function makeRamp(length: number, channel = 0): Float32Array {
+  const out = new Float32Array(length);
+  for (let i = 0; i < length; i++) out[i] = (i + channel * 0.5) / length;
+  return out;
+}
+
+describe("chunker", () => {
+  it("emits a single chunk for short inputs", () => {
+    const channels = [makeRamp(SEGMENT_SAMPLES / 2)];
+    const chunks = Array.from(iterateChunks(channels));
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].start).toBe(0);
+    expect(chunks[0].end).toBe(SEGMENT_SAMPLES / 2);
+    expect(chunks[0].data[0].length).toBe(SEGMENT_SAMPLES);
+  });
+
+  it("chunkCount matches iterateChunks length", () => {
+    for (const frames of [1000, SEGMENT_SAMPLES, SEGMENT_SAMPLES + 1, SEGMENT_SAMPLES * 2 + 5000]) {
+      const channels = [makeRamp(frames)];
+      const iterated = Array.from(iterateChunks(channels)).length;
+      expect(chunkCount(frames)).toBe(iterated);
+    }
+  });
+
+  it("strides by SEGMENT_SAMPLES - OVERLAP_SAMPLES", () => {
+    const totalFrames = SEGMENT_SAMPLES * 3;
+    const channels = [makeRamp(totalFrames)];
+    const chunks = Array.from(iterateChunks(channels));
+    for (let i = 1; i < chunks.length; i++) {
+      expect(chunks[i].start - chunks[i - 1].start).toBe(STRIDE_SAMPLES);
+    }
+  });
+
+  it("stitchChunks recovers original signal when passing chunks through unchanged", () => {
+    const totalFrames = SEGMENT_SAMPLES * 2 + 1000;
+    const channels = [makeRamp(totalFrames, 0), makeRamp(totalFrames, 1)];
+    const chunks = Array.from(iterateChunks(channels));
+    const stitched = stitchChunks(chunks, totalFrames, channels.length);
+    for (let c = 0; c < channels.length; c++) {
+      let maxErr = 0;
+      for (let i = 0; i < totalFrames; i++) {
+        maxErr = Math.max(maxErr, Math.abs(stitched[c][i] - channels[c][i]));
+      }
+      expect(maxErr).toBeLessThan(1e-5);
+    }
+  });
+});

--- a/src/audio/separation/chunker.ts
+++ b/src/audio/separation/chunker.ts
@@ -1,0 +1,90 @@
+import { TARGET_SAMPLE_RATE } from "@/audio/separation/audio-codec";
+
+const SEGMENT_SECONDS = 7.8;
+const SEGMENT_SAMPLES = Math.round(SEGMENT_SECONDS * TARGET_SAMPLE_RATE);
+const OVERLAP_RATIO = 0.25;
+const OVERLAP_SAMPLES = Math.round(SEGMENT_SAMPLES * OVERLAP_RATIO);
+const STRIDE_SAMPLES = SEGMENT_SAMPLES - OVERLAP_SAMPLES;
+
+interface Chunk {
+  start: number;
+  end: number;
+  data: Float32Array[];
+}
+
+function* iterateChunks(channels: Float32Array[]): Generator<Chunk> {
+  const length = channels[0]?.length ?? 0;
+  if (length === 0) return;
+
+  let start = 0;
+  while (start < length) {
+    const end = Math.min(start + SEGMENT_SAMPLES, length);
+    const data = channels.map((channel) => {
+      const segment = new Float32Array(SEGMENT_SAMPLES);
+      segment.set(channel.subarray(start, end));
+      return segment;
+    });
+    yield { start, end, data };
+    if (end >= length) break;
+    start += STRIDE_SAMPLES;
+  }
+}
+
+function chunkCount(totalFrames: number): number {
+  if (totalFrames === 0) return 0;
+  if (totalFrames <= SEGMENT_SAMPLES) return 1;
+  return 1 + Math.ceil((totalFrames - SEGMENT_SAMPLES) / STRIDE_SAMPLES);
+}
+
+function makeFadeWindow(): Float32Array {
+  const win = new Float32Array(OVERLAP_SAMPLES);
+  for (let i = 0; i < OVERLAP_SAMPLES; i++) {
+    win[i] = 0.5 * (1 - Math.cos((Math.PI * i) / OVERLAP_SAMPLES));
+  }
+  return win;
+}
+
+function stitchChunks(chunks: Chunk[], totalFrames: number, numChannels: number): Float32Array[] {
+  const output: Float32Array[] = [];
+  for (let c = 0; c < numChannels; c++) output.push(new Float32Array(totalFrames));
+
+  if (chunks.length === 0) return output;
+
+  const fadeIn = makeFadeWindow();
+  const fadeOut = new Float32Array(OVERLAP_SAMPLES);
+  for (let i = 0; i < OVERLAP_SAMPLES; i++) fadeOut[i] = 1 - fadeIn[i];
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    const chunkLength = chunk.end - chunk.start;
+    for (let c = 0; c < numChannels; c++) {
+      const target = output[c];
+      const source = chunk.data[c];
+
+      for (let n = 0; n < chunkLength; n++) {
+        const globalIdx = chunk.start + n;
+        if (globalIdx >= totalFrames) break;
+
+        let gain = 1;
+        if (i > 0 && n < OVERLAP_SAMPLES) {
+          gain = fadeIn[n];
+        }
+        if (i < chunks.length - 1 && n >= chunkLength - OVERLAP_SAMPLES) {
+          const k = n - (chunkLength - OVERLAP_SAMPLES);
+          gain *= fadeOut[k];
+        }
+
+        if (i === 0 || n >= OVERLAP_SAMPLES) {
+          target[globalIdx] += source[n] * gain;
+        } else {
+          target[globalIdx] += source[n] * gain;
+        }
+      }
+    }
+  }
+
+  return output;
+}
+
+export { SEGMENT_SECONDS, SEGMENT_SAMPLES, OVERLAP_SAMPLES, STRIDE_SAMPLES, iterateChunks, chunkCount, stitchChunks };
+export type { Chunk };

--- a/src/audio/separation/demucs-postprocess.ts
+++ b/src/audio/separation/demucs-postprocess.ts
@@ -1,0 +1,99 @@
+import { SEGMENT_SAMPLES } from "@/audio/separation/chunker";
+import {
+  MAGSPEC_CHANNELS,
+  NUM_FREQ_BINS,
+  NUM_TIME_FRAMES,
+  waveformFromComplexAsChannels,
+} from "@/audio/separation/demucs-spec";
+
+// -- Constants ----------------------------------------------------------------
+
+// add_67 has dims [1, 4, 2, 343980]: batch, stem, channel, sample.
+// output has dims [1, 4, 4, 2048, 336]: batch, stem, complex-as-channels, freq, time.
+// Vocals = stem index 3. Stride per stem = 2 * SEGMENT_SAMPLES.
+const STEM_INDEX_VOCALS = 3;
+
+// -- Types --------------------------------------------------------------------
+
+interface NormalizationStats {
+  mean: number;
+  std: number;
+}
+
+interface NormalizedAudio extends NormalizationStats {
+  channels: Float32Array[];
+}
+
+// Duck-typed so tests and callers don't need the full ORT tensor surface.
+interface TensorLike {
+  data: Float32Array;
+}
+
+// -- Normalization ------------------------------------------------------------
+
+function normalizeForDemucs(channels: Float32Array[], totalFrames: number): NormalizedAudio {
+  if (totalFrames === 0) return { channels, mean: 0, std: 1 };
+
+  let mean = 0;
+  for (let i = 0; i < totalFrames; i++) {
+    mean += ((channels[0]?.[i] ?? 0) + (channels[1]?.[i] ?? 0)) * 0.5;
+  }
+  mean /= totalFrames;
+
+  let variance = 0;
+  for (let i = 0; i < totalFrames; i++) {
+    const mono = ((channels[0]?.[i] ?? 0) + (channels[1]?.[i] ?? 0)) * 0.5;
+    const d = mono - mean;
+    variance += d * d;
+  }
+  const std = Math.sqrt(variance / Math.max(1, totalFrames - 1));
+  if (!Number.isFinite(std) || std < 1e-8) return { channels, mean: 0, std: 1 };
+
+  return {
+    mean,
+    std,
+    channels: channels.map((channel) => {
+      const out = new Float32Array(channel.length);
+      for (let i = 0; i < channel.length; i++) out[i] = (channel[i] - mean) / std;
+      return out;
+    }),
+  };
+}
+
+function denormalizeDemucsOutput(channels: Float32Array[], normalized: NormalizationStats): Float32Array[] {
+  if (normalized.mean === 0 && normalized.std === 1) return channels;
+  for (const channel of channels) {
+    for (let i = 0; i < channel.length; i++) channel[i] = channel[i] * normalized.std + normalized.mean;
+  }
+  return channels;
+}
+
+// -- Stem extraction ----------------------------------------------------------
+
+function extractVocalsStem(timeTensor: TensorLike, freqTensor: TensorLike): Float32Array[] {
+  const timeData = timeTensor.data;
+  const stemStride = 2 * SEGMENT_SAMPLES;
+  const channelStride = SEGMENT_SAMPLES;
+  const base = STEM_INDEX_VOCALS * stemStride;
+
+  const freqSourceStride = MAGSPEC_CHANNELS * NUM_FREQ_BINS * NUM_TIME_FRAMES;
+  const freqBase = STEM_INDEX_VOCALS * freqSourceStride;
+  const freqChannels = waveformFromComplexAsChannels(freqTensor.data.subarray(freqBase, freqBase + freqSourceStride));
+
+  const result: Float32Array[] = [];
+  for (let c = 0; c < 2; c++) {
+    const out = new Float32Array(SEGMENT_SAMPLES);
+    const timeBranch = timeData.subarray(base + c * channelStride, base + c * channelStride + SEGMENT_SAMPLES);
+    const freqBranch = freqChannels[c];
+    for (let i = 0; i < SEGMENT_SAMPLES; i++) {
+      out[i] = timeBranch[i] + freqBranch[i];
+    }
+    result.push(out);
+  }
+  return result;
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { STEM_INDEX_VOCALS, normalizeForDemucs, denormalizeDemucsOutput, extractVocalsStem };
+export type { NormalizationStats, NormalizedAudio, TensorLike };

--- a/src/audio/separation/demucs-spec.test.ts
+++ b/src/audio/separation/demucs-spec.test.ts
@@ -1,0 +1,104 @@
+import {
+  MAGSPEC_CHANNELS,
+  NUM_FREQ_BINS,
+  NUM_TIME_FRAMES,
+  SEGMENT_SAMPLES,
+  computeMagspec,
+  waveformFromComplexAsChannels,
+} from "@/audio/separation/demucs-spec";
+import { describe, expect, it } from "vitest";
+
+function silence(): Float32Array[] {
+  return [new Float32Array(SEGMENT_SAMPLES), new Float32Array(SEGMENT_SAMPLES)];
+}
+
+function tone(freqHz: number, sampleRate = 44_100): Float32Array[] {
+  const left = new Float32Array(SEGMENT_SAMPLES);
+  const right = new Float32Array(SEGMENT_SAMPLES);
+  for (let i = 0; i < SEGMENT_SAMPLES; i++) {
+    const v = Math.sin((2 * Math.PI * freqHz * i) / sampleRate);
+    left[i] = v;
+    right[i] = v * 0.5;
+  }
+  return [left, right];
+}
+
+describe("computeMagspec", () => {
+  it("returns a flat tensor of shape [4, 2048, 336]", () => {
+    const out = computeMagspec(silence());
+    expect(out.length).toBe(MAGSPEC_CHANNELS * NUM_FREQ_BINS * NUM_TIME_FRAMES);
+    expect(MAGSPEC_CHANNELS).toBe(4);
+    expect(NUM_FREQ_BINS).toBe(2048);
+    expect(NUM_TIME_FRAMES).toBe(336);
+  });
+
+  it("yields zeros for silence", () => {
+    const out = computeMagspec(silence());
+    let maxAbs = 0;
+    for (let i = 0; i < out.length; i++) {
+      const v = Math.abs(out[i]);
+      if (v > maxAbs) maxAbs = v;
+    }
+    expect(maxAbs).toBe(0);
+  });
+
+  it("concentrates energy at the expected freq bin for a pure tone", () => {
+    const freq = 440;
+    const sampleRate = 44_100;
+    const nFft = 4096;
+    const expectedBin = Math.round((freq * nFft) / sampleRate);
+
+    const out = computeMagspec(tone(freq, sampleRate));
+
+    // Channel 0 is L_real. Sum |coeff| across time frames per freq bin.
+    const energyPerBin = new Float32Array(NUM_FREQ_BINS);
+    for (let f = 0; f < NUM_FREQ_BINS; f++) {
+      let s = 0;
+      for (let t = 0; t < NUM_TIME_FRAMES; t++) {
+        const reIdx = 0 * NUM_FREQ_BINS * NUM_TIME_FRAMES + f * NUM_TIME_FRAMES + t;
+        const imIdx = 1 * NUM_FREQ_BINS * NUM_TIME_FRAMES + f * NUM_TIME_FRAMES + t;
+        s += Math.hypot(out[reIdx], out[imIdx]);
+      }
+      energyPerBin[f] = s;
+    }
+    let argmax = 0;
+    for (let f = 1; f < NUM_FREQ_BINS; f++) if (energyPerBin[f] > energyPerBin[argmax]) argmax = f;
+    expect(Math.abs(argmax - expectedBin)).toBeLessThanOrEqual(1);
+  });
+
+  it("rejects wrong segment length", () => {
+    expect(() => computeMagspec([new Float32Array(1000), new Float32Array(1000)])).toThrow();
+  });
+
+  it("rejects mono input", () => {
+    expect(() => computeMagspec([new Float32Array(SEGMENT_SAMPLES)])).toThrow();
+  });
+});
+
+describe("waveformFromComplexAsChannels", () => {
+  it("returns silence for an empty source spectrogram", () => {
+    const out = waveformFromComplexAsChannels(new Float32Array(MAGSPEC_CHANNELS * NUM_FREQ_BINS * NUM_TIME_FRAMES));
+    expect(out).toHaveLength(2);
+    expect(out[0]).toHaveLength(SEGMENT_SAMPLES);
+    expect(out[1]).toHaveLength(SEGMENT_SAMPLES);
+    expect(out[0].some((v) => v !== 0)).toBe(false);
+    expect(out[1].some((v) => v !== 0)).toBe(false);
+  });
+
+  it("reconstructs a Demucs-shaped complex spectrogram at the original scale", () => {
+    const input = tone(440);
+    const spec = computeMagspec(input);
+    const out = waveformFromComplexAsChannels(spec);
+
+    const start = 8192;
+    const end = SEGMENT_SAMPLES - 8192;
+    let err = 0;
+    let ref = 0;
+    for (let i = start; i < end; i++) {
+      const d = out[0][i] - input[0][i];
+      err += d * d;
+      ref += input[0][i] * input[0][i];
+    }
+    expect(Math.sqrt(err / ref)).toBeLessThan(0.08);
+  });
+});

--- a/src/audio/separation/demucs-spec.ts
+++ b/src/audio/separation/demucs-spec.ts
@@ -1,0 +1,100 @@
+import { HOP_LENGTH, type Spectrogram, istft, reflectPad, stft } from "@/audio/separation/stft";
+
+// Mirrors HTDemucs's `_spec` / `_magnitude` (sevagh's `standalone_*` helpers).
+// For a 7.8s stereo segment at 44.1 kHz (343,980 samples), the model expects
+// magspec shape [1, 4, 2048, 336]:
+//   - 4 channels = stereo (2) × complex (2), laid out [L_re, L_im, R_re, R_im]
+//   - 2048 freq bins = n_fft/2 = 4096/2; the Nyquist bin is dropped
+//   - 336 time frames = ceil(343980 / 1024), with 2 leading + 2 trailing context
+//     frames produced by the spectro pre-pad and then trimmed off
+
+const SEGMENT_SAMPLES = 343_980;
+const PRE_PAD_LEFT = (HOP_LENGTH / 2) * 3; // 1536
+const PRE_PAD_RIGHT = PRE_PAD_LEFT + 336 * HOP_LENGTH - SEGMENT_SAMPLES; // 1716
+const NUM_TIME_FRAMES = 336;
+const NUM_FREQ_BINS = 2048;
+const TIME_TRIM_START = 2;
+const MAGSPEC_CHANNELS = 4;
+const ISTFT_TIME_PAD = 2;
+const ISTFT_FREQ_BINS = NUM_FREQ_BINS + 1;
+const ISTFT_TIME_FRAMES = NUM_TIME_FRAMES + ISTFT_TIME_PAD * 2;
+const ISTFT_LENGTH = Math.ceil(SEGMENT_SAMPLES / HOP_LENGTH) * HOP_LENGTH + 2 * PRE_PAD_LEFT;
+
+function computeMagspec(channels: Float32Array[]): Float32Array {
+  if (channels.length !== 2) {
+    throw new Error(`HTDemucs magspec requires stereo input (got ${channels.length} channels)`);
+  }
+  for (const ch of channels) {
+    if (ch.length !== SEGMENT_SAMPLES) {
+      throw new Error(`HTDemucs magspec expects ${SEGMENT_SAMPLES} samples (got ${ch.length})`);
+    }
+  }
+
+  const out = new Float32Array(MAGSPEC_CHANNELS * NUM_FREQ_BINS * NUM_TIME_FRAMES);
+
+  for (let c = 0; c < 2; c++) {
+    const prePadded = reflectPad(channels[c], PRE_PAD_LEFT, PRE_PAD_RIGHT);
+    const spec = stft(prePadded, { center: true, normalized: true });
+
+    const realCh = c * 2;
+    const imagCh = c * 2 + 1;
+    for (let f = 0; f < NUM_FREQ_BINS; f++) {
+      for (let t = 0; t < NUM_TIME_FRAMES; t++) {
+        const srcFrame = t + TIME_TRIM_START;
+        const srcIdx = srcFrame * spec.numBins + f;
+        out[realCh * NUM_FREQ_BINS * NUM_TIME_FRAMES + f * NUM_TIME_FRAMES + t] = spec.real[srcIdx];
+        out[imagCh * NUM_FREQ_BINS * NUM_TIME_FRAMES + f * NUM_TIME_FRAMES + t] = spec.imag[srcIdx];
+      }
+    }
+  }
+
+  return out;
+}
+
+function waveformFromComplexAsChannels(sourceSpec: Float32Array): Float32Array[] {
+  const channelStride = NUM_FREQ_BINS * NUM_TIME_FRAMES;
+  if (sourceSpec.length < MAGSPEC_CHANNELS * channelStride) {
+    throw new Error(
+      `HTDemucs source spectrogram expects at least ${MAGSPEC_CHANNELS * channelStride} samples (got ${sourceSpec.length})`,
+    );
+  }
+
+  const channels: Float32Array[] = [];
+  for (let c = 0; c < 2; c++) {
+    const real = new Float32Array(ISTFT_TIME_FRAMES * ISTFT_FREQ_BINS);
+    const imag = new Float32Array(ISTFT_TIME_FRAMES * ISTFT_FREQ_BINS);
+    const realBase = c * 2 * channelStride;
+    const imagBase = (c * 2 + 1) * channelStride;
+
+    for (let f = 0; f < NUM_FREQ_BINS; f++) {
+      for (let t = 0; t < NUM_TIME_FRAMES; t++) {
+        const srcIdx = f * NUM_TIME_FRAMES + t;
+        const dstIdx = (t + ISTFT_TIME_PAD) * ISTFT_FREQ_BINS + f;
+        real[dstIdx] = sourceSpec[realBase + srcIdx];
+        imag[dstIdx] = sourceSpec[imagBase + srcIdx];
+      }
+    }
+
+    const reconstructed = istft(
+      { real, imag, numFrames: ISTFT_TIME_FRAMES, numBins: ISTFT_FREQ_BINS } satisfies Spectrogram,
+      ISTFT_LENGTH,
+      { normalized: true },
+    );
+    const out = new Float32Array(SEGMENT_SAMPLES);
+    out.set(reconstructed.subarray(PRE_PAD_LEFT, PRE_PAD_LEFT + SEGMENT_SAMPLES));
+    channels.push(out);
+  }
+  return channels;
+}
+
+const MAGSPEC_DIMS: readonly number[] = [1, MAGSPEC_CHANNELS, NUM_FREQ_BINS, NUM_TIME_FRAMES];
+
+export {
+  SEGMENT_SAMPLES,
+  NUM_TIME_FRAMES,
+  NUM_FREQ_BINS,
+  MAGSPEC_CHANNELS,
+  MAGSPEC_DIMS,
+  computeMagspec,
+  waveformFromComplexAsChannels,
+};

--- a/src/audio/separation/derived-stems.test.ts
+++ b/src/audio/separation/derived-stems.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { computeInstrumental } from "@/audio/separation/derived-stems";
+
+describe("computeInstrumental", () => {
+  it("returns original − vocals per channel", () => {
+    const original = [Float32Array.from([1, 2, 3, 4]), Float32Array.from([10, 20, 30, 40])];
+    const vocals = [Float32Array.from([0.5, 0.5, 0.5, 0.5]), Float32Array.from([1, 2, 3, 4])];
+    const out = computeInstrumental(original, vocals);
+    expect(Array.from(out[0])).toEqual([0.5, 1.5, 2.5, 3.5]);
+    expect(Array.from(out[1])).toEqual([9, 18, 27, 36]);
+  });
+
+  it("treats missing vocals channel as silence", () => {
+    const original = [Float32Array.from([1, 2, 3])];
+    const vocals: Float32Array[] = [];
+    const out = computeInstrumental(original, vocals);
+    expect(Array.from(out[0])).toEqual([1, 2, 3]);
+  });
+});

--- a/src/audio/separation/derived-stems.ts
+++ b/src/audio/separation/derived-stems.ts
@@ -1,0 +1,17 @@
+function computeInstrumental(original: Float32Array[], vocals: Float32Array[]): Float32Array[] {
+  const numChannels = original.length;
+  const numFrames = original[0]?.length ?? 0;
+  const result: Float32Array[] = [];
+  for (let c = 0; c < numChannels; c++) {
+    const out = new Float32Array(numFrames);
+    const orig = original[c];
+    const voc = vocals[c] ?? new Float32Array(numFrames);
+    for (let i = 0; i < numFrames; i++) {
+      out[i] = orig[i] - voc[i];
+    }
+    result.push(out);
+  }
+  return result;
+}
+
+export { computeInstrumental };

--- a/src/audio/separation/model-cache.ts
+++ b/src/audio/separation/model-cache.ts
@@ -1,0 +1,78 @@
+import type { ModelDescriptor } from "@/audio/separation/model-registry";
+
+const CACHE_NAME = "composer-vocal-model-v1";
+
+type DownloadProgress = (loaded: number, total: number) => void;
+
+async function hasCachedModel(model: ModelDescriptor): Promise<boolean> {
+  if (typeof caches === "undefined") return false;
+  const cache = await caches.open(CACHE_NAME);
+  const hit = await cache.match(model.url);
+  return hit !== undefined;
+}
+
+async function readCachedModel(model: ModelDescriptor): Promise<ArrayBuffer | null> {
+  if (typeof caches === "undefined") return null;
+  const cache = await caches.open(CACHE_NAME);
+  const hit = await cache.match(model.url);
+  if (!hit) return null;
+  return hit.arrayBuffer();
+}
+
+async function fetchAndCacheModel(
+  model: ModelDescriptor,
+  signal: AbortSignal,
+  onProgress: DownloadProgress,
+): Promise<ArrayBuffer> {
+  const response = await fetch(model.url, { signal });
+  if (!response.ok) {
+    throw new Error(`Model fetch failed (${response.status} ${response.statusText})`);
+  }
+
+  const contentLengthHeader = response.headers.get("content-length");
+  const total = contentLengthHeader ? Number(contentLengthHeader) : model.approxBytes;
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const buf = await response.arrayBuffer();
+    onProgress(buf.byteLength, buf.byteLength);
+    if (typeof caches !== "undefined") {
+      const cache = await caches.open(CACHE_NAME);
+      await cache.put(model.url, new Response(buf, { headers: { "content-type": "application/octet-stream" } }));
+    }
+    return buf;
+  }
+
+  const chunks: Uint8Array[] = [];
+  let loaded = 0;
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (signal.aborted) {
+      reader.cancel().catch(() => {});
+      throw new DOMException("Aborted", "AbortError");
+    }
+    if (done) break;
+    if (value) {
+      chunks.push(value);
+      loaded += value.byteLength;
+      onProgress(loaded, total);
+    }
+  }
+
+  const merged = new Uint8Array(loaded);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  if (typeof caches !== "undefined") {
+    const cache = await caches.open(CACHE_NAME);
+    await cache.put(model.url, new Response(merged, { headers: { "content-type": "application/octet-stream" } }));
+  }
+
+  return merged.buffer;
+}
+
+export { hasCachedModel, readCachedModel, fetchAndCacheModel };
+export type { DownloadProgress };

--- a/src/audio/separation/model-registry.ts
+++ b/src/audio/separation/model-registry.ts
@@ -1,0 +1,47 @@
+import type { VocalModelVariant } from "@/stores/settings";
+
+interface ModelDescriptor {
+  variant: VocalModelVariant;
+  url: string;
+  filename: string;
+  approxBytes: number;
+  approxMb: number;
+}
+
+const MODEL_FILENAMES: Record<VocalModelVariant, string> = {
+  fp16: "htdemucs_fp16.onnx",
+  fp32: "htdemucs_fp32.onnx",
+};
+
+const MODEL_APPROX_BYTES: Record<VocalModelVariant, number> = {
+  fp16: 85 * 1024 * 1024,
+  fp32: 171 * 1024 * 1024,
+};
+
+function getBaseUrl(): string | null {
+  const raw = import.meta.env.VITE_VOCAL_MODEL_BASE_URL;
+  if (!raw || typeof raw !== "string") return null;
+  const trimmed = raw.trim().replace(/\/$/, "");
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function getModelDescriptor(variant: VocalModelVariant): ModelDescriptor | null {
+  const base = getBaseUrl();
+  if (!base) return null;
+  const filename = MODEL_FILENAMES[variant];
+  const approxBytes = MODEL_APPROX_BYTES[variant];
+  return {
+    variant,
+    url: `${base}/${filename}`,
+    filename,
+    approxBytes,
+    approxMb: Math.round(approxBytes / (1024 * 1024)),
+  };
+}
+
+function isModelHostingConfigured(): boolean {
+  return getBaseUrl() !== null;
+}
+
+export { getModelDescriptor, isModelHostingConfigured };
+export type { ModelDescriptor };

--- a/src/audio/separation/stem-store.ts
+++ b/src/audio/separation/stem-store.ts
@@ -1,0 +1,108 @@
+import type { Stem } from "@/audio/separation/types";
+import { STEM_STORE_NAME, openDB } from "@/lib/persistence";
+import type { VocalModelVariant } from "@/stores/settings";
+
+const MAX_ENTRIES = 3;
+const STEM_CACHE_VERSION = 2;
+
+interface StemRecord {
+  blob: Blob;
+  createdAt: number;
+  jobKey: string;
+}
+
+function makeKey(audioHash: string, stem: Stem, variant: VocalModelVariant): string {
+  return `${audioHash}|${stem}|${variant}|v${STEM_CACHE_VERSION}`;
+}
+
+function makeJobKey(audioHash: string, variant: VocalModelVariant): string {
+  return `${audioHash}|${variant}|v${STEM_CACHE_VERSION}`;
+}
+
+async function getStem(audioHash: string, stem: Stem, variant: VocalModelVariant): Promise<Blob | null> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STEM_STORE_NAME, "readonly");
+    const store = tx.objectStore(STEM_STORE_NAME);
+    const req = store.get(makeKey(audioHash, stem, variant));
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => {
+      const record = req.result as StemRecord | undefined;
+      resolve(record?.blob ?? null);
+    };
+    tx.oncomplete = () => db.close();
+  });
+}
+
+async function hasStems(audioHash: string, variant: VocalModelVariant): Promise<boolean> {
+  const vocals = await getStem(audioHash, "vocals", variant);
+  if (!vocals) return false;
+  const instrumental = await getStem(audioHash, "instrumental", variant);
+  return instrumental !== null;
+}
+
+async function putStem(audioHash: string, stem: Stem, variant: VocalModelVariant, blob: Blob): Promise<void> {
+  const db = await openDB();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STEM_STORE_NAME, "readwrite");
+    const store = tx.objectStore(STEM_STORE_NAME);
+    const record: StemRecord = {
+      blob,
+      createdAt: Date.now(),
+      jobKey: makeJobKey(audioHash, variant),
+    };
+    const req = store.put(record, makeKey(audioHash, stem, variant));
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve();
+    tx.oncomplete = () => db.close();
+  });
+  await evictIfOverCapacity();
+}
+
+async function evictIfOverCapacity(): Promise<void> {
+  const db = await openDB();
+  const records = await new Promise<Array<{ key: IDBValidKey; record: StemRecord }>>((resolve, reject) => {
+    const tx = db.transaction(STEM_STORE_NAME, "readonly");
+    const store = tx.objectStore(STEM_STORE_NAME);
+    const out: Array<{ key: IDBValidKey; record: StemRecord }> = [];
+    const cursorReq = store.openCursor();
+    cursorReq.onerror = () => reject(cursorReq.error);
+    cursorReq.onsuccess = () => {
+      const cursor = cursorReq.result;
+      if (cursor) {
+        out.push({ key: cursor.key, record: cursor.value as StemRecord });
+        cursor.continue();
+      } else {
+        resolve(out);
+      }
+    };
+    tx.oncomplete = () => db.close();
+  });
+
+  const jobs = new Map<string, { newest: number; keys: IDBValidKey[] }>();
+  for (const { key, record } of records) {
+    const job = jobs.get(record.jobKey) ?? { newest: 0, keys: [] };
+    job.newest = Math.max(job.newest, record.createdAt);
+    job.keys.push(key);
+    jobs.set(record.jobKey, job);
+  }
+  if (jobs.size <= MAX_ENTRIES) return;
+
+  const sortedJobs = [...jobs.entries()].sort((a, b) => a[1].newest - b[1].newest);
+  const toEvict = sortedJobs.slice(0, sortedJobs.length - MAX_ENTRIES);
+  const keysToDelete = toEvict.flatMap(([, job]) => job.keys);
+
+  const dbDelete = await openDB();
+  await new Promise<void>((resolve, reject) => {
+    const tx = dbDelete.transaction(STEM_STORE_NAME, "readwrite");
+    const store = tx.objectStore(STEM_STORE_NAME);
+    for (const key of keysToDelete) store.delete(key);
+    tx.onerror = () => reject(tx.error);
+    tx.oncomplete = () => {
+      dbDelete.close();
+      resolve();
+    };
+  });
+}
+
+export { getStem, hasStems, putStem, makeKey, makeJobKey };

--- a/src/audio/separation/stft.test.ts
+++ b/src/audio/separation/stft.test.ts
@@ -1,0 +1,56 @@
+import { istft, stft } from "@/audio/separation/stft";
+import { describe, expect, it } from "vitest";
+
+function rms(a: Float32Array): number {
+  let sum = 0;
+  for (let i = 0; i < a.length; i++) sum += a[i] * a[i];
+  return Math.sqrt(sum / a.length);
+}
+
+function diffRms(a: Float32Array, b: Float32Array): number {
+  let sum = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    const d = a[i] - b[i];
+    sum += d * d;
+  }
+  return Math.sqrt(sum / n);
+}
+
+describe("stft", () => {
+  it("round-trips a sine wave with low RMS error", () => {
+    const sr = 44100;
+    const length = 32768;
+    const signal = new Float32Array(length);
+    for (let i = 0; i < length; i++) signal[i] = Math.sin((2 * Math.PI * 440 * i) / sr) * 0.5;
+
+    const spec = stft(signal);
+    const reconstructed = istft(spec, length);
+    expect(reconstructed.length).toBe(length);
+
+    const pad = 8192;
+    const a = signal.subarray(pad, length - pad);
+    const b = reconstructed.subarray(pad, length - pad);
+    const err = diffRms(a, b);
+    const ref = rms(a);
+    expect(err / ref).toBeLessThan(0.05);
+  });
+
+  it("round-trips a normalized spectrogram without losing amplitude", () => {
+    const sr = 44100;
+    const length = 32768;
+    const signal = new Float32Array(length);
+    for (let i = 0; i < length; i++) signal[i] = Math.sin((2 * Math.PI * 880 * i) / sr) * 0.25;
+
+    const spec = stft(signal, { normalized: true });
+    const reconstructed = istft(spec, length, { normalized: true });
+
+    const pad = 8192;
+    const a = signal.subarray(pad, length - pad);
+    const b = reconstructed.subarray(pad, length - pad);
+    const err = diffRms(a, b);
+    const ref = rms(a);
+    expect(err / ref).toBeLessThan(0.05);
+    expect(rms(b) / ref).toBeGreaterThan(0.95);
+  });
+});

--- a/src/audio/separation/stft.ts
+++ b/src/audio/separation/stft.ts
@@ -1,0 +1,179 @@
+const N_FFT = 4096;
+const HOP_LENGTH = 1024;
+const WIN_LENGTH = N_FFT;
+
+// Periodic Hann window: divisor is `size` (not `size - 1`). Matches PyTorch's
+// `torch.hann_window(size, periodic=True)`, which is what `torch.stft` uses by
+// default. The symmetric variant (divisor `size - 1`) introduces a small but
+// consistent shape error across every frame that gets amplified through the
+// HTDemucs magnitude branch — audible as distortion in the separated stems.
+function hannWindow(size: number): Float32Array {
+  const w = new Float32Array(size);
+  for (let i = 0; i < size; i++) {
+    w[i] = 0.5 * (1 - Math.cos((2 * Math.PI * i) / size));
+  }
+  return w;
+}
+
+function bitReverse(value: number, bits: number): number {
+  let reversed = 0;
+  let v = value;
+  for (let i = 0; i < bits; i++) {
+    reversed = (reversed << 1) | (v & 1);
+    v >>>= 1;
+  }
+  return reversed;
+}
+
+function fftRadix2(real: Float32Array, imag: Float32Array): void {
+  const n = real.length;
+  const bits = Math.log2(n);
+  if (!Number.isInteger(bits)) throw new Error("FFT length must be power of 2");
+
+  for (let i = 0; i < n; i++) {
+    const j = bitReverse(i, bits);
+    if (j > i) {
+      [real[i], real[j]] = [real[j], real[i]];
+      [imag[i], imag[j]] = [imag[j], imag[i]];
+    }
+  }
+
+  for (let size = 2; size <= n; size *= 2) {
+    const halfsize = size / 2;
+    const angleStep = (-2 * Math.PI) / size;
+    for (let i = 0; i < n; i += size) {
+      for (let k = 0; k < halfsize; k++) {
+        const angle = angleStep * k;
+        const wr = Math.cos(angle);
+        const wi = Math.sin(angle);
+        const idx = i + k;
+        const jdx = idx + halfsize;
+        const tr = wr * real[jdx] - wi * imag[jdx];
+        const ti = wr * imag[jdx] + wi * real[jdx];
+        real[jdx] = real[idx] - tr;
+        imag[jdx] = imag[idx] - ti;
+        real[idx] += tr;
+        imag[idx] += ti;
+      }
+    }
+  }
+}
+
+function ifftRadix2(real: Float32Array, imag: Float32Array): void {
+  const n = real.length;
+  for (let i = 0; i < n; i++) imag[i] = -imag[i];
+  fftRadix2(real, imag);
+  const invN = 1 / n;
+  for (let i = 0; i < n; i++) {
+    real[i] *= invN;
+    imag[i] = -imag[i] * invN;
+  }
+}
+
+interface Spectrogram {
+  real: Float32Array;
+  imag: Float32Array;
+  numFrames: number;
+  numBins: number;
+}
+
+function reflectPad(signal: Float32Array, padLeft: number, padRight: number): Float32Array {
+  const out = new Float32Array(signal.length + padLeft + padRight);
+  out.set(signal, padLeft);
+  // Left reflect: out[padLeft - 1 - i] = signal[1 + i]  (mirror around index 0)
+  for (let i = 0; i < padLeft; i++) {
+    const src = i + 1;
+    out[padLeft - 1 - i] = signal[src < signal.length ? src : signal.length - 1];
+  }
+  // Right reflect: out[padLeft + signal.length + i] = signal[signal.length - 2 - i]
+  for (let i = 0; i < padRight; i++) {
+    const src = signal.length - 2 - i;
+    out[padLeft + signal.length + i] = signal[src >= 0 ? src : 0];
+  }
+  return out;
+}
+
+interface StftOptions {
+  /** Center-pad the signal (reflect, n_fft/2 each side) before framing. Default true. */
+  center?: boolean;
+  /** Divide each complex coefficient by sqrt(n_fft). Default false. */
+  normalized?: boolean;
+}
+
+function stft(signal: Float32Array, opts: StftOptions = {}): Spectrogram {
+  const { center = true, normalized = false } = opts;
+  const window = hannWindow(WIN_LENGTH);
+
+  const framed = center ? reflectPad(signal, WIN_LENGTH / 2, WIN_LENGTH / 2) : signal;
+  const numFrames = 1 + Math.floor((framed.length - WIN_LENGTH) / HOP_LENGTH);
+  const numBins = N_FFT / 2 + 1;
+  const real = new Float32Array(numFrames * numBins);
+  const imag = new Float32Array(numFrames * numBins);
+
+  const frameReal = new Float32Array(N_FFT);
+  const frameImag = new Float32Array(N_FFT);
+  const scale = normalized ? 1 / Math.sqrt(N_FFT) : 1;
+
+  for (let f = 0; f < numFrames; f++) {
+    const start = f * HOP_LENGTH;
+    for (let i = 0; i < WIN_LENGTH; i++) {
+      frameReal[i] = framed[start + i] * window[i];
+    }
+    if (N_FFT > WIN_LENGTH) frameReal.fill(0, WIN_LENGTH);
+    frameImag.fill(0);
+    fftRadix2(frameReal, frameImag);
+    for (let b = 0; b < numBins; b++) {
+      real[f * numBins + b] = frameReal[b] * scale;
+      imag[f * numBins + b] = frameImag[b] * scale;
+    }
+  }
+
+  return { real, imag, numFrames, numBins };
+}
+
+interface IstftOptions {
+  /** Invert coefficients produced with normalized=true. Default false. */
+  normalized?: boolean;
+}
+
+function istft(spec: Spectrogram, outputLength: number, opts: IstftOptions = {}): Float32Array {
+  const { normalized = false } = opts;
+  const window = hannWindow(WIN_LENGTH);
+  const halfWin = WIN_LENGTH / 2;
+  const paddedLength = outputLength + WIN_LENGTH;
+  const out = new Float32Array(paddedLength);
+  const norm = new Float32Array(paddedLength);
+
+  const frameReal = new Float32Array(N_FFT);
+  const frameImag = new Float32Array(N_FFT);
+  const scale = normalized ? Math.sqrt(N_FFT) : 1;
+
+  for (let f = 0; f < spec.numFrames; f++) {
+    frameReal.fill(0);
+    frameImag.fill(0);
+    for (let b = 0; b < spec.numBins; b++) {
+      frameReal[b] = spec.real[f * spec.numBins + b];
+      frameImag[b] = spec.imag[f * spec.numBins + b];
+    }
+    for (let b = 1; b < spec.numBins - 1; b++) {
+      frameReal[N_FFT - b] = frameReal[b];
+      frameImag[N_FFT - b] = -frameImag[b];
+    }
+    ifftRadix2(frameReal, frameImag);
+    const start = f * HOP_LENGTH;
+    for (let i = 0; i < WIN_LENGTH; i++) {
+      out[start + i] += frameReal[i] * scale * window[i];
+      norm[start + i] += window[i] * window[i];
+    }
+  }
+
+  const result = new Float32Array(outputLength);
+  for (let i = 0; i < outputLength; i++) {
+    const idx = i + halfWin;
+    result[i] = norm[idx] > 1e-8 ? out[idx] / norm[idx] : 0;
+  }
+  return result;
+}
+
+export { N_FFT, HOP_LENGTH, WIN_LENGTH, hannWindow, fftRadix2, ifftRadix2, reflectPad, stft, istft };
+export type { Spectrogram, StftOptions, IstftOptions };

--- a/src/audio/separation/types.ts
+++ b/src/audio/separation/types.ts
@@ -1,0 +1,17 @@
+type Stem = "original" | "vocals" | "instrumental";
+
+type SeparationStatus = "idle" | "downloading" | "processing" | "ready" | "error" | "cancelled";
+
+interface SeparationError {
+  code:
+    | "no-base-url"
+    | "fetch-failed"
+    | "integrity-mismatch"
+    | "decode-failed"
+    | "ort-failed"
+    | "cancelled"
+    | "unknown";
+  message: string;
+}
+
+export type { Stem, SeparationStatus, SeparationError };

--- a/src/audio/separation/validate-channels.test.ts
+++ b/src/audio/separation/validate-channels.test.ts
@@ -1,0 +1,13 @@
+import { hasOnlyFiniteSamples } from "@/audio/separation/validate-channels";
+import { describe, expect, it } from "vitest";
+
+describe("hasOnlyFiniteSamples", () => {
+  it("returns true for finite audio samples", () => {
+    expect(hasOnlyFiniteSamples([Float32Array.from([0, -0.5, 1])])).toBe(true);
+  });
+
+  it("returns false for NaN and infinity", () => {
+    expect(hasOnlyFiniteSamples([Float32Array.from([0, Number.NaN])])).toBe(false);
+    expect(hasOnlyFiniteSamples([Float32Array.from([Number.POSITIVE_INFINITY])])).toBe(false);
+  });
+});

--- a/src/audio/separation/validate-channels.ts
+++ b/src/audio/separation/validate-channels.ts
@@ -1,0 +1,10 @@
+function hasOnlyFiniteSamples(channels: Float32Array[]): boolean {
+  for (const channel of channels) {
+    for (let i = 0; i < channel.length; i++) {
+      if (!Number.isFinite(channel[i])) return false;
+    }
+  }
+  return true;
+}
+
+export { hasOnlyFiniteSamples };

--- a/src/audio/separation/worker-host.ts
+++ b/src/audio/separation/worker-host.ts
@@ -1,0 +1,127 @@
+import type { InboundMessage, OutboundMessage } from "@/audio/separation/worker";
+import type { VocalModelVariant } from "@/stores/settings";
+
+interface InitOptions {
+  variant: VocalModelVariant;
+  forceWasm?: boolean;
+  onProgress?: (loaded: number, total: number) => void;
+}
+
+interface ProcessOptions {
+  channels: Float32Array[];
+  totalFrames: number;
+  onProgress?: (processed: number, total: number) => void;
+}
+
+interface ProcessResult {
+  vocals: Float32Array[];
+  numChannels: number;
+  totalFrames: number;
+}
+
+class SeparationWorker {
+  private worker: Worker | null = null;
+  private currentResolve: ((value: unknown) => void) | null = null;
+  private currentReject: ((reason: Error) => void) | null = null;
+  private currentProgress: ((loaded: number, total: number) => void) | null = null;
+
+  private ensureWorker(): Worker {
+    if (!this.worker) {
+      this.worker = new Worker(new URL("./worker.ts", import.meta.url), { type: "module" });
+      this.worker.addEventListener("message", (ev: MessageEvent<OutboundMessage>) => this.onMessage(ev.data));
+    }
+    return this.worker;
+  }
+
+  private onMessage(msg: OutboundMessage) {
+    if (msg.type === "init-progress" || msg.type === "process-progress") {
+      const loaded = msg.type === "init-progress" ? msg.loaded : msg.processed;
+      const total = msg.type === "init-progress" ? msg.total : msg.total;
+      this.currentProgress?.(loaded, total);
+      return;
+    }
+    if (msg.type === "init-done") {
+      this.currentResolve?.(undefined);
+      this.clearCurrent();
+      return;
+    }
+    if (msg.type === "process-done") {
+      this.currentResolve?.({ vocals: msg.vocals, numChannels: msg.numChannels, totalFrames: msg.totalFrames });
+      this.clearCurrent();
+      return;
+    }
+    if (msg.type === "cancelled") {
+      this.currentReject?.(new DOMException("Cancelled", "AbortError"));
+      this.clearCurrent();
+      return;
+    }
+    if (msg.type === "error") {
+      const err = new Error(msg.message);
+      (err as Error & { code?: string }).code = msg.code;
+      this.currentReject?.(err);
+      this.clearCurrent();
+      return;
+    }
+  }
+
+  private clearCurrent() {
+    this.currentResolve = null;
+    this.currentReject = null;
+    this.currentProgress = null;
+  }
+
+  private post(message: InboundMessage, transfer?: Transferable[]) {
+    this.ensureWorker().postMessage(message, transfer ?? []);
+  }
+
+  async init(opts: InitOptions): Promise<void> {
+    await new Promise<unknown>((resolve, reject) => {
+      this.currentResolve = resolve;
+      this.currentReject = reject;
+      this.currentProgress = opts.onProgress ?? null;
+      this.post({ type: "init", variant: opts.variant, forceWasm: opts.forceWasm });
+    });
+  }
+
+  async process(opts: ProcessOptions): Promise<ProcessResult> {
+    try {
+      const result = await new Promise<unknown>((resolve, reject) => {
+        this.currentResolve = resolve;
+        this.currentReject = reject;
+        this.currentProgress = opts.onProgress ?? null;
+        // Copy each channel into a fresh buffer before transferring. Transferring
+        // the original buffers would detach the caller's Float32Arrays (length
+        // -> 0), which then breaks any post-processing in the main thread
+        // (e.g. computeInstrumental over decoded.channels).
+        const copies = opts.channels.map((c) => new Float32Array(c));
+        const transfer = copies.map((c) => c.buffer);
+        this.post({ type: "process", channels: copies, totalFrames: opts.totalFrames }, transfer);
+      });
+      return result as ProcessResult;
+    } finally {
+      // Tear the worker down after every process(), regardless of outcome.
+      // ORT's WebGPU backend keeps a GPU buffer pool tied to the worker's
+      // WebGPU device — `session.release()` alone doesn't free it. Terminating
+      // the worker destroys the device and reclaims VRAM. The next separate()
+      // call pays a small re-init cost (model bytes come from Cache API, only
+      // the decode + GPU upload re-runs).
+      this.dispose();
+    }
+  }
+
+  cancel(): void {
+    if (!this.worker) return;
+    this.post({ type: "cancel" });
+  }
+
+  dispose(): void {
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+    this.clearCurrent();
+  }
+}
+
+export { SeparationWorker };
+export type { ProcessResult };

--- a/src/audio/separation/worker.ts
+++ b/src/audio/separation/worker.ts
@@ -1,14 +1,8 @@
 /// <reference lib="webworker" />
 // biome-ignore organizeImports: the webworker triple-slash reference must stay before imports.
 import { type Chunk, SEGMENT_SAMPLES, chunkCount, iterateChunks, stitchChunks } from "@/audio/separation/chunker";
-import {
-  MAGSPEC_CHANNELS,
-  MAGSPEC_DIMS,
-  NUM_FREQ_BINS,
-  NUM_TIME_FRAMES,
-  computeMagspec,
-  waveformFromComplexAsChannels,
-} from "@/audio/separation/demucs-spec";
+import { MAGSPEC_DIMS, computeMagspec } from "@/audio/separation/demucs-spec";
+import { denormalizeDemucsOutput, extractVocalsStem, normalizeForDemucs } from "@/audio/separation/demucs-postprocess";
 import { fetchAndCacheModel, hasCachedModel, readCachedModel } from "@/audio/separation/model-cache";
 import { getModelDescriptor } from "@/audio/separation/model-registry";
 import type { VocalModelVariant } from "@/stores/settings";
@@ -21,7 +15,6 @@ import type { VocalModelVariant } from "@/stores/settings";
 //     "output": [1, 4, 4, 2048, 336]  separated spectrogram branch
 //     "add_67": [1, 4, 2, 343980]     separated time branch
 //                                     stem order: drums, bass, other, vocals
-const STEM_INDEX_VOCALS = 3;
 const FREQ_OUTPUT_NAME = "output";
 const TIME_OUTPUT_NAME = "add_67";
 const WAVEFORM_INPUT_NAME = "input";
@@ -231,76 +224,6 @@ async function handleProcess(channels: Float32Array[], totalFrames: number) {
     },
     transfers,
   );
-}
-
-function normalizeForDemucs(
-  channels: Float32Array[],
-  totalFrames: number,
-): {
-  channels: Float32Array[];
-  mean: number;
-  std: number;
-} {
-  if (totalFrames === 0) return { channels, mean: 0, std: 1 };
-
-  let mean = 0;
-  for (let i = 0; i < totalFrames; i++) {
-    mean += ((channels[0]?.[i] ?? 0) + (channels[1]?.[i] ?? 0)) * 0.5;
-  }
-  mean /= totalFrames;
-
-  let variance = 0;
-  for (let i = 0; i < totalFrames; i++) {
-    const mono = ((channels[0]?.[i] ?? 0) + (channels[1]?.[i] ?? 0)) * 0.5;
-    const d = mono - mean;
-    variance += d * d;
-  }
-  const std = Math.sqrt(variance / Math.max(1, totalFrames - 1));
-  if (!Number.isFinite(std) || std < 1e-8) return { channels, mean: 0, std: 1 };
-
-  return {
-    mean,
-    std,
-    channels: channels.map((channel) => {
-      const out = new Float32Array(channel.length);
-      for (let i = 0; i < channel.length; i++) out[i] = (channel[i] - mean) / std;
-      return out;
-    }),
-  };
-}
-
-function denormalizeDemucsOutput(channels: Float32Array[], normalized: { mean: number; std: number }): Float32Array[] {
-  if (normalized.mean === 0 && normalized.std === 1) return channels;
-  for (const channel of channels) {
-    for (let i = 0; i < channel.length; i++) channel[i] = channel[i] * normalized.std + normalized.mean;
-  }
-  return channels;
-}
-
-// add_67 has dims [1, 4, 2, 343980]: batch, stem, channel, sample.
-// output has dims [1, 4, 4, 2048, 336]: batch, stem, complex-as-channels, freq, time.
-// Vocals = stem index 3. Stride per stem = 2 * SEGMENT_SAMPLES.
-function extractVocalsStem(timeTensor: OrtTensor, freqTensor: OrtTensor): Float32Array[] {
-  const timeData = timeTensor.data;
-  const stemStride = 2 * SEGMENT_SAMPLES;
-  const channelStride = SEGMENT_SAMPLES;
-  const base = STEM_INDEX_VOCALS * stemStride;
-
-  const freqSourceStride = MAGSPEC_CHANNELS * NUM_FREQ_BINS * NUM_TIME_FRAMES;
-  const freqBase = STEM_INDEX_VOCALS * freqSourceStride;
-  const freqChannels = waveformFromComplexAsChannels(freqTensor.data.subarray(freqBase, freqBase + freqSourceStride));
-
-  const result: Float32Array[] = [];
-  for (let c = 0; c < 2; c++) {
-    const out = new Float32Array(SEGMENT_SAMPLES);
-    const timeBranch = timeData.subarray(base + c * channelStride, base + c * channelStride + SEGMENT_SAMPLES);
-    const freqBranch = freqChannels[c];
-    for (let i = 0; i < SEGMENT_SAMPLES; i++) {
-      out[i] = timeBranch[i] + freqBranch[i];
-    }
-    result.push(out);
-  }
-  return result;
 }
 
 self.addEventListener("message", (ev: MessageEvent<InboundMessage>) => {

--- a/src/audio/separation/worker.ts
+++ b/src/audio/separation/worker.ts
@@ -1,0 +1,318 @@
+/// <reference lib="webworker" />
+// biome-ignore organizeImports: the webworker triple-slash reference must stay before imports.
+import { type Chunk, SEGMENT_SAMPLES, chunkCount, iterateChunks, stitchChunks } from "@/audio/separation/chunker";
+import {
+  MAGSPEC_CHANNELS,
+  MAGSPEC_DIMS,
+  NUM_FREQ_BINS,
+  NUM_TIME_FRAMES,
+  computeMagspec,
+  waveformFromComplexAsChannels,
+} from "@/audio/separation/demucs-spec";
+import { fetchAndCacheModel, hasCachedModel, readCachedModel } from "@/audio/separation/model-cache";
+import { getModelDescriptor } from "@/audio/separation/model-registry";
+import type { VocalModelVariant } from "@/stores/settings";
+
+// HTDemucs ONNX I/O contract (matches sevagh/demucs.onnx export):
+//   inputs:
+//     "input": [1, 2, 343980]      stereo waveform @ 44.1 kHz, 7.8 s
+//     "x":     [1, 4, 2048, 336]   pre-computed magspec (L_re, L_im, R_re, R_im)
+//   outputs:
+//     "output": [1, 4, 4, 2048, 336]  separated spectrogram branch
+//     "add_67": [1, 4, 2, 343980]     separated time branch
+//                                     stem order: drums, bass, other, vocals
+const STEM_INDEX_VOCALS = 3;
+const FREQ_OUTPUT_NAME = "output";
+const TIME_OUTPUT_NAME = "add_67";
+const WAVEFORM_INPUT_NAME = "input";
+const MAGSPEC_INPUT_NAME = "x";
+
+declare const self: DedicatedWorkerGlobalScope;
+
+type InboundMessage =
+  | { type: "init"; variant: VocalModelVariant; forceWasm?: boolean }
+  | { type: "process"; channels: Float32Array[]; totalFrames: number }
+  | { type: "cancel" };
+
+type OutboundMessage =
+  | { type: "init-progress"; loaded: number; total: number }
+  | { type: "init-done" }
+  | { type: "process-progress"; processed: number; total: number }
+  | { type: "process-done"; vocals: Float32Array[]; numChannels: number; totalFrames: number }
+  | { type: "cancelled" }
+  | { type: "error"; code: string; message: string };
+
+interface Ort {
+  InferenceSession: {
+    create(
+      bytes: ArrayBuffer | Uint8Array,
+      opts: { executionProviders: string[]; graphOptimizationLevel?: string },
+    ): Promise<OrtSession>;
+  };
+  Tensor: new (dtype: "float32", data: Float32Array, dims: number[]) => OrtTensor;
+  env: { wasm: { wasmPaths?: string; numThreads?: number } };
+}
+
+interface OrtTensor {
+  data: Float32Array;
+  dims: number[];
+}
+
+interface OrtSession {
+  inputNames: string[];
+  outputNames: string[];
+  run(feeds: Record<string, OrtTensor>): Promise<Record<string, OrtTensor>>;
+  release?(): Promise<void>;
+}
+
+let ort: Ort | null = null;
+let session: OrtSession | null = null;
+let cancelled = false;
+
+function post(message: OutboundMessage, transfer?: Transferable[]) {
+  self.postMessage(message, transfer ?? []);
+}
+
+async function loadOrt(forceWasm: boolean | undefined): Promise<Ort> {
+  if (ort) return ort;
+  const mod = forceWasm
+    ? await import("onnxruntime-web")
+    : await import("onnxruntime-web/webgpu").catch(() => import("onnxruntime-web"));
+  const candidate = (mod as unknown as { default?: Ort }).default ?? (mod as unknown as Ort);
+  candidate.env.wasm.numThreads = 1;
+  candidate.env.wasm.wasmPaths = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${getOrtVersion()}/dist/`;
+  ort = candidate;
+  return candidate;
+}
+
+function getOrtVersion(): string {
+  return "1.26.0";
+}
+
+async function handleInit(variant: VocalModelVariant, forceWasm?: boolean) {
+  cancelled = false;
+  const descriptor = getModelDescriptor(variant);
+  if (!descriptor) {
+    post({ type: "error", code: "no-base-url", message: "VITE_VOCAL_MODEL_BASE_URL is not configured." });
+    return;
+  }
+
+  let modelBytes: ArrayBuffer;
+  if (await hasCachedModel(descriptor)) {
+    const cached = await readCachedModel(descriptor);
+    if (!cached) {
+      post({ type: "error", code: "fetch-failed", message: "Model cache hit but read failed." });
+      return;
+    }
+    modelBytes = cached;
+    post({ type: "init-progress", loaded: cached.byteLength, total: cached.byteLength });
+  } else {
+    const ac = new AbortController();
+    const onCancel = () => ac.abort();
+    cancelHandlers.add(onCancel);
+    try {
+      modelBytes = await fetchAndCacheModel(descriptor, ac.signal, (loaded, total) => {
+        post({ type: "init-progress", loaded, total });
+      });
+    } catch (err) {
+      if (cancelled || (err as Error)?.name === "AbortError") {
+        post({ type: "cancelled" });
+        return;
+      }
+      post({ type: "error", code: "fetch-failed", message: (err as Error).message });
+      return;
+    } finally {
+      cancelHandlers.delete(onCancel);
+    }
+  }
+
+  try {
+    const runtime = await loadOrt(forceWasm);
+    const providers = forceWasm ? ["wasm"] : ["webgpu", "wasm"];
+    session = await runtime.InferenceSession.create(modelBytes, {
+      executionProviders: providers,
+      graphOptimizationLevel: "all",
+    });
+    post({ type: "init-done" });
+  } catch (err) {
+    post({ type: "error", code: "ort-failed", message: (err as Error).message });
+  }
+}
+
+const cancelHandlers = new Set<() => void>();
+
+async function handleProcess(channels: Float32Array[], totalFrames: number) {
+  if (!session || !ort) {
+    post({ type: "error", code: "ort-failed", message: "Session not initialized." });
+    return;
+  }
+  if (channels.length !== 2) {
+    post({
+      type: "error",
+      code: "ort-failed",
+      message: `HTDemucs requires stereo input (got ${channels.length} channels).`,
+    });
+    return;
+  }
+  cancelled = false;
+  const totalChunks = chunkCount(totalFrames);
+  const vocalChunks: Chunk[] = [];
+  const normalized = normalizeForDemucs(channels, totalFrames);
+
+  let chunkIndex = 0;
+  for (const chunk of iterateChunks(normalized.channels)) {
+    if (cancelled) {
+      post({ type: "cancelled" });
+      return;
+    }
+
+    // Build "input" waveform tensor: [1, 2, 343980], laid out [L..., R...].
+    const waveformFlat = new Float32Array(2 * SEGMENT_SAMPLES);
+    waveformFlat.set(chunk.data[0], 0);
+    waveformFlat.set(chunk.data[1], SEGMENT_SAMPLES);
+    const waveformTensor = new ort.Tensor("float32", waveformFlat, [1, 2, SEGMENT_SAMPLES]);
+
+    // Build "x" magspec tensor: [1, 4, 2048, 336].
+    let magspecFlat: Float32Array;
+    try {
+      magspecFlat = computeMagspec(chunk.data);
+    } catch (err) {
+      post({ type: "error", code: "ort-failed", message: (err as Error).message });
+      return;
+    }
+    const magspecTensor = new ort.Tensor("float32", magspecFlat, [...MAGSPEC_DIMS]);
+
+    let result: Record<string, OrtTensor>;
+    try {
+      result = await session.run({
+        [WAVEFORM_INPUT_NAME]: waveformTensor,
+        [MAGSPEC_INPUT_NAME]: magspecTensor,
+      });
+    } catch (err) {
+      post({ type: "error", code: "ort-failed", message: (err as Error).message });
+      return;
+    }
+
+    const timeTensor = result[TIME_OUTPUT_NAME];
+    const freqTensor = result[FREQ_OUTPUT_NAME];
+    if (!timeTensor || !freqTensor) {
+      post({
+        type: "error",
+        code: "ort-failed",
+        message: `Missing output tensor ${!timeTensor ? TIME_OUTPUT_NAME : FREQ_OUTPUT_NAME}. Available: ${Object.keys(result).join(", ")}`,
+      });
+      return;
+    }
+    const vocalsChannels = extractVocalsStem(timeTensor, freqTensor);
+    vocalChunks.push({ start: chunk.start, end: chunk.end, data: vocalsChannels });
+
+    chunkIndex++;
+    post({ type: "process-progress", processed: chunkIndex, total: totalChunks });
+  }
+
+  const stitched = denormalizeDemucsOutput(stitchChunks(vocalChunks, totalFrames, channels.length), normalized);
+
+  // Drop GPU/CPU resources tied to the model session before we hand the result
+  // back. The host terminates the worker immediately after process-done, but
+  // releasing the session explicitly also covers the keep-worker-alive case
+  // and helps WebGPU EP flush its buffer pool.
+  try {
+    await session.release?.();
+  } catch {}
+  session = null;
+
+  const transfers: Transferable[] = stitched.map((c) => c.buffer);
+  post(
+    {
+      type: "process-done",
+      vocals: stitched,
+      numChannels: channels.length,
+      totalFrames,
+    },
+    transfers,
+  );
+}
+
+function normalizeForDemucs(
+  channels: Float32Array[],
+  totalFrames: number,
+): {
+  channels: Float32Array[];
+  mean: number;
+  std: number;
+} {
+  if (totalFrames === 0) return { channels, mean: 0, std: 1 };
+
+  let mean = 0;
+  for (let i = 0; i < totalFrames; i++) {
+    mean += ((channels[0]?.[i] ?? 0) + (channels[1]?.[i] ?? 0)) * 0.5;
+  }
+  mean /= totalFrames;
+
+  let variance = 0;
+  for (let i = 0; i < totalFrames; i++) {
+    const mono = ((channels[0]?.[i] ?? 0) + (channels[1]?.[i] ?? 0)) * 0.5;
+    const d = mono - mean;
+    variance += d * d;
+  }
+  const std = Math.sqrt(variance / Math.max(1, totalFrames - 1));
+  if (!Number.isFinite(std) || std < 1e-8) return { channels, mean: 0, std: 1 };
+
+  return {
+    mean,
+    std,
+    channels: channels.map((channel) => {
+      const out = new Float32Array(channel.length);
+      for (let i = 0; i < channel.length; i++) out[i] = (channel[i] - mean) / std;
+      return out;
+    }),
+  };
+}
+
+function denormalizeDemucsOutput(channels: Float32Array[], normalized: { mean: number; std: number }): Float32Array[] {
+  if (normalized.mean === 0 && normalized.std === 1) return channels;
+  for (const channel of channels) {
+    for (let i = 0; i < channel.length; i++) channel[i] = channel[i] * normalized.std + normalized.mean;
+  }
+  return channels;
+}
+
+// add_67 has dims [1, 4, 2, 343980]: batch, stem, channel, sample.
+// output has dims [1, 4, 4, 2048, 336]: batch, stem, complex-as-channels, freq, time.
+// Vocals = stem index 3. Stride per stem = 2 * SEGMENT_SAMPLES.
+function extractVocalsStem(timeTensor: OrtTensor, freqTensor: OrtTensor): Float32Array[] {
+  const timeData = timeTensor.data;
+  const stemStride = 2 * SEGMENT_SAMPLES;
+  const channelStride = SEGMENT_SAMPLES;
+  const base = STEM_INDEX_VOCALS * stemStride;
+
+  const freqSourceStride = MAGSPEC_CHANNELS * NUM_FREQ_BINS * NUM_TIME_FRAMES;
+  const freqBase = STEM_INDEX_VOCALS * freqSourceStride;
+  const freqChannels = waveformFromComplexAsChannels(freqTensor.data.subarray(freqBase, freqBase + freqSourceStride));
+
+  const result: Float32Array[] = [];
+  for (let c = 0; c < 2; c++) {
+    const out = new Float32Array(SEGMENT_SAMPLES);
+    const timeBranch = timeData.subarray(base + c * channelStride, base + c * channelStride + SEGMENT_SAMPLES);
+    const freqBranch = freqChannels[c];
+    for (let i = 0; i < SEGMENT_SAMPLES; i++) {
+      out[i] = timeBranch[i] + freqBranch[i];
+    }
+    result.push(out);
+  }
+  return result;
+}
+
+self.addEventListener("message", (ev: MessageEvent<InboundMessage>) => {
+  const msg = ev.data;
+  if (msg.type === "init") {
+    handleInit(msg.variant, msg.forceWasm);
+  } else if (msg.type === "process") {
+    handleProcess(msg.channels, msg.totalFrames);
+  } else if (msg.type === "cancel") {
+    cancelled = true;
+    for (const h of cancelHandlers) h();
+  }
+});
+
+export type { InboundMessage, OutboundMessage };

--- a/src/hooks/useAutoSeparate.ts
+++ b/src/hooks/useAutoSeparate.ts
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import { useAudioStore } from "@/stores/audio";
+import { useSeparationStore } from "@/stores/separation";
+import { useSettingsStore } from "@/stores/settings";
+
+function useAutoSeparate(): void {
+  useEffect(() => {
+    let prevKey: string | null = null;
+    const unsub = useAudioStore.subscribe((state) => {
+      const source = state.source;
+      const file = source?.type === "file" ? source.file : source?.type === "youtube" ? source.file : null;
+      const key = file ? `${file.name}|${file.size}|${file.lastModified ?? 0}` : null;
+      if (key === prevKey) return;
+      prevKey = key;
+
+      const sep = useSeparationStore.getState();
+      sep.refreshForCurrentSource();
+
+      if (!key) return;
+      if (!useSettingsStore.getState().autoSeparateOnImport) return;
+      if (!sep.hostingConfigured) return;
+      if (sep.status === "downloading" || sep.status === "processing") return;
+      sep.separate();
+    });
+    return () => unsub();
+  }, []);
+}
+
+export { useAutoSeparate };

--- a/src/hooks/useAutoSeparate.ts
+++ b/src/hooks/useAutoSeparate.ts
@@ -13,7 +13,6 @@ function useAutoSeparate(): void {
       if (key === prevKey) return;
       prevKey = key;
 
-
       const sep = useSeparationStore.getState();
       await sep.refreshForCurrentSource();
 
@@ -22,7 +21,6 @@ function useAutoSeparate(): void {
       if (!sep.hostingConfigured) return;
       if (sep.status === "downloading" || sep.status === "processing") return;
       sep.separate();
-
     });
     return () => unsub();
   }, []);

--- a/src/hooks/useAutoSeparate.ts
+++ b/src/hooks/useAutoSeparate.ts
@@ -6,21 +6,23 @@ import { useSettingsStore } from "@/stores/settings";
 function useAutoSeparate(): void {
   useEffect(() => {
     let prevKey: string | null = null;
-    const unsub = useAudioStore.subscribe((state) => {
+    const unsub = useAudioStore.subscribe(async (state) => {
       const source = state.source;
       const file = source?.type === "file" ? source.file : source?.type === "youtube" ? source.file : null;
       const key = file ? `${file.name}|${file.size}|${file.lastModified ?? 0}` : null;
       if (key === prevKey) return;
       prevKey = key;
 
+
       const sep = useSeparationStore.getState();
-      sep.refreshForCurrentSource();
+      await sep.refreshForCurrentSource();
 
       if (!key) return;
       if (!useSettingsStore.getState().autoSeparateOnImport) return;
       if (!sep.hostingConfigured) return;
       if (sep.status === "downloading" || sep.status === "processing") return;
       sep.separate();
+
     });
     return () => unsub();
   }, []);

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -1,12 +1,11 @@
 import {
   clearAudioFile,
-  debouncedSave,
-  flushPendingSave,
   loadAudioFile,
   loadCurrentProject,
   saveAudioFile,
   type SavedAudioSource,
 } from "@/lib/persistence";
+import { debouncedSave, flushPendingSave } from "@/lib/persistence-debounce";
 import { markPersistenceSettled } from "@/lib/persistence-settled";
 import { type AudioSource, useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";

--- a/src/lib/persistence-debounce.ts
+++ b/src/lib/persistence-debounce.ts
@@ -1,0 +1,89 @@
+import type { Agent } from "@/domain/agent/model";
+import type { LinkGroup } from "@/domain/group/template";
+import type { LyricLine } from "@/domain/line/model";
+import type { ProjectMetadata } from "@/domain/project/metadata";
+import { type SavedAudioSource, saveCurrentProject } from "@/lib/persistence";
+import type { GranularityMode } from "@/stores/project";
+import type { SyllableSplitDefaults } from "@/stores/project/types";
+import { useSettingsStore } from "@/stores/settings";
+
+// -- Constants ----------------------------------------------------------------
+
+const LOG_PREFIX = "[Persistence]";
+
+// -- Module state -------------------------------------------------------------
+
+type SaveArgs = [
+  ProjectMetadata,
+  Agent[],
+  LyricLine[],
+  LinkGroup[],
+  GranularityMode,
+  SyllableSplitDefaults,
+  SavedAudioSource | undefined,
+  string[],
+  string[],
+];
+
+let saveTimeout: ReturnType<typeof setTimeout> | null = null;
+let pendingSaveArgs: SaveArgs | null = null;
+
+// -- Public API ---------------------------------------------------------------
+
+function debouncedSave(
+  metadata: ProjectMetadata,
+  agents: Agent[],
+  lines: LyricLine[],
+  groups: LinkGroup[],
+  granularity: GranularityMode,
+  syllableSplitDefaults: SyllableSplitDefaults,
+  audioSource: SavedAudioSource | undefined,
+  dismissedSuggestions: string[],
+  dismissedExplicitSuggestions: string[],
+): void {
+  pendingSaveArgs = [
+    metadata,
+    agents,
+    lines,
+    groups,
+    granularity,
+    syllableSplitDefaults,
+    audioSource,
+    dismissedSuggestions,
+    dismissedExplicitSuggestions,
+  ];
+  if (saveTimeout) {
+    clearTimeout(saveTimeout);
+  }
+  const saveDelay = useSettingsStore.getState().autoSaveDelay;
+  saveTimeout = setTimeout(() => {
+    if (pendingSaveArgs) {
+      saveCurrentProject(...pendingSaveArgs).catch((err) => console.error(LOG_PREFIX, "Auto-save failed:", err));
+      pendingSaveArgs = null;
+    }
+    saveTimeout = null;
+  }, saveDelay);
+}
+
+function cancelPendingSave(): void {
+  if (saveTimeout) {
+    clearTimeout(saveTimeout);
+    saveTimeout = null;
+  }
+  pendingSaveArgs = null;
+}
+
+function flushPendingSave(): void {
+  if (saveTimeout) {
+    clearTimeout(saveTimeout);
+    saveTimeout = null;
+  }
+  if (pendingSaveArgs) {
+    saveCurrentProject(...pendingSaveArgs).catch((err) => console.error(LOG_PREFIX, "Flush save failed:", err));
+    pendingSaveArgs = null;
+  }
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { debouncedSave, cancelPendingSave, flushPendingSave };

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -28,8 +28,9 @@ interface SavedProject {
 // -- Constants ----------------------------------------------------------------
 
 const DB_NAME = "ttml-composer";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const STORE_NAME = "projects";
+const STEM_STORE_NAME = "separated-stems";
 const CURRENT_PROJECT_KEY = "current";
 const AUDIO_FILE_KEY = "current-audio";
 const LOG_PREFIX = "[Persistence]";
@@ -47,6 +48,9 @@ function openDB(): Promise<IDBDatabase> {
       const db = (event.target as IDBOpenDBRequest).result;
       if (!db.objectStoreNames.contains(STORE_NAME)) {
         db.createObjectStore(STORE_NAME);
+      }
+      if (!db.objectStoreNames.contains(STEM_STORE_NAME)) {
+        db.createObjectStore(STEM_STORE_NAME);
       }
     };
   });
@@ -296,5 +300,7 @@ export {
   saveAudioFile,
   loadAudioFile,
   clearAudioFile,
+  openDB,
+  STEM_STORE_NAME,
 };
 export type { SavedAudioSource };

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -4,7 +4,6 @@ import type { Agent } from "@/domain/agent/model";
 import type { LinkGroup } from "@/domain/group/template";
 import type { LyricLine } from "@/domain/line/model";
 import type { ProjectMetadata } from "@/domain/project/metadata";
-import { useSettingsStore } from "@/stores/settings";
 
 // -- Types --------------------------------------------------------------------
 
@@ -33,7 +32,6 @@ const STORE_NAME = "projects";
 const STEM_STORE_NAME = "separated-stems";
 const CURRENT_PROJECT_KEY = "current";
 const AUDIO_FILE_KEY = "current-audio";
-const LOG_PREFIX = "[Persistence]";
 
 // -- IndexedDB Helpers --------------------------------------------------------
 
@@ -216,87 +214,14 @@ async function importProjectFromFile(file: File): Promise<SavedProject> {
   return project;
 }
 
-// -- Debounced Auto-save ------------------------------------------------------
-
-let saveTimeout: ReturnType<typeof setTimeout> | null = null;
-let pendingSaveArgs:
-  | [
-      ProjectMetadata,
-      Agent[],
-      LyricLine[],
-      LinkGroup[],
-      GranularityMode,
-      SyllableSplitDefaults,
-      SavedAudioSource | undefined,
-      string[],
-      string[],
-    ]
-  | null = null;
-
-function debouncedSave(
-  metadata: ProjectMetadata,
-  agents: Agent[],
-  lines: LyricLine[],
-  groups: LinkGroup[],
-  granularity: GranularityMode,
-  syllableSplitDefaults: SyllableSplitDefaults,
-  audioSource: SavedAudioSource | undefined,
-  dismissedSuggestions: string[],
-  dismissedExplicitSuggestions: string[],
-): void {
-  pendingSaveArgs = [
-    metadata,
-    agents,
-    lines,
-    groups,
-    granularity,
-    syllableSplitDefaults,
-    audioSource,
-    dismissedSuggestions,
-    dismissedExplicitSuggestions,
-  ];
-  if (saveTimeout) {
-    clearTimeout(saveTimeout);
-  }
-  const saveDelay = useSettingsStore.getState().autoSaveDelay;
-  saveTimeout = setTimeout(() => {
-    if (pendingSaveArgs) {
-      saveCurrentProject(...pendingSaveArgs).catch((err) => console.error(LOG_PREFIX, "Auto-save failed:", err));
-      pendingSaveArgs = null;
-    }
-    saveTimeout = null;
-  }, saveDelay);
-}
-
-function cancelPendingSave(): void {
-  if (saveTimeout) {
-    clearTimeout(saveTimeout);
-    saveTimeout = null;
-  }
-  pendingSaveArgs = null;
-}
-
-function flushPendingSave(): void {
-  if (saveTimeout) {
-    clearTimeout(saveTimeout);
-    saveTimeout = null;
-  }
-  if (pendingSaveArgs) {
-    saveCurrentProject(...pendingSaveArgs).catch((err) => console.error(LOG_PREFIX, "Flush save failed:", err));
-    pendingSaveArgs = null;
-  }
-}
-
 // -- Exports ------------------------------------------------------------------
 
 export {
+  saveCurrentProject,
   loadCurrentProject,
   clearCurrentProject,
   exportProjectToFile,
   importProjectFromFile,
-  debouncedSave,
-  flushPendingSave,
-  cancelPendingSave,
   saveAudioFile,
   loadAudioFile,
   clearAudioFile,

--- a/src/lib/recovery.browser.test.tsx
+++ b/src/lib/recovery.browser.test.tsx
@@ -140,7 +140,7 @@ describe("recovery", () => {
       expect((await readRecoveryMetadata()).found).toBe(false);
 
       await new Promise<void>((resolve, reject) => {
-        const open = indexedDB.open(DB_NAME, 1);
+        const open = indexedDB.open(DB_NAME, 2);
         open.onerror = () => reject(open.error);
         open.onsuccess = () => {
           const db = open.result;

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -23,8 +23,9 @@ interface RecoveryResult {
 // -- Constants ----------------------------------------------------------------
 
 const DB_NAME = "ttml-composer";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const STORE_NAME = "projects";
+const STEM_STORE_NAME = "separated-stems";
 const CURRENT_PROJECT_KEY = "current";
 
 // -- Helpers ------------------------------------------------------------------
@@ -45,6 +46,9 @@ function openRecoveryDB(): Promise<IDBDatabase> {
       const db = (event.target as IDBOpenDBRequest).result;
       if (!db.objectStoreNames.contains(STORE_NAME)) {
         db.createObjectStore(STORE_NAME);
+      }
+      if (!db.objectStoreNames.contains(STEM_STORE_NAME)) {
+        db.createObjectStore(STEM_STORE_NAME);
       }
     };
   });

--- a/src/stores/audio.test.ts
+++ b/src/stores/audio.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it } from "vitest";
 import { useAudioStore } from "@/stores/audio";
+import { useSettingsStore } from "@/stores/settings";
+import { beforeEach, describe, expect, it } from "vitest";
 
 beforeEach(() => {
   useAudioStore.getState().reset();
@@ -105,5 +106,22 @@ describe("useAudioStore - seekTo", () => {
   it("accepts a valid time", () => {
     useAudioStore.getState().seekTo(5);
     expect(useAudioStore.getState().currentTime).toBe(5);
+  });
+});
+
+describe("useAudioStore - setPlaybackRate", () => {
+  it("persists the selected playback rate as the default", () => {
+    useAudioStore.getState().setPlaybackRate(1.5);
+    expect(useAudioStore.getState().playbackRate).toBe(1.5);
+    expect(useSettingsStore.getState().defaultPlaybackRate).toBe(1.5);
+  });
+
+  it("ignores invalid playback rates", () => {
+    useAudioStore.setState({ playbackRate: 1 });
+    useSettingsStore.getState().set("defaultPlaybackRate", 1);
+    useAudioStore.getState().setPlaybackRate(0);
+    useAudioStore.getState().setPlaybackRate(Number.NaN);
+    expect(useAudioStore.getState().playbackRate).toBe(1);
+    expect(useSettingsStore.getState().defaultPlaybackRate).toBe(1);
   });
 });

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -79,7 +79,11 @@ const useAudioStore = create<AudioState & AudioActions>((set, get) => ({
   setIsPlaying: (isPlaying) => set({ isPlaying }),
   setCurrentTime: (currentTime) => set({ currentTime }),
   setDuration: (duration) => set({ duration }),
-  setPlaybackRate: (playbackRate) => set({ playbackRate }),
+  setPlaybackRate: (playbackRate) => {
+    if (!Number.isFinite(playbackRate) || playbackRate <= 0) return;
+    useSettingsStore.getState().set("defaultPlaybackRate", playbackRate);
+    set({ playbackRate });
+  },
   setVolume: (volume) => set({ volume: Math.max(0, Math.min(1, volume)) }),
   toggleMute: () => set((s) => ({ isMuted: !s.isMuted })),
   setIsLoading: (isLoading) => set({ isLoading }),

--- a/src/stores/separation.ts
+++ b/src/stores/separation.ts
@@ -1,0 +1,265 @@
+import {
+  TARGET_SAMPLE_RATE,
+  decodeFileToFloat32,
+  floatChannelsToWavBlob,
+  hashFile,
+} from "@/audio/separation/audio-codec";
+import { computeInstrumental } from "@/audio/separation/derived-stems";
+import { hasCachedModel } from "@/audio/separation/model-cache";
+import { getModelDescriptor, isModelHostingConfigured } from "@/audio/separation/model-registry";
+import { getStem, hasStems, putStem } from "@/audio/separation/stem-store";
+import type { SeparationError, SeparationStatus, Stem } from "@/audio/separation/types";
+import { hasOnlyFiniteSamples } from "@/audio/separation/validate-channels";
+import { SeparationWorker } from "@/audio/separation/worker-host";
+import { useAudioStore } from "@/stores/audio";
+import { useSettingsStore } from "@/stores/settings";
+import { create } from "zustand";
+
+interface SeparationState {
+  status: SeparationStatus;
+  progress: { loaded: number; total: number };
+  error: SeparationError | null;
+  currentStem: Stem;
+  availableStems: Stem[];
+  modelCached: boolean;
+  jobKey: string | null;
+  stemUrls: Partial<Record<Stem, string>>;
+  hostingConfigured: boolean;
+}
+
+interface SeparationActions {
+  refreshModelCacheStatus: () => Promise<void>;
+  refreshForCurrentSource: () => Promise<void>;
+  downloadModel: () => Promise<void>;
+  separate: () => Promise<void>;
+  selectStem: (stem: Stem) => void;
+  cancel: () => void;
+  retry: () => Promise<void>;
+  reset: () => void;
+}
+
+let worker: SeparationWorker | null = null;
+let isCancelling = false;
+
+function getWorker(): SeparationWorker {
+  if (!worker) worker = new SeparationWorker();
+  return worker;
+}
+
+function disposeWorker() {
+  if (worker) {
+    worker.dispose();
+    worker = null;
+  }
+}
+
+function revokeUrls(urls: Partial<Record<Stem, string>>) {
+  for (const url of Object.values(urls)) {
+    if (url) URL.revokeObjectURL(url);
+  }
+}
+
+const useSeparationStore = create<SeparationState & SeparationActions>((set, get) => ({
+  status: "idle",
+  progress: { loaded: 0, total: 0 },
+  error: null,
+  currentStem: "original",
+  availableStems: ["original"],
+  modelCached: false,
+  jobKey: null,
+  stemUrls: {},
+  hostingConfigured: isModelHostingConfigured(),
+
+  refreshModelCacheStatus: async () => {
+    const variant = useSettingsStore.getState().vocalModelVariant;
+    const descriptor = getModelDescriptor(variant);
+    if (!descriptor) {
+      set({ modelCached: false, hostingConfigured: false });
+      return;
+    }
+    const cached = await hasCachedModel(descriptor);
+    set({ modelCached: cached, hostingConfigured: true });
+  },
+
+  refreshForCurrentSource: async () => {
+    revokeUrls(get().stemUrls);
+    const source = useAudioStore.getState().source;
+    const file = source?.type === "file" ? source.file : source?.type === "youtube" ? source.file : null;
+    if (!file) {
+      set({ jobKey: null, availableStems: ["original"], stemUrls: {}, currentStem: "original", status: "idle" });
+      return;
+    }
+    const variant = useSettingsStore.getState().vocalModelVariant;
+    const audioHash = await hashFile(file);
+    const jobKey = `${audioHash}|${variant}`;
+
+    const has = await hasStems(audioHash, variant);
+    if (!has) {
+      set({ jobKey, availableStems: ["original"], stemUrls: {}, currentStem: "original", status: "idle" });
+      return;
+    }
+
+    const vocalsBlob = await getStem(audioHash, "vocals", variant);
+    const instrumentalBlob = await getStem(audioHash, "instrumental", variant);
+    const stemUrls: Partial<Record<Stem, string>> = {};
+    if (vocalsBlob) stemUrls.vocals = URL.createObjectURL(vocalsBlob);
+    if (instrumentalBlob) stemUrls.instrumental = URL.createObjectURL(instrumentalBlob);
+    set({
+      jobKey,
+      availableStems: ["original", "vocals", "instrumental"],
+      stemUrls,
+      status: "ready",
+    });
+  },
+
+  downloadModel: async () => {
+    if (!get().hostingConfigured) {
+      set({
+        status: "error",
+        error: { code: "no-base-url", message: "Vocal model URL is not configured." },
+      });
+      return;
+    }
+    isCancelling = false;
+    const variant = useSettingsStore.getState().vocalModelVariant;
+    set({ status: "downloading", error: null, progress: { loaded: 0, total: 0 } });
+    try {
+      await getWorker().init({
+        variant,
+        onProgress: (loaded, total) => set({ progress: { loaded, total } }),
+      });
+      set({ status: "idle", modelCached: true });
+    } catch (err) {
+      if ((err as Error).name === "AbortError" || isCancelling) {
+        set({ status: "idle" });
+        return;
+      }
+      set({
+        status: "error",
+        error: { code: "fetch-failed", message: (err as Error).message },
+      });
+    }
+  },
+
+  separate: async () => {
+    if (!get().hostingConfigured) {
+      set({
+        status: "error",
+        error: { code: "no-base-url", message: "Vocal model URL is not configured." },
+      });
+      return;
+    }
+    const source = useAudioStore.getState().source;
+    const file = source?.type === "file" ? source.file : source?.type === "youtube" ? source.file : null;
+    if (!file) return;
+
+    isCancelling = false;
+    const variant = useSettingsStore.getState().vocalModelVariant;
+    set({ status: "downloading", error: null, progress: { loaded: 0, total: 0 } });
+    try {
+      await getWorker().init({
+        variant,
+        onProgress: (loaded, total) => set({ progress: { loaded, total } }),
+      });
+      set({ modelCached: true });
+    } catch (err) {
+      if ((err as Error).name === "AbortError" || isCancelling) {
+        set({ status: "idle" });
+        return;
+      }
+      set({ status: "error", error: { code: "fetch-failed", message: (err as Error).message } });
+      return;
+    }
+
+    set({ status: "processing", progress: { loaded: 0, total: 0 } });
+    let decoded: Awaited<ReturnType<typeof decodeFileToFloat32>>;
+    try {
+      decoded = await decodeFileToFloat32(file);
+    } catch (err) {
+      set({ status: "error", error: { code: "decode-failed", message: (err as Error).message } });
+      return;
+    }
+
+    const audioHash = await hashFile(file);
+    const jobKey = `${audioHash}|${variant}`;
+    set({ jobKey });
+
+    let result: Awaited<ReturnType<SeparationWorker["process"]>>;
+    try {
+      result = await getWorker().process({
+        channels: decoded.channels,
+        totalFrames: decoded.numFrames,
+        onProgress: (processed, total) => set({ progress: { loaded: processed, total } }),
+      });
+    } catch (err) {
+      if ((err as Error).name === "AbortError" || isCancelling) {
+        set({ status: "idle" });
+        return;
+      }
+      set({ status: "error", error: { code: "ort-failed", message: (err as Error).message } });
+      return;
+    }
+
+    if (!hasOnlyFiniteSamples(result.vocals)) {
+      set({
+        status: "error",
+        error: {
+          code: "ort-failed",
+          message:
+            "The vocal model returned invalid audio samples. Switch Vocal model precision to fp32 and run separation again.",
+        },
+      });
+      return;
+    }
+
+    const instrumental = computeInstrumental(decoded.channels, result.vocals);
+    const vocalsBlob = floatChannelsToWavBlob(result.vocals, TARGET_SAMPLE_RATE);
+    const instrumentalBlob = floatChannelsToWavBlob(instrumental, TARGET_SAMPLE_RATE);
+    await putStem(audioHash, "vocals", variant, vocalsBlob);
+    await putStem(audioHash, "instrumental", variant, instrumentalBlob);
+
+    revokeUrls(get().stemUrls);
+    const stemUrls: Partial<Record<Stem, string>> = {
+      vocals: URL.createObjectURL(vocalsBlob),
+      instrumental: URL.createObjectURL(instrumentalBlob),
+    };
+    set({
+      status: "ready",
+      availableStems: ["original", "vocals", "instrumental"],
+      stemUrls,
+    });
+  },
+
+  selectStem: (stem) => {
+    const available = get().availableStems;
+    if (!available.includes(stem)) return;
+    set({ currentStem: stem });
+  },
+
+  cancel: () => {
+    isCancelling = true;
+    if (worker) worker.cancel();
+    set({ status: "idle", progress: { loaded: 0, total: 0 } });
+  },
+
+  retry: async () => {
+    set({ error: null });
+    await get().separate();
+  },
+
+  reset: () => {
+    revokeUrls(get().stemUrls);
+    disposeWorker();
+    set({
+      status: "idle",
+      progress: { loaded: 0, total: 0 },
+      error: null,
+      currentStem: "original",
+      availableStems: ["original"],
+      jobKey: null,
+      stemUrls: {},
+    });
+  },
+}));
+
+export { useSeparationStore };

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -1,11 +1,11 @@
-import { beforeEach, describe, expect, it } from "vitest";
 import {
-  DEFAULT_COBALT_INSTANCE_ID,
   DEFAULTS,
+  DEFAULT_COBALT_INSTANCE_ID,
   getActiveCobaltInstance,
   isUsingDefaultCobaltInstance,
   useSettingsStore,
 } from "@/stores/settings";
+import { beforeEach, describe, expect, it } from "vitest";
 
 describe("preview renderer settings", () => {
   beforeEach(() => {
@@ -29,6 +29,16 @@ describe("preview renderer settings", () => {
     useSettingsStore.getState().set("previewRenderer", "am-lyrics");
     useSettingsStore.getState().resetToDefaults();
     expect(useSettingsStore.getState().previewRenderer).toBe("braccato");
+  });
+});
+
+describe("vocal model settings", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ ...DEFAULTS });
+  });
+
+  it("defaults to fp32 for stable browser inference", () => {
+    expect(useSettingsStore.getState().vocalModelVariant).toBe("fp32");
   });
 });
 

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -6,6 +6,7 @@ import { persist } from "zustand/middleware";
 type GranularityDefault = "word" | "line";
 type LinkedDivergenceAction = "ask" | "apply" | "detach";
 type PreviewRenderer = "braccato" | "am-lyrics";
+type VocalModelVariant = "fp16" | "fp32";
 
 interface CobaltInstance {
   id: string;
@@ -58,6 +59,9 @@ interface SettingsState {
   linkedDivergenceAction: LinkedDivergenceAction;
 
   previewRenderer: PreviewRenderer;
+
+  autoSeparateOnImport: boolean;
+  vocalModelVariant: VocalModelVariant;
 
   cobaltInstances: CobaltInstance[];
   selectedCobaltInstanceId: string;
@@ -114,6 +118,9 @@ const DEFAULTS: SettingsState = {
 
   previewRenderer: "braccato",
 
+  autoSeparateOnImport: false,
+  vocalModelVariant: "fp32",
+
   cobaltInstances: [],
   selectedCobaltInstanceId: DEFAULT_COBALT_INSTANCE_ID,
   cobaltInstanceStatus: {},
@@ -124,6 +131,17 @@ const BUILTIN_COBALT_INSTANCE: CobaltInstance = {
   label: "Composer",
   url: "https://cobalt.boidu.dev",
 };
+
+const SETTINGS_PERSIST_VERSION = 2;
+
+function migrateSettings(persistedState: unknown): unknown {
+  if (!persistedState || typeof persistedState !== "object") return persistedState;
+  const state = persistedState as Partial<SettingsState>;
+  return {
+    ...state,
+    vocalModelVariant: state.vocalModelVariant === "fp16" ? "fp32" : state.vocalModelVariant,
+  };
+}
 
 // -- Store --------------------------------------------------------------------
 
@@ -178,7 +196,7 @@ const useSettingsStore = create<SettingsState & SettingsActions>()(
           },
         })),
     }),
-    { name: "composer-settings" },
+    { name: "composer-settings", version: SETTINGS_PERSIST_VERSION, migrate: migrateSettings },
   ),
 );
 
@@ -205,4 +223,4 @@ export {
   getActiveCobaltInstance,
   isUsingDefaultCobaltInstance,
 };
-export type { SettingsState, CobaltInstanceStatus, LinkedDivergenceAction };
+export type { SettingsState, CobaltInstanceStatus, LinkedDivergenceAction, VocalModelVariant };

--- a/src/test/idb.ts
+++ b/src/test/idb.ts
@@ -1,7 +1,9 @@
 // -- Constants -----------------------------------------------------------------
 
 const DB_NAME = "ttml-composer";
+const DB_VERSION = 2;
 const STORE_NAME = "projects";
+const STEM_STORE_NAME = "separated-stems";
 const CURRENT_KEY = "current";
 const AUDIO_KEY = "current-audio";
 
@@ -9,9 +11,11 @@ const AUDIO_KEY = "current-audio";
 
 function putValue(key: string, value: unknown): Promise<void> {
   return new Promise((resolve, reject) => {
-    const open = indexedDB.open(DB_NAME, 1);
+    const open = indexedDB.open(DB_NAME, DB_VERSION);
     open.onupgradeneeded = () => {
-      open.result.createObjectStore(STORE_NAME);
+      const db = open.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) db.createObjectStore(STORE_NAME);
+      if (!db.objectStoreNames.contains(STEM_STORE_NAME)) db.createObjectStore(STEM_STORE_NAME);
     };
     open.onerror = () => reject(open.error);
     open.onsuccess = () => {

--- a/src/test/stores.ts
+++ b/src/test/stores.ts
@@ -5,6 +5,7 @@ import { useDivergenceStore } from "@/stores/divergence-store";
 import { INITIAL_STATE as IMPORT_MODAL_INITIAL_STATE, useImportModalStore } from "@/stores/import-modal-store";
 import { useModalStackStore } from "@/stores/modal-stack";
 import { INITIAL_STATE as PROJECT_INITIAL_STATE, useProjectStore } from "@/stores/project";
+import { useSeparationStore } from "@/stores/separation";
 import { DEFAULTS as SETTINGS_DEFAULTS, useSettingsStore } from "@/stores/settings";
 import { useShortcutBindingsStore } from "@/stores/shortcut-bindings";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
@@ -29,6 +30,7 @@ async function resetAllStores(): Promise<void> {
 
   useAuthStore.getState().clear();
   useAudioStore.getState().reset();
+  useSeparationStore.getState().reset();
   useProjectStore.setState(PROJECT_INITIAL_STATE);
 
   useConfirmStore.setState({ isOpen: false, options: null, resolve: null, queue: [] });

--- a/src/ui/help-sections/importing.tsx
+++ b/src/ui/help-sections/importing.tsx
@@ -17,9 +17,9 @@ const ImportSection: React.FC = () => (
       </ul>
       <p className={`${PROSE} mt-3`}>
         For YouTube imports, audio comes from a Cobalt backend. Composer ships with a default instance that handles
-        verification automatically, but YouTube is currently blocking it. To import from YouTube, add a working
-        instance from cobalt.directory in Settings → Advanced, or self-host. Each custom instance shows a small status
-        icon next to its name reflecting the last attempt, with the actual error in the tooltip if anything went wrong.
+        verification automatically, but YouTube is currently blocking it. To import from YouTube, add a working instance
+        from cobalt.directory in Settings → Advanced, or self-host. Each custom instance shows a small status icon next
+        to its name reflecting the last attempt, with the actual error in the tooltip if anything went wrong.
       </p>
     </div>
 

--- a/src/ui/settings/advanced-section.tsx
+++ b/src/ui/settings/advanced-section.tsx
@@ -33,8 +33,8 @@ const AdvancedSection: React.FC = () => {
         <div className="flex flex-col gap-0.5 mb-3">
           <span className="text-sm font-medium text-composer-text">Cobalt instance</span>
           <span className="text-xs text-composer-text-muted">
-            Composer uses a Cobalt backend to fetch YouTube audio. The default one is currently blocked by
-            YouTube, so add a working instance from cobalt.directory below, or self-host.
+            Composer uses a Cobalt backend to fetch YouTube audio. The default one is currently blocked by YouTube, so
+            add a working instance from cobalt.directory below, or self-host.
           </span>
         </div>
 

--- a/src/ui/settings/playback-section.tsx
+++ b/src/ui/settings/playback-section.tsx
@@ -1,6 +1,6 @@
 import { useAudioStore } from "@/stores/audio";
 import { useSettingsStore } from "@/stores/settings";
-import { SliderSetting, ToggleSetting } from "@/ui/settings/setting-controls";
+import { SelectSetting, SliderSetting, ToggleSetting } from "@/ui/settings/setting-controls";
 
 // -- Playback Section ---------------------------------------------------------
 
@@ -36,6 +36,20 @@ const PlaybackSection: React.FC = () => {
         label="Audio scrub preview"
         description="Play a short audio snippet while dragging or wheel-scrubbing the playhead."
         settingKey="audioScrubPreview"
+      />
+      <ToggleSetting
+        label="Auto-separate vocals on import"
+        description="Run the vocal-separation model automatically each time a new audio file is loaded."
+        settingKey="autoSeparateOnImport"
+      />
+      <SelectSetting
+        label="Vocal model precision"
+        description="fp32 is the stable default. fp16 is smaller but may produce invalid output in some browsers."
+        settingKey="vocalModelVariant"
+        options={[
+          { value: "fp32", label: "fp32 (~171 MB, recommended)" },
+          { value: "fp16", label: "fp16 (~85 MB, experimental)" },
+        ]}
       />
     </div>
   );

--- a/src/ui/vocal-separation-dropdown.tsx
+++ b/src/ui/vocal-separation-dropdown.tsx
@@ -1,0 +1,229 @@
+import { useSeparationStore } from "@/stores/separation";
+import { useSettingsStore } from "@/stores/settings";
+import { getModelDescriptor } from "@/audio/separation/model-registry";
+import { useAudioStore } from "@/stores/audio";
+import { Button } from "@/ui/button";
+import { Popover } from "@/ui/popover";
+import { IconLoader2, IconMicrophone } from "@tabler/icons-react";
+import { useEffect } from "react";
+import type { Stem } from "@/audio/separation/types";
+
+const STEM_LABELS: Record<Stem, string> = {
+  original: "Original",
+  vocals: "Vocals",
+  instrumental: "Instr.",
+};
+
+function formatMb(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+const ProgressBar: React.FC<{ pct: number }> = ({ pct }) => (
+  <div className="h-1.5 w-full bg-composer-button rounded overflow-hidden">
+    <div
+      className="h-full bg-composer-accent transition-[width] duration-150"
+      style={{ width: `${Math.max(0, Math.min(100, pct))}%` }}
+    />
+  </div>
+);
+
+const VocalSeparationDropdown: React.FC = () => {
+  const source = useAudioStore((s) => s.source);
+  const status = useSeparationStore((s) => s.status);
+  const progress = useSeparationStore((s) => s.progress);
+  const error = useSeparationStore((s) => s.error);
+  const currentStem = useSeparationStore((s) => s.currentStem);
+  const availableStems = useSeparationStore((s) => s.availableStems);
+  const modelCached = useSeparationStore((s) => s.modelCached);
+  const hostingConfigured = useSeparationStore((s) => s.hostingConfigured);
+  const refreshModelCacheStatus = useSeparationStore((s) => s.refreshModelCacheStatus);
+
+  const variant = useSettingsStore((s) => s.vocalModelVariant);
+  const descriptor = getModelDescriptor(variant);
+
+  const downloadModel = useSeparationStore((s) => s.downloadModel);
+  const separate = useSeparationStore((s) => s.separate);
+  const selectStem = useSeparationStore((s) => s.selectStem);
+  const cancel = useSeparationStore((s) => s.cancel);
+  const retry = useSeparationStore((s) => s.retry);
+
+  useEffect(() => {
+    void variant;
+    refreshModelCacheStatus();
+  }, [refreshModelCacheStatus, variant]);
+
+  if (!hostingConfigured) return null;
+  if (!source) return null;
+
+  const pct = progress.total > 0 ? Math.round((progress.loaded / progress.total) * 100) : 0;
+  const triggerLabel = status === "downloading" || status === "processing" ? `${pct}%` : STEM_LABELS[currentStem];
+  const triggerIcon =
+    status === "downloading" || status === "processing" ? (
+      <IconLoader2 className="size-4 animate-spin" />
+    ) : (
+      <IconMicrophone className="size-4" />
+    );
+
+  return (
+    <Popover
+      placement="top-end"
+      trigger={
+        <Button variant="ghost" hasIcon className="font-mono tabular-nums min-w-20" aria-label="Vocal separation">
+          {triggerIcon}
+          <span>{triggerLabel}</span>
+        </Button>
+      }
+    >
+      <div className="p-3 w-72">
+        {status === "error" && error && (
+          <ErrorState message={error.message} onRetry={retry} onDismiss={() => useSeparationStore.getState().reset()} />
+        )}
+
+        {status === "downloading" && (
+          <ProgressState
+            title="Downloading model…"
+            detail={`${formatMb(progress.loaded)} / ${formatMb(progress.total || (descriptor?.approxBytes ?? 0))}`}
+            pct={pct}
+            onCancel={cancel}
+          />
+        )}
+
+        {status === "processing" && (
+          <ProgressState
+            title="Separating vocals…"
+            detail={progress.total > 0 ? `Chunk ${progress.loaded} of ${progress.total}` : "Preparing…"}
+            pct={pct}
+            onCancel={cancel}
+          />
+        )}
+
+        {status === "idle" && !modelCached && (
+          <IdleNoModelState approxMb={descriptor?.approxMb ?? 85} onDownload={downloadModel} onSeparate={separate} />
+        )}
+
+        {status === "idle" && modelCached && (
+          <IdleReadyState
+            availableStems={availableStems}
+            currentStem={currentStem}
+            onSelect={selectStem}
+            onSeparate={separate}
+          />
+        )}
+
+        {status === "ready" && (
+          <IdleReadyState
+            availableStems={availableStems}
+            currentStem={currentStem}
+            onSelect={selectStem}
+            onSeparate={separate}
+          />
+        )}
+
+        {status === "cancelled" && <p className="text-xs text-composer-text-muted">Cancelled. Open again to retry.</p>}
+      </div>
+    </Popover>
+  );
+};
+
+const ProgressState: React.FC<{ title: string; detail: string; pct: number; onCancel: () => void }> = ({
+  title,
+  detail,
+  pct,
+  onCancel,
+}) => (
+  <div className="flex flex-col gap-2">
+    <p className="text-sm font-medium text-composer-text">{title}</p>
+    <p className="text-xs text-composer-text-muted tabular-nums">{detail}</p>
+    <ProgressBar pct={pct} />
+    <div className="flex justify-end pt-1">
+      <Button size="sm" variant="ghost" onClick={onCancel}>
+        Cancel
+      </Button>
+    </div>
+  </div>
+);
+
+const IdleNoModelState: React.FC<{
+  approxMb: number;
+  onDownload: () => void;
+  onSeparate: () => void;
+}> = ({ approxMb, onDownload, onSeparate }) => (
+  <div className="flex flex-col gap-2">
+    <p className="text-sm font-medium text-composer-text">Vocal separation</p>
+    <p className="text-xs text-composer-text-muted">
+      Isolate the vocals or hear an instrumental version of this track. Requires a one-time ~{approxMb} MB model
+      download.
+    </p>
+    <div className="flex gap-2 pt-1">
+      <Button size="sm" variant="secondary" onClick={onDownload}>
+        Download model
+      </Button>
+      <Button size="sm" variant="primary" onClick={onSeparate}>
+        Download &amp; separate
+      </Button>
+    </div>
+  </div>
+);
+
+const IdleReadyState: React.FC<{
+  availableStems: Stem[];
+  currentStem: Stem;
+  onSelect: (stem: Stem) => void;
+  onSeparate: () => void;
+}> = ({ availableStems, currentStem, onSelect, onSeparate }) => {
+  const hasSeparated = availableStems.includes("vocals");
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-sm font-medium text-composer-text">Playback source</p>
+      <div className="flex flex-col gap-1">
+        {(["original", "vocals", "instrumental"] as Stem[]).map((stem) => {
+          const enabled = stem === "original" || availableStems.includes(stem);
+          return (
+            <label
+              key={stem}
+              className={`flex items-center gap-2 text-sm ${
+                enabled ? "text-composer-text cursor-pointer" : "text-composer-text-muted cursor-not-allowed opacity-60"
+              }`}
+            >
+              <input
+                type="radio"
+                name="stem"
+                checked={currentStem === stem}
+                onChange={() => onSelect(stem)}
+                disabled={!enabled}
+                className="accent-composer-accent"
+              />
+              {STEM_LABELS[stem]}
+            </label>
+          );
+        })}
+      </div>
+      {!hasSeparated && (
+        <Button size="sm" variant="primary" onClick={onSeparate} className="mt-1">
+          Separate now
+        </Button>
+      )}
+    </div>
+  );
+};
+
+const ErrorState: React.FC<{ message: string; onRetry: () => void; onDismiss: () => void }> = ({
+  message,
+  onRetry,
+  onDismiss,
+}) => (
+  <div className="flex flex-col gap-2">
+    <p className="text-sm font-medium text-composer-text">Vocal separation failed</p>
+    <p className="text-xs text-composer-text-muted break-words">{message}</p>
+    <div className="flex gap-2 pt-1 justify-end">
+      <Button size="sm" variant="ghost" onClick={onDismiss}>
+        Dismiss
+      </Button>
+      <Button size="sm" variant="primary" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  </div>
+);
+
+export { VocalSeparationDropdown };

--- a/src/ui/vocal-separation-dropdown.tsx
+++ b/src/ui/vocal-separation-dropdown.tsx
@@ -139,7 +139,7 @@ const ProgressState: React.FC<{ title: string; detail: string; pct: number; onCa
   pct,
   onCancel,
 }) => (
-  <div className="flex flex-col gap-2">
+  <div className="flex flex-col gap-2 min-w-60">
     <p className="text-sm font-medium text-composer-text">{title}</p>
     <p className="text-xs text-composer-text-muted tabular-nums">{detail}</p>
     <ProgressBar pct={pct} />

--- a/src/ui/vocal-separation-dropdown.tsx
+++ b/src/ui/vocal-separation-dropdown.tsx
@@ -4,14 +4,21 @@ import { getModelDescriptor } from "@/audio/separation/model-registry";
 import { useAudioStore } from "@/stores/audio";
 import { Button } from "@/ui/button";
 import { Popover } from "@/ui/popover";
-import { IconLoader2, IconMicrophone } from "@tabler/icons-react";
-import { useEffect } from "react";
+import { cn } from "@/utils/cn";
+import { IconCheck, type IconProps, IconLoader2, IconMicrophone, IconMusic, IconWaveSine } from "@tabler/icons-react";
+import { type ComponentType, useEffect } from "react";
 import type { Stem } from "@/audio/separation/types";
 
 const STEM_LABELS: Record<Stem, string> = {
   original: "Original",
   vocals: "Vocals",
-  instrumental: "Instr.",
+  instrumental: "Instrumental",
+};
+
+const STEM_ICONS: Record<Stem, ComponentType<IconProps>> = {
+  original: IconWaveSine,
+  vocals: IconMicrophone,
+  instrumental: IconMusic,
 };
 
 function formatMb(bytes: number): string {
@@ -75,7 +82,7 @@ const VocalSeparationDropdown: React.FC = () => {
         </Button>
       }
     >
-      <div className="p-3 w-72">
+      <div className="p-3 w-max max-w-80">
         {status === "error" && error && (
           <ErrorState message={error.message} onRetry={retry} onDismiss={() => useSeparationStore.getState().reset()} />
         )}
@@ -176,26 +183,33 @@ const IdleReadyState: React.FC<{
   return (
     <div className="flex flex-col gap-2">
       <p className="text-sm font-medium text-composer-text">Playback source</p>
-      <div className="flex flex-col gap-1">
+      <div className="flex flex-col gap-0.5">
         {(["original", "vocals", "instrumental"] as Stem[]).map((stem) => {
           const enabled = stem === "original" || availableStems.includes(stem);
+          const selected = currentStem === stem;
+          const Icon = STEM_ICONS[stem];
           return (
-            <label
+            <button
               key={stem}
-              className={`flex items-center gap-2 text-sm ${
-                enabled ? "text-composer-text cursor-pointer" : "text-composer-text-muted cursor-not-allowed opacity-60"
-              }`}
+              type="button"
+              disabled={!enabled}
+              onClick={() => onSelect(stem)}
+              className={cn(
+                "flex items-center gap-2.5 px-2 py-1.5 rounded-md text-sm text-left text-composer-text transition-colors",
+                selected && "bg-composer-button font-medium",
+                !selected && enabled && "cursor-pointer hover:bg-composer-button",
+                !enabled && "cursor-not-allowed opacity-55",
+              )}
             >
-              <input
-                type="radio"
-                name="stem"
-                checked={currentStem === stem}
-                onChange={() => onSelect(stem)}
-                disabled={!enabled}
-                className="accent-composer-accent"
+              <Icon
+                className={cn(
+                  "size-4 shrink-0",
+                  selected ? "text-composer-accent-text" : "text-composer-text opacity-55",
+                )}
               />
-              {STEM_LABELS[stem]}
-            </label>
+              <span className="flex-1">{STEM_LABELS[stem]}</span>
+              {selected && <IconCheck className="size-3.5 text-composer-accent shrink-0" />}
+            </button>
           );
         })}
       </div>

--- a/src/ui/vocal-separation-dropdown.tsx
+++ b/src/ui/vocal-separation-dropdown.tsx
@@ -57,18 +57,19 @@ const VocalSeparationDropdown: React.FC = () => {
 
   const pct = progress.total > 0 ? Math.round((progress.loaded / progress.total) * 100) : 0;
   const triggerLabel = status === "downloading" || status === "processing" ? `${pct}%` : STEM_LABELS[currentStem];
+  const triggerIconClass = "size-4 text-composer-text opacity-50 group-hover:opacity-100 transition-opacity";
   const triggerIcon =
     status === "downloading" || status === "processing" ? (
-      <IconLoader2 className="size-4 animate-spin" />
+      <IconLoader2 className={`${triggerIconClass} animate-spin`} />
     ) : (
-      <IconMicrophone className="size-4" />
+      <IconMicrophone className={triggerIconClass} />
     );
 
   return (
     <Popover
       placement="top-end"
       trigger={
-        <Button variant="ghost" hasIcon className="font-mono tabular-nums min-w-20" aria-label="Vocal separation">
+        <Button variant="ghost" hasIcon className="group font-mono tabular-nums min-w-20" aria-label="Vocal separation">
           {triggerIcon}
           <span>{triggerLabel}</span>
         </Button>

--- a/src/ui/vocal-separation-dropdown.tsx
+++ b/src/ui/vocal-separation-dropdown.tsx
@@ -181,7 +181,7 @@ const IdleReadyState: React.FC<{
 }> = ({ availableStems, currentStem, onSelect, onSeparate }) => {
   const hasSeparated = availableStems.includes("vocals");
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2 min-w-60">
       <p className="text-sm font-medium text-composer-text">Playback source</p>
       <div className="flex flex-col gap-0.5">
         {(["original", "vocals", "instrumental"] as Stem[]).map((stem) => {
@@ -208,7 +208,10 @@ const IdleReadyState: React.FC<{
                 )}
               />
               <span className="flex-1">{STEM_LABELS[stem]}</span>
-              {selected && <IconCheck className="size-3.5 text-composer-accent shrink-0" />}
+              <IconCheck
+                aria-hidden={!selected}
+                className={cn("size-3.5 text-composer-accent shrink-0", !selected && "invisible")}
+              />
             </button>
           );
         })}

--- a/src/views/export.tsx
+++ b/src/views/export.tsx
@@ -1,4 +1,5 @@
-import { exportProjectToFile, importProjectFromFile, clearCurrentProject, cancelPendingSave } from "@/lib/persistence";
+import { exportProjectToFile, importProjectFromFile, clearCurrentProject } from "@/lib/persistence";
+import { cancelPendingSave } from "@/lib/persistence-debounce";
 import { useAudioStore } from "@/stores/audio";
 import { useConfirm } from "@/stores/confirm-store";
 import { useProjectStore } from "@/stores/project";

--- a/src/views/preview/braccato-renderer.browser.test.tsx
+++ b/src/views/preview/braccato-renderer.browser.test.tsx
@@ -1,5 +1,5 @@
 import type { BraccatoElement } from "@braccato/core";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, afterEach, describe, expect, it } from "vitest";
 import { useAudioStore } from "@/stores/audio";
 import { addGlobalAllowedConsolePattern } from "@/test/console-guard";
 import { render } from "@/test/render";
@@ -7,6 +7,13 @@ import { buildSyncedTtml } from "@/test/ttml-fixtures";
 import { BraccatoRenderer } from "@/views/preview/braccato-renderer";
 
 // -- Helpers ------------------------------------------------------------------
+function makeAudio(src: string): HTMLAudioElement {
+  const audio = document.createElement("audio");
+  audio.id = "composer-audio";
+  audio.src = src;
+  document.body.appendChild(audio);
+  return audio;
+}
 
 function getBraccatoElement(container: Element): BraccatoElement {
   const el = container.querySelector("braccato-lyrics");
@@ -14,9 +21,27 @@ function getBraccatoElement(container: Element): BraccatoElement {
   return el as BraccatoElement;
 }
 
+async function waitFor(predicate: () => boolean, timeout = 1000): Promise<void> {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      if (predicate()) return resolve();
+      if (Date.now() - start > timeout) return reject(new Error("waitFor timeout"));
+      requestAnimationFrame(tick);
+    };
+    tick();
+  });
+}
+
 async function waitForLyrics(el: BraccatoElement): Promise<void> {
   await expect.poll(() => el.shadowRoot?.querySelectorAll(".braccato--line").length ?? 0).toBeGreaterThan(0);
 }
+
+afterEach(() => {
+  for (const el of document.querySelectorAll("#composer-audio")) {
+    el.remove();
+  }
+});
 
 function activeLineText(el: BraccatoElement): string {
   return el.shadowRoot?.querySelector(".braccato--line.braccato--active")?.textContent ?? "";
@@ -25,81 +50,106 @@ function activeLineText(el: BraccatoElement): string {
 // -- Tests --------------------------------------------------------------------
 
 describe("BraccatoRenderer", () => {
-  beforeAll(() => {
-    addGlobalAllowedConsolePattern(/dev mode/i);
-  });
+    beforeAll(() => {
+        addGlobalAllowedConsolePattern(/dev mode/i);
+    });
 
-  it("highlights the line under the current audio time", async () => {
-    const ttml = buildSyncedTtml();
-    const audio = new Audio();
-    audio.currentTime = 14;
-    useAudioStore.setState({ audioElement: audio });
+    it("highlights the line under the current audio time", async () => {
+        const ttml = buildSyncedTtml();
+        const audio = new Audio();
+        audio.currentTime = 14;
+        useAudioStore.setState({ audioElement: audio });
 
-    const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
-    const el = getBraccatoElement(screen.container);
-    await waitForLyrics(el);
+        const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
+        const el = getBraccatoElement(screen.container);
+        await waitForLyrics(el);
 
-    await expect.poll(() => activeLineText(el)).toContain("second line");
-  });
+        await expect.poll(() => activeLineText(el)).toContain("second line");
+    });
 
-  it("moves the highlight as the audio time advances", async () => {
-    const ttml = buildSyncedTtml();
-    const audio = new Audio();
-    audio.currentTime = 14;
-    useAudioStore.setState({ audioElement: audio });
+    it("moves the highlight as the audio time advances", async () => {
+        const ttml = buildSyncedTtml();
+        const audio = new Audio();
+        audio.currentTime = 14;
+        useAudioStore.setState({ audioElement: audio });
 
-    const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
-    const el = getBraccatoElement(screen.container);
-    await waitForLyrics(el);
-    await expect.poll(() => activeLineText(el)).toContain("second line");
+        const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
+        const el = getBraccatoElement(screen.container);
+        await waitForLyrics(el);
+        await expect.poll(() => activeLineText(el)).toContain("second line");
 
-    audio.currentTime = 26;
-    await expect.poll(() => activeLineText(el)).toContain("third line");
-  });
+        audio.currentTime = 26;
+        await expect.poll(() => activeLineText(el)).toContain("third line");
+    });
 
-  it("tracks a newly registered audio element", async () => {
-    const ttml = buildSyncedTtml();
-    const firstAudio = new Audio();
-    firstAudio.currentTime = 14;
-    useAudioStore.setState({ audioElement: firstAudio });
+    it("tracks a newly registered audio element", async () => {
+        const ttml = buildSyncedTtml();
+        const firstAudio = new Audio();
+        firstAudio.currentTime = 14;
+        useAudioStore.setState({ audioElement: firstAudio });
 
-    const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
-    const el = getBraccatoElement(screen.container);
-    await waitForLyrics(el);
-    await expect.poll(() => activeLineText(el)).toContain("second line");
+        const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
+        const el = getBraccatoElement(screen.container);
+        await waitForLyrics(el);
+        await expect.poll(() => activeLineText(el)).toContain("second line");
 
-    const replacementAudio = new Audio();
-    replacementAudio.currentTime = 26;
-    useAudioStore.setState({ audioElement: replacementAudio });
+        const replacementAudio = new Audio();
+        replacementAudio.currentTime = 26;
+        useAudioStore.setState({ audioElement: replacementAudio });
 
-    await expect.poll(() => activeLineText(el)).toContain("third line");
-  });
+        await expect.poll(() => activeLineText(el)).toContain("third line");
+    });
 
-  it("starts playback when a line is clicked", async () => {
-    const ttml = buildSyncedTtml();
-    const audio = new Audio();
-    useAudioStore.setState({ audioElement: audio, isPlaying: false });
+    it("starts playback when a line is clicked", async () => {
+        const ttml = buildSyncedTtml();
+        const audio = new Audio();
+        useAudioStore.setState({ audioElement: audio, isPlaying: false });
 
-    const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
-    const el = getBraccatoElement(screen.container);
-    await waitForLyrics(el);
+        const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
+        const el = getBraccatoElement(screen.container);
+        await waitForLyrics(el);
 
-    el.shadowRoot?.querySelector<HTMLElement>(".braccato--line")?.click();
+        el.shadowRoot?.querySelector<HTMLElement>(".braccato--line")?.click();
 
-    await expect.poll(() => useAudioStore.getState().isPlaying).toBe(true);
-  });
+        await expect.poll(() => useAudioStore.getState().isPlaying).toBe(true);
+    });
 
-  it("seeks the audio to the clicked line's start time", async () => {
-    const ttml = buildSyncedTtml();
-    const audio = new Audio();
-    useAudioStore.setState({ audioElement: audio });
+    it("seeks the audio to the clicked line's start time", async () => {
+        const ttml = buildSyncedTtml();
+        const audio = new Audio();
+        useAudioStore.setState({ audioElement: audio });
 
-    const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
-    const el = getBraccatoElement(screen.container);
-    await waitForLyrics(el);
+        const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
+        const el = getBraccatoElement(screen.container);
+        await waitForLyrics(el);
 
-    el.shadowRoot?.querySelector<HTMLElement>(".braccato--line")?.click();
+        el.shadowRoot?.querySelector<HTMLElement>(".braccato--line")?.click();
 
-    await expect.poll(() => useAudioStore.getState().currentTime).toBe(2);
-  });
+        await expect.poll(() => useAudioStore.getState().currentTime).toBe(2);
+    });
+
+    it("does not bind to #composer-audio before the audio element is registered", async () => {
+        const screen = await render(<BraccatoRenderer ttmlString="<tt></tt>" />);
+        const el = screen.container.querySelector("braccato-lyrics");
+        expect(el?.getAttribute("source")).toBeNull();
+    });
+
+    it("rebinds when the registered audio element is replaced", async () => {
+        const firstAudio = makeAudio("https://example.test/first.mp3");
+        useAudioStore.setState({ audioElement: firstAudio });
+
+        const screen = await render(<BraccatoRenderer ttmlString="<tt></tt>" />);
+        await waitFor(
+            () => screen.container.querySelector("braccato-lyrics")?.getAttribute("source") === "#composer-audio",
+        );
+        const firstRenderer = screen.container.querySelector("braccato-lyrics");
+
+        firstAudio.remove();
+        const secondAudio = makeAudio("https://example.test/second.mp3");
+        useAudioStore.setState({ audioElement: secondAudio });
+
+        await waitFor(() => screen.container.querySelector("braccato-lyrics") !== firstRenderer);
+        const secondRenderer = screen.container.querySelector("braccato-lyrics");
+        expect(secondRenderer?.getAttribute("source")).toBe("#composer-audio");
+    });
 });

--- a/src/views/preview/braccato-renderer.browser.test.tsx
+++ b/src/views/preview/braccato-renderer.browser.test.tsx
@@ -50,106 +50,106 @@ function activeLineText(el: BraccatoElement): string {
 // -- Tests --------------------------------------------------------------------
 
 describe("BraccatoRenderer", () => {
-    beforeAll(() => {
-        addGlobalAllowedConsolePattern(/dev mode/i);
-    });
+  beforeAll(() => {
+    addGlobalAllowedConsolePattern(/dev mode/i);
+  });
 
-    it("highlights the line under the current audio time", async () => {
-        const ttml = buildSyncedTtml();
-        const audio = new Audio();
-        audio.currentTime = 14;
-        useAudioStore.setState({ audioElement: audio });
+  it("highlights the line under the current audio time", async () => {
+    const ttml = buildSyncedTtml();
+    const audio = new Audio();
+    audio.currentTime = 14;
+    useAudioStore.setState({ audioElement: audio });
 
-        const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
-        const el = getBraccatoElement(screen.container);
-        await waitForLyrics(el);
+    const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
+    const el = getBraccatoElement(screen.container);
+    await waitForLyrics(el);
 
-        await expect.poll(() => activeLineText(el)).toContain("second line");
-    });
+    await expect.poll(() => activeLineText(el)).toContain("second line");
+  });
 
-    it("moves the highlight as the audio time advances", async () => {
-        const ttml = buildSyncedTtml();
-        const audio = new Audio();
-        audio.currentTime = 14;
-        useAudioStore.setState({ audioElement: audio });
+  it("moves the highlight as the audio time advances", async () => {
+    const ttml = buildSyncedTtml();
+    const audio = new Audio();
+    audio.currentTime = 14;
+    useAudioStore.setState({ audioElement: audio });
 
-        const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
-        const el = getBraccatoElement(screen.container);
-        await waitForLyrics(el);
-        await expect.poll(() => activeLineText(el)).toContain("second line");
+    const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
+    const el = getBraccatoElement(screen.container);
+    await waitForLyrics(el);
+    await expect.poll(() => activeLineText(el)).toContain("second line");
 
-        audio.currentTime = 26;
-        await expect.poll(() => activeLineText(el)).toContain("third line");
-    });
+    audio.currentTime = 26;
+    await expect.poll(() => activeLineText(el)).toContain("third line");
+  });
 
-    it("tracks a newly registered audio element", async () => {
-        const ttml = buildSyncedTtml();
-        const firstAudio = new Audio();
-        firstAudio.currentTime = 14;
-        useAudioStore.setState({ audioElement: firstAudio });
+  it("tracks a newly registered audio element", async () => {
+    const ttml = buildSyncedTtml();
+    const firstAudio = new Audio();
+    firstAudio.currentTime = 14;
+    useAudioStore.setState({ audioElement: firstAudio });
 
-        const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
-        const el = getBraccatoElement(screen.container);
-        await waitForLyrics(el);
-        await expect.poll(() => activeLineText(el)).toContain("second line");
+    const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
+    const el = getBraccatoElement(screen.container);
+    await waitForLyrics(el);
+    await expect.poll(() => activeLineText(el)).toContain("second line");
 
-        const replacementAudio = new Audio();
-        replacementAudio.currentTime = 26;
-        useAudioStore.setState({ audioElement: replacementAudio });
+    const replacementAudio = new Audio();
+    replacementAudio.currentTime = 26;
+    useAudioStore.setState({ audioElement: replacementAudio });
 
-        await expect.poll(() => activeLineText(el)).toContain("third line");
-    });
+    await expect.poll(() => activeLineText(el)).toContain("third line");
+  });
 
-    it("starts playback when a line is clicked", async () => {
-        const ttml = buildSyncedTtml();
-        const audio = new Audio();
-        useAudioStore.setState({ audioElement: audio, isPlaying: false });
+  it("starts playback when a line is clicked", async () => {
+    const ttml = buildSyncedTtml();
+    const audio = new Audio();
+    useAudioStore.setState({ audioElement: audio, isPlaying: false });
 
-        const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
-        const el = getBraccatoElement(screen.container);
-        await waitForLyrics(el);
+    const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
+    const el = getBraccatoElement(screen.container);
+    await waitForLyrics(el);
 
-        el.shadowRoot?.querySelector<HTMLElement>(".braccato--line")?.click();
+    el.shadowRoot?.querySelector<HTMLElement>(".braccato--line")?.click();
 
-        await expect.poll(() => useAudioStore.getState().isPlaying).toBe(true);
-    });
+    await expect.poll(() => useAudioStore.getState().isPlaying).toBe(true);
+  });
 
-    it("seeks the audio to the clicked line's start time", async () => {
-        const ttml = buildSyncedTtml();
-        const audio = new Audio();
-        useAudioStore.setState({ audioElement: audio });
+  it("seeks the audio to the clicked line's start time", async () => {
+    const ttml = buildSyncedTtml();
+    const audio = new Audio();
+    useAudioStore.setState({ audioElement: audio });
 
-        const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
-        const el = getBraccatoElement(screen.container);
-        await waitForLyrics(el);
+    const screen = await render(<BraccatoRenderer ttmlString={ttml} />);
+    const el = getBraccatoElement(screen.container);
+    await waitForLyrics(el);
 
-        el.shadowRoot?.querySelector<HTMLElement>(".braccato--line")?.click();
+    el.shadowRoot?.querySelector<HTMLElement>(".braccato--line")?.click();
 
-        await expect.poll(() => useAudioStore.getState().currentTime).toBe(2);
-    });
+    await expect.poll(() => useAudioStore.getState().currentTime).toBe(2);
+  });
 
-    it("does not bind to #composer-audio before the audio element is registered", async () => {
-        const screen = await render(<BraccatoRenderer ttmlString="<tt></tt>" />);
-        const el = screen.container.querySelector("braccato-lyrics");
-        expect(el?.getAttribute("source")).toBeNull();
-    });
+  it("does not bind to #composer-audio before the audio element is registered", async () => {
+    const screen = await render(<BraccatoRenderer ttmlString="<tt></tt>" />);
+    const el = screen.container.querySelector("braccato-lyrics");
+    expect(el?.getAttribute("source")).toBeNull();
+  });
 
-    it("rebinds when the registered audio element is replaced", async () => {
-        const firstAudio = makeAudio("https://example.test/first.mp3");
-        useAudioStore.setState({ audioElement: firstAudio });
+  it("rebinds when the registered audio element is replaced", async () => {
+    const firstAudio = makeAudio("https://example.test/first.mp3");
+    useAudioStore.setState({ audioElement: firstAudio });
 
-        const screen = await render(<BraccatoRenderer ttmlString="<tt></tt>" />);
-        await waitFor(
-            () => screen.container.querySelector("braccato-lyrics")?.getAttribute("source") === "#composer-audio",
-        );
-        const firstRenderer = screen.container.querySelector("braccato-lyrics");
+    const screen = await render(<BraccatoRenderer ttmlString="<tt></tt>" />);
+    await waitFor(
+      () => screen.container.querySelector("braccato-lyrics")?.getAttribute("source") === "#composer-audio",
+    );
+    const firstRenderer = screen.container.querySelector("braccato-lyrics");
 
-        firstAudio.remove();
-        const secondAudio = makeAudio("https://example.test/second.mp3");
-        useAudioStore.setState({ audioElement: secondAudio });
+    firstAudio.remove();
+    const secondAudio = makeAudio("https://example.test/second.mp3");
+    useAudioStore.setState({ audioElement: secondAudio });
 
-        await waitFor(() => screen.container.querySelector("braccato-lyrics") !== firstRenderer);
-        const secondRenderer = screen.container.querySelector("braccato-lyrics");
-        expect(secondRenderer?.getAttribute("source")).toBe("#composer-audio");
-    });
+    await waitFor(() => screen.container.querySelector("braccato-lyrics") !== firstRenderer);
+    const secondRenderer = screen.container.querySelector("braccato-lyrics");
+    expect(secondRenderer?.getAttribute("source")).toBe("#composer-audio");
+  });
 });

--- a/src/views/preview/braccato-renderer.tsx
+++ b/src/views/preview/braccato-renderer.tsx
@@ -2,12 +2,22 @@ import "@braccato/core";
 import type { BraccatoElement } from "@braccato/core";
 import { useRendererAudioSync } from "@/hooks/use-renderer-audio-sync";
 import { useAudioStore } from "@/stores/audio";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 // -- Interfaces ---------------------------------------------------------------
 
 interface BraccatoRendererProps {
   ttmlString: string;
+}
+
+// -- Helpers ------------------------------------------------------------------
+
+function handleBraccatoLineClick(e: Event): void {
+  const detail = (e as CustomEvent<{ time: number }>).detail;
+  if (detail?.time == null) return;
+  const audio = useAudioStore.getState();
+  audio.seekTo(detail.time / 1000);
+  audio.setIsPlaying(true);
 }
 
 // -- Component ----------------------------------------------------------------
@@ -16,6 +26,7 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
   const elementRef = useRef<BraccatoElement>(null);
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
   const audioElement = useAudioStore((s) => s.audioElement);
+  const elementKey = `${audioElement?.src ?? "no-audio"}:${blobUrl ?? "no-lyrics"}`;
 
   useEffect(() => {
     const blob = new Blob([ttmlString], { type: "application/ttml+xml" });
@@ -24,18 +35,17 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
     return () => URL.revokeObjectURL(url);
   }, [ttmlString]);
 
-  useEffect(() => {
-    const el = elementRef.current;
+  // Callback ref so the click listener re-attaches when the <braccato-lyrics>
+  // element is recreated via the `key` change. React 19 runs the returned
+  // cleanup when the element is detached or this ref is reassigned.
+  const setElement = useCallback((el: BraccatoElement | null) => {
+    elementRef.current = el;
     if (!el) return;
-    const handleLineClick = (e: Event) => {
-      const detail = (e as CustomEvent<{ time: number }>).detail;
-      if (detail?.time == null) return;
-      const audio = useAudioStore.getState();
-      audio.seekTo(detail.time / 1000);
-      audio.setIsPlaying(true);
+    el.addEventListener("braccato:line-click", handleBraccatoLineClick);
+    return () => {
+      el.removeEventListener("braccato:line-click", handleBraccatoLineClick);
+      elementRef.current = null;
     };
-    el.addEventListener("braccato:line-click", handleLineClick);
-    return () => el.removeEventListener("braccato:line-click", handleLineClick);
   }, []);
 
   useRendererAudioSync(elementRef, (el, audio) => {
@@ -45,8 +55,8 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
 
   return (
     <braccato-lyrics
-      key={`${audioElement?.src ?? "no-audio"}:${blobUrl ?? "no-lyrics"}`}
-      ref={elementRef}
+      key={elementKey}
+      ref={setElement}
       source={audioElement ? "#composer-audio" : undefined}
       src={blobUrl ?? undefined}
       className="flex-1 mx-auto w-full max-w-3xl px-6"

--- a/src/views/preview/braccato-renderer.tsx
+++ b/src/views/preview/braccato-renderer.tsx
@@ -15,6 +15,7 @@ interface BraccatoRendererProps {
 const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
   const elementRef = useRef<BraccatoElement>(null);
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const audioElement = useAudioStore((s) => s.audioElement);
 
   useEffect(() => {
     const blob = new Blob([ttmlString], { type: "application/ttml+xml" });
@@ -44,7 +45,9 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
 
   return (
     <braccato-lyrics
+      key={`${audioElement?.src ?? "no-audio"}:${blobUrl ?? "no-lyrics"}`}
       ref={elementRef}
+      source={audioElement ? "#composer-audio" : undefined}
       src={blobUrl ?? undefined}
       className="flex-1 mx-auto w-full max-w-3xl px-6"
       style={

--- a/src/views/timeline/timeline-waveform.tsx
+++ b/src/views/timeline/timeline-waveform.tsx
@@ -17,6 +17,7 @@ const TimelineWaveform: React.FC = () => {
   const [ws, setWs] = useState<WaveSurfer | null>(null);
 
   const totalWidth = duration > 0 ? duration * zoom : 0;
+  const waveformKey = audioElement?.src ?? "no-audio";
 
   // Sync zoom imperatively
   useEffect(() => {
@@ -54,22 +55,25 @@ const TimelineWaveform: React.FC = () => {
       className="sticky ml-12 top-0 z-40 bg-composer-bg w-max border-b border-composer-border shadow-lg transition-opacity duration-150 ease-in"
       style={{ opacity: ws ? 1 : 0 }}
     >
-      <WavesurferPlayer
-        height={WAVEFORM_HEIGHT}
-        waveColor="#737476"
-        progressColor="#818cf8"
-        cursorColor="transparent"
-        barWidth={2}
-        barGap={1}
-        barRadius={12}
-        media={audioElement ?? undefined}
-        interact={false}
-        hideScrollbar={true}
-        fillParent={false}
-        minPxPerSec={useTimelineStore.getState().zoom}
-        onDestroy={onDestroy}
-        onReady={onReady}
-      />
+      {audioElement && (
+        <WavesurferPlayer
+          key={waveformKey}
+          height={WAVEFORM_HEIGHT}
+          waveColor="#737476"
+          progressColor="#818cf8"
+          cursorColor="transparent"
+          barWidth={2}
+          barGap={1}
+          barRadius={12}
+          media={audioElement}
+          interact={false}
+          hideScrollbar={true}
+          fillParent={false}
+          minPxPerSec={useTimelineStore.getState().zoom}
+          onDestroy={onDestroy}
+          onReady={onReady}
+        />
+      )}
       <div
         role="button"
         tabIndex={-1}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,13 @@ export default defineConfig({
     alias: {
       "@": resolve(__dirname, "./src"),
     },
+    conditions: ["onnxruntime-web-use-extern-wasm", "import", "module", "browser", "default"],
+  },
+  worker: {
+    format: "es",
+  },
+  optimizeDeps: {
+    exclude: ["onnxruntime-web"],
   },
   ssgOptions: {
     formatting: "none",


### PR DESCRIPTION
### TL;DR

Adds browser-side vocal separation powered by HTDemucs (ONNX Runtime Web), with a new audio player dropdown for switching between original, vocals, and instrumental stems.

### What changed?

**Vocal separation pipeline**

- Added `onnxruntime-web` as a dependency, running HTDemucs v4 inference in a dedicated Web Worker with WebGPU as the primary execution provider and WASM as fallback.
- Implemented a full DSP stack in `src/audio/separation/`: a radix-2 FFT/IFFT, STFT/iSTFT with periodic Hann windowing, HTDemucs magspec computation matching the `sevagh/demucs.onnx` export contract, overlap-add chunker for arbitrary-length audio, and derived-stem arithmetic (instrumental = original − vocals).
- The worker fetches the ONNX model from a configurable `VITE_VOCAL_MODEL_BASE_URL`, caches it in the Cache API, and streams download progress back to the main thread. Separated stems (vocals + instrumental) are persisted as WAV blobs in IndexedDB (`separated-stems` store, DB version bumped to 2) with LRU eviction keeping the three most recent jobs.
- Added `src/stores/separation.ts` (Zustand) to manage separation status, progress, stem URLs, and stem selection.

**Audio engine integration**

- `AudioEngine` now watches `useSeparationStore` and swaps the `<audio>` element's `src` to the selected stem URL while preserving playback rate, volume, mute state, and playback position.
- `useAutoSeparate` hook triggers separation automatically on source change when `autoSeparateOnImport` is enabled in settings.

**UI**

- Added `VocalSeparationDropdown` to the audio player bar, showing download/separation progress, stem radio buttons, and error/retry states. The component is hidden when `VITE_VOCAL_MODEL_BASE_URL` is unset.
- Added vocal separation settings to the Playback section of the settings modal: an auto-separate toggle and a precision selector (fp32 recommended, fp16 experimental).

**Settings**

- Added `autoSeparateOnImport: boolean` and `vocalModelVariant: "fp16" | "fp32"` (defaults to `fp32`) to the settings store. A migration resets any persisted `fp16` selection back to `fp32` on upgrade.
- `setPlaybackRate` now validates the value and persists it as `defaultPlaybackRate`.

**Build tooling**

- Added `scripts/build-htdemucs-onnx.sh` to clone `sevagh/demucs.onnx`, export the HTDemucs PyTorch weights to ONNX (fp32), and quantize to fp16 via `onnxconverter-common`.
- Added `scripts/upload-htdemucs.sh` to apply CORS rules and upload the built models to a Cloudflare R2 bucket via `wrangler`.
- Vite config updated to exclude `onnxruntime-web` from dep optimization, set the worker bundle format to ES modules, and add the `onnxruntime-web-use-extern-wasm` condition so WASM binaries are loaded from jsDelivr at runtime rather than bundled.

**Other fixes**

- `BraccatoRenderer` now keys on the audio element's `src` so it remounts when the stem changes, and clicking a lyric line also resumes playback.
- `TimelineWaveform` keys `WavesurferPlayer` on `audioElement.src` so the waveform redraws when the stem URL changes.

### How to test?

1. Set `VITE_VOCAL_MODEL_BASE_URL` to a hosted R2 bucket URL (or build and upload models using the new scripts — see `README.md > Vocal separation hosting`).
    1. Try `VITE_VOCAL_MODEL_BASE_URL=https://models.composer.dacubeking.com`
2. Import an audio file. The microphone button appears in the audio player bar.
3. Open the dropdown and click **Download & separate**. Verify the download progress bar advances and the model is cached (subsequent runs skip the download).
4. After separation completes, switch between Original, Vocals, and Instrumental stems and confirm the audio changes without interrupting playback position or rate.
5. Enable **Auto-separate vocals on import** in Settings → Playback and re-import a file; separation should start automatically.
6. Test cancellation mid-download and mid-processing; confirm the UI returns to idle.
7. Run the unit test suite (`pnpm test`) — new tests cover the STFT round-trip, magspec shape and energy concentration, chunker stride/stitch correctness, derived-stem arithmetic, and finite-sample validation.

### Why make this change?

Vocal separation is a common need when working with lyrics — being able to hear isolated vocals or an instrumental mix makes it significantly easier to time-align lyrics accurately. Running the model entirely in the browser via ONNX Runtime Web avoids any server-side processing cost or privacy concerns, and serving the model from R2 keeps egress free while staying within Cloudflare Pages' asset size limits.