### PR TITLE
fix: keep youtube url in input after a failed load

### DIFF
--- a/src/audio/youtube-url-input.browser.test.tsx
+++ b/src/audio/youtube-url-input.browser.test.tsx
@@ -4,6 +4,23 @@ import { YouTubeUrlInput } from "@/audio/youtube-url-input";
 import { useAudioStore } from "@/stores/audio";
 import { render } from "@/test/render";
 
+const VALID_VIDEO_ID = "dQw4w9WgXcQ";
+
+function simulateTunnelSuccess(videoId: string): void {
+  useAudioStore.setState({ isLoading: true });
+  const file = new File([new Uint8Array([1, 2, 3])], `${videoId}.opus`, { type: "audio/ogg" });
+  useAudioStore.getState().setYouTubeFile(file);
+  useAudioStore.getState().setYouTubeLoadError(null);
+  useAudioStore.setState({ isLoading: false });
+}
+
+function simulateTunnelFailure(message: string): void {
+  useAudioStore.setState({ isLoading: true });
+  useAudioStore.getState().setSource(null);
+  useAudioStore.getState().setYouTubeLoadError(message);
+  useAudioStore.setState({ isLoading: false });
+}
+
 describe("YouTubeUrlInput", () => {
   it("renders the input and a disabled Load button when empty", async () => {
     const screen = await render(<YouTubeUrlInput />);
@@ -15,7 +32,7 @@ describe("YouTubeUrlInput", () => {
 
   it("enables the Load button once a non-empty value is entered", async () => {
     const screen = await render(<YouTubeUrlInput />);
-    await screen.getByPlaceholder(/YouTube URL/i).fill("dQw4w9WgXcQ");
+    await screen.getByPlaceholder(/YouTube URL/i).fill(VALID_VIDEO_ID);
     const loadButton = screen.getByRole("button", { name: /Load$/ });
     expect((loadButton.element() as HTMLButtonElement).disabled).toBe(false);
   });
@@ -52,5 +69,35 @@ describe("YouTubeUrlInput", () => {
     const input = screen.getByPlaceholder(/YouTube URL/i).element() as HTMLInputElement;
     expect(input.disabled).toBe(true);
     await expect.element(screen.getByRole("button", { name: /Loading/ })).toBeInTheDocument();
+  });
+
+  it("clears the input after a successful YouTube load", async () => {
+    const screen = await render(<YouTubeUrlInput />);
+    const input = screen.getByPlaceholder(/YouTube URL/i);
+    await input.fill(VALID_VIDEO_ID);
+    await screen.getByRole("button", { name: /Load$/ }).click();
+    simulateTunnelSuccess(VALID_VIDEO_ID);
+    await expect.poll(() => (input.element() as HTMLInputElement).value).toBe("");
+  });
+
+  it("keeps the URL in the input when the YouTube load fails", async () => {
+    const screen = await render(<YouTubeUrlInput />);
+    const input = screen.getByPlaceholder(/YouTube URL/i);
+    await input.fill(VALID_VIDEO_ID);
+    await screen.getByRole("button", { name: /Load$/ }).click();
+    simulateTunnelFailure("Could not load that video. Try again.");
+    await expect.poll(() => (input.element() as HTMLInputElement).value).toBe(VALID_VIDEO_ID);
+    await expect.poll(() => (input.element() as HTMLInputElement).disabled).toBe(false);
+  });
+
+  it("clears the stale upstream load error when the user starts editing again", async () => {
+    const screen = await render(<YouTubeUrlInput />);
+    const input = screen.getByPlaceholder(/YouTube URL/i);
+    await input.fill(VALID_VIDEO_ID);
+    await screen.getByRole("button", { name: /Load$/ }).click();
+    simulateTunnelFailure("Could not load that video. Try again.");
+    await expect.poll(() => useAudioStore.getState().youtubeLoadError).toBe("Could not load that video. Try again.");
+    await input.fill(`${VALID_VIDEO_ID}X`);
+    await expect.poll(() => useAudioStore.getState().youtubeLoadError).toBeNull();
   });
 });

--- a/src/audio/youtube-url-input.tsx
+++ b/src/audio/youtube-url-input.tsx
@@ -1,5 +1,5 @@
 import { IconBrandYoutube, IconLoader2 } from "@tabler/icons-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useLoadYouTubeSource } from "@/hooks/useLoadYouTubeSource";
 import { useAudioStore } from "@/stores/audio";
 import { Button } from "@/ui/button";
@@ -18,18 +18,33 @@ const YouTubeUrlInput: React.FC<YouTubeUrlInputProps> = ({
 }) => {
   const [value, setValue] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [pendingVideoId, setPendingVideoId] = useState<string | null>(null);
   const isLoading = useAudioStore((s) => s.isLoading);
+  const source = useAudioStore((s) => s.source);
+  const youtubeLoadError = useAudioStore((s) => s.youtubeLoadError);
   const loadYouTubeSource = useLoadYouTubeSource();
 
-  const handleSubmit = useCallback(async () => {
+  useEffect(() => {
+    if (!pendingVideoId || isLoading) return;
+    if (youtubeLoadError) {
+      setPendingVideoId(null);
+      return;
+    }
+    if (source?.type === "youtube" && source.videoId === pendingVideoId && source.file) {
+      setValue("");
+      setPendingVideoId(null);
+    }
+  }, [pendingVideoId, isLoading, source, youtubeLoadError]);
+
+  const handleSubmit = useCallback(() => {
     const videoId = extractVideoId(value);
     if (!videoId) {
       setError("That doesn't look like a valid YouTube URL or ID");
       return;
     }
     setError(null);
-    await loadYouTubeSource(videoId);
-    setValue("");
+    setPendingVideoId(videoId);
+    loadYouTubeSource(videoId);
   }, [value, loadYouTubeSource]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -51,6 +66,7 @@ const YouTubeUrlInput: React.FC<YouTubeUrlInputProps> = ({
           onChange={(e) => {
             setValue(e.target.value);
             if (error) setError(null);
+            if (youtubeLoadError) useAudioStore.getState().setYouTubeLoadError(null);
           }}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}

--- a/src/hooks/useResolveYouTubeTunnel.ts
+++ b/src/hooks/useResolveYouTubeTunnel.ts
@@ -126,6 +126,7 @@ function useResolveYouTubeTunnel(): void {
     const current = useAudioStore.getState().source;
     if (current?.type !== "youtube" || current.videoId !== videoId) return;
     useAudioStore.getState().setYouTubeFile(data.file);
+    useAudioStore.getState().setYouTubeLoadError(null);
 
     if (data.filename) {
       const project = useProjectStore.getState();
@@ -158,6 +159,7 @@ function useResolveYouTubeTunnel(): void {
     if (current?.type === "youtube" && current.videoId === videoId) {
       useAudioStore.getState().setSource(previousSourceRef.current);
     }
+    useAudioStore.getState().setYouTubeLoadError(message);
   }, [query.error, videoId]);
 }
 

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -15,6 +15,7 @@ interface AudioState {
   isMuted: boolean;
   isLoading: boolean;
   audioElement: HTMLAudioElement | null;
+  youtubeLoadError: string | null;
 }
 
 interface AudioActions {
@@ -28,6 +29,7 @@ interface AudioActions {
   setVolume: (volume: number) => void;
   toggleMute: () => void;
   setIsLoading: (isLoading: boolean) => void;
+  setYouTubeLoadError: (error: string | null) => void;
   registerAudioElement: (element: HTMLAudioElement | null) => void;
   seekTo: (time: number) => void;
   reset: () => void;
@@ -47,6 +49,7 @@ function createInitialState(): AudioState {
     isMuted: false,
     isLoading: false,
     audioElement: null,
+    youtubeLoadError: null,
   };
 }
 
@@ -57,13 +60,14 @@ const INITIAL_STATE: AudioState = createInitialState();
 const useAudioStore = create<AudioState & AudioActions>((set, get) => ({
   ...INITIAL_STATE,
 
-  setSource: (source) => set({ source, currentTime: 0, duration: 0, isPlaying: false }),
+  setSource: (source) => set({ source, currentTime: 0, duration: 0, isPlaying: false, youtubeLoadError: null }),
   setYouTubeSource: (videoId, file) =>
     set({
       source: { type: "youtube", videoId, file },
       currentTime: 0,
       duration: 0,
       isPlaying: false,
+      youtubeLoadError: null,
     }),
   setYouTubeFile: (file) =>
     set((s) => {
@@ -79,6 +83,7 @@ const useAudioStore = create<AudioState & AudioActions>((set, get) => ({
   setVolume: (volume) => set({ volume: Math.max(0, Math.min(1, volume)) }),
   toggleMute: () => set((s) => ({ isMuted: !s.isMuted })),
   setIsLoading: (isLoading) => set({ isLoading }),
+  setYouTubeLoadError: (youtubeLoadError) => set({ youtubeLoadError }),
   registerAudioElement: (audioElement) => set({ audioElement }),
   seekTo: (time: number) => {
     if (!Number.isFinite(time) || time < 0) return;


### PR DESCRIPTION
## Overview

- YouTube URL input no longer clears after a failed load. 