### PR TITLE
Feat/background vocal extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.17.3",
+  "version": "1.18.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/domain/line/reconstruct-text.test.ts
+++ b/src/domain/line/reconstruct-text.test.ts
@@ -1,7 +1,7 @@
 import type { WordTiming } from "@/domain/word/timing";
 import { splitIntoWordsWithMeta } from "@/utils/sync-helpers";
 import { describe, expect, it } from "vitest";
-import { reconstructLineText } from "@/domain/line/reconstruct-text";
+import { reconstructLineText, wordContentSpans } from "@/domain/line/reconstruct-text";
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -56,4 +56,69 @@ describe("reconstructLineText round-trips through splitIntoWordsWithMeta", () =>
       expect(splitIntoWordsWithMeta(reconstructed).parts).toEqual(parts);
     });
   }
+});
+
+// -- wordContentSpans ---------------------------------------------------------
+
+describe("wordContentSpans", () => {
+  it("returns an empty array for no words", () => {
+    expect(wordContentSpans([], "|")).toEqual([]);
+  });
+
+  it("maps plain space-separated words to their content ranges", () => {
+    expect(wordContentSpans([w("Hello "), w("world")], "|")).toEqual([
+      { start: 0, end: 5 },
+      { start: 6, end: 11 },
+    ]);
+  });
+
+  it("excludes a trailing space from the span end", () => {
+    const spans = wordContentSpans([w("Hello "), w("world")], "|");
+    expect(spans[0]).toEqual({ start: 0, end: 5 });
+  });
+
+  it("skips a leading space in the span start", () => {
+    const words = [w("hello "), w(" world")];
+    const reconstructed = reconstructLineText(words, "|");
+    const spans = wordContentSpans(words, "|");
+    expect(reconstructed).toBe("hello  world");
+    expect(spans[1]).toEqual({ start: 7, end: 12 });
+    expect(reconstructed.slice(spans[1].start, spans[1].end)).toBe("world");
+  });
+
+  it("shifts subsequent offsets by the split character at a space-free joint", () => {
+    const words = [w("hel"), w("lo world")];
+    const reconstructed = reconstructLineText(words, "|");
+    const spans = wordContentSpans(words, "|");
+    expect(reconstructed).toBe("hel|lo world");
+    expect(spans).toEqual([
+      { start: 0, end: 3 },
+      { start: 4, end: 12 },
+    ]);
+    for (let i = 0; i < words.length; i++) {
+      expect(reconstructed.slice(spans[i].start, spans[i].end)).toBe(words[i].text.trim());
+    }
+  });
+
+  it("accounts for a multi-character split string", () => {
+    const words = [w("hel"), w("lo")];
+    const reconstructed = reconstructLineText(words, "::");
+    const spans = wordContentSpans(words, "::");
+    expect(reconstructed).toBe("hel::lo");
+    expect(spans).toEqual([
+      { start: 0, end: 3 },
+      { start: 5, end: 7 },
+    ]);
+  });
+
+  it("cross-checks every span against reconstructLineText output", () => {
+    const splitChar = "|";
+    const words = [w("hel"), w("lo "), w("brave "), w("new"), w(" world")];
+    const reconstructed = reconstructLineText(words, splitChar);
+    const spans = wordContentSpans(words, splitChar);
+    expect(spans).toHaveLength(words.length);
+    for (let i = 0; i < words.length; i++) {
+      expect(reconstructed.slice(spans[i].start, spans[i].end)).toBe(words[i].text.trim());
+    }
+  });
 });

--- a/src/domain/line/reconstruct-text.ts
+++ b/src/domain/line/reconstruct-text.ts
@@ -18,6 +18,30 @@ function reconstructLineText(words: WordTiming[], splitChar: string): string {
   return result;
 }
 
+// -- Word content spans -------------------------------------------------------
+
+interface WordContentSpan {
+  start: number;
+  end: number;
+}
+
+// Maps each word to the half-open char range [start, end) of its non-whitespace
+// content within reconstructLineText's output. Mirrors that function's
+// splitChar-insertion logic, so the two must evolve together.
+function wordContentSpans(words: WordTiming[], splitChar: string): WordContentSpan[] {
+  const spans: WordContentSpan[] = [];
+  let cursor = 0;
+  for (let i = 0; i < words.length; i++) {
+    const text = words[i].text;
+    const leading = text.length - text.trimStart().length;
+    const trailing = text.length - text.trimEnd().length;
+    spans.push({ start: cursor + leading, end: cursor + text.length - trailing });
+    cursor += text.length;
+    if (i < words.length - 1 && !text.endsWith(" ")) cursor += splitChar.length;
+  }
+  return spans;
+}
+
 // text/backgroundText are derived from words/backgroundWords whenever those
 // arrays are present: a line with words has no independent text. A line with no
 // words keeps text as its primary, editable field. Returns the same reference
@@ -34,4 +58,5 @@ function withDerivedText(line: LyricLine, splitChar: string): LyricLine {
 
 // -- Exports ------------------------------------------------------------------
 
-export { reconstructLineText, withDerivedText };
+export { reconstructLineText, withDerivedText, wordContentSpans };
+export type { WordContentSpan };

--- a/src/stores/project.background-extraction.test.ts
+++ b/src/stores/project.background-extraction.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment node
+ */
+import { type LooseLine, reconcileLine } from "@/domain/line/model";
+import { useProjectStore } from "@/stores/project";
+import { extractInlineFromLine } from "@/utils/background-vocal-extraction";
+import { beforeEach, describe, expect, it } from "vitest";
+
+beforeEach(() => {
+  useProjectStore.getState().reset();
+  useProjectStore.getState().clearHistory();
+});
+
+const CHORUS_GROUP = { id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 } as const;
+
+// -- Per-line "Pull from ( )" action through the real store -------------------
+//
+// Replicates handleExtractLine from src/views/edit.tsx: classify the target
+// line, extract its inline parentheses, and write { text, words, backgroundText }
+// via updateLineWithHistory. The reviewer claimed this desyncs linked instance
+// siblings. These tests run the real mutator and assert siblings stay in sync.
+
+describe("project store · background extraction on linked lines", () => {
+  function seedLinkedChorus(lines: LooseLine[]) {
+    useProjectStore.setState({ groups: [CHORUS_GROUP], lines: lines.map(reconcileLine) });
+    useProjectStore.getState().clearHistory();
+  }
+
+  function applyPullFromParens(lineId: string) {
+    const target = useProjectStore.getState().lines.find((l) => l.id === lineId);
+    if (!target) throw new Error(`line ${lineId} not found`);
+    const extracted = extractInlineFromLine(target);
+    useProjectStore.getState().updateLineWithHistory(target.id, {
+      text: extracted.text,
+      words: extracted.words,
+      backgroundText: extracted.backgroundText,
+    });
+  }
+
+  it("propagates an untimed inline extraction to the linked sibling", () => {
+    seedLinkedChorus([
+      { id: "a0", text: "Hello (ooh)", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
+      { id: "a1", text: "Hello (ooh)", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
+    ]);
+
+    applyPullFromParens("a0");
+
+    const lines = useProjectStore.getState().lines;
+    const a0 = lines.find((l) => l.id === "a0");
+    const a1 = lines.find((l) => l.id === "a1");
+
+    expect(a0?.text).toBe("Hello");
+    expect(a0?.backgroundText).toBe("ooh");
+    expect(a1?.text).toBe("Hello");
+    expect(a1?.backgroundText).toBe("ooh");
+    expect(a0?.text).not.toContain("(");
+    expect(a1?.text).not.toContain("(");
+  });
+
+  it("keeps link metadata on both siblings after an untimed extraction", () => {
+    seedLinkedChorus([
+      { id: "a0", text: "Hello (ooh)", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
+      { id: "a1", text: "Hello (ooh)", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
+    ]);
+
+    applyPullFromParens("a0");
+
+    const lines = useProjectStore.getState().lines;
+    for (const id of ["a0", "a1"]) {
+      const line = lines.find((l) => l.id === id);
+      expect(line?.groupId).toBe("g1");
+      expect(line?.templateLineIdx).toBe(0);
+    }
+    expect(lines.find((l) => l.id === "a0")?.instanceIdx).toBe(0);
+    expect(lines.find((l) => l.id === "a1")?.instanceIdx).toBe(1);
+  });
+
+  it("propagates a word-synced inline extraction to the linked sibling, preserving sibling timing", () => {
+    seedLinkedChorus([
+      {
+        id: "a0",
+        text: "Hello (ooh)",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 0,
+        templateLineIdx: 0,
+        words: [
+          { text: "Hello ", begin: 0, end: 1 },
+          { text: "(ooh)", begin: 1, end: 2 },
+        ],
+      },
+      {
+        id: "a1",
+        text: "Hello (ooh)",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 1,
+        templateLineIdx: 0,
+        words: [
+          { text: "Hello ", begin: 30, end: 31.5 },
+          { text: "(ooh)", begin: 31.5, end: 33 },
+        ],
+      },
+    ]);
+
+    applyPullFromParens("a0");
+
+    const lines = useProjectStore.getState().lines;
+    const a0 = lines.find((l) => l.id === "a0");
+    const a1 = lines.find((l) => l.id === "a1");
+
+    expect(a0?.text).toBe("Hello");
+    expect(a1?.text).toBe("Hello");
+    expect(a0?.backgroundText).toBe("ooh");
+    expect(a1?.backgroundText).toBe("ooh");
+
+    expect(a0?.words?.map((w) => w.text)).toEqual(["Hello"]);
+    expect(a1?.words?.map((w) => w.text)).toEqual(["Hello"]);
+
+    expect(a0?.words?.[0].begin).toBe(0);
+    expect(a0?.words?.[0].end).toBe(1);
+    expect(a1?.words?.[0].begin).toBe(30);
+    expect(a1?.words?.[0].end).toBe(31.5);
+  });
+
+  it("leaves a detached sibling untouched when extracting on the source", () => {
+    seedLinkedChorus([
+      { id: "a0", text: "Hello (ooh)", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
+      {
+        id: "a1",
+        text: "Hello (ooh)",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 1,
+        templateLineIdx: 0,
+        detached: true,
+      },
+    ]);
+
+    applyPullFromParens("a0");
+
+    const lines = useProjectStore.getState().lines;
+    expect(lines.find((l) => l.id === "a0")?.text).toBe("Hello");
+    expect(lines.find((l) => l.id === "a1")?.text).toBe("Hello (ooh)");
+  });
+
+  it("produces a single undoable history entry covering source + sibling", () => {
+    seedLinkedChorus([
+      { id: "a0", text: "Hello (ooh)", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
+      { id: "a1", text: "Hello (ooh)", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
+    ]);
+
+    applyPullFromParens("a0");
+    expect(useProjectStore.getState().canUndo()).toBe(true);
+
+    useProjectStore.getState().undo();
+    const lines = useProjectStore.getState().lines;
+    expect(lines.find((l) => l.id === "a0")?.text).toBe("Hello (ooh)");
+    expect(lines.find((l) => l.id === "a1")?.text).toBe("Hello (ooh)");
+  });
+});

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -37,9 +37,9 @@ describe("background vocal extraction settings", () => {
     useSettingsStore.setState({ ...DEFAULTS });
   });
 
-  it("defaults autoExtractBackgroundVocals to true", () => {
-    expect(DEFAULTS.autoExtractBackgroundVocals).toBe(true);
-    expect(useSettingsStore.getState().autoExtractBackgroundVocals).toBe(true);
+  it("defaults autoExtractBackgroundVocals to false", () => {
+    expect(DEFAULTS.autoExtractBackgroundVocals).toBe(false);
+    expect(useSettingsStore.getState().autoExtractBackgroundVocals).toBe(false);
   });
 
   it("defaults mergeStandaloneBackgroundLines to true", () => {
@@ -47,9 +47,9 @@ describe("background vocal extraction settings", () => {
     expect(useSettingsStore.getState().mergeStandaloneBackgroundLines).toBe(true);
   });
 
-  it("allows disabling autoExtractBackgroundVocals via set()", () => {
-    useSettingsStore.getState().set("autoExtractBackgroundVocals", false);
-    expect(useSettingsStore.getState().autoExtractBackgroundVocals).toBe(false);
+  it("allows enabling autoExtractBackgroundVocals via set()", () => {
+    useSettingsStore.getState().set("autoExtractBackgroundVocals", true);
+    expect(useSettingsStore.getState().autoExtractBackgroundVocals).toBe(true);
   });
 
   it("allows disabling mergeStandaloneBackgroundLines via set()", () => {
@@ -57,11 +57,11 @@ describe("background vocal extraction settings", () => {
     expect(useSettingsStore.getState().mergeStandaloneBackgroundLines).toBe(false);
   });
 
-  it("resetToDefaults restores both background vocal toggles to true", () => {
-    useSettingsStore.getState().set("autoExtractBackgroundVocals", false);
+  it("resetToDefaults restores the background vocal toggles", () => {
+    useSettingsStore.getState().set("autoExtractBackgroundVocals", true);
     useSettingsStore.getState().set("mergeStandaloneBackgroundLines", false);
     useSettingsStore.getState().resetToDefaults();
-    expect(useSettingsStore.getState().autoExtractBackgroundVocals).toBe(true);
+    expect(useSettingsStore.getState().autoExtractBackgroundVocals).toBe(false);
     expect(useSettingsStore.getState().mergeStandaloneBackgroundLines).toBe(true);
   });
 });

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -32,6 +32,40 @@ describe("preview renderer settings", () => {
   });
 });
 
+describe("background vocal extraction settings", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ ...DEFAULTS });
+  });
+
+  it("defaults autoExtractBackgroundVocals to true", () => {
+    expect(DEFAULTS.autoExtractBackgroundVocals).toBe(true);
+    expect(useSettingsStore.getState().autoExtractBackgroundVocals).toBe(true);
+  });
+
+  it("defaults mergeStandaloneBackgroundLines to true", () => {
+    expect(DEFAULTS.mergeStandaloneBackgroundLines).toBe(true);
+    expect(useSettingsStore.getState().mergeStandaloneBackgroundLines).toBe(true);
+  });
+
+  it("allows disabling autoExtractBackgroundVocals via set()", () => {
+    useSettingsStore.getState().set("autoExtractBackgroundVocals", false);
+    expect(useSettingsStore.getState().autoExtractBackgroundVocals).toBe(false);
+  });
+
+  it("allows disabling mergeStandaloneBackgroundLines via set()", () => {
+    useSettingsStore.getState().set("mergeStandaloneBackgroundLines", false);
+    expect(useSettingsStore.getState().mergeStandaloneBackgroundLines).toBe(false);
+  });
+
+  it("resetToDefaults restores both background vocal toggles to true", () => {
+    useSettingsStore.getState().set("autoExtractBackgroundVocals", false);
+    useSettingsStore.getState().set("mergeStandaloneBackgroundLines", false);
+    useSettingsStore.getState().resetToDefaults();
+    expect(useSettingsStore.getState().autoExtractBackgroundVocals).toBe(true);
+    expect(useSettingsStore.getState().mergeStandaloneBackgroundLines).toBe(true);
+  });
+});
+
 describe("cobalt instance helpers", () => {
   beforeEach(() => {
     useSettingsStore.setState({

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -44,6 +44,8 @@ interface SettingsState {
   showShortcutHints: boolean;
   showSyllableIndicators: boolean;
   splitCharacter: string;
+  autoExtractBackgroundVocals: boolean;
+  mergeStandaloneBackgroundLines: boolean;
 
   confirmReplaceProjectFromHash: boolean;
   confirmReplaceLyrics: boolean;
@@ -97,6 +99,8 @@ const DEFAULTS: SettingsState = {
   showShortcutHints: true,
   showSyllableIndicators: true,
   splitCharacter: "|",
+  autoExtractBackgroundVocals: true,
+  mergeStandaloneBackgroundLines: true,
 
   confirmReplaceProjectFromHash: true,
   confirmReplaceLyrics: true,

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -99,7 +99,7 @@ const DEFAULTS: SettingsState = {
   showShortcutHints: true,
   showSyllableIndicators: true,
   splitCharacter: "|",
-  autoExtractBackgroundVocals: true,
+  autoExtractBackgroundVocals: false,
   mergeStandaloneBackgroundLines: true,
 
   confirmReplaceProjectFromHash: true,

--- a/src/ui/settings/general-section.browser.test.tsx
+++ b/src/ui/settings/general-section.browser.test.tsx
@@ -6,7 +6,27 @@ import { GeneralSection } from "@/ui/settings/general-section";
 describe("GeneralSection", () => {
   it("renders a switch for each toggle setting", async () => {
     const screen = await render(<GeneralSection onResetTour={() => {}} onClose={() => {}} />);
-    expect(screen.container.querySelectorAll('[role="switch"]').length).toBe(2);
+    expect(screen.container.querySelectorAll('[role="switch"]').length).toBe(4);
+  });
+
+  it("renders the background vocal toggles", async () => {
+    const screen = await render(<GeneralSection onResetTour={() => {}} onClose={() => {}} />);
+    await expect.element(screen.getByRole("switch", { name: "Auto-extract background vocals" })).toBeInTheDocument();
+    await expect.element(screen.getByRole("switch", { name: "Merge standalone background lines" })).toBeInTheDocument();
+  });
+
+  it("flips autoExtractBackgroundVocals when its switch is clicked", async () => {
+    useSettingsStore.setState({ autoExtractBackgroundVocals: true });
+    const screen = await render(<GeneralSection onResetTour={() => {}} onClose={() => {}} />);
+    await screen.getByRole("switch", { name: "Auto-extract background vocals" }).click();
+    await expect.poll(() => useSettingsStore.getState().autoExtractBackgroundVocals).toBe(false);
+  });
+
+  it("flips mergeStandaloneBackgroundLines when its switch is clicked", async () => {
+    useSettingsStore.setState({ mergeStandaloneBackgroundLines: true });
+    const screen = await render(<GeneralSection onResetTour={() => {}} onClose={() => {}} />);
+    await screen.getByRole("switch", { name: "Merge standalone background lines" }).click();
+    await expect.poll(() => useSettingsStore.getState().mergeStandaloneBackgroundLines).toBe(false);
   });
 
   it("calls onResetTour and onClose when Reset tour is clicked", async () => {

--- a/src/ui/settings/general-section.tsx
+++ b/src/ui/settings/general-section.tsx
@@ -36,6 +36,16 @@ const GeneralSection: React.FC<{
         description="Visually group syllables split from one word."
         settingKey="showSyllableIndicators"
       />
+      <ToggleSetting
+        label="Auto-extract background vocals"
+        description="Move parenthesised text into background vocals when lyrics are pasted or imported."
+        settingKey="autoExtractBackgroundVocals"
+      />
+      <ToggleSetting
+        label="Merge standalone background lines"
+        description="When a whole line is in parentheses, attach it to the line above instead of keeping it as its own line."
+        settingKey="mergeStandaloneBackgroundLines"
+      />
       <div className="flex items-center justify-between py-3">
         <div className="flex flex-col gap-0.5">
           <span className="text-sm font-medium text-composer-text">Reset product tour</span>

--- a/src/utils/background-vocal-extraction.test.ts
+++ b/src/utils/background-vocal-extraction.test.ts
@@ -1043,6 +1043,117 @@ describe("extractBackgroundVocals: idempotence", () => {
   });
 });
 
+// -- linked lines -------------------------------------------------------------
+//
+// Inline extraction is an in-place content edit, so it is intentionally applied
+// to linked lines (lines belonging to a timeline group/instance). These tests
+// pin that an inline-extracted linked line keeps its link metadata intact and
+// that linked siblings carrying identical text extract identically, so the
+// whole-list transform never desyncs an instance set.
+
+describe("extractInlineFromLine: linked lines", () => {
+  it("extracts an untimed inline group and keeps link metadata intact", () => {
+    const line: LyricLine = {
+      id: "l1",
+      text: "Hello (ooh)",
+      agentId: "v1",
+      groupId: "g1",
+      instanceIdx: 0,
+      templateLineIdx: 0,
+    };
+    const result = extractInlineFromLine(line);
+    expect(result.text).toBe("Hello");
+    expect(result.backgroundText).toBe("ooh");
+    expect(result.groupId).toBe("g1");
+    expect(result.instanceIdx).toBe(0);
+    expect(result.templateLineIdx).toBe(0);
+  });
+
+  it("extracts a word-synced inline group and keeps link metadata intact", () => {
+    const line: LyricLine = {
+      id: "l1",
+      text: "Hello (ooh)",
+      agentId: "v1",
+      groupId: "g1",
+      instanceIdx: 1,
+      templateLineIdx: 2,
+      words: [
+        { text: "Hello ", begin: 30, end: 31 },
+        { text: "(ooh)", begin: 31, end: 32 },
+      ],
+    };
+    const result = extractInlineFromLine(line);
+    expect(result.text).toBe("Hello");
+    expect(result.backgroundText).toBe("ooh");
+    expect(result.words).toEqual([{ text: "Hello", begin: 30, end: 31 }]);
+    expect(result.groupId).toBe("g1");
+    expect(result.instanceIdx).toBe(1);
+    expect(result.templateLineIdx).toBe(2);
+  });
+});
+
+describe("extractBackgroundVocals: linked sibling lines", () => {
+  it("extracts both untimed linked siblings identically", () => {
+    const lines = [
+      createLine({ id: "s0", text: "Hello (ooh)", groupId: "g1", instanceIdx: 0 }),
+      createLine({ id: "s1", text: "Hello (ooh)", groupId: "g1", instanceIdx: 1 }),
+    ].map((line, idx) => ({ ...line, templateLineIdx: 0, instanceIdx: idx }));
+
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+
+    expect(result).toHaveLength(2);
+    for (const line of result) {
+      expect(line.text).toBe("Hello");
+      expect(line.backgroundText).toBe("ooh");
+      expect(line.groupId).toBe("g1");
+      expect(line.templateLineIdx).toBe(0);
+    }
+    expect(result[0].instanceIdx).toBe(0);
+    expect(result[1].instanceIdx).toBe(1);
+  });
+
+  it("extracts both word-synced linked siblings identically while keeping instance timing", () => {
+    const s0: LyricLine = {
+      id: "s0",
+      text: "Hello (ooh)",
+      agentId: "v1",
+      groupId: "g1",
+      instanceIdx: 0,
+      templateLineIdx: 0,
+      words: [
+        { text: "Hello ", begin: 0, end: 1 },
+        { text: "(ooh)", begin: 1, end: 2 },
+      ],
+    };
+    const s1: LyricLine = {
+      id: "s1",
+      text: "Hello (ooh)",
+      agentId: "v1",
+      groupId: "g1",
+      instanceIdx: 1,
+      templateLineIdx: 0,
+      words: [
+        { text: "Hello ", begin: 30, end: 31.5 },
+        { text: "(ooh)", begin: 31.5, end: 33 },
+      ],
+    };
+
+    const result = extractBackgroundVocals([s0, s1], { mergeStandaloneLines: true });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].text).toBe("Hello");
+    expect(result[1].text).toBe("Hello");
+    expect(result[0].backgroundText).toBe("ooh");
+    expect(result[1].backgroundText).toBe("ooh");
+    expect(result[0].words).toEqual([{ text: "Hello", begin: 0, end: 1 }]);
+    expect(result[1].words).toEqual([{ text: "Hello", begin: 30, end: 31.5 }]);
+    expect(result[0].groupId).toBe("g1");
+    expect(result[1].groupId).toBe("g1");
+    expect(result[0].templateLineIdx).toBe(0);
+    expect(result[1].templateLineIdx).toBe(0);
+  });
+});
+
 // -- lineHasInlineParens ------------------------------------------------------
 
 describe("lineHasInlineParens", () => {

--- a/src/utils/background-vocal-extraction.test.ts
+++ b/src/utils/background-vocal-extraction.test.ts
@@ -413,7 +413,7 @@ describe("extractInlineFromLine", () => {
     expect(result.words).toBeUndefined();
   });
 
-  it("returns the same reference for a word-synced inline line", () => {
+  it("extracts an inline group from a word-synced line", () => {
     const line: LyricLine = {
       id: "1",
       text: "Hi (ooh) there",
@@ -424,7 +424,15 @@ describe("extractInlineFromLine", () => {
         { text: "there", begin: 2, end: 3 },
       ],
     };
-    expect(extractInlineFromLine(line)).toBe(line);
+    const result = extractInlineFromLine(line);
+    expect(result).not.toBe(line);
+    expect(result.text).toBe("Hi there");
+    expect(result.backgroundText).toBe("ooh");
+    expect(result.backgroundWords).toBeUndefined();
+    expect(result.words).toEqual([
+      { text: "Hi ", begin: 0, end: 1 },
+      { text: "there", begin: 2, end: 3 },
+    ]);
   });
 
   it("does not mutate the input line", () => {
@@ -437,6 +445,186 @@ describe("extractInlineFromLine", () => {
     extractInlineFromLine(line);
     expect(line.text).toBe("Hello (ooh) world");
     expect(line.backgroundText).toBe("ah");
+  });
+});
+
+// -- extractInlineFromLine: word-synced extraction -----------------------------
+
+describe("extractInlineFromLine: word-synced extraction", () => {
+  it("extracts a mid-line paren word and preserves survivor timing", () => {
+    const line: LyricLine = {
+      id: "1",
+      text: "Hello (ooh) world",
+      agentId: "v1",
+      words: [
+        { text: "Hello ", begin: 0.5, end: 1.2 },
+        { text: "(ooh) ", begin: 1.2, end: 1.9 },
+        { text: "world", begin: 1.9, end: 2.7 },
+      ],
+    };
+    const result = extractInlineFromLine(line);
+    expect(result).not.toBe(line);
+    expect(result.text).toBe("Hello world");
+    expect(result.backgroundText).toBe("ooh");
+    expect(result.backgroundWords).toBeUndefined();
+    expect(result.words).toEqual([
+      { text: "Hello ", begin: 0.5, end: 1.2 },
+      { text: "world", begin: 1.9, end: 2.7 },
+    ]);
+  });
+
+  it("extracts a trailing paren word and trims the last survivor's trailing space", () => {
+    const line: LyricLine = {
+      id: "1",
+      text: "Hello (ooh)",
+      agentId: "v1",
+      words: [
+        { text: "Hello ", begin: 0, end: 1 },
+        { text: "(ooh)", begin: 1, end: 2 },
+      ],
+    };
+    const result = extractInlineFromLine(line);
+    expect(result).not.toBe(line);
+    expect(result.text).toBe("Hello");
+    expect(result.backgroundText).toBe("ooh");
+    expect(result.words).toEqual([{ text: "Hello", begin: 0, end: 1 }]);
+  });
+
+  it("extracts a multi-token group spanning several words", () => {
+    const line: LyricLine = {
+      id: "1",
+      text: "Hello (ooh yeah) world",
+      agentId: "v1",
+      words: [
+        { text: "Hello ", begin: 0, end: 1 },
+        { text: "(ooh ", begin: 1, end: 1.5 },
+        { text: "yeah) ", begin: 1.5, end: 2 },
+        { text: "world", begin: 2, end: 3 },
+      ],
+    };
+    const result = extractInlineFromLine(line);
+    expect(result).not.toBe(line);
+    expect(result.text).toBe("Hello world");
+    expect(result.backgroundText).toBe("ooh yeah");
+    expect(result.words).toEqual([
+      { text: "Hello ", begin: 0, end: 1 },
+      { text: "world", begin: 2, end: 3 },
+    ]);
+  });
+
+  it("returns the same reference when a paren is glued onto a word token", () => {
+    const line: LyricLine = {
+      id: "1",
+      text: "Hello(ooh) world",
+      agentId: "v1",
+      words: [
+        { text: "Hello(ooh) ", begin: 0, end: 1 },
+        { text: "world", begin: 1, end: 2 },
+      ],
+    };
+    expect(extractInlineFromLine(line)).toBe(line);
+  });
+
+  it("preserves explicit and syllableGroupId fields on survivors", () => {
+    const line: LyricLine = {
+      id: "1",
+      text: "Hello (ooh) world",
+      agentId: "v1",
+      words: [
+        { text: "Hello ", begin: 0, end: 1, explicit: true, syllableGroupId: "g1" },
+        { text: "(ooh) ", begin: 1, end: 2 },
+        { text: "world", begin: 2, end: 3, explicit: true, syllableGroupId: "g2" },
+      ],
+    };
+    const result = extractInlineFromLine(line);
+    expect(result.words).toEqual([
+      { text: "Hello ", begin: 0, end: 1, explicit: true, syllableGroupId: "g1" },
+      { text: "world", begin: 2, end: 3, explicit: true, syllableGroupId: "g2" },
+    ]);
+  });
+
+  it("extracts cleanly when the line has syllable-split words", () => {
+    const line: LyricLine = {
+      id: "1",
+      text: "Hel|lo (ooh) world",
+      agentId: "v1",
+      words: [
+        { text: "Hel", begin: 0, end: 0.5 },
+        { text: "lo ", begin: 0.5, end: 1 },
+        { text: "(ooh) ", begin: 1, end: 2 },
+        { text: "world", begin: 2, end: 3 },
+      ],
+    };
+    const result = extractInlineFromLine(line);
+    expect(result).not.toBe(line);
+    expect(result.text).toBe("Hel|lo world");
+    expect(result.backgroundText).toBe("ooh");
+    expect(result.words).toEqual([
+      { text: "Hel", begin: 0, end: 0.5 },
+      { text: "lo ", begin: 0.5, end: 1 },
+      { text: "world", begin: 2, end: 3 },
+    ]);
+  });
+
+  it("returns the same reference when the line already has background words", () => {
+    const line: LyricLine = {
+      id: "1",
+      text: "Hello (ooh) world",
+      agentId: "v1",
+      words: [
+        { text: "Hello ", begin: 0, end: 1 },
+        { text: "(ooh) ", begin: 1, end: 2 },
+        { text: "world", begin: 2, end: 3 },
+      ],
+      backgroundWords: [{ text: "ah", begin: 0, end: 1 }],
+    };
+    expect(extractInlineFromLine(line)).toBe(line);
+  });
+
+  it("appends to existing backgroundText on a word-synced line", () => {
+    const line: LyricLine = {
+      id: "1",
+      text: "Hello (ooh) world",
+      agentId: "v1",
+      backgroundText: "ah",
+      words: [
+        { text: "Hello ", begin: 0, end: 1 },
+        { text: "(ooh) ", begin: 1, end: 2 },
+        { text: "world", begin: 2, end: 3 },
+      ],
+    };
+    const result = extractInlineFromLine(line);
+    expect(result.backgroundText).toBe("ah ooh");
+  });
+
+  it("does not mutate the input line or its words array", () => {
+    const words = [
+      { text: "Hello ", begin: 0, end: 1 },
+      { text: "(ooh) ", begin: 1, end: 2 },
+      { text: "world", begin: 2, end: 3 },
+    ];
+    const line: LyricLine = { id: "1", text: "Hello (ooh) world", agentId: "v1", words };
+    extractInlineFromLine(line);
+    expect(line.text).toBe("Hello (ooh) world");
+    expect(line.words).toBe(words);
+    expect(line.words).toEqual([
+      { text: "Hello ", begin: 0, end: 1 },
+      { text: "(ooh) ", begin: 1, end: 2 },
+      { text: "world", begin: 2, end: 3 },
+    ]);
+  });
+
+  it("returns the same reference for a word-synced standalone line", () => {
+    const line: LyricLine = {
+      id: "1",
+      text: "(ooh yeah)",
+      agentId: "v1",
+      words: [
+        { text: "(ooh ", begin: 0, end: 1 },
+        { text: "yeah)", begin: 1, end: 2 },
+      ],
+    };
+    expect(extractInlineFromLine(line)).toBe(line);
   });
 });
 

--- a/src/utils/background-vocal-extraction.test.ts
+++ b/src/utils/background-vocal-extraction.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { classifyLine, scanParenGroups } from "@/utils/background-vocal-extraction";
+import type { LyricLine } from "@/domain/line/model";
+import { classifyLine, extractInlineFromLine, scanParenGroups } from "@/utils/background-vocal-extraction";
 
 // -- Specification table -------------------------------------------------------
 
@@ -338,5 +339,96 @@ describe("classifyLine: returned shape", () => {
     expect(result.groups).toHaveLength(2);
     expect(result.groups[0].inner).toBe("a");
     expect(result.groups[1].inner).toBe("b");
+  });
+});
+
+// -- extractInlineFromLine -----------------------------------------------------
+
+describe("extractInlineFromLine", () => {
+  it("extracts an inline group from an untimed line", () => {
+    const line: LyricLine = { id: "1", text: "Hello (ooh) world", agentId: "v1" };
+    const result = extractInlineFromLine(line);
+    expect(result.text).toBe("Hello world");
+    expect(result.backgroundText).toBe("ooh");
+  });
+
+  it("appends to existing backgroundText on an untimed line", () => {
+    const line: LyricLine = {
+      id: "1",
+      text: "Hello (ooh)",
+      agentId: "v1",
+      backgroundText: "ah",
+    };
+    const result = extractInlineFromLine(line);
+    expect(result.text).toBe("Hello");
+    expect(result.backgroundText).toBe("ah ooh");
+  });
+
+  it("sets backgroundText to just the extracted text when none exists", () => {
+    const line: LyricLine = {
+      id: "1",
+      text: "Hello (ooh) world",
+      agentId: "v1",
+      backgroundText: undefined,
+    };
+    const result = extractInlineFromLine(line);
+    expect(result.backgroundText).toBe("ooh");
+  });
+
+  it("returns the same reference for a line with no parentheses", () => {
+    const line: LyricLine = { id: "1", text: "Hello world", agentId: "v1" };
+    expect(extractInlineFromLine(line)).toBe(line);
+  });
+
+  it("returns the same reference for a standalone line", () => {
+    const line: LyricLine = { id: "1", text: "(ooh yeah)", agentId: "v1" };
+    expect(extractInlineFromLine(line)).toBe(line);
+  });
+
+  it("returns the same reference for a skip line", () => {
+    const line: LyricLine = { id: "1", text: "Hello (ooh", agentId: "v1" };
+    expect(extractInlineFromLine(line)).toBe(line);
+  });
+
+  it("preserves begin and end on a line-synced line", () => {
+    const line: LyricLine = {
+      id: "1",
+      text: "Hi (ooh) there",
+      agentId: "v1",
+      begin: 1,
+      end: 3,
+    };
+    const result = extractInlineFromLine(line);
+    expect(result.text).toBe("Hi there");
+    expect(result.backgroundText).toBe("ooh");
+    expect(result.begin).toBe(1);
+    expect(result.end).toBe(3);
+    expect(result.words).toBeUndefined();
+  });
+
+  it("returns the same reference for a word-synced inline line", () => {
+    const line: LyricLine = {
+      id: "1",
+      text: "Hi (ooh) there",
+      agentId: "v1",
+      words: [
+        { text: "Hi ", begin: 0, end: 1 },
+        { text: "(ooh) ", begin: 1, end: 2 },
+        { text: "there", begin: 2, end: 3 },
+      ],
+    };
+    expect(extractInlineFromLine(line)).toBe(line);
+  });
+
+  it("does not mutate the input line", () => {
+    const line: LyricLine = {
+      id: "1",
+      text: "Hello (ooh) world",
+      agentId: "v1",
+      backgroundText: "ah",
+    };
+    extractInlineFromLine(line);
+    expect(line.text).toBe("Hello (ooh) world");
+    expect(line.backgroundText).toBe("ah");
   });
 });

--- a/src/utils/background-vocal-extraction.test.ts
+++ b/src/utils/background-vocal-extraction.test.ts
@@ -741,13 +741,181 @@ describe("extractBackgroundVocals: none and skip lines", () => {
     expect(result[0]).toBe(lines[0]);
   });
 
-  it("merges a standalone line into a skip predecessor with non-empty text", () => {
+  it("does not merge a standalone line into a skip predecessor", () => {
     const lines = [createLine({ id: "1", text: "Hello (ooh" }), createLine({ id: "2", text: "(yeah)" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(lines[0]);
+    expect(result[1]).toBe(lines[1]);
+  });
+});
+
+// -- extractBackgroundVocals: timing-aware standalone merge -------------------
+
+describe("extractBackgroundVocals: timing-aware standalone merge", () => {
+  it("merges an untimed standalone line into an untimed predecessor as text only", () => {
+    const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh yeah)" })];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("1");
-    expect(result[0].text).toBe("Hello (ooh");
-    expect(result[0].backgroundText).toBe("yeah");
+    expect(result[0].backgroundText).toBe("ooh yeah");
+    expect(result[0].backgroundWords).toBeUndefined();
+  });
+
+  it("carries word-synced standalone timing into an untimed predecessor with no background", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line" }),
+      createLine({
+        id: "2",
+        text: "(ooh yeah)",
+        words: [
+          { text: "(ooh ", begin: 5.0, end: 5.6 },
+          { text: "yeah)", begin: 5.6, end: 6.2 },
+        ],
+      }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("1");
+    expect(result[0].backgroundWords).toEqual([
+      { text: "ooh ", begin: 5.0, end: 5.6 },
+      { text: "yeah", begin: 5.6, end: 6.2 },
+    ]);
+    expect(result[0].backgroundText).toBe("ooh yeah");
+  });
+
+  it("appends carried words after the predecessor's existing background words", () => {
+    const lines = [
+      createLine({
+        id: "1",
+        text: "Real line",
+        backgroundText: "ah ",
+        backgroundWords: [{ text: "ah ", begin: 1.0, end: 1.5 }],
+      }),
+      createLine({
+        id: "2",
+        text: "(ooh yeah)",
+        words: [
+          { text: "(ooh ", begin: 5.0, end: 5.6 },
+          { text: "yeah)", begin: 5.6, end: 6.2 },
+        ],
+      }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].backgroundWords).toEqual([
+      { text: "ah ", begin: 1.0, end: 1.5 },
+      { text: "ooh ", begin: 5.0, end: 5.6 },
+      { text: "yeah", begin: 5.6, end: 6.2 },
+    ]);
+    expect(result[0].backgroundText).toBe("ah ooh yeah");
+  });
+
+  it("falls back to text-only when predecessor has background text but no words", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line", backgroundText: "ah" }),
+      createLine({
+        id: "2",
+        text: "(ooh yeah)",
+        words: [
+          { text: "(ooh ", begin: 5.0, end: 5.6 },
+          { text: "yeah)", begin: 5.6, end: 6.2 },
+        ],
+      }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].backgroundText).toBe("ah ooh yeah");
+    expect(result[0].backgroundWords).toBeUndefined();
+  });
+
+  it("seeds background words from a line-synced standalone via createInitialBgWords", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line" }),
+      createLine({ id: "2", text: "(ooh)", begin: 4.0, end: 6.0 }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].backgroundText).toBe("ooh");
+    const bgWords = result[0].backgroundWords;
+    expect(bgWords).toHaveLength(1);
+    expect(bgWords?.[0].text).toBe("ooh");
+    expect(bgWords?.[0].begin).toBe(4.0);
+    expect(bgWords?.[0].end).toBe(6.0);
+  });
+
+  it("spans the standalone time range across multiple words from a line-synced standalone", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line" }),
+      createLine({ id: "2", text: "(ooh yeah)", begin: 4.0, end: 6.0 }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const bgWords = result[0].backgroundWords;
+    expect(bgWords).toHaveLength(2);
+    expect(bgWords?.[0].begin).toBe(4.0);
+    expect(bgWords?.[bgWords.length - 1].end).toBe(6.0);
+  });
+
+  it("does not merge an untimed standalone into a predecessor with timed background words", () => {
+    const lines = [
+      createLine({
+        id: "1",
+        text: "Real line",
+        backgroundText: "ah",
+        backgroundWords: [{ text: "ah", begin: 1.0, end: 1.5 }],
+      }),
+      createLine({ id: "2", text: "(ooh)" }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(lines[0]);
+    expect(result[1]).toBe(lines[1]);
+    expect(result[0].backgroundWords).toEqual([{ text: "ah", begin: 1.0, end: 1.5 }]);
+  });
+
+  it("falls back to text-only when standalone word count does not match bg text", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line" }),
+      createLine({
+        id: "2",
+        text: "( ooh yeah )",
+        words: [
+          { text: "( ", begin: 5.0, end: 5.2 },
+          { text: "ooh ", begin: 5.2, end: 5.6 },
+          { text: "yeah ", begin: 5.6, end: 6.0 },
+          { text: ")", begin: 6.0, end: 6.2 },
+        ],
+      }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].backgroundText).toBe("ooh yeah");
+    expect(result[0].backgroundWords).toBeUndefined();
+  });
+});
+
+// -- extractBackgroundVocals: merge gate -------------------------------------
+
+describe("extractBackgroundVocals: merge gate", () => {
+  it("does not merge a standalone line into a standalone predecessor", () => {
+    const lines = [createLine({ id: "1", text: "(ooh)" }), createLine({ id: "2", text: "(yeah)" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(lines[0]);
+    expect(result[1]).toBe(lines[1]);
+  });
+
+  it("still merges a standalone line into a real lyric predecessor", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real" }),
+      createLine({ id: "2", text: "(ooh)" }),
+      createLine({ id: "3", text: "(yeah)" }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("1");
+    expect(result[0].text).toBe("Real");
+    expect(result[0].backgroundText).toBe("ooh yeah");
   });
 });
 
@@ -801,6 +969,27 @@ describe("extractBackgroundVocals: input not mutated", () => {
     expect(lines[1].text).toBe("(yeah)");
     expect(lines[2].text).toBe("Plain");
   });
+
+  it("does not mutate a timed standalone line or its words array", () => {
+    const standaloneWords = [
+      { text: "(ooh ", begin: 5.0, end: 5.6 },
+      { text: "yeah)", begin: 5.6, end: 6.2 },
+    ];
+    const lines = [
+      createLine({ id: "1", text: "Real line" }),
+      createLine({ id: "2", text: "(ooh yeah)", words: standaloneWords }),
+    ];
+    const standaloneWordsRef = lines[1].words;
+    extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(lines).toHaveLength(2);
+    expect(lines[1].text).toBe("(ooh yeah)");
+    expect(lines[1].words).toBe(standaloneWordsRef);
+    expect(lines[1].words).toEqual([
+      { text: "(ooh ", begin: 5.0, end: 5.6 },
+      { text: "yeah)", begin: 5.6, end: 6.2 },
+    ]);
+    expect(lines[0].backgroundWords).toBeUndefined();
+  });
 });
 
 // -- extractBackgroundVocals: idempotence -------------------------------------
@@ -820,6 +1009,36 @@ describe("extractBackgroundVocals: idempotence", () => {
       expect(second[i]).toBe(first[i]);
       expect(second[i].text).toBe(first[i].text);
       expect(second[i].backgroundText).toBe(first[i].backgroundText);
+    }
+  });
+
+  it("yields no further changes for a mix including timed standalone lines", () => {
+    const lines = [
+      createLine({
+        id: "1",
+        text: "Real line",
+        words: [
+          { text: "Real ", begin: 0, end: 1 },
+          { text: "line", begin: 1, end: 2 },
+        ],
+      }),
+      createLine({
+        id: "2",
+        text: "(ooh yeah)",
+        words: [
+          { text: "(ooh ", begin: 5.0, end: 5.6 },
+          { text: "yeah)", begin: 5.6, end: 6.2 },
+        ],
+      }),
+      createLine({ id: "3", text: "Plain line" }),
+    ];
+    const first = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const second = extractBackgroundVocals(first, { mergeStandaloneLines: true });
+    expect(second).toHaveLength(first.length);
+    for (let i = 0; i < first.length; i++) {
+      expect(second[i]).toBe(first[i]);
+      expect(second[i].backgroundText).toBe(first[i].backgroundText);
+      expect(second[i].backgroundWords).toEqual(first[i].backgroundWords);
     }
   });
 });

--- a/src/utils/background-vocal-extraction.test.ts
+++ b/src/utils/background-vocal-extraction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { scanParenGroups } from "@/utils/background-vocal-extraction";
+import { classifyLine, scanParenGroups } from "@/utils/background-vocal-extraction";
 
 // -- Specification table -------------------------------------------------------
 
@@ -166,5 +166,177 @@ describe("scanParenGroups: unbalanced edge cases", () => {
     const scan = scanParenGroups("(a) (b) (");
     expect(scan.status).toBe("unbalanced");
     expect(scan.groups).toEqual([]);
+  });
+});
+
+// -- classifyLine: specification table -----------------------------------------
+
+describe("classifyLine: specification table", () => {
+  it("classifies plain text as none", () => {
+    const result = classifyLine("Hello world");
+    expect(result.kind).toBe("none");
+    expect(result.mainText).toBe("Hello world");
+    expect(result.bgText).toBe("");
+  });
+
+  it("classifies a mid-line group as inline", () => {
+    const result = classifyLine("Hello (ooh) world");
+    expect(result.kind).toBe("inline");
+    expect(result.mainText).toBe("Hello world");
+    expect(result.bgText).toBe("ooh");
+  });
+
+  it("classifies a trailing group as inline", () => {
+    const result = classifyLine("Hello (ooh)");
+    expect(result.kind).toBe("inline");
+    expect(result.mainText).toBe("Hello");
+    expect(result.bgText).toBe("ooh");
+  });
+
+  it("classifies a leading group as inline", () => {
+    const result = classifyLine("(ooh) world");
+    expect(result.kind).toBe("inline");
+    expect(result.mainText).toBe("world");
+    expect(result.bgText).toBe("ooh");
+  });
+
+  it("classifies multiple inline groups, joining bg text with a space", () => {
+    const result = classifyLine("Hi (a) and (b) bye");
+    expect(result.kind).toBe("inline");
+    expect(result.mainText).toBe("Hi and bye");
+    expect(result.bgText).toBe("a b");
+  });
+
+  it("classifies a single full-line group as standalone", () => {
+    const result = classifyLine("(ooh yeah)");
+    expect(result.kind).toBe("standalone");
+    expect(result.mainText).toBe("");
+    expect(result.bgText).toBe("ooh yeah");
+  });
+
+  it("classifies multiple groups covering the whole line as standalone", () => {
+    const result = classifyLine("(ooh) (yeah)");
+    expect(result.kind).toBe("standalone");
+    expect(result.mainText).toBe("");
+    expect(result.bgText).toBe("ooh yeah");
+  });
+
+  it("classifies an unclosed group as skip", () => {
+    const result = classifyLine("Hello (ooh");
+    expect(result.kind).toBe("skip");
+  });
+
+  it("classifies nested groups as skip", () => {
+    const result = classifyLine("((ooh))");
+    expect(result.kind).toBe("skip");
+  });
+
+  it("classifies a trailing unclosed group as skip", () => {
+    const result = classifyLine("Hello (ooh) world (ah");
+    expect(result.kind).toBe("skip");
+  });
+
+  it("leaves a line with an empty group untouched as none", () => {
+    const result = classifyLine("Hello ()");
+    expect(result.kind).toBe("none");
+    expect(result.mainText).toBe("Hello ()");
+    expect(result.bgText).toBe("");
+  });
+
+  it("classifies a whitespace-only group as none with empty bg text", () => {
+    const result = classifyLine("(  )");
+    expect(result.kind).toBe("none");
+    expect(result.bgText).toBe("");
+  });
+});
+
+// -- classifyLine: whitespace handling -----------------------------------------
+
+describe("classifyLine: whitespace handling", () => {
+  it("trims leading and trailing spaces inside a group for bg text", () => {
+    const result = classifyLine("la (  ooh  ) la");
+    expect(result.kind).toBe("inline");
+    expect(result.bgText).toBe("ooh");
+    expect(result.mainText).toBe("la la");
+  });
+
+  it("collapses runs of two or more spaces in mainText to one space", () => {
+    const result = classifyLine("a  (x)  b");
+    expect(result.kind).toBe("inline");
+    expect(result.mainText).toBe("a b");
+    expect(result.bgText).toBe("x");
+  });
+
+  it("classifies a whitespace-only line as none", () => {
+    const result = classifyLine("   ");
+    expect(result.kind).toBe("none");
+    expect(result.bgText).toBe("");
+    expect(result.mainText).toBe("   ");
+  });
+
+  it("classifies an empty string as none", () => {
+    const result = classifyLine("");
+    expect(result.kind).toBe("none");
+    expect(result.bgText).toBe("");
+    expect(result.mainText).toBe("");
+  });
+});
+
+// -- classifyLine: mixed empty and non-empty groups ----------------------------
+
+describe("classifyLine: mixed empty and non-empty groups", () => {
+  it("filters out an empty group when joining bg text", () => {
+    const result = classifyLine("Hi (a) and () bye");
+    expect(result.kind).toBe("inline");
+    expect(result.bgText).toBe("a");
+    expect(result.mainText).toBe("Hi and bye");
+  });
+
+  it("filters out a whitespace-only group when joining bg text", () => {
+    const result = classifyLine("Hi (a) and (   ) bye");
+    expect(result.kind).toBe("inline");
+    expect(result.bgText).toBe("a");
+    expect(result.mainText).toBe("Hi and bye");
+  });
+
+  it("classifies a standalone line when the only non-empty group covers everything", () => {
+    const result = classifyLine("() (ooh)");
+    expect(result.kind).toBe("standalone");
+    expect(result.bgText).toBe("ooh");
+    expect(result.mainText).toBe("");
+  });
+});
+
+// -- classifyLine: returned shape ----------------------------------------------
+
+describe("classifyLine: returned shape", () => {
+  it("returns a well-formed shape for skip outcomes", () => {
+    const result = classifyLine("Hello (ooh");
+    expect(result.kind).toBe("skip");
+    expect(result.groups).toEqual([]);
+    expect(result.bgText).toBe("");
+    expect(result.mainText).toBe("Hello (ooh");
+  });
+
+  it("returns a well-formed shape for none outcomes with no groups", () => {
+    const result = classifyLine("Hello world");
+    expect(result.kind).toBe("none");
+    expect(result.groups).toEqual([]);
+    expect(result.bgText).toBe("");
+    expect(result.mainText).toBe("Hello world");
+  });
+
+  it("retains scanned groups for none outcomes with empty groups", () => {
+    const result = classifyLine("Hello ()");
+    expect(result.kind).toBe("none");
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0].inner).toBe("");
+  });
+
+  it("exposes scanned groups for inline outcomes", () => {
+    const result = classifyLine("Hi (a) and (b) bye");
+    expect(result.groups).toHaveLength(2);
+    expect(result.groups[0].inner).toBe("a");
+    expect(result.groups[1].inner).toBe("b");
   });
 });

--- a/src/utils/background-vocal-extraction.test.ts
+++ b/src/utils/background-vocal-extraction.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import { scanParenGroups } from "@/utils/background-vocal-extraction";
+
+// -- Specification table -------------------------------------------------------
+
+describe("scanParenGroups: specification table", () => {
+  it("returns balanced with no groups for plain text", () => {
+    const scan = scanParenGroups("Hello world");
+    expect(scan.status).toBe("balanced");
+    expect(scan.groups).toEqual([]);
+  });
+
+  it("returns one group for a single balanced pair", () => {
+    const text = "Hello (ooh) world";
+    const scan = scanParenGroups(text);
+    expect(scan.status).toBe("balanced");
+    expect(scan.groups).toHaveLength(1);
+    expect(scan.groups[0].inner).toBe("ooh");
+    expect(scan.groups[0].start).toBe(text.indexOf("("));
+    expect(scan.groups[0].end).toBe(text.indexOf(")"));
+  });
+
+  it("returns two groups for two balanced pairs", () => {
+    const scan = scanParenGroups("Hi (a) and (b)");
+    expect(scan.status).toBe("balanced");
+    expect(scan.groups).toHaveLength(2);
+    expect(scan.groups[0].inner).toBe("a");
+    expect(scan.groups[1].inner).toBe("b");
+  });
+
+  it("returns unbalanced for an unclosed open paren", () => {
+    const scan = scanParenGroups("Hello (ooh");
+    expect(scan.status).toBe("unbalanced");
+    expect(scan.groups).toEqual([]);
+  });
+
+  it("returns unbalanced for a stray close paren", () => {
+    const scan = scanParenGroups("yeah)");
+    expect(scan.status).toBe("unbalanced");
+    expect(scan.groups).toEqual([]);
+  });
+
+  it("returns unbalanced when depth goes negative before recovering", () => {
+    const scan = scanParenGroups("Hello )ooh(");
+    expect(scan.status).toBe("unbalanced");
+    expect(scan.groups).toEqual([]);
+  });
+
+  it("returns nested for back-to-back opens", () => {
+    const scan = scanParenGroups("((ooh))");
+    expect(scan.status).toBe("nested");
+    expect(scan.groups).toEqual([]);
+  });
+
+  it("returns nested for an open paren inside an open group", () => {
+    const scan = scanParenGroups("(ooh (ah))");
+    expect(scan.status).toBe("nested");
+    expect(scan.groups).toEqual([]);
+  });
+
+  it("returns balanced with no groups for an empty string", () => {
+    const scan = scanParenGroups("");
+    expect(scan.status).toBe("balanced");
+    expect(scan.groups).toEqual([]);
+  });
+});
+
+// -- Inner content edge cases --------------------------------------------------
+
+describe("scanParenGroups: inner content", () => {
+  it("treats an empty pair as a balanced group with empty inner", () => {
+    const scan = scanParenGroups("()");
+    expect(scan.status).toBe("balanced");
+    expect(scan.groups).toHaveLength(1);
+    expect(scan.groups[0].inner).toBe("");
+  });
+
+  it("returns raw inner without trimming surrounding spaces", () => {
+    const scan = scanParenGroups("( a b )");
+    expect(scan.status).toBe("balanced");
+    expect(scan.groups).toHaveLength(1);
+    expect(scan.groups[0].inner).toBe(" a b ");
+  });
+
+  it("preserves inner whitespace exactly for a multi-word group", () => {
+    const scan = scanParenGroups("la (ooh ah  yeah) la");
+    expect(scan.status).toBe("balanced");
+    expect(scan.groups[0].inner).toBe("ooh ah  yeah");
+  });
+});
+
+// -- Group positioning ---------------------------------------------------------
+
+describe("scanParenGroups: group positioning", () => {
+  it("handles adjacent groups with no separator", () => {
+    const text = "(a)(b)";
+    const scan = scanParenGroups(text);
+    expect(scan.status).toBe("balanced");
+    expect(scan.groups).toHaveLength(2);
+    expect(scan.groups[0].inner).toBe("a");
+    expect(scan.groups[1].inner).toBe("b");
+  });
+
+  it("handles a group at the start of the string", () => {
+    const text = "(a) b";
+    const scan = scanParenGroups(text);
+    expect(scan.status).toBe("balanced");
+    expect(scan.groups).toHaveLength(1);
+    expect(scan.groups[0].start).toBe(0);
+    expect(scan.groups[0].end).toBe(2);
+    expect(scan.groups[0].inner).toBe("a");
+  });
+
+  it("handles a group at the end of the string", () => {
+    const text = "a (b)";
+    const scan = scanParenGroups(text);
+    expect(scan.status).toBe("balanced");
+    expect(scan.groups).toHaveLength(1);
+    expect(scan.groups[0].start).toBe(text.length - 3);
+    expect(scan.groups[0].end).toBe(text.length - 1);
+    expect(scan.groups[0].inner).toBe("b");
+  });
+
+  it("reports start at '(' and end at ')' for every group", () => {
+    const text = "Hi (a) and (b)";
+    const scan = scanParenGroups(text);
+    expect(scan.status).toBe("balanced");
+    for (const group of scan.groups) {
+      expect(text[group.start]).toBe("(");
+      expect(text[group.end]).toBe(")");
+      expect(text.slice(group.start + 1, group.end)).toBe(group.inner);
+    }
+  });
+
+  it("reports correct indices for adjacent groups", () => {
+    const scan = scanParenGroups("(a)(b)");
+    expect(scan.groups[0].start).toBe(0);
+    expect(scan.groups[0].end).toBe(2);
+    expect(scan.groups[1].start).toBe(3);
+    expect(scan.groups[1].end).toBe(5);
+  });
+});
+
+// -- Unbalanced edge cases -----------------------------------------------------
+
+describe("scanParenGroups: unbalanced edge cases", () => {
+  it("returns unbalanced for a lone close paren", () => {
+    const scan = scanParenGroups(")");
+    expect(scan.status).toBe("unbalanced");
+    expect(scan.groups).toEqual([]);
+  });
+
+  it("returns unbalanced for a lone open paren", () => {
+    const scan = scanParenGroups("(");
+    expect(scan.status).toBe("unbalanced");
+    expect(scan.groups).toEqual([]);
+  });
+
+  it("returns unbalanced when a close paren precedes a balanced pair", () => {
+    const scan = scanParenGroups(")(a)");
+    expect(scan.status).toBe("unbalanced");
+    expect(scan.groups).toEqual([]);
+  });
+
+  it("returns unbalanced when an extra open paren trails balanced groups", () => {
+    const scan = scanParenGroups("(a) (b) (");
+    expect(scan.status).toBe("unbalanced");
+    expect(scan.groups).toEqual([]);
+  });
+});

--- a/src/utils/background-vocal-extraction.test.ts
+++ b/src/utils/background-vocal-extraction.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { LyricLine } from "@/domain/line/model";
-import { classifyLine, extractInlineFromLine, scanParenGroups } from "@/utils/background-vocal-extraction";
+import { createLine } from "@/test/factories";
+import {
+  classifyLine,
+  extractBackgroundVocals,
+  extractInlineFromLine,
+  lineHasInlineParens,
+  scanParenGroups,
+} from "@/utils/background-vocal-extraction";
 
 // -- Specification table -------------------------------------------------------
 
@@ -430,5 +437,221 @@ describe("extractInlineFromLine", () => {
     extractInlineFromLine(line);
     expect(line.text).toBe("Hello (ooh) world");
     expect(line.backgroundText).toBe("ah");
+  });
+});
+
+// -- extractBackgroundVocals: specification table ------------------------------
+
+describe("extractBackgroundVocals: specification table", () => {
+  it("extracts an inline line regardless of mergeStandaloneLines", () => {
+    for (const mergeStandaloneLines of [true, false]) {
+      const lines = [createLine({ id: "1", text: "A (ooh) B" })];
+      const result = extractBackgroundVocals(lines, { mergeStandaloneLines });
+      expect(result).toHaveLength(1);
+      expect(result[0].text).toBe("A B");
+      expect(result[0].backgroundText).toBe("ooh");
+    }
+  });
+
+  it("merges a standalone line into the previous line when merge is enabled", () => {
+    const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh yeah)" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("1");
+    expect(result[0].text).toBe("Real line");
+    expect(result[0].backgroundText).toBe("ooh yeah");
+  });
+
+  it("leaves a standalone line in place when merge is disabled", () => {
+    const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh yeah)" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: false });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(lines[0]);
+    expect(result[1]).toBe(lines[1]);
+  });
+
+  it("merges consecutive standalone lines into the same previous line", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line" }),
+      createLine({ id: "2", text: "(ooh)" }),
+      createLine({ id: "3", text: "(yeah)" }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("1");
+    expect(result[0].text).toBe("Real line");
+    expect(result[0].backgroundText).toBe("ooh yeah");
+  });
+
+  it("does not merge a leading standalone line with no valid predecessor", () => {
+    const lines = [createLine({ id: "1", text: "(ooh)" }), createLine({ id: "2", text: "Real line" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(lines[0]);
+    expect(result[1]).toBe(lines[1]);
+  });
+
+  it("does not merge into an empty-text predecessor", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real" }),
+      createLine({ id: "2", text: "" }),
+      createLine({ id: "3", text: "(ooh)" }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe(lines[0]);
+    expect(result[1]).toBe(lines[1]);
+    expect(result[2]).toBe(lines[2]);
+  });
+
+  it("does not merge when the predecessor is a linked line", () => {
+    const lines = [
+      createLine({ id: "1", text: "Chorus", groupId: "g1", instanceIdx: 0 }),
+      createLine({ id: "2", text: "(ooh)" }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(lines[0]);
+    expect(result[1]).toBe(lines[1]);
+  });
+
+  it("does not merge when the standalone line is itself linked", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real" }),
+      createLine({ id: "2", text: "(ooh)", groupId: "g1", instanceIdx: 0 }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(lines[0]);
+    expect(result[1]).toBe(lines[1]);
+  });
+
+  it("merges a standalone line into a predecessor that was itself inline-extracted", () => {
+    const lines = [createLine({ id: "1", text: "A (ooh) B" }), createLine({ id: "2", text: "(yeah)" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("1");
+    expect(result[0].text).toBe("A B");
+    expect(result[0].backgroundText).toBe("ooh yeah");
+  });
+});
+
+// -- extractBackgroundVocals: none and skip lines -----------------------------
+
+describe("extractBackgroundVocals: none and skip lines", () => {
+  it("pushes a none line by reference", () => {
+    const lines = [createLine({ id: "1", text: "Plain line" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(lines[0]);
+  });
+
+  it("pushes a skip line by reference", () => {
+    const lines = [createLine({ id: "1", text: "Hello (ooh" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(lines[0]);
+  });
+
+  it("merges a standalone line into a skip predecessor with non-empty text", () => {
+    const lines = [createLine({ id: "1", text: "Hello (ooh" }), createLine({ id: "2", text: "(yeah)" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("1");
+    expect(result[0].text).toBe("Hello (ooh");
+    expect(result[0].backgroundText).toBe("yeah");
+  });
+});
+
+// -- extractBackgroundVocals: reference stability -----------------------------
+
+describe("extractBackgroundVocals: reference stability", () => {
+  it("returns every line by reference when no parentheses are present", () => {
+    for (const mergeStandaloneLines of [true, false]) {
+      const lines = [
+        createLine({ id: "1", text: "First line" }),
+        createLine({ id: "2", text: "Second line" }),
+        createLine({ id: "3", text: "Third line" }),
+      ];
+      const result = extractBackgroundVocals(lines, { mergeStandaloneLines });
+      expect(result).toHaveLength(lines.length);
+      for (let i = 0; i < lines.length; i++) {
+        expect(result[i]).toBe(lines[i]);
+      }
+    }
+  });
+});
+
+// -- extractBackgroundVocals: existing backgroundText -------------------------
+
+describe("extractBackgroundVocals: existing backgroundText", () => {
+  it("appends a merged standalone bg text after the predecessor's existing bg text", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line", backgroundText: "ah" }),
+      createLine({ id: "2", text: "(ooh)" }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].backgroundText).toBe("ah ooh");
+  });
+});
+
+// -- extractBackgroundVocals: input not mutated -------------------------------
+
+describe("extractBackgroundVocals: input not mutated", () => {
+  it("does not mutate the input array or its line objects", () => {
+    const lines = [
+      createLine({ id: "1", text: "A (ooh) B", backgroundText: "ah" }),
+      createLine({ id: "2", text: "(yeah)" }),
+      createLine({ id: "3", text: "Plain" }),
+    ];
+    const originalLength = lines.length;
+    extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    expect(lines).toHaveLength(originalLength);
+    expect(lines[0].text).toBe("A (ooh) B");
+    expect(lines[0].backgroundText).toBe("ah");
+    expect(lines[1].text).toBe("(yeah)");
+    expect(lines[2].text).toBe("Plain");
+  });
+});
+
+// -- extractBackgroundVocals: idempotence -------------------------------------
+
+describe("extractBackgroundVocals: idempotence", () => {
+  it("yields no further changes when run on its own output", () => {
+    const lines = [
+      createLine({ id: "1", text: "A (ooh) B" }),
+      createLine({ id: "2", text: "(yeah)" }),
+      createLine({ id: "3", text: "Plain line" }),
+      createLine({ id: "4", text: "C (ah) D" }),
+    ];
+    const first = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const second = extractBackgroundVocals(first, { mergeStandaloneLines: true });
+    expect(second).toHaveLength(first.length);
+    for (let i = 0; i < first.length; i++) {
+      expect(second[i]).toBe(first[i]);
+      expect(second[i].text).toBe(first[i].text);
+      expect(second[i].backgroundText).toBe(first[i].backgroundText);
+    }
+  });
+});
+
+// -- lineHasInlineParens ------------------------------------------------------
+
+describe("lineHasInlineParens", () => {
+  it("returns true for an inline line", () => {
+    expect(lineHasInlineParens(createLine({ id: "1", text: "A (ooh) B" }))).toBe(true);
+  });
+
+  it("returns false for a plain line", () => {
+    expect(lineHasInlineParens(createLine({ id: "1", text: "Plain line" }))).toBe(false);
+  });
+
+  it("returns false for a standalone line", () => {
+    expect(lineHasInlineParens(createLine({ id: "1", text: "(ooh yeah)" }))).toBe(false);
+  });
+
+  it("returns false for a skip line", () => {
+    expect(lineHasInlineParens(createLine({ id: "1", text: "Hello (ooh" }))).toBe(false);
   });
 });

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -2,7 +2,7 @@ import { isLinked } from "@/domain/instance/predicates";
 import type { LyricLine } from "@/domain/line/model";
 import { reconcileLine } from "@/domain/line/model";
 import { isWordSynced } from "@/domain/line/predicates";
-import { reconstructLineText } from "@/domain/line/reconstruct-text";
+import { reconstructLineText, wordContentSpans } from "@/domain/line/reconstruct-text";
 import type { WordTiming } from "@/domain/word/timing";
 import { getSplitCharacter } from "@/utils/split-character";
 
@@ -85,25 +85,6 @@ function classifyLine(text: string): LineClassification {
 }
 
 // -- Extraction ---------------------------------------------------------------
-
-interface WordContentSpan {
-  start: number;
-  end: number;
-}
-
-function wordContentSpans(words: WordTiming[], splitChar: string): WordContentSpan[] {
-  const spans: WordContentSpan[] = [];
-  let cursor = 0;
-  for (let i = 0; i < words.length; i++) {
-    const text = words[i].text;
-    const leading = text.length - text.trimStart().length;
-    const trailing = text.length - text.trimEnd().length;
-    spans.push({ start: cursor + leading, end: cursor + text.length - trailing });
-    cursor += text.length;
-    if (i < words.length - 1 && !text.endsWith(" ")) cursor += splitChar.length;
-  }
-  return spans;
-}
 
 function extractInlineWordSynced(line: LyricLine, classified: LineClassification): LyricLine {
   const words = line.words;

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -1,6 +1,10 @@
 import { isLinked } from "@/domain/instance/predicates";
 import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine } from "@/domain/line/model";
 import { isWordSynced } from "@/domain/line/predicates";
+import { reconstructLineText } from "@/domain/line/reconstruct-text";
+import type { WordTiming } from "@/domain/word/timing";
+import { getSplitCharacter } from "@/utils/split-character";
 
 // -- Types --------------------------------------------------------------------
 
@@ -82,10 +86,63 @@ function classifyLine(text: string): LineClassification {
 
 // -- Extraction ---------------------------------------------------------------
 
+interface WordContentSpan {
+  start: number;
+  end: number;
+}
+
+function wordContentSpans(words: WordTiming[], splitChar: string): WordContentSpan[] {
+  const spans: WordContentSpan[] = [];
+  let cursor = 0;
+  for (let i = 0; i < words.length; i++) {
+    const text = words[i].text;
+    const leading = text.length - text.trimStart().length;
+    const trailing = text.length - text.trimEnd().length;
+    spans.push({ start: cursor + leading, end: cursor + text.length - trailing });
+    cursor += text.length;
+    if (i < words.length - 1 && !text.endsWith(" ")) cursor += splitChar.length;
+  }
+  return spans;
+}
+
+function extractInlineWordSynced(line: LyricLine, classified: LineClassification): LyricLine {
+  const words = line.words;
+  if (!words || words.length === 0) return line;
+  if (line.backgroundWords && line.backgroundWords.length > 0) return line;
+  const splitChar = getSplitCharacter();
+  if (reconstructLineText(words, splitChar) !== line.text) return line;
+  const spans = wordContentSpans(words, splitChar);
+  const survivors: WordTiming[] = [];
+  for (let i = 0; i < words.length; i++) {
+    const span = spans[i];
+    let insideCount = 0;
+    for (const g of classified.groups) {
+      const groupStart = g.start;
+      const groupEnd = g.end + 1;
+      const overlaps = span.start < groupEnd && span.end > groupStart;
+      if (!overlaps) continue;
+      const fullyInside = span.start >= groupStart && span.end <= groupEnd;
+      if (!fullyInside) return line;
+      insideCount++;
+    }
+    if (insideCount === 0) survivors.push(words[i]);
+  }
+  if (survivors.length === 0) return line;
+  const trimmedSurvivors = survivors.map((word, i) =>
+    i === survivors.length - 1 ? { ...word, text: word.text.replace(/ +$/, "") } : word,
+  );
+  return reconcileLine({
+    ...line,
+    words: trimmedSurvivors,
+    text: reconstructLineText(trimmedSurvivors, splitChar),
+    backgroundText: joinBackgroundText(line.backgroundText, classified.bgText),
+  });
+}
+
 function extractInlineFromLine(line: LyricLine): LyricLine {
   const classified = classifyLine(line.text);
   if (classified.kind !== "inline") return line;
-  if (isWordSynced(line)) return line;
+  if (isWordSynced(line)) return extractInlineWordSynced(line, classified);
   return {
     ...line,
     text: classified.mainText,

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -1,10 +1,12 @@
 import { isLinked } from "@/domain/instance/predicates";
 import type { LyricLine } from "@/domain/line/model";
 import { reconcileLine } from "@/domain/line/model";
-import { isWordSynced } from "@/domain/line/predicates";
+import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
 import { reconstructLineText, wordContentSpans } from "@/domain/line/reconstruct-text";
 import type { WordTiming } from "@/domain/word/timing";
+import { remapWordTextsPreservingTiming } from "@/utils/lyrics-text";
 import { getSplitCharacter } from "@/utils/split-character";
+import { createInitialBgWords } from "@/utils/sync-helpers";
 
 // -- Types --------------------------------------------------------------------
 
@@ -137,7 +139,29 @@ interface ExtractOptions {
   mergeStandaloneLines: boolean;
 }
 
-function mergeStandaloneInto(prev: LyricLine, _standalone: LyricLine, bgText: string): LyricLine {
+function carriedBackgroundWords(standalone: LyricLine, bgText: string): WordTiming[] | null {
+  const words = standalone.words;
+  if (words && words.length > 0) return remapWordTextsPreservingTiming(words, bgText);
+  if (isLineSynced(standalone)) return createInitialBgWords(bgText, standalone.begin, standalone.end);
+  return null;
+}
+
+function mergeStandaloneInto(prev: LyricLine, standalone: LyricLine, bgText: string): LyricLine | null {
+  const carried = carriedBackgroundWords(standalone, bgText);
+  const prevBgWords = prev.backgroundWords;
+
+  if (carried && carried.length > 0) {
+    if (prevBgWords && prevBgWords.length > 0) {
+      const combined = [...prevBgWords, ...carried];
+      return { ...prev, backgroundWords: combined, backgroundText: reconstructLineText(combined, getSplitCharacter()) };
+    }
+    if (!prev.backgroundText) {
+      return { ...prev, backgroundWords: carried, backgroundText: reconstructLineText(carried, getSplitCharacter()) };
+    }
+    return { ...prev, backgroundText: joinBackgroundText(prev.backgroundText, bgText) };
+  }
+
+  if (prevBgWords && prevBgWords.length > 0) return null;
   return { ...prev, backgroundText: joinBackgroundText(prev.backgroundText, bgText) };
 }
 
@@ -151,9 +175,18 @@ function extractBackgroundVocals(lines: LyricLine[], options: ExtractOptions): L
     }
     if (classified.kind === "standalone" && options.mergeStandaloneLines) {
       const prev = result[result.length - 1];
-      if (prev && prev.text.trim().length > 0 && !isLinked(prev) && !isLinked(line)) {
-        result[result.length - 1] = mergeStandaloneInto(prev, line, classified.bgText);
-        continue;
+      if (
+        prev &&
+        prev.text.trim().length > 0 &&
+        classifyLine(prev.text).kind === "none" &&
+        !isLinked(prev) &&
+        !isLinked(line)
+      ) {
+        const merged = mergeStandaloneInto(prev, line, classified.bgText);
+        if (merged) {
+          result[result.length - 1] = merged;
+          continue;
+        }
       }
     }
     result.push(line);

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -1,0 +1,41 @@
+// -- Types --------------------------------------------------------------------
+
+interface ParenGroup {
+  inner: string;
+  start: number;
+  end: number;
+}
+
+type ParenScanStatus = "balanced" | "unbalanced" | "nested";
+
+interface ParenScan {
+  status: ParenScanStatus;
+  groups: ParenGroup[];
+}
+
+// -- Scanner ------------------------------------------------------------------
+
+function scanParenGroups(text: string): ParenScan {
+  const groups: ParenGroup[] = [];
+  let depth = 0;
+  let openIndex = -1;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === "(") {
+      depth++;
+      if (depth > 1) return { status: "nested", groups: [] };
+      openIndex = i;
+    } else if (ch === ")") {
+      depth--;
+      if (depth < 0) return { status: "unbalanced", groups: [] };
+      groups.push({ inner: text.slice(openIndex + 1, i), start: openIndex, end: i });
+    }
+  }
+  if (depth !== 0) return { status: "unbalanced", groups: [] };
+  return { status: "balanced", groups };
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { scanParenGroups };
+export type { ParenGroup, ParenScan, ParenScanStatus };

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -13,6 +13,15 @@ interface ParenScan {
   groups: ParenGroup[];
 }
 
+type LineClassKind = "none" | "inline" | "standalone" | "skip";
+
+interface LineClassification {
+  kind: LineClassKind;
+  groups: ParenGroup[];
+  bgText: string;
+  mainText: string;
+}
+
 // -- Scanner ------------------------------------------------------------------
 
 function scanParenGroups(text: string): ParenScan {
@@ -35,7 +44,34 @@ function scanParenGroups(text: string): ParenScan {
   return { status: "balanced", groups };
 }
 
+// -- Classification -----------------------------------------------------------
+
+function stripGroups(text: string, groups: ParenGroup[]): string {
+  let result = text;
+  for (let i = groups.length - 1; i >= 0; i--) {
+    result = result.slice(0, groups[i].start) + result.slice(groups[i].end + 1);
+  }
+  return result;
+}
+
+function collapseSpaces(text: string): string {
+  return text.replace(/ {2,}/g, " ").trim();
+}
+
+function classifyLine(text: string): LineClassification {
+  const scan = scanParenGroups(text);
+  if (scan.status !== "balanced") return { kind: "skip", groups: [], bgText: "", mainText: text };
+  if (scan.groups.length === 0) return { kind: "none", groups: [], bgText: "", mainText: text };
+  const bgText = scan.groups
+    .map((g) => g.inner.trim())
+    .filter((s) => s.length > 0)
+    .join(" ");
+  if (bgText.length === 0) return { kind: "none", groups: scan.groups, bgText: "", mainText: text };
+  const mainText = collapseSpaces(stripGroups(text, scan.groups));
+  return { kind: mainText.length === 0 ? "standalone" : "inline", groups: scan.groups, bgText, mainText };
+}
+
 // -- Exports ------------------------------------------------------------------
 
-export { scanParenGroups };
-export type { ParenGroup, ParenScan, ParenScanStatus };
+export { classifyLine, scanParenGroups };
+export type { LineClassification, LineClassKind, ParenGroup, ParenScan, ParenScanStatus };

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -1,3 +1,4 @@
+import { isLinked } from "@/domain/instance/predicates";
 import type { LyricLine } from "@/domain/line/model";
 import { isWordSynced } from "@/domain/line/predicates";
 
@@ -92,7 +93,41 @@ function extractInlineFromLine(line: LyricLine): LyricLine {
   };
 }
 
+// -- Whole-list transform -----------------------------------------------------
+
+interface ExtractOptions {
+  mergeStandaloneLines: boolean;
+}
+
+function mergeStandaloneInto(prev: LyricLine, _standalone: LyricLine, bgText: string): LyricLine {
+  return { ...prev, backgroundText: joinBackgroundText(prev.backgroundText, bgText) };
+}
+
+function extractBackgroundVocals(lines: LyricLine[], options: ExtractOptions): LyricLine[] {
+  const result: LyricLine[] = [];
+  for (const line of lines) {
+    const classified = classifyLine(line.text);
+    if (classified.kind === "inline") {
+      result.push(extractInlineFromLine(line));
+      continue;
+    }
+    if (classified.kind === "standalone" && options.mergeStandaloneLines) {
+      const prev = result[result.length - 1];
+      if (prev && prev.text.trim().length > 0 && !isLinked(prev) && !isLinked(line)) {
+        result[result.length - 1] = mergeStandaloneInto(prev, line, classified.bgText);
+        continue;
+      }
+    }
+    result.push(line);
+  }
+  return result;
+}
+
+function lineHasInlineParens(line: LyricLine): boolean {
+  return classifyLine(line.text).kind === "inline";
+}
+
 // -- Exports ------------------------------------------------------------------
 
-export { classifyLine, extractInlineFromLine, scanParenGroups };
-export type { LineClassification, LineClassKind, ParenGroup, ParenScan, ParenScanStatus };
+export { classifyLine, extractBackgroundVocals, extractInlineFromLine, lineHasInlineParens, scanParenGroups };
+export type { ExtractOptions, LineClassification, LineClassKind, ParenGroup, ParenScan, ParenScanStatus };

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -1,3 +1,6 @@
+import type { LyricLine } from "@/domain/line/model";
+import { isWordSynced } from "@/domain/line/predicates";
+
 // -- Types --------------------------------------------------------------------
 
 interface ParenGroup {
@@ -58,6 +61,11 @@ function collapseSpaces(text: string): string {
   return text.replace(/ {2,}/g, " ").trim();
 }
 
+function joinBackgroundText(existing: string | undefined, addition: string): string {
+  const base = existing?.trim() ?? "";
+  return base.length > 0 ? `${base} ${addition}` : addition;
+}
+
 function classifyLine(text: string): LineClassification {
   const scan = scanParenGroups(text);
   if (scan.status !== "balanced") return { kind: "skip", groups: [], bgText: "", mainText: text };
@@ -71,7 +79,20 @@ function classifyLine(text: string): LineClassification {
   return { kind: mainText.length === 0 ? "standalone" : "inline", groups: scan.groups, bgText, mainText };
 }
 
+// -- Extraction ---------------------------------------------------------------
+
+function extractInlineFromLine(line: LyricLine): LyricLine {
+  const classified = classifyLine(line.text);
+  if (classified.kind !== "inline") return line;
+  if (isWordSynced(line)) return line;
+  return {
+    ...line,
+    text: classified.mainText,
+    backgroundText: joinBackgroundText(line.backgroundText, classified.bgText),
+  };
+}
+
 // -- Exports ------------------------------------------------------------------
 
-export { classifyLine, scanParenGroups };
+export { classifyLine, extractInlineFromLine, scanParenGroups };
 export type { LineClassification, LineClassKind, ParenGroup, ParenScan, ParenScanStatus };

--- a/src/utils/lyrics-text.test.ts
+++ b/src/utils/lyrics-text.test.ts
@@ -3,6 +3,7 @@
  */
 import type { LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
+import { extractBackgroundVocals } from "@/utils/background-vocal-extraction";
 import { textToLyricLines } from "./lyrics-text";
 
 describe("textToLyricLines · group attrs preservation", () => {
@@ -243,6 +244,62 @@ describe("textToLyricLines · group attrs preservation", () => {
   it("explicit blank line in textarea round-trips as text: ''", () => {
     const result = textToLyricLines("a\n\nb", "v1", []);
     expect(result.map((l) => l.text)).toEqual(["a", "", "b"]);
+  });
+
+  it("drops carried backgroundText when re-pasted text reintroduces parentheses (position match)", () => {
+    const existing: LyricLine[] = [{ id: "L1", text: "Hello world", agentId: "v1", backgroundText: "ooh" }];
+    const result = textToLyricLines("Hello (ooh) world", "v1", existing);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("Hello (ooh) world");
+    expect(result[0].backgroundText).toBeUndefined();
+    expect(result[0].backgroundWords).toBeUndefined();
+  });
+
+  it("keeps carried backgroundText when re-pasted text has no parentheses", () => {
+    const existing: LyricLine[] = [{ id: "L1", text: "Hello world", agentId: "v1", backgroundText: "ooh" }];
+    const result = textToLyricLines("Hello there", "v1", existing);
+    expect(result[0].backgroundText).toBe("ooh");
+  });
+
+  it("drops carried backgroundText on an exact-text match whose text contains parentheses", () => {
+    const existing: LyricLine[] = [{ id: "L1", text: "Hello (ooh) world", agentId: "v1", backgroundText: "ooh" }];
+    const result = textToLyricLines("Hello (ooh) world", "v1", existing);
+    expect(result[0].id).toBe("L1");
+    expect(result[0].text).toBe("Hello (ooh) world");
+    expect(result[0].backgroundText).toBeUndefined();
+    expect(result[0].backgroundWords).toBeUndefined();
+  });
+
+  it("drops carried backgroundWords when re-pasted text reintroduces parentheses", () => {
+    const existing: LyricLine[] = [
+      {
+        id: "L1",
+        text: "Hello world",
+        agentId: "v1",
+        backgroundText: "ooh",
+        backgroundWords: [{ text: "ooh", begin: 0, end: 0.5 }],
+      },
+    ];
+    const result = textToLyricLines("Hello (ooh) world", "v1", existing);
+    expect(result[0].backgroundText).toBeUndefined();
+    expect(result[0].backgroundWords).toBeUndefined();
+  });
+
+  it("produces a fresh unmatched line with parentheses without crashing or inventing backgroundText", () => {
+    const result = textToLyricLines("Hello (ooh) world\nSecond line", "v1", []);
+    expect(result).toHaveLength(2);
+    expect(result[0].text).toBe("Hello (ooh) world");
+    expect(result[0].backgroundText).toBeUndefined();
+    expect(result[0].backgroundWords).toBeUndefined();
+  });
+
+  it("re-pasting parenthesised lyrics over an already-extracted line does not double the background text", () => {
+    const existing: LyricLine[] = [{ id: "L1", text: "Hello world", agentId: "v1", backgroundText: "ooh" }];
+    const reparsed = textToLyricLines("Hello (ooh) world", "v1", existing);
+    const extracted = extractBackgroundVocals(reparsed, { mergeStandaloneLines: false });
+    expect(extracted).toHaveLength(1);
+    expect(extracted[0].text).toBe("Hello world");
+    expect(extracted[0].backgroundText).toBe("ooh");
   });
 
   it("typo on first instance preserves the second instance's words", () => {

--- a/src/utils/lyrics-text.ts
+++ b/src/utils/lyrics-text.ts
@@ -31,7 +31,7 @@ function textToLyricLines(text: string, defaultAgentId: string, existingLines: L
   // wrong existing line, so we generate a fresh id for any unmatched typed line.
   const allowPositionMatch = newLines.length === existingLines.length;
 
-  return newLines.map((lineText, index) => {
+  const mapped = newLines.map((lineText, index) => {
     const trimmed = lineText.trim();
     const cleanedText = cleanSplitCharacters(trimmed);
     const matchText = stripSplitCharacter(cleanedText);
@@ -80,6 +80,12 @@ function textToLyricLines(text: string, defaultAgentId: string, existingLines: L
       agentId: defaultAgentId,
     };
   });
+
+  // Raw parentheses in `text` are the source of truth for background vocals;
+  // a carried-over extracted backgroundText would double on re-extraction.
+  return mapped.map((line) =>
+    /\([^)]*\)/.test(line.text) ? { ...line, backgroundText: undefined, backgroundWords: undefined } : line,
+  );
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/src/views/edit.browser.test.tsx
+++ b/src/views/edit.browser.test.tsx
@@ -1,7 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { EditPanel } from "@/views/edit";
 import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
+import { createLine } from "@/test/factories";
 import { render } from "@/test/render";
+import { EditPanel } from "@/views/edit";
+
+// -- Helpers ------------------------------------------------------------------
+
+function setTextareaValue(textarea: HTMLTextAreaElement, value: string): void {
+  Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set?.call(textarea, value);
+  textarea.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function pasteIntoTextarea(textarea: HTMLTextAreaElement, value: string): void {
+  textarea.focus();
+  textarea.dispatchEvent(new Event("paste", { bubbles: true, cancelable: true }));
+  setTextareaValue(textarea, value);
+}
+
+function previewMainTexts(container: HTMLElement): string[] {
+  return [...container.querySelectorAll('span[style*="padding-left"]')].map((el) => el.textContent ?? "");
+}
+
+function previewBackgroundTexts(container: HTMLElement): string[] {
+  return [...container.querySelectorAll("span.text-xs.italic")].map((el) => el.textContent ?? "");
+}
+
+// -- Tests --------------------------------------------------------------------
 
 describe("EditPanel", () => {
   it("renders a textarea or contenteditable region for editing lyrics", async () => {
@@ -9,5 +34,112 @@ describe("EditPanel", () => {
     const screen = await render(<EditPanel />);
     const editable = screen.container.querySelector("textarea, [contenteditable]");
     expect(editable).not.toBeNull();
+  });
+});
+
+describe("background vocal extraction", () => {
+  it("disables the header button when no line has parentheses", async () => {
+    useProjectStore.setState({
+      lines: [createLine({ text: "Hello world" }), createLine({ text: "No parens here" })],
+    });
+    const screen = await render(<EditPanel />);
+
+    const button = screen.getByRole("button", { name: "Extract background vocals" });
+    await expect.element(button).toBeDisabled();
+  });
+
+  it("enables the header button and converts inline parentheses on click", async () => {
+    useProjectStore.setState({ lines: [createLine({ text: "Hello (ooh) world" })] });
+    const screen = await render(<EditPanel />);
+
+    const button = screen.getByRole("button", { name: "Extract background vocals" });
+    await expect.element(button).toBeEnabled();
+
+    await button.click();
+
+    await expect.poll(() => previewMainTexts(screen.container)).toContain("Hello world");
+    await expect.poll(() => previewBackgroundTexts(screen.container)).toContain("ooh");
+    expect(useProjectStore.getState().lines[0].text).toBe("Hello world");
+    expect(useProjectStore.getState().lines[0].backgroundText).toBe("ooh");
+  });
+
+  it("merges a standalone parenthesis line into the line above on bulk extract", async () => {
+    useSettingsStore.setState({ mergeStandaloneBackgroundLines: true });
+    useProjectStore.setState({
+      lines: [createLine({ text: "Real lyric line" }), createLine({ text: "(ooh yeah)" })],
+    });
+    const screen = await render(<EditPanel />);
+
+    const button = screen.getByRole("button", { name: "Extract background vocals" });
+    await expect.element(button).toBeEnabled();
+    await button.click();
+
+    await expect.poll(() => useProjectStore.getState().lines.length).toBe(1);
+    expect(useProjectStore.getState().lines[0].backgroundText).toBe("ooh yeah");
+    await expect.poll(() => previewMainTexts(screen.container)).toEqual(["Real lyric line"]);
+    await expect.poll(() => previewBackgroundTexts(screen.container)).toContain("ooh yeah");
+  });
+
+  it("pulls inline parentheses from a single line via the per-line popover action", async () => {
+    useProjectStore.setState({ lines: [createLine({ id: "l1", text: "Hello (ooh) world" })] });
+    const screen = await render(<EditPanel />);
+
+    const bgTrigger = screen.getByRole("button", { name: "BG", exact: true });
+    await bgTrigger.click();
+
+    const pullButton = screen.getByRole("button", { name: "Pull from ( )" });
+    await expect.element(pullButton).toBeInTheDocument();
+    await pullButton.click();
+
+    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello world");
+    expect(useProjectStore.getState().lines[0].backgroundText).toBe("ooh");
+  });
+
+  it("hides the per-line pull action when the line has no parentheses", async () => {
+    useProjectStore.setState({ lines: [createLine({ id: "l1", text: "Hello world" })] });
+    const screen = await render(<EditPanel />);
+
+    const bgTrigger = screen.getByRole("button", { name: "BG", exact: true });
+    await bgTrigger.click();
+
+    await expect
+      .poll(() => [...document.querySelectorAll("p")].some((p) => p.textContent === "Background vocals"))
+      .toBe(true);
+    const allButtons = [...document.querySelectorAll("button")];
+    expect(allButtons.some((b) => b.textContent?.includes("Pull from ( )"))).toBe(false);
+  });
+
+  it("auto-extracts parentheses when pasting lyrics with the setting on", async () => {
+    useSettingsStore.setState({ autoExtractBackgroundVocals: true });
+    useProjectStore.setState({ lines: [] });
+    const screen = await render(<EditPanel />);
+
+    const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea).not.toBeNull();
+
+    pasteIntoTextarea(textarea, "Hello (ooh) world\nSecond (ah) line");
+
+    await expect
+      .poll(() => useProjectStore.getState().lines.map((l) => l.text))
+      .toEqual(["Hello world", "Second line"]);
+    expect(useProjectStore.getState().lines.map((l) => l.backgroundText)).toEqual(["ooh", "ah"]);
+    await expect.poll(() => previewMainTexts(screen.container)).toEqual(["Hello world", "Second line"]);
+    await expect.poll(() => previewBackgroundTexts(screen.container)).toEqual(["ooh", "ah"]);
+  });
+
+  it("keeps parentheses in the text when pasting with the setting off", async () => {
+    useSettingsStore.setState({ autoExtractBackgroundVocals: false });
+    useProjectStore.setState({ lines: [] });
+    const screen = await render(<EditPanel />);
+
+    const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea).not.toBeNull();
+
+    pasteIntoTextarea(textarea, "Hello (ooh) world\nSecond (ah) line");
+
+    await expect
+      .poll(() => useProjectStore.getState().lines.map((l) => l.text))
+      .toEqual(["Hello (ooh) world", "Second (ah) line"]);
+    expect(useProjectStore.getState().lines.every((l) => l.backgroundText === undefined)).toBe(true);
   });
 });

--- a/src/views/edit.browser.test.tsx
+++ b/src/views/edit.browser.test.tsx
@@ -19,11 +19,11 @@ function pasteIntoTextarea(textarea: HTMLTextAreaElement, value: string): void {
 }
 
 function previewMainTexts(container: HTMLElement): string[] {
-  return [...container.querySelectorAll('span[style*="padding-left"]')].map((el) => el.textContent ?? "");
+  return [...container.querySelectorAll('[data-testid="line-preview-text"]')].map((el) => el.textContent ?? "");
 }
 
 function previewBackgroundTexts(container: HTMLElement): string[] {
-  return [...container.querySelectorAll("span.text-xs.italic")].map((el) => el.textContent ?? "");
+  return [...container.querySelectorAll('[data-testid="line-preview-background"]')].map((el) => el.textContent ?? "");
 }
 
 // -- Tests --------------------------------------------------------------------

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -2,11 +2,13 @@ import { isLinked } from "@/domain/instance/predicates";
 import { useAudioStore } from "@/stores/audio";
 import { useConfirm } from "@/stores/confirm-store";
 import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
 import { getAgentColor } from "@/domain/agent/colors";
 import type { LyricLine } from "@/domain/line/model";
 import { Button } from "@/ui/button";
 import { Popover } from "@/ui/popover";
 import { Scroll } from "@/ui/scroll";
+import { extractBackgroundVocals } from "@/utils/background-vocal-extraction";
 import { type ParseResult, parseLyricsFile } from "@/utils/lyrics-parsers";
 import { remapWordTextsPreservingTiming } from "@/utils/lyrics-text";
 import { stripSplitCharacter } from "@/utils/split-character";
@@ -302,6 +304,22 @@ const EditPanel: React.FC = () => {
     return counts;
   }, [lines]);
 
+  const mergeStandalone = useSettingsStore((s) => s.mergeStandaloneBackgroundLines);
+  const extractOptions = useMemo(() => ({ mergeStandaloneLines: mergeStandalone }), [mergeStandalone]);
+  const canExtractBackgroundVocals = useMemo(() => {
+    const extracted = extractBackgroundVocals(lines, extractOptions);
+    return extracted.length !== lines.length || extracted.some((line, i) => line !== lines[i]);
+  }, [lines, extractOptions]);
+
+  const handleExtractBackgroundVocals = useCallback(() => {
+    const current = useProjectStore.getState().lines;
+    const next = extractBackgroundVocals(current, extractOptions);
+    if (next.length === current.length && next.every((line, i) => line === current[i])) return;
+    linesSetByUs.current = next;
+    useProjectStore.getState().setLinesWithHistory(next);
+    setRawText(next.map((line) => line.text).join("\n"));
+  }, [extractOptions]);
+
   const handleAgentChange = useCallback((lineId: string, agentId: string) => {
     useProjectStore.getState().updateLineWithHistory(lineId, { agentId });
   }, []);
@@ -549,6 +567,15 @@ const EditPanel: React.FC = () => {
           <span className="text-sm text-composer-text-muted">
             {nonEmptyCount} line{nonEmptyCount !== 1 ? "s" : ""}
           </span>
+          <Button
+            hasIcon
+            variant="secondary"
+            onClick={handleExtractBackgroundVocals}
+            disabled={!canExtractBackgroundVocals}
+          >
+            <IconMicrophone className="size-4" />
+            Extract background vocals
+          </Button>
           <Button hasIcon onClick={handleImportClick}>
             <IconFileImport className="size-4" />
             Import File

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -315,9 +315,10 @@ const EditPanel: React.FC = () => {
     const current = useProjectStore.getState().lines;
     const next = extractBackgroundVocals(current, extractOptions);
     if (next.length === current.length && next.every((line, i) => line === current[i])) return;
-    linesSetByUs.current = next;
     useProjectStore.getState().setLinesWithHistory(next);
-    setRawText(next.map((line) => line.text).join("\n"));
+    const committed = useProjectStore.getState().lines;
+    linesSetByUs.current = committed;
+    setRawText(committed.map((line) => line.text).join("\n"));
   }, [extractOptions]);
 
   const handleAgentChange = useCallback((lineId: string, agentId: string) => {

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -8,7 +8,7 @@ import type { LyricLine } from "@/domain/line/model";
 import { Button } from "@/ui/button";
 import { Popover } from "@/ui/popover";
 import { Scroll } from "@/ui/scroll";
-import { extractBackgroundVocals } from "@/utils/background-vocal-extraction";
+import { classifyLine, extractBackgroundVocals, extractInlineFromLine } from "@/utils/background-vocal-extraction";
 import { type ParseResult, parseLyricsFile } from "@/utils/lyrics-parsers";
 import { remapWordTextsPreservingTiming } from "@/utils/lyrics-text";
 import { stripSplitCharacter } from "@/utils/split-character";
@@ -73,6 +73,7 @@ const LinePreview: React.FC<{
   onAgentChange: (lineId: string, agentId: string) => void;
   onBulkAgentChange: (agentId: string) => void;
   onBackgroundChange: (lineId: string, text: string) => void;
+  onExtractLine: (lineId: string) => void;
   onGutterMouseDown: (lineNumber: number, e: React.MouseEvent) => void;
   onGutterMouseEnter: (lineNumber: number, e: React.MouseEvent) => void;
   didDragRef: React.MutableRefObject<boolean>;
@@ -87,6 +88,7 @@ const LinePreview: React.FC<{
   onAgentChange,
   onBulkAgentChange,
   onBackgroundChange,
+  onExtractLine,
   onGutterMouseDown,
   onGutterMouseEnter,
   didDragRef,
@@ -222,6 +224,18 @@ const LinePreview: React.FC<{
             {(close) => (
               <div className="p-2 w-48">
                 <p className="mb-1 text-xs text-composer-text-secondary">Background vocals</p>
+                {classifyLine(line.text).kind === "inline" && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (line.lineId) onExtractLine(line.lineId);
+                      close();
+                    }}
+                    className="mb-1 flex w-full items-center gap-1 text-xs cursor-pointer text-composer-accent-text hover:text-composer-accent"
+                  >
+                    Pull from ( )
+                  </button>
+                )}
                 <input
                   type="text"
                   value={bgInput}
@@ -340,6 +354,18 @@ const EditPanel: React.FC = () => {
     }
 
     useProjectStore.getState().updateLineWithHistory(lineId, updates);
+  }, []);
+
+  const handleExtractLine = useCallback((lineId: string) => {
+    const target = useProjectStore.getState().lines.find((line) => line.id === lineId);
+    if (!target) return;
+    const extracted = extractInlineFromLine(target);
+    if (extracted === target) return;
+    useProjectStore.getState().updateLineWithHistory(lineId, {
+      text: extracted.text,
+      words: extracted.words,
+      backgroundText: extracted.backgroundText,
+    });
   }, []);
 
   const handleLineSelect = useCallback(
@@ -724,6 +750,7 @@ Or drag and drop a lyrics file (.txt, .lrc, .srt, .ttml)"
                         onAgentChange={handleAgentChange}
                         onBulkAgentChange={handleBulkAgentChange}
                         onBackgroundChange={handleBackgroundChange}
+                        onExtractLine={handleExtractLine}
                         onGutterMouseDown={handleGutterMouseDown}
                         onGutterMouseEnter={handleGutterMouseEnter}
                         didDragRef={didDragRef}

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -498,9 +498,14 @@ const EditPanel: React.FC = () => {
           if (!ok) return;
         }
 
-        linesSetByUs.current = result.lines;
-        setLines(result.lines);
-        setRawText(result.lines.map((l) => l.text).join("\n"));
+        const importedLines = useSettingsStore.getState().autoExtractBackgroundVocals
+          ? extractBackgroundVocals(result.lines, {
+              mergeStandaloneLines: useSettingsStore.getState().mergeStandaloneBackgroundLines,
+            })
+          : result.lines;
+        linesSetByUs.current = importedLines;
+        setLines(importedLines);
+        setRawText(importedLines.map((l) => l.text).join("\n"));
         useProjectStore.getState().setGroups(result.groups ?? []);
 
         if (Object.keys(result.metadata).length > 0) {

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -177,13 +177,18 @@ const LinePreview: React.FC<{
       </span>
 
       <span
+        data-testid="line-preview-text"
         className={`text-sm ${line.hasBrackets ? "text-composer-error" : "text-composer-text"}`}
         style={{ borderLeft: `2px solid ${agentColor}`, paddingLeft: "6px" }}
       >
         {stripSplitCharacter(line.text)}
       </span>
 
-      {line.backgroundText && <span className="text-xs italic text-composer-text-muted">{line.backgroundText}</span>}
+      {line.backgroundText && (
+        <span data-testid="line-preview-background" className="text-xs italic text-composer-text-muted">
+          {line.backgroundText}
+        </span>
+      )}
 
       <div className="flex items-center gap-1.5 ml-auto transition-opacity opacity-0 group-hover:opacity-100">
         {agents.length > 1 && line.lineId && (

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -265,6 +265,7 @@ const EditPanel: React.FC = () => {
   rawTextRef.current = rawText;
   const linesSetByUs = useRef<LyricLine[] | null>(null);
   const modalPendingRef = useRef(false);
+  const pastedRef = useRef(false);
   const [importResult, setImportResult] = useState<{
     result: ParseResult;
     filename: string;
@@ -410,6 +411,9 @@ const EditPanel: React.FC = () => {
 
   const handleTextChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const wasPaste = pastedRef.current;
+      pastedRef.current = false;
+
       const text = e.target.value;
       const action = decideEditTextAction({
         text,
@@ -473,8 +477,15 @@ const EditPanel: React.FC = () => {
 
       if (action.kind === "noop") return;
 
-      linesSetByUs.current = action.finalLines;
-      setLines(action.finalLines);
+      let finalLines = action.finalLines;
+      if (wasPaste && useSettingsStore.getState().autoExtractBackgroundVocals) {
+        finalLines = extractBackgroundVocals(finalLines, {
+          mergeStandaloneLines: useSettingsStore.getState().mergeStandaloneBackgroundLines,
+        });
+        setRawText(finalLines.map((line) => line.text).join("\n"));
+      }
+      linesSetByUs.current = finalLines;
+      setLines(finalLines);
     },
     [confirm, defaultAgentId, groups, lines, setLines],
   );
@@ -618,6 +629,9 @@ const EditPanel: React.FC = () => {
             id={textareaId}
             value={rawText}
             onChange={handleTextChange}
+            onPaste={() => {
+              pastedRef.current = true;
+            }}
             placeholder="Paste your lyrics here, one line at a time...
 
 Or drag and drop a lyrics file (.txt, .lrc, .srt, .ttml)"


### PR DESCRIPTION
## Overview

- Fixes #91 - New `extractBackgroundVocals` transform: parenthesised text in lyrics becomes background vocals, inline `(...)` is stripped into `backgroundText`, a standalone all-parens line merges into the line above.

