### PR TITLE
Feat/audio scrub preview

### DIFF
--- a/src/audio/audio-engine.browser.test.tsx
+++ b/src/audio/audio-engine.browser.test.tsx
@@ -66,6 +66,7 @@ describe("AudioEngine", () => {
 
   it("falls back to the original file when mp3 decode fails", async () => {
     allowConsole(/mp3 decode failed/);
+    allowConsole(/scrub-preview decode failed/);
     allowConsole(/Audio error/);
     await render(<AudioEngine />);
     const garbage = new File([new Uint8Array([1, 2, 3, 4, 5])], "broken.mp3", { type: "audio/mpeg" });

--- a/src/audio/audio-engine.scrub-preview.browser.test.tsx
+++ b/src/audio/audio-engine.scrub-preview.browser.test.tsx
@@ -1,0 +1,52 @@
+import { AudioEngine } from "@/audio/audio-engine";
+import { scrubPreview } from "@/audio/scrub-preview";
+import { useAudioStore } from "@/stores/audio";
+import { createAudioFile } from "@/test/audio-fixtures";
+import { render } from "@/test/render";
+import { afterEach, describe, expect, it } from "vitest";
+
+async function waitForBufferInstalled(timeout = 3000): Promise<void> {
+  await expect
+    .poll(
+      () => {
+        scrubPreview.play(0.01, 1);
+        const installed = scrubPreview.getActiveSnippet() !== null;
+        if (installed) scrubPreview.stop();
+        return installed;
+      },
+      { timeout },
+    )
+    .toBe(true);
+}
+
+describe("AudioEngine scrub-preview integration", () => {
+  afterEach(() => {
+    scrubPreview.stop();
+    scrubPreview.useBuffer(null);
+    useAudioStore.setState({ source: null });
+  });
+
+  it("installs a decoded buffer into scrub-preview when a file source loads", async () => {
+    await render(<AudioEngine />);
+    useAudioStore.setState({ source: { type: "file", file: createAudioFile() } });
+    await waitForBufferInstalled();
+  });
+
+  it("clears scrub-preview buffer when source is set to null", async () => {
+    await render(<AudioEngine />);
+    useAudioStore.setState({ source: { type: "file", file: createAudioFile() } });
+    await waitForBufferInstalled();
+
+    useAudioStore.setState({ source: null });
+
+    await expect
+      .poll(
+        () => {
+          scrubPreview.play(0.01, 1);
+          return scrubPreview.getActiveSnippet() === null;
+        },
+        { timeout: 1000 },
+      )
+      .toBe(true);
+  });
+});

--- a/src/audio/audio-engine.scrub-preview.browser.test.tsx
+++ b/src/audio/audio-engine.scrub-preview.browser.test.tsx
@@ -45,7 +45,7 @@ describe("AudioEngine scrub-preview integration", () => {
           scrubPreview.play(0.01, 1);
           return scrubPreview.getActiveSnippet() === null;
         },
-        { timeout: 1000 },
+        { timeout: 200 },
       )
       .toBe(true);
   });

--- a/src/audio/audio-engine.tsx
+++ b/src/audio/audio-engine.tsx
@@ -1,5 +1,6 @@
 import { decodeMp3ToWav, isMp3File } from "@/audio/audio-decode";
 import { bindAudioStateEvents } from "@/audio/audio-state-events";
+import { scrubPreview } from "@/audio/scrub-preview";
 import { useAudioStore } from "@/stores/audio";
 import { useEffect, useRef } from "react";
 
@@ -27,12 +28,14 @@ const AudioEngine: React.FC = () => {
   useEffect(() => {
     if (!source) {
       registerAudioElement(null);
+      scrubPreview.useBuffer(null);
       return;
     }
 
     const playableFile = source.type === "file" ? source.file : source.type === "youtube" ? source.file : null;
     if (!playableFile) {
       registerAudioElement(null);
+      scrubPreview.useBuffer(null);
       return;
     }
 
@@ -72,6 +75,21 @@ const AudioEngine: React.FC = () => {
         return URL.createObjectURL(playableFile);
       }
     };
+
+    const loadScrubBuffer = async () => {
+      try {
+        const bytes = await playableFile.arrayBuffer();
+        if (aborted) return;
+        const audioBuffer = await scrubPreview.decode(bytes);
+        if (aborted) return;
+        scrubPreview.useBuffer(audioBuffer);
+      } catch (err) {
+        if (aborted) return;
+        console.warn(LOG_PREFIX, "scrub-preview decode failed", err);
+        scrubPreview.useBuffer(null);
+      }
+    };
+    void loadScrubBuffer();
 
     const setup = async () => {
       let objectUrl: string;
@@ -137,6 +155,7 @@ const AudioEngine: React.FC = () => {
       clearSlowLoading();
       if (teardown) teardown();
       registerAudioElement(null);
+      scrubPreview.useBuffer(null);
     };
   }, [source, setDuration, setCurrentTime, setIsPlaying, setIsLoading, registerAudioElement]);
 

--- a/src/audio/scrub-preview.browser.test.ts
+++ b/src/audio/scrub-preview.browser.test.ts
@@ -1,0 +1,102 @@
+import { scrubPreview } from "@/audio/scrub-preview";
+import { makeSineBuffer } from "@/test/audio-fixtures";
+import { afterEach, describe, expect, test } from "vitest";
+
+describe("scrub-preview", () => {
+  afterEach(() => {
+    scrubPreview.stop();
+    scrubPreview.useBuffer(null);
+  });
+
+  test("play with no buffer is a no-op", () => {
+    scrubPreview.play(0.5, 1);
+    expect(scrubPreview.getActiveSnippet()).toBeNull();
+  });
+
+  test("play with buffer + audible velocity records an active snippet", () => {
+    scrubPreview.useBuffer(makeSineBuffer(1));
+    scrubPreview.play(0.5, 1);
+    const snippet = scrubPreview.getActiveSnippet();
+    expect(snippet).not.toBeNull();
+    expect(snippet?.time).toBe(0.5);
+    expect(snippet?.rate).toBe(1);
+  });
+
+  test("play with velocity 0 is a no-op", () => {
+    scrubPreview.useBuffer(makeSineBuffer(1));
+    scrubPreview.play(0.5, 0);
+    expect(scrubPreview.getActiveSnippet()).toBeNull();
+  });
+
+  test("stop clears the active snippet", () => {
+    scrubPreview.useBuffer(makeSineBuffer(1));
+    scrubPreview.play(0.5, 1);
+    scrubPreview.stop();
+    expect(scrubPreview.getActiveSnippet()).toBeNull();
+  });
+
+  test("consecutive play calls swap the active snippet without throwing", () => {
+    scrubPreview.useBuffer(makeSineBuffer(1));
+    scrubPreview.play(0.2, 1);
+    scrubPreview.play(0.4, 2);
+    const snippet = scrubPreview.getActiveSnippet();
+    expect(snippet?.time).toBe(0.4);
+    expect(snippet?.rate).toBe(2);
+  });
+
+  test("play clamps time to within buffer duration", () => {
+    scrubPreview.useBuffer(makeSineBuffer(1));
+    scrubPreview.play(99, 1);
+    const snippet = scrubPreview.getActiveSnippet();
+    expect(snippet?.time).toBeCloseTo(1 - 0.12, 2);
+  });
+
+  test("decode round-trips an ArrayBuffer into an AudioBuffer", async () => {
+    const ctx = new AudioContext();
+    const sourceBuffer = ctx.createBuffer(1, 44100, 44100);
+    const offline = new OfflineAudioContext(1, 44100, 44100);
+    const src = offline.createBufferSource();
+    src.buffer = sourceBuffer;
+    src.connect(offline.destination);
+    src.start();
+    const rendered = await offline.startRendering();
+    const wavBytes = encodeWav(rendered);
+    const decoded = await scrubPreview.decode(wavBytes);
+    expect(decoded.duration).toBeCloseTo(1, 1);
+  });
+});
+
+function encodeWav(audioBuffer: AudioBuffer): ArrayBuffer {
+  const channelCount = audioBuffer.numberOfChannels;
+  const sampleRate = audioBuffer.sampleRate;
+  const samples = audioBuffer.length;
+  const dataLength = samples * channelCount * 2;
+  const buffer = new ArrayBuffer(44 + dataLength);
+  const view = new DataView(buffer);
+  const writeString = (offset: number, text: string) => {
+    for (let i = 0; i < text.length; i++) view.setUint8(offset + i, text.charCodeAt(i));
+  };
+  writeString(0, "RIFF");
+  view.setUint32(4, 36 + dataLength, true);
+  writeString(8, "WAVE");
+  writeString(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, channelCount, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * channelCount * 2, true);
+  view.setUint16(32, channelCount * 2, true);
+  view.setUint16(34, 16, true);
+  writeString(36, "data");
+  view.setUint32(40, dataLength, true);
+  const channels = Array.from({ length: channelCount }, (_, c) => audioBuffer.getChannelData(c));
+  let offset = 44;
+  for (let i = 0; i < samples; i++) {
+    for (let c = 0; c < channelCount; c++) {
+      const sample = Math.max(-1, Math.min(1, channels[c][i]));
+      view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+      offset += 2;
+    }
+  }
+  return buffer;
+}

--- a/src/audio/scrub-preview.browser.test.ts
+++ b/src/audio/scrub-preview.browser.test.ts
@@ -1,4 +1,5 @@
 import { scrubPreview } from "@/audio/scrub-preview";
+import { useSettingsStore } from "@/stores/settings";
 import { makeSineBuffer } from "@/test/audio-fixtures";
 import { afterEach, describe, expect, test } from "vitest";
 
@@ -49,6 +50,18 @@ describe("scrub-preview", () => {
     scrubPreview.play(99, 1);
     const snippet = scrubPreview.getActiveSnippet();
     expect(snippet?.time).toBeCloseTo(1 - 0.12, 2);
+  });
+
+  test("play is a no-op when audioScrubPreview setting is off", () => {
+    scrubPreview.useBuffer(makeSineBuffer(1));
+    const previous = useSettingsStore.getState().audioScrubPreview;
+    useSettingsStore.setState({ audioScrubPreview: false });
+    try {
+      scrubPreview.play(0.5, 1);
+      expect(scrubPreview.getActiveSnippet()).toBeNull();
+    } finally {
+      useSettingsStore.setState({ audioScrubPreview: previous });
+    }
   });
 
   test("decode round-trips an ArrayBuffer into an AudioBuffer", async () => {

--- a/src/audio/scrub-preview.ts
+++ b/src/audio/scrub-preview.ts
@@ -1,9 +1,8 @@
 const SNIPPET_S = 0.12;
 const CROSSFADE_S = 0.008;
 const MIN_AUDIBLE_RATE = 0.1;
-const LOG_PREFIX = "[ScrubPreview]";
 
-type ActiveSnippet = { time: number; rate: number; startedAt: number };
+type ActiveSnippet = { time: number; rate: number };
 
 let context: AudioContext | null = null;
 let buffer: AudioBuffer | null = null;
@@ -19,6 +18,7 @@ function getContext(): AudioContext {
 
 async function decode(bytes: ArrayBuffer): Promise<AudioBuffer> {
   const ctx = getContext();
+  // decodeAudioData detaches its input ArrayBuffer in some browsers; copy first
   return await ctx.decodeAudioData(bytes.slice(0));
 }
 
@@ -30,25 +30,18 @@ function useBuffer(next: AudioBuffer | null): void {
 function fadeOutAndStop(source: AudioBufferSourceNode, gain: GainNode): void {
   const ctx = getContext();
   const now = ctx.currentTime;
+  gain.gain.cancelScheduledValues(now);
+  gain.gain.setValueAtTime(gain.gain.value, now);
+  gain.gain.linearRampToValueAtTime(0, now + CROSSFADE_S);
   try {
-    gain.gain.cancelScheduledValues(now);
-    gain.gain.setValueAtTime(gain.gain.value, now);
-    gain.gain.linearRampToValueAtTime(0, now + CROSSFADE_S);
     source.stop(now + CROSSFADE_S + 0.002);
-  } catch (err) {
-    console.warn(LOG_PREFIX, "fadeOutAndStop failed", err);
+  } catch {
+    /* source already ended; safe to ignore */
   }
 }
 
 function isEnabled(): boolean {
-  try {
-    const settings = (globalThis as { __scrubPreviewSettings?: () => { audioScrubPreview?: boolean } })
-      .__scrubPreviewSettings;
-    if (settings) return settings().audioScrubPreview !== false;
-    return true;
-  } catch {
-    return true;
-  }
+  return true;
 }
 
 function play(time: number, velocity: number): void {
@@ -80,7 +73,7 @@ function play(time: number, velocity: number): void {
 
   currentSource = source;
   currentGain = gain;
-  activeSnippet = { time: clampedTime, rate: velocity, startedAt: now };
+  activeSnippet = { time: clampedTime, rate: velocity };
 
   source.onended = () => {
     if (currentSource === source) {
@@ -103,6 +96,7 @@ function stop(): void {
 function dispose(): void {
   stop();
   buffer = null;
+  context = null;
 }
 
 function getActiveSnippet(): ActiveSnippet | null {

--- a/src/audio/scrub-preview.ts
+++ b/src/audio/scrub-preview.ts
@@ -1,8 +1,11 @@
+import { useAudioStore } from "@/stores/audio";
 import { useSettingsStore } from "@/stores/settings";
 
 const SNIPPET_S = 0.12;
 const CROSSFADE_S = 0.008;
 const MIN_AUDIBLE_RATE = 0.1;
+const MAX_BUFFER_DURATION_S = 60 * 60;
+const LOG_PREFIX = "[ScrubPreview]";
 
 type ActiveSnippet = { time: number; rate: number };
 
@@ -26,6 +29,11 @@ async function decode(bytes: ArrayBuffer): Promise<AudioBuffer> {
 
 function useBuffer(next: AudioBuffer | null): void {
   stop();
+  if (next && next.duration > MAX_BUFFER_DURATION_S) {
+    console.warn(LOG_PREFIX, `buffer exceeds ${MAX_BUFFER_DURATION_S}s cap; scrub preview disabled for this source`);
+    buffer = null;
+    return;
+  }
   buffer = next;
 }
 
@@ -65,8 +73,10 @@ function play(time: number, velocity: number): void {
 
   const gain = ctx.createGain();
   const now = ctx.currentTime;
+  const audioState = useAudioStore.getState();
+  const targetVolume = audioState.isMuted ? 0 : audioState.volume;
   gain.gain.setValueAtTime(0, now);
-  gain.gain.linearRampToValueAtTime(1, now + CROSSFADE_S);
+  gain.gain.linearRampToValueAtTime(targetVolume, now + CROSSFADE_S);
 
   source.connect(gain);
   gain.connect(ctx.destination);
@@ -95,17 +105,11 @@ function stop(): void {
   activeSnippet = null;
 }
 
-function dispose(): void {
-  stop();
-  buffer = null;
-  context = null;
-}
-
 function getActiveSnippet(): ActiveSnippet | null {
   return activeSnippet;
 }
 
-const scrubPreview = { decode, useBuffer, play, stop, dispose, getActiveSnippet };
+const scrubPreview = { decode, useBuffer, play, stop, getActiveSnippet };
 
 export { scrubPreview };
 export type { ActiveSnippet };

--- a/src/audio/scrub-preview.ts
+++ b/src/audio/scrub-preview.ts
@@ -1,3 +1,5 @@
+import { useSettingsStore } from "@/stores/settings";
+
 const SNIPPET_S = 0.12;
 const CROSSFADE_S = 0.008;
 const MIN_AUDIBLE_RATE = 0.1;
@@ -41,7 +43,7 @@ function fadeOutAndStop(source: AudioBufferSourceNode, gain: GainNode): void {
 }
 
 function isEnabled(): boolean {
-  return true;
+  return useSettingsStore.getState().audioScrubPreview !== false;
 }
 
 function play(time: number, velocity: number): void {

--- a/src/audio/scrub-preview.ts
+++ b/src/audio/scrub-preview.ts
@@ -69,7 +69,6 @@ function play(time: number, velocity: number): void {
 
   const source = ctx.createBufferSource();
   source.buffer = buffer;
-  source.playbackRate.value = velocity;
 
   const gain = ctx.createGain();
   const now = ctx.currentTime;

--- a/src/audio/scrub-preview.ts
+++ b/src/audio/scrub-preview.ts
@@ -1,0 +1,115 @@
+const SNIPPET_S = 0.12;
+const CROSSFADE_S = 0.008;
+const MIN_AUDIBLE_RATE = 0.1;
+const LOG_PREFIX = "[ScrubPreview]";
+
+type ActiveSnippet = { time: number; rate: number; startedAt: number };
+
+let context: AudioContext | null = null;
+let buffer: AudioBuffer | null = null;
+let currentSource: AudioBufferSourceNode | null = null;
+let currentGain: GainNode | null = null;
+let activeSnippet: ActiveSnippet | null = null;
+
+function getContext(): AudioContext {
+  if (!context) context = new AudioContext();
+  if (context.state === "suspended") void context.resume();
+  return context;
+}
+
+async function decode(bytes: ArrayBuffer): Promise<AudioBuffer> {
+  const ctx = getContext();
+  return await ctx.decodeAudioData(bytes.slice(0));
+}
+
+function useBuffer(next: AudioBuffer | null): void {
+  stop();
+  buffer = next;
+}
+
+function fadeOutAndStop(source: AudioBufferSourceNode, gain: GainNode): void {
+  const ctx = getContext();
+  const now = ctx.currentTime;
+  try {
+    gain.gain.cancelScheduledValues(now);
+    gain.gain.setValueAtTime(gain.gain.value, now);
+    gain.gain.linearRampToValueAtTime(0, now + CROSSFADE_S);
+    source.stop(now + CROSSFADE_S + 0.002);
+  } catch (err) {
+    console.warn(LOG_PREFIX, "fadeOutAndStop failed", err);
+  }
+}
+
+function isEnabled(): boolean {
+  try {
+    const settings = (globalThis as { __scrubPreviewSettings?: () => { audioScrubPreview?: boolean } })
+      .__scrubPreviewSettings;
+    if (settings) return settings().audioScrubPreview !== false;
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+function play(time: number, velocity: number): void {
+  if (!isEnabled()) return;
+  if (!buffer) return;
+  if (velocity < MIN_AUDIBLE_RATE) return;
+
+  const ctx = getContext();
+  const maxStartTime = Math.max(0, buffer.duration - SNIPPET_S);
+  const clampedTime = Math.max(0, Math.min(time, maxStartTime));
+
+  if (currentSource && currentGain) {
+    fadeOutAndStop(currentSource, currentGain);
+  }
+
+  const source = ctx.createBufferSource();
+  source.buffer = buffer;
+  source.playbackRate.value = velocity;
+
+  const gain = ctx.createGain();
+  const now = ctx.currentTime;
+  gain.gain.setValueAtTime(0, now);
+  gain.gain.linearRampToValueAtTime(1, now + CROSSFADE_S);
+
+  source.connect(gain);
+  gain.connect(ctx.destination);
+
+  source.start(now, clampedTime, SNIPPET_S);
+
+  currentSource = source;
+  currentGain = gain;
+  activeSnippet = { time: clampedTime, rate: velocity, startedAt: now };
+
+  source.onended = () => {
+    if (currentSource === source) {
+      currentSource = null;
+      currentGain = null;
+      activeSnippet = null;
+    }
+  };
+}
+
+function stop(): void {
+  if (currentSource && currentGain) {
+    fadeOutAndStop(currentSource, currentGain);
+  }
+  currentSource = null;
+  currentGain = null;
+  activeSnippet = null;
+}
+
+function dispose(): void {
+  stop();
+  buffer = null;
+}
+
+function getActiveSnippet(): ActiveSnippet | null {
+  return activeSnippet;
+}
+
+const scrubPreview = { decode, useBuffer, play, stop, dispose, getActiveSnippet };
+
+export { scrubPreview };
+export type { ActiveSnippet };

--- a/src/audio/scrub-preview.ts
+++ b/src/audio/scrub-preview.ts
@@ -43,7 +43,7 @@ function fadeOutAndStop(source: AudioBufferSourceNode, gain: GainNode): void {
 }
 
 function isEnabled(): boolean {
-  return useSettingsStore.getState().audioScrubPreview !== false;
+  return useSettingsStore.getState().audioScrubPreview;
 }
 
 function play(time: number, velocity: number): void {

--- a/src/audio/scrub-velocity.test.ts
+++ b/src/audio/scrub-velocity.test.ts
@@ -1,14 +1,14 @@
 import { computeScrubVelocity } from "@/audio/scrub-velocity";
 import { describe, expect, test } from "vitest";
 
-const OPTS = { minDtMs: 16, minRate: 0.25, maxRate: 4, minAudible: 0.1 };
+const OPTS = { minDtMs: 16, minRate: 0.25, maxRate: 4, minAudibleRate: 0.1 };
 
 describe("computeScrubVelocity", () => {
   test("returns 0 when prev is null", () => {
     expect(computeScrubVelocity(null, { time: 1, wallClockMs: 0 }, OPTS)).toBe(0);
   });
 
-  test("returns 0 when magnitude below minAudible", () => {
+  test("returns 0 when magnitude below minAudibleRate", () => {
     const prev = { time: 1, wallClockMs: 0 };
     const curr = { time: 1.001, wallClockMs: 100 };
     expect(computeScrubVelocity(prev, curr, OPTS)).toBe(0);
@@ -36,5 +36,23 @@ describe("computeScrubVelocity", () => {
     const prev = { time: 0, wallClockMs: 0 };
     const curr = { time: 0.05, wallClockMs: 1 };
     expect(computeScrubVelocity(prev, curr, OPTS)).toBe(4);
+  });
+
+  test("does not floor small positive dt; maxRate is the only rate cap", () => {
+    const prev = { time: 0, wallClockMs: 0 };
+    const curr = { time: 0.001, wallClockMs: 1 };
+    expect(computeScrubVelocity(prev, curr, OPTS)).toBe(1);
+  });
+
+  test("treats backwards wallClock as zero-dt fallback", () => {
+    const prev = { time: 5, wallClockMs: 1000 };
+    const curr = { time: 5.5, wallClockMs: 500 };
+    expect(computeScrubVelocity(prev, curr, OPTS)).toBe(4);
+  });
+
+  test("NaN inputs do not produce a non-zero rate", () => {
+    const prev = { time: 0, wallClockMs: 0 };
+    const curr = { time: Number.NaN, wallClockMs: 100 };
+    expect(computeScrubVelocity(prev, curr, OPTS)).toBe(0);
   });
 });

--- a/src/audio/scrub-velocity.test.ts
+++ b/src/audio/scrub-velocity.test.ts
@@ -1,0 +1,40 @@
+import { computeScrubVelocity } from "@/audio/scrub-velocity";
+import { describe, expect, test } from "vitest";
+
+const OPTS = { minDtMs: 16, minRate: 0.25, maxRate: 4, minAudible: 0.1 };
+
+describe("computeScrubVelocity", () => {
+  test("returns 0 when prev is null", () => {
+    expect(computeScrubVelocity(null, { time: 1, wallClockMs: 0 }, OPTS)).toBe(0);
+  });
+
+  test("returns 0 when magnitude below minAudible", () => {
+    const prev = { time: 1, wallClockMs: 0 };
+    const curr = { time: 1.001, wallClockMs: 100 };
+    expect(computeScrubVelocity(prev, curr, OPTS)).toBe(0);
+  });
+
+  test("clamps to maxRate on a very fast drag", () => {
+    const prev = { time: 0, wallClockMs: 0 };
+    const curr = { time: 10, wallClockMs: 100 };
+    expect(computeScrubVelocity(prev, curr, OPTS)).toBe(4);
+  });
+
+  test("clamps to minRate when audible but below floor", () => {
+    const prev = { time: 0, wallClockMs: 0 };
+    const curr = { time: 0.02, wallClockMs: 100 };
+    expect(computeScrubVelocity(prev, curr, OPTS)).toBe(0.25);
+  });
+
+  test("returns magnitude for reverse drag", () => {
+    const prev = { time: 5, wallClockMs: 0 };
+    const curr = { time: 3, wallClockMs: 100 };
+    expect(computeScrubVelocity(prev, curr, OPTS)).toBe(4);
+  });
+
+  test("applies minDtMs floor so tiny dt cannot inflate rate", () => {
+    const prev = { time: 0, wallClockMs: 0 };
+    const curr = { time: 0.05, wallClockMs: 1 };
+    expect(computeScrubVelocity(prev, curr, OPTS)).toBe(4);
+  });
+});

--- a/src/audio/scrub-velocity.ts
+++ b/src/audio/scrub-velocity.ts
@@ -4,16 +4,18 @@ type ComputeScrubVelocityOpts = {
   minDtMs: number;
   minRate: number;
   maxRate: number;
-  minAudible: number;
+  minAudibleRate: number;
 };
 
 function computeScrubVelocity(prev: ScrubSample | null, curr: ScrubSample, opts: ComputeScrubVelocityOpts): number {
   if (!prev) return 0;
+  if (!Number.isFinite(curr.time) || !Number.isFinite(prev.time)) return 0;
+  if (!Number.isFinite(curr.wallClockMs) || !Number.isFinite(prev.wallClockMs)) return 0;
   const rawDtMs = curr.wallClockMs - prev.wallClockMs;
   const dtMs = rawDtMs > 0 ? rawDtMs : opts.minDtMs;
   const rawRate = (curr.time - prev.time) / (dtMs / 1000);
   const magnitude = Math.abs(rawRate);
-  if (magnitude < opts.minAudible) return 0;
+  if (magnitude < opts.minAudibleRate) return 0;
   return Math.max(opts.minRate, Math.min(opts.maxRate, magnitude));
 }
 

--- a/src/audio/scrub-velocity.ts
+++ b/src/audio/scrub-velocity.ts
@@ -1,0 +1,21 @@
+type ScrubSample = { time: number; wallClockMs: number };
+
+type ComputeScrubVelocityOpts = {
+  minDtMs: number;
+  minRate: number;
+  maxRate: number;
+  minAudible: number;
+};
+
+function computeScrubVelocity(prev: ScrubSample | null, curr: ScrubSample, opts: ComputeScrubVelocityOpts): number {
+  if (!prev) return 0;
+  const rawDtMs = curr.wallClockMs - prev.wallClockMs;
+  const dtMs = rawDtMs > 0 ? rawDtMs : opts.minDtMs;
+  const rawRate = (curr.time - prev.time) / (dtMs / 1000);
+  const magnitude = Math.abs(rawRate);
+  if (magnitude < opts.minAudible) return 0;
+  return Math.max(opts.minRate, Math.min(opts.maxRate, magnitude));
+}
+
+export { computeScrubVelocity };
+export type { ScrubSample, ComputeScrubVelocityOpts };

--- a/src/audio/scrub-velocity.ts
+++ b/src/audio/scrub-velocity.ts
@@ -19,5 +19,12 @@ function computeScrubVelocity(prev: ScrubSample | null, curr: ScrubSample, opts:
   return Math.max(opts.minRate, Math.min(opts.maxRate, magnitude));
 }
 
-export { computeScrubVelocity };
+const DEFAULT_SCRUB_OPTS: ComputeScrubVelocityOpts = {
+  minDtMs: 16,
+  minRate: 0.25,
+  maxRate: 4,
+  minAudibleRate: 0.1,
+};
+
+export { computeScrubVelocity, DEFAULT_SCRUB_OPTS };
 export type { ScrubSample, ComputeScrubVelocityOpts };

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -16,6 +16,10 @@ describe("preview renderer settings", () => {
     expect(useSettingsStore.getState().previewRenderer).toBe("braccato");
   });
 
+  it("defaults audioScrubPreview to true", () => {
+    expect(useSettingsStore.getState().audioScrubPreview).toBe(true);
+  });
+
   it("allows switching renderer via set()", () => {
     useSettingsStore.getState().set("previewRenderer", "am-lyrics");
     expect(useSettingsStore.getState().previewRenderer).toBe("am-lyrics");

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -25,6 +25,7 @@ interface SettingsState {
   defaultPlaybackRate: number;
   rememberVolume: boolean;
   lastVolume: number;
+  audioScrubPreview: boolean;
 
   defaultZoom: number;
   defaultRowHeight: number;
@@ -77,6 +78,7 @@ const DEFAULTS: SettingsState = {
   defaultPlaybackRate: 0.75,
   rememberVolume: true,
   lastVolume: 1,
+  audioScrubPreview: true,
 
   defaultZoom: 100,
   defaultRowHeight: 44,

--- a/src/test/audio-fixtures.ts
+++ b/src/test/audio-fixtures.ts
@@ -56,4 +56,15 @@ function createMp3File(name = "silence.mp3"): File {
   return new File([SILENT_MP3_BYTES], name, { type: "audio/mpeg" });
 }
 
-export { createAudioFile, createMp3File };
+function makeSineBuffer(durationS: number, sampleRate = 44100): AudioBuffer {
+  const ctx = new AudioContext();
+  const length = Math.max(1, Math.round(sampleRate * durationS));
+  const audioBuffer = ctx.createBuffer(1, length, sampleRate);
+  const data = audioBuffer.getChannelData(0);
+  for (let i = 0; i < length; i++) {
+    data[i] = Math.sin((2 * Math.PI * 440 * i) / sampleRate) * 0.2;
+  }
+  return audioBuffer;
+}
+
+export { createAudioFile, createMp3File, makeSineBuffer };

--- a/src/ui/help-sections/timeline.browser.test.tsx
+++ b/src/ui/help-sections/timeline.browser.test.tsx
@@ -56,6 +56,12 @@ describe("TimelineSection", () => {
     await expect.element(screen.getByText(/cycle through any overlapping words/i)).toBeInTheDocument();
   });
 
+  it("documents audio scrub preview at native pitch", async () => {
+    const screen = await render(<TimelineSection />);
+    await expect.element(screen.getByRole("heading", { name: "Audio scrub preview" })).toBeInTheDocument();
+    await expect.element(screen.getByText(/at normal pitch/)).toBeInTheDocument();
+  });
+
   it("does not describe a plain wheel as horizontal-only", async () => {
     const screen = await render(<TimelineSection />);
     expect(screen.container.textContent).not.toContain("Scroll horizontally to move through time");

--- a/src/ui/help-sections/timeline.tsx
+++ b/src/ui/help-sections/timeline.tsx
@@ -52,6 +52,16 @@ const TimelineSection: React.FC = () => (
     </div>
 
     <div>
+      <h4 className={HEADING}>Audio scrub preview</h4>
+      <p className={PROSE}>
+        When you scrub the playhead (drag it, or scroll the wheel over the waveform), Composer plays a short bit of
+        audio at the playhead position, at normal pitch. It helps you find a specific word by ear without having to
+        press play. Faster scrubs play more snippets, slower scrubs play fewer. The preview matches your main volume and
+        stays silent when the audio is muted. If it gets in the way, turn it off in Settings, under Playback.
+      </p>
+    </div>
+
+    <div>
       <h4 className={HEADING}>Selecting words</h4>
       <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
         <li>Click a word block to select it. {MOD_KEY} + Click to add or remove from selection.</li>

--- a/src/ui/settings/playback-section.browser.test.tsx
+++ b/src/ui/settings/playback-section.browser.test.tsx
@@ -14,8 +14,21 @@ describe("PlaybackSection", () => {
   it("flips Remember volume when its toggle is clicked", async () => {
     useSettingsStore.setState({ rememberVolume: true });
     const screen = await render(<PlaybackSection />);
-    await screen.getByRole("switch").click();
+    await screen.getByRole("switch", { name: "Remember volume" }).click();
     await expect.poll(() => useSettingsStore.getState().rememberVolume).toBe(false);
+  });
+
+  it("renders the Audio scrub preview toggle on by default", async () => {
+    const screen = await render(<PlaybackSection />);
+    const toggle = screen.getByRole("switch", { name: "Audio scrub preview" });
+    await expect.element(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("flips Audio scrub preview when its toggle is clicked", async () => {
+    useSettingsStore.setState({ audioScrubPreview: true });
+    const screen = await render(<PlaybackSection />);
+    await screen.getByRole("switch", { name: "Audio scrub preview" }).click();
+    await expect.poll(() => useSettingsStore.getState().audioScrubPreview).toBe(false);
   });
 
   it("hides the Use current action when no audio is loaded", async () => {

--- a/src/ui/settings/playback-section.tsx
+++ b/src/ui/settings/playback-section.tsx
@@ -32,6 +32,11 @@ const PlaybackSection: React.FC = () => {
         description="Keep your volume level between sessions."
         settingKey="rememberVolume"
       />
+      <ToggleSetting
+        label="Audio scrub preview"
+        description="Play a short audio snippet while dragging or wheel-scrubbing the playhead."
+        settingKey="audioScrubPreview"
+      />
     </div>
   );
 };

--- a/src/views/timeline/playhead-drag.scrub-preview.browser.test.ts
+++ b/src/views/timeline/playhead-drag.scrub-preview.browser.test.ts
@@ -1,0 +1,77 @@
+import { scrubPreview } from "@/audio/scrub-preview";
+import { useSettingsStore } from "@/stores/settings";
+import { makeSineBuffer } from "@/test/audio-fixtures";
+import { createPlayheadDrag, type PlayheadDragConfig } from "@/views/timeline/playhead-drag";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+function makeConfig(overrides: Partial<PlayheadDragConfig> = {}): PlayheadDragConfig {
+  return {
+    getContainerRect: () => new DOMRect(0, 0, 1000, 100),
+    getScrollContainer: () => null,
+    getDuration: () => 10,
+    getZoom: () => 100,
+    getStoreScrollLeft: () => 0,
+    getCurrentTime: () => 1,
+    setIsPlaying: () => undefined,
+    setDraggingPlayhead: () => undefined,
+    setDragTime: () => undefined,
+    seekTo: () => undefined,
+    ...overrides,
+  };
+}
+
+function makeFakeMouseEvent(clientX: number): React.MouseEvent {
+  return { button: 0, clientX, preventDefault: () => undefined } as unknown as React.MouseEvent;
+}
+
+describe("playhead-drag scrub preview", () => {
+  beforeEach(() => {
+    scrubPreview.useBuffer(makeSineBuffer(10));
+  });
+
+  afterEach(() => {
+    scrubPreview.stop();
+    scrubPreview.useBuffer(null);
+  });
+
+  it("schedules scrub-preview snippets during a drag", async () => {
+    const drag = createPlayheadDrag(makeConfig());
+    drag.onMouseDown(makeFakeMouseEvent(200));
+
+    document.dispatchEvent(new MouseEvent("mousemove", { clientX: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mousemove", { clientX: 500, bubbles: true }));
+
+    await expect.poll(() => scrubPreview.getActiveSnippet()).not.toBeNull();
+
+    document.dispatchEvent(new MouseEvent("mouseup", { clientX: 500, bubbles: true }));
+
+    await expect.poll(() => scrubPreview.getActiveSnippet()).toBeNull();
+    drag.dispose();
+  });
+
+  it("is silent when the audioScrubPreview setting is off", async () => {
+    useSettingsStore.setState({ audioScrubPreview: false });
+    const drag = createPlayheadDrag(makeConfig());
+    drag.onMouseDown(makeFakeMouseEvent(200));
+    document.dispatchEvent(new MouseEvent("mousemove", { clientX: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mousemove", { clientX: 500, bubbles: true }));
+
+    await expect.poll(() => scrubPreview.getActiveSnippet(), { timeout: 200 }).toBeNull();
+    document.dispatchEvent(new MouseEvent("mouseup", { clientX: 500, bubbles: true }));
+    drag.dispose();
+  });
+
+  it("stops scrub preview on dispose mid-drag", async () => {
+    const drag = createPlayheadDrag(makeConfig());
+    drag.onMouseDown(makeFakeMouseEvent(200));
+
+    document.dispatchEvent(new MouseEvent("mousemove", { clientX: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mousemove", { clientX: 500, bubbles: true }));
+
+    await expect.poll(() => scrubPreview.getActiveSnippet()).not.toBeNull();
+
+    drag.dispose();
+
+    await expect.poll(() => scrubPreview.getActiveSnippet()).toBeNull();
+  });
+});

--- a/src/views/timeline/playhead-drag.ts
+++ b/src/views/timeline/playhead-drag.ts
@@ -1,3 +1,5 @@
+import { scrubPreview } from "@/audio/scrub-preview";
+import { computeScrubVelocity, type ScrubSample } from "@/audio/scrub-velocity";
 import { computeEdgeScrollVelocity } from "@/views/timeline/edge-scroll";
 import { GUTTER_WIDTH } from "@/views/timeline/timeline-store";
 
@@ -25,6 +27,7 @@ interface PlayheadDrag {
 
 const EDGE_SCROLL_ZONE = 60;
 const EDGE_SCROLL_MAX_SPEED = 22;
+const SCRUB_OPTS = { minDtMs: 16, minRate: 0.25, maxRate: 4, minAudibleRate: 0.1 } as const;
 
 // -- Functions -----------------------------------------------------------------
 
@@ -50,7 +53,15 @@ function createPlayheadDrag(config: PlayheadDragConfig): PlayheadDrag {
 
     let pointerX = e.clientX;
     let edgeScrollRaf: number | null = null;
+    let prevSample: ScrubSample | null = null;
     const controller = new AbortController();
+
+    const tickScrubPreview = (time: number): void => {
+      const curr: ScrubSample = { time, wallClockMs: performance.now() };
+      const velocity = computeScrubVelocity(prevSample, curr, SCRUB_OPTS);
+      prevSample = curr;
+      if (velocity > 0) scrubPreview.play(time, velocity);
+    };
 
     const tickEdgeScroll = (): void => {
       edgeScrollRaf = requestAnimationFrame(tickEdgeScroll);
@@ -68,13 +79,19 @@ function createPlayheadDrag(config: PlayheadDragConfig): PlayheadDrag {
       const maxScroll = container.scrollWidth - container.clientWidth;
       container.scrollLeft = Math.max(0, Math.min(maxScroll, container.scrollLeft + velocity));
       const time = computeTimeFromPointer(pointerX);
-      if (time !== null) config.setDragTime(time);
+      if (time !== null) {
+        config.setDragTime(time);
+        tickScrubPreview(time);
+      }
     };
 
     const handleMouseMove = (moveEvent: MouseEvent): void => {
       pointerX = moveEvent.clientX;
       const time = computeTimeFromPointer(pointerX);
-      if (time !== null) config.setDragTime(time);
+      if (time !== null) {
+        config.setDragTime(time);
+        tickScrubPreview(time);
+      }
     };
 
     const cleanup = (): void => {
@@ -83,6 +100,7 @@ function createPlayheadDrag(config: PlayheadDragConfig): PlayheadDrag {
         edgeScrollRaf = null;
       }
       controller.abort();
+      scrubPreview.stop();
       activeCleanup = null;
     };
 

--- a/src/views/timeline/playhead-drag.ts
+++ b/src/views/timeline/playhead-drag.ts
@@ -1,5 +1,5 @@
 import { scrubPreview } from "@/audio/scrub-preview";
-import { computeScrubVelocity, type ScrubSample } from "@/audio/scrub-velocity";
+import { computeScrubVelocity, DEFAULT_SCRUB_OPTS, type ScrubSample } from "@/audio/scrub-velocity";
 import { computeEdgeScrollVelocity } from "@/views/timeline/edge-scroll";
 import { GUTTER_WIDTH } from "@/views/timeline/timeline-store";
 
@@ -27,7 +27,6 @@ interface PlayheadDrag {
 
 const EDGE_SCROLL_ZONE = 60;
 const EDGE_SCROLL_MAX_SPEED = 22;
-const SCRUB_OPTS = { minDtMs: 16, minRate: 0.25, maxRate: 4, minAudibleRate: 0.1 } as const;
 
 // -- Functions -----------------------------------------------------------------
 
@@ -58,7 +57,7 @@ function createPlayheadDrag(config: PlayheadDragConfig): PlayheadDrag {
 
     const tickScrubPreview = (time: number): void => {
       const curr: ScrubSample = { time, wallClockMs: performance.now() };
-      const velocity = computeScrubVelocity(prevSample, curr, SCRUB_OPTS);
+      const velocity = computeScrubVelocity(prevSample, curr, DEFAULT_SCRUB_OPTS);
       prevSample = curr;
       if (velocity > 0) scrubPreview.play(time, velocity);
     };

--- a/src/views/timeline/use-timeline-wheel.scrub-preview.browser.test.tsx
+++ b/src/views/timeline/use-timeline-wheel.scrub-preview.browser.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { scrubPreview } from "@/audio/scrub-preview";
+import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
+import { createAudioFile, makeSineBuffer } from "@/test/audio-fixtures";
+import { createLine, createWord } from "@/test/factories";
+import { render } from "@/test/render";
+import { TimelinePanel } from "@/views/timeline/timeline-panel";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+
+// -- Helpers ------------------------------------------------------------------
+
+function getScrollContainer(): HTMLDivElement {
+  return document.querySelector("[data-scroll-container]") as HTMLDivElement;
+}
+
+function makeScrollable(container: HTMLDivElement): void {
+  container.style.width = "400px";
+  container.style.height = "300px";
+  container.style.overflow = "auto";
+}
+
+function dispatchWheel(container: HTMLElement, init: { deltaY: number; clientX: number; clientY: number }): void {
+  container.dispatchEvent(
+    new WheelEvent("wheel", {
+      deltaY: init.deltaY,
+      clientX: init.clientX,
+      clientY: init.clientY,
+      cancelable: true,
+      bubbles: true,
+    }),
+  );
+}
+
+function seedTimeline(): void {
+  useAudioStore.setState({ source: { type: "file", file: createAudioFile() }, duration: 10, currentTime: 5 });
+  useTimelineStore.setState({ zoom: 100, scrollLeft: 0 });
+  useProjectStore.setState({
+    activeTab: "timeline",
+    lines: Array.from({ length: 10 }, (_, i) =>
+      createLine({
+        id: `line-${i}`,
+        text: `lyric ${i}`,
+        words: [createWord({ text: `lyric${i}`, begin: i, end: i + 0.5 })],
+      }),
+    ),
+  });
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("wheel scrub-preview", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ timelineHorizontalScroll: false, audioScrubPreview: true });
+    seedTimeline();
+    scrubPreview.useBuffer(makeSineBuffer(10));
+  });
+
+  afterEach(() => {
+    scrubPreview.stop();
+    scrubPreview.useBuffer(null);
+  });
+
+  it("schedules a snippet per wheel event and stops after idle", async () => {
+    await render(<TimelinePanel />);
+    const container = getScrollContainer();
+    makeScrollable(container);
+
+    const rect = container.getBoundingClientRect();
+    const clientY = rect.top + 20;
+    const clientX = rect.left + 200;
+
+    dispatchWheel(container, { deltaY: 200, clientX, clientY });
+    dispatchWheel(container, { deltaY: 200, clientX, clientY });
+
+    await expect.poll(() => scrubPreview.getActiveSnippet()).not.toBeNull();
+
+    await expect.poll(() => scrubPreview.getActiveSnippet(), { timeout: 1000, interval: 30 }).toBeNull();
+  });
+
+  it("does not schedule when the audioScrubPreview setting is off", async () => {
+    useSettingsStore.setState({ audioScrubPreview: false });
+    await render(<TimelinePanel />);
+    const container = getScrollContainer();
+    makeScrollable(container);
+    const rect = container.getBoundingClientRect();
+    dispatchWheel(container, { deltaY: 200, clientX: rect.left + 200, clientY: rect.top + 20 });
+    dispatchWheel(container, { deltaY: 200, clientX: rect.left + 200, clientY: rect.top + 20 });
+    await expect.poll(() => scrubPreview.getActiveSnippet(), { timeout: 200 }).toBeNull();
+  });
+});

--- a/src/views/timeline/use-timeline-wheel.ts
+++ b/src/views/timeline/use-timeline-wheel.ts
@@ -1,5 +1,5 @@
 import { scrubPreview } from "@/audio/scrub-preview";
-import { computeScrubVelocity, type ScrubSample } from "@/audio/scrub-velocity";
+import { computeScrubVelocity, DEFAULT_SCRUB_OPTS, type ScrubSample } from "@/audio/scrub-velocity";
 import { useAudioStore } from "@/stores/audio";
 import { useSettingsStore } from "@/stores/settings";
 import { GUTTER_WIDTH, MAX_ZOOM, MIN_ZOOM, useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
@@ -8,7 +8,6 @@ import { type RefObject, useCallback, useEffect, useRef } from "react";
 
 // -- Constants -----------------------------------------------------------------
 
-const SCRUB_OPTS = { minDtMs: 16, minRate: 0.25, maxRate: 4, minAudibleRate: 0.1 } as const;
 const WHEEL_IDLE_MS = 120;
 
 // -- Hook ----------------------------------------------------------------------
@@ -68,7 +67,7 @@ function useTimelineWheel(scrollContainerRef: RefObject<HTMLDivElement | null>, 
         }
 
         const curr: ScrubSample = { time: newTime, wallClockMs: performance.now() };
-        const velocity = computeScrubVelocity(prevScrubSampleRef.current, curr, SCRUB_OPTS);
+        const velocity = computeScrubVelocity(prevScrubSampleRef.current, curr, DEFAULT_SCRUB_OPTS);
         prevScrubSampleRef.current = curr;
         if (velocity > 0) scrubPreview.play(newTime, velocity);
 

--- a/src/views/timeline/use-timeline-wheel.ts
+++ b/src/views/timeline/use-timeline-wheel.ts
@@ -1,12 +1,22 @@
+import { scrubPreview } from "@/audio/scrub-preview";
+import { computeScrubVelocity, type ScrubSample } from "@/audio/scrub-velocity";
 import { useAudioStore } from "@/stores/audio";
 import { useSettingsStore } from "@/stores/settings";
 import { GUTTER_WIDTH, MAX_ZOOM, MIN_ZOOM, useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
 import { computeScrubTime, decideWheelAction, normalizeWheelDelta } from "@/views/timeline/timeline-wheel";
-import { type RefObject, useCallback, useEffect } from "react";
+import { type RefObject, useCallback, useEffect, useRef } from "react";
+
+// -- Constants -----------------------------------------------------------------
+
+const SCRUB_OPTS = { minDtMs: 16, minRate: 0.25, maxRate: 4, minAudibleRate: 0.1 } as const;
+const WHEEL_IDLE_MS = 120;
 
 // -- Hook ----------------------------------------------------------------------
 
 function useTimelineWheel(scrollContainerRef: RefObject<HTMLDivElement | null>, enabled: boolean) {
+  const prevScrubSampleRef = useRef<ScrubSample | null>(null);
+  const wheelIdleTimerRef = useRef<number | null>(null);
+
   const handleWheel = useCallback(
     (e: WheelEvent) => {
       const container = scrollContainerRef.current;
@@ -56,6 +66,18 @@ function useTimelineWheel(scrollContainerRef: RefObject<HTMLDivElement | null>, 
         } else if (playheadX > container.scrollLeft + viewportInner) {
           container.scrollLeft = playheadX - viewportInner;
         }
+
+        const curr: ScrubSample = { time: newTime, wallClockMs: performance.now() };
+        const velocity = computeScrubVelocity(prevScrubSampleRef.current, curr, SCRUB_OPTS);
+        prevScrubSampleRef.current = curr;
+        if (velocity > 0) scrubPreview.play(newTime, velocity);
+
+        if (wheelIdleTimerRef.current !== null) window.clearTimeout(wheelIdleTimerRef.current);
+        wheelIdleTimerRef.current = window.setTimeout(() => {
+          scrubPreview.stop();
+          prevScrubSampleRef.current = null;
+          wheelIdleTimerRef.current = null;
+        }, WHEEL_IDLE_MS);
         return;
       }
 
@@ -74,7 +96,15 @@ function useTimelineWheel(scrollContainerRef: RefObject<HTMLDivElement | null>, 
     const container = scrollContainerRef.current;
     if (!enabled || !container) return;
     container.addEventListener("wheel", handleWheel, { passive: false });
-    return () => container.removeEventListener("wheel", handleWheel);
+    return () => {
+      container.removeEventListener("wheel", handleWheel);
+      if (wheelIdleTimerRef.current !== null) {
+        window.clearTimeout(wheelIdleTimerRef.current);
+        wheelIdleTimerRef.current = null;
+      }
+      scrubPreview.stop();
+      prevScrubSampleRef.current = null;
+    };
   }, [enabled, handleWheel, scrollContainerRef]);
 }
 


### PR DESCRIPTION
## Overview

- Fixes #70 - Plays a short native-pitch snippet from the loaded audio at the playhead position when the user drags the playhead or wheel-scrubs over the waveform. Toggle lives in Settings, under Playback. On by default.

