### PR TITLE
Fix/instance resync sibling timing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.19.0",
+  "version": "1.19.1",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -70,7 +70,7 @@ function useSyncHandlers({
 
     if (existingWords.length > 0) {
       const updatedWords = commitTappedWord(existingWords, wordIndex, textWithSpace, currentTime, fallbackEnd);
-      updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false });
+      updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false, propagateToSiblings: false });
     } else {
       const updates: Partial<LyricLine> = {
         words: [{ text: textWithSpace, begin: currentTime, end: fallbackEnd }],
@@ -78,7 +78,7 @@ function useSyncHandlers({
       if (line.backgroundText && !line.backgroundWords?.length) {
         updates.backgroundWords = createInitialBgWords(line.backgroundText, currentTime);
       }
-      updateLineWithHistory(line.id, updates, { deriveText: false });
+      updateLineWithHistory(line.id, updates, { deriveText: false, propagateToSiblings: false });
     }
 
     if (wordIndex === 0 && prevLine?.words?.length) {
@@ -132,7 +132,7 @@ function useSyncHandlers({
     if (line.backgroundText && !line.backgroundWords?.length) {
       updates.backgroundWords = createInitialBgWords(line.backgroundText, currentTime);
     }
-    updateLineWithHistory(line.id, updates, { deriveText: false });
+    updateLineWithHistory(line.id, updates, { deriveText: false, propagateToSiblings: false });
 
     setShowPulse(true);
     setTimeout(() => setShowPulse(false), 100);
@@ -169,7 +169,7 @@ function useSyncHandlers({
 
     if (existingWords.length > 0) {
       const updatedWords = commitHeldWord(existingWords, wordIndex, textWithSpace, currentTime);
-      updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false });
+      updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false, propagateToSiblings: false });
     } else {
       const updates: Partial<LyricLine> = {
         words: [{ text: textWithSpace, begin: currentTime, end: currentTime }],
@@ -177,7 +177,7 @@ function useSyncHandlers({
       if (line.backgroundText && !line.backgroundWords?.length) {
         updates.backgroundWords = createInitialBgWords(line.backgroundText, currentTime);
       }
-      updateLineWithHistory(line.id, updates, { deriveText: false });
+      updateLineWithHistory(line.id, updates, { deriveText: false, propagateToSiblings: false });
     }
 
     if (wordIndex === 0 && prevLine?.words?.length) {
@@ -201,7 +201,7 @@ function useSyncHandlers({
     const updatedWords = [...line.words];
     const currentWordEntry = updatedWords[updatedWords.length - 1];
     updatedWords[updatedWords.length - 1] = { ...currentWordEntry, end: currentTime };
-    updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false });
+    updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false, propagateToSiblings: false });
 
     setShowPulse(true);
     setTimeout(() => setShowPulse(false), 100);
@@ -236,7 +236,7 @@ function useSyncHandlers({
     const advancesToNextLine = nextWordIndex >= lineWords.length;
 
     if (advancesToNextLine) {
-      updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false });
+      updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false, propagateToSiblings: false });
 
       const nextLine = lines[lineIndex + 1];
       if (nextLine) {
@@ -250,7 +250,7 @@ function useSyncHandlers({
           if (nextLine.backgroundText && !nextLine.backgroundWords?.length) {
             nextUpdates.backgroundWords = createInitialBgWords(nextLine.backgroundText, currentTime);
           }
-          updateLineWithHistory(nextLine.id, nextUpdates, { deriveText: false });
+          updateLineWithHistory(nextLine.id, nextUpdates, { deriveText: false, propagateToSiblings: false });
         }
       }
 
@@ -264,7 +264,7 @@ function useSyncHandlers({
         const textWithSpace = trailingSpace[nextWordIndex] ? `${nextWordText} ` : nextWordText;
         updatedWords.push({ text: textWithSpace, begin: currentTime, end: currentTime });
       }
-      updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false });
+      updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false, propagateToSiblings: false });
 
       setSyncState((prev) => ({
         ...prev,
@@ -304,7 +304,7 @@ function useSyncHandlers({
         backgroundWords: undefined,
       },
     }));
-    useProjectStore.getState().updateLinesWithHistory(updates);
+    useProjectStore.getState().updateLinesWithHistory(updates, { propagateToSiblings: false });
     setSyncState({ position: { lineIndex: 0, wordIndex: 0 }, isActive: false });
   }, [lines, setSyncState, confirm]);
 

--- a/src/stores/project.propagation-opt-out.test.ts
+++ b/src/stores/project.propagation-opt-out.test.ts
@@ -1,0 +1,560 @@
+/**
+ * @vitest-environment node
+ */
+import type { LinkGroup } from "@/domain/group/template";
+import type { WordTiming } from "@/domain/word/timing";
+import { useProjectStore } from "@/stores/project";
+import { commitTappedWord, splitIntoWordsWithMeta } from "@/utils/sync-helpers";
+import { nudgeLineBegin } from "@/utils/timing/line-timing";
+import { nudgeWordBegin, setWordBegin } from "@/utils/timing/word-timing";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// Regression coverage for issue #96: resyncing one instance of a group must not
+// retime the other instances. The shared root cause is that per-instance timing
+// edits routed through updateLineWithHistory / updateLinesWithHistory triggered
+// smart-sync propagation. The propagateToSiblings option opts those writes out.
+
+beforeEach(() => {
+  useProjectStore.getState().reset();
+  useProjectStore.getState().clearHistory();
+});
+
+function seedGroup(id: string): LinkGroup {
+  return { id, label: "Chorus", color: "#f472b6", templateVersion: 1 };
+}
+
+const INSTANCE_A_WORDS: WordTiming[] = [
+  { text: "I ", begin: 0, end: 0.4 },
+  { text: "love ", begin: 0.4, end: 0.8 },
+  { text: "you", begin: 0.8, end: 1.2 },
+];
+
+const INSTANCE_B_WORDS: WordTiming[] = [
+  { text: "I ", begin: 10, end: 10.5 },
+  { text: "love ", begin: 10.5, end: 11.0 },
+  { text: "you", begin: 11.0, end: 11.5 },
+];
+
+// Seeds in a single setState and marks the store dirty-since-history so the
+// first *WithHistory mutation snapshots this state as the undo baseline.
+function seedTwoWordSyncedInstances() {
+  useProjectStore.setState({
+    groups: [seedGroup("g1")],
+    lines: [
+      {
+        id: "a0",
+        text: "I love you",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 0,
+        templateLineIdx: 0,
+        words: INSTANCE_A_WORDS.map((w) => ({ ...w })),
+      },
+      {
+        id: "a1",
+        text: "I love you",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 1,
+        templateLineIdx: 0,
+        words: INSTANCE_B_WORDS.map((w) => ({ ...w })),
+      },
+    ],
+    isDirtySinceHistory: true,
+  });
+}
+
+const MERGED_WORDS: WordTiming[] = [
+  { text: "I ", begin: 0, end: 0.4 },
+  { text: "love you", begin: 0.4, end: 1.2 },
+];
+
+function getLine(id: string) {
+  const line = useProjectStore.getState().lines.find((l) => l.id === id);
+  if (!line) throw new Error(`line ${id} not found`);
+  return line;
+}
+
+describe("updateLineWithHistory · propagateToSiblings: false", () => {
+  it("does not retime a sibling when the source word count shrinks", () => {
+    seedTwoWordSyncedInstances();
+
+    useProjectStore
+      .getState()
+      .updateLineWithHistory("a0", { words: [{ text: "I ", begin: 5, end: 5.4 }] }, { propagateToSiblings: false });
+
+    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+  });
+
+  it("does not retime a sibling when the source word count grows", () => {
+    seedTwoWordSyncedInstances();
+
+    const grown: WordTiming[] = [...INSTANCE_A_WORDS, { text: "you", begin: 1.2, end: 1.6 }];
+    useProjectStore.getState().updateLineWithHistory("a0", { words: grown }, { propagateToSiblings: false });
+
+    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+  });
+
+  it("does not reorder a sibling's word texts when the source word order changes", () => {
+    seedTwoWordSyncedInstances();
+
+    const reordered: WordTiming[] = [
+      { text: "love ", begin: 0, end: 0.4 },
+      { text: "I ", begin: 0.4, end: 0.8 },
+      { text: "you", begin: 0.8, end: 1.2 },
+    ];
+    useProjectStore.getState().updateLineWithHistory("a0", { words: reordered }, { propagateToSiblings: false });
+
+    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+  });
+
+  it("does not retime a sibling's background words", () => {
+    useProjectStore.getState().addGroup(seedGroup("g1"));
+    const bgA: WordTiming[] = [{ text: "ah", begin: 0, end: 0.5 }];
+    const bgB: WordTiming[] = [{ text: "ah", begin: 20, end: 20.5 }];
+    useProjectStore.setState({
+      lines: [
+        {
+          id: "a0",
+          text: "lead",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          backgroundText: "ah",
+          backgroundWords: bgA.map((w) => ({ ...w })),
+        },
+        {
+          id: "a1",
+          text: "lead",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          backgroundText: "ah",
+          backgroundWords: bgB.map((w) => ({ ...w })),
+        },
+      ],
+    });
+
+    useProjectStore.getState().updateLineWithHistory(
+      "a0",
+      {
+        backgroundWords: [
+          { text: "ah", begin: 1, end: 1.2 },
+          { text: "ah", begin: 1.2, end: 1.4 },
+        ],
+      },
+      { propagateToSiblings: false },
+    );
+
+    expect(getLine("a1").backgroundWords).toEqual(bgB);
+  });
+
+  it("still writes the source line", () => {
+    seedTwoWordSyncedInstances();
+    const sourceWords: WordTiming[] = [{ text: "I ", begin: 9, end: 9.5 }];
+
+    useProjectStore.getState().updateLineWithHistory("a0", { words: sourceWords }, { propagateToSiblings: false });
+
+    expect(getLine("a0").words).toEqual(sourceWords);
+  });
+
+  it("still propagates structural word changes by default (option defaults to true)", () => {
+    seedTwoWordSyncedInstances();
+
+    useProjectStore.getState().updateLineWithHistory("a0", { words: MERGED_WORDS });
+
+    expect(getLine("a1").words).toHaveLength(2);
+  });
+
+  it("works for a non-grouped line (regression)", () => {
+    useProjectStore.setState({ lines: [{ id: "s", text: "standalone", agentId: "v1" }] });
+
+    useProjectStore
+      .getState()
+      .updateLineWithHistory(
+        "s",
+        { words: [{ text: "standalone", begin: 1, end: 2 }] },
+        { propagateToSiblings: false },
+      );
+
+    expect(getLine("s").words).toEqual([{ text: "standalone", begin: 1, end: 2 }]);
+  });
+
+  it("commits a single history entry that undo reverts", () => {
+    seedTwoWordSyncedInstances();
+
+    useProjectStore
+      .getState()
+      .updateLineWithHistory("a0", { words: [{ text: "I ", begin: 5, end: 5.4 }] }, { propagateToSiblings: false });
+    useProjectStore.getState().undo();
+
+    expect(getLine("a0").words).toEqual(INSTANCE_A_WORDS);
+    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+  });
+});
+
+describe("updateLinesWithHistory · propagateToSiblings: false", () => {
+  it("does not retime siblings of any line in the batch", () => {
+    seedTwoWordSyncedInstances();
+
+    useProjectStore
+      .getState()
+      .updateLinesWithHistory([{ id: "a0", updates: { words: [{ text: "I ", begin: 5, end: 5.4 }] } }], {
+        propagateToSiblings: false,
+      });
+
+    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+  });
+
+  it("still propagates structural word changes by default", () => {
+    seedTwoWordSyncedInstances();
+
+    useProjectStore.getState().updateLinesWithHistory([{ id: "a0", updates: { words: MERGED_WORDS } }]);
+
+    expect(getLine("a1").words).toHaveLength(2);
+  });
+});
+
+describe("instance resync · issue #96 reproduction", () => {
+  // Replays the tap-by-tap word resync that useSyncHandlers.handleTapWord
+  // performs, using the real commitTappedWord helper.
+  function tapResync(lineId: string, wordIndex: number, begin: number, end: number) {
+    const line = getLine(lineId);
+    const { parts, trailingSpace } = splitIntoWordsWithMeta(line.text);
+    const text = trailingSpace[wordIndex] ? `${parts[wordIndex]} ` : parts[wordIndex];
+    const updated = commitTappedWord(line.words ?? [], wordIndex, text, begin, end);
+    useProjectStore
+      .getState()
+      .updateLineWithHistory(lineId, { words: updated }, { deriveText: false, propagateToSiblings: false });
+  }
+
+  it("resyncing instance A word-by-word leaves instance B's timing untouched", () => {
+    seedTwoWordSyncedInstances();
+
+    tapResync("a0", 0, 0.5, 0.8);
+    tapResync("a0", 1, 1.0, 1.3);
+    tapResync("a0", 2, 1.5, 1.8);
+
+    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+  });
+
+  it("the resynced instance A keeps its full word set with the new timing", () => {
+    seedTwoWordSyncedInstances();
+
+    tapResync("a0", 0, 0.5, 0.8);
+    tapResync("a0", 1, 1.0, 1.3);
+    tapResync("a0", 2, 1.5, 1.8);
+
+    expect(getLine("a0").words).toEqual([
+      { text: "I ", begin: 0.5, end: 1.0 },
+      { text: "love ", begin: 1.0, end: 1.5 },
+      { text: "you", begin: 1.5, end: 1.8 },
+    ]);
+  });
+
+  it("resyncing does not squash a third instance either", () => {
+    useProjectStore.getState().addGroup(seedGroup("g1"));
+    const cWords: WordTiming[] = [
+      { text: "I ", begin: 30, end: 30.6 },
+      { text: "love ", begin: 30.6, end: 31.2 },
+      { text: "you", begin: 31.2, end: 31.8 },
+    ];
+    useProjectStore.setState({
+      lines: [
+        {
+          id: "a0",
+          text: "I love you",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          words: INSTANCE_A_WORDS.map((w) => ({ ...w })),
+        },
+        {
+          id: "a1",
+          text: "I love you",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          words: INSTANCE_B_WORDS.map((w) => ({ ...w })),
+        },
+        {
+          id: "a2",
+          text: "I love you",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 2,
+          templateLineIdx: 0,
+          words: cWords.map((w) => ({ ...w })),
+        },
+      ],
+    });
+
+    tapResync("a0", 0, 0.5, 0.8);
+    tapResync("a0", 1, 1.0, 1.3);
+    tapResync("a0", 2, 1.5, 1.8);
+
+    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+    expect(getLine("a2").words).toEqual(cWords);
+  });
+
+  it("a single partial tap (the worst-case squash state) leaves the sibling intact", () => {
+    seedTwoWordSyncedInstances();
+
+    // Resync only word 0 and stop. Mid-resync the source array transiently
+    // holds one word: this is the state that previously collapsed the sibling.
+    tapResync("a0", 0, 0.5, 0.8);
+
+    expect(getLine("a0").words).toHaveLength(1);
+    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+    expect(getLine("a1").words).toHaveLength(3);
+  });
+
+  it("characterizes the bug: a resync left to propagate DOES squash the sibling", () => {
+    seedTwoWordSyncedInstances();
+
+    // The pre-fix call signature: handleTapWord passed only { deriveText: false }
+    // with no opt-out, so propagation fired on the transient one-word array and
+    // collapsed the sibling. This is the behavior the opt-out must prevent.
+    const line = getLine("a0");
+    const { parts, trailingSpace } = splitIntoWordsWithMeta(line.text);
+    const text = trailingSpace[0] ? `${parts[0]} ` : parts[0];
+    const updated = commitTappedWord(line.words ?? [], 0, text, 0.5, 0.8);
+    useProjectStore.getState().updateLineWithHistory("a0", { words: updated }, { deriveText: false });
+
+    expect(getLine("a1").words).toHaveLength(1);
+    expect(getLine("a1").words).not.toEqual(INSTANCE_B_WORDS);
+  });
+});
+
+describe("propagateToSiblings: false · edge cases", () => {
+  it("leaves a detached sibling untouched", () => {
+    seedTwoWordSyncedInstances();
+    useProjectStore.setState((s) => ({
+      lines: s.lines.map((l) => (l.id === "a1" ? { ...l, detached: true } : l)),
+    }));
+
+    useProjectStore
+      .getState()
+      .updateLineWithHistory("a0", { words: [{ text: "I ", begin: 5, end: 5.4 }] }, { propagateToSiblings: false });
+
+    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+  });
+
+  it("does not throw and changes nothing for an unknown line id", () => {
+    seedTwoWordSyncedInstances();
+
+    expect(() =>
+      useProjectStore.getState().updateLineWithHistory("nope", { words: [] }, { propagateToSiblings: false }),
+    ).not.toThrow();
+    expect(getLine("a0").words).toEqual(INSTANCE_A_WORDS);
+    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+  });
+
+  it("handles a single-instance group with no siblings", () => {
+    useProjectStore.getState().addGroup(seedGroup("g1"));
+    useProjectStore.setState({
+      lines: [
+        {
+          id: "solo",
+          text: "I love you",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          words: INSTANCE_A_WORDS.map((w) => ({ ...w })),
+        },
+      ],
+    });
+
+    expect(() =>
+      useProjectStore
+        .getState()
+        .updateLineWithHistory("solo", { words: [{ text: "I ", begin: 5, end: 5.4 }] }, { propagateToSiblings: false }),
+    ).not.toThrow();
+    expect(getLine("solo").words).toEqual([{ text: "I ", begin: 5, end: 5.4 }]);
+  });
+
+  it("does not touch lines belonging to a different group", () => {
+    seedTwoWordSyncedInstances();
+    const otherWords: WordTiming[] = [{ text: "other", begin: 50, end: 51 }];
+    useProjectStore.setState((s) => ({
+      lines: [
+        ...s.lines,
+        {
+          id: "x",
+          text: "other",
+          agentId: "v1",
+          groupId: "g2",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          words: otherWords.map((w) => ({ ...w })),
+        },
+      ],
+    }));
+
+    useProjectStore
+      .getState()
+      .updateLineWithHistory("a0", { words: [{ text: "I ", begin: 5, end: 5.4 }] }, { propagateToSiblings: false });
+
+    expect(getLine("x").words).toEqual(otherWords);
+  });
+
+  it("leaves the sibling intact even when the sibling already diverged in word count", () => {
+    useProjectStore.getState().addGroup(seedGroup("g1"));
+    const divergedB: WordTiming[] = [
+      { text: "I ", begin: 10, end: 10.5 },
+      { text: "love you", begin: 10.5, end: 11.5 },
+    ];
+    useProjectStore.setState({
+      lines: [
+        {
+          id: "a0",
+          text: "I love you",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          words: INSTANCE_A_WORDS.map((w) => ({ ...w })),
+        },
+        {
+          id: "a1",
+          text: "I love you",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          words: divergedB.map((w) => ({ ...w })),
+        },
+      ],
+    });
+
+    useProjectStore
+      .getState()
+      .updateLineWithHistory("a0", { words: [{ text: "I ", begin: 5, end: 5.4 }] }, { propagateToSiblings: false });
+
+    expect(getLine("a1").words).toEqual(divergedB);
+  });
+
+  it("updateLinesWithHistory opt-out does not throw on an empty batch", () => {
+    seedTwoWordSyncedInstances();
+    expect(() => useProjectStore.getState().updateLinesWithHistory([], { propagateToSiblings: false })).not.toThrow();
+  });
+
+  it("updateLinesWithHistory opt-out spares the siblings of every batched line", () => {
+    useProjectStore.getState().addGroup(seedGroup("g1"));
+    const mk = (id: string, templateLineIdx: number, instanceIdx: number, words: WordTiming[]) => ({
+      id,
+      text: "I love you",
+      agentId: "v1",
+      groupId: "g1",
+      instanceIdx,
+      templateLineIdx,
+      words: words.map((w) => ({ ...w })),
+    });
+    useProjectStore.setState({
+      lines: [
+        mk("t0i0", 0, 0, INSTANCE_A_WORDS),
+        mk("t1i0", 1, 0, INSTANCE_A_WORDS),
+        mk("t0i1", 0, 1, INSTANCE_B_WORDS),
+        mk("t1i1", 1, 1, INSTANCE_B_WORDS),
+      ],
+    });
+
+    useProjectStore.getState().updateLinesWithHistory(
+      [
+        { id: "t0i0", updates: { words: [{ text: "I ", begin: 5, end: 5.4 }] } },
+        { id: "t1i0", updates: { words: [{ text: "I ", begin: 6, end: 6.4 }] } },
+      ],
+      { propagateToSiblings: false },
+    );
+
+    expect(getLine("t0i1").words).toEqual(INSTANCE_B_WORDS);
+    expect(getLine("t1i1").words).toEqual(INSTANCE_B_WORDS);
+  });
+});
+
+describe("timing nudges · do not propagate to siblings", () => {
+  it("nudgeWordBegin on one instance leaves the sibling's words untouched", () => {
+    seedTwoWordSyncedInstances();
+
+    nudgeWordBegin(useProjectStore.getState().lines, 0, 1, 0.1, useProjectStore.getState().updateLineWithHistory);
+
+    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+  });
+
+  it("setWordBegin does not overwrite a sibling word whose text has diverged", () => {
+    // A nudge is a pure timing edit. Before the opt-out it ran propagation,
+    // and propagation's fast path would copy the source word texts onto a
+    // text-diverged sibling. A timing edit must never rewrite sibling text.
+    useProjectStore.setState({
+      groups: [seedGroup("g1")],
+      lines: [
+        {
+          id: "a0",
+          text: "I love you",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          words: INSTANCE_A_WORDS.map((w) => ({ ...w })),
+        },
+        {
+          id: "a1",
+          text: "I love you",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          words: [
+            { text: "I ", begin: 10, end: 10.5 },
+            { text: "LOVE ", begin: 10.5, end: 11.0 },
+            { text: "you", begin: 11.0, end: 11.5 },
+          ],
+        },
+      ],
+      isDirtySinceHistory: true,
+    });
+
+    setWordBegin(useProjectStore.getState().lines, 0, 0, 0.2, useProjectStore.getState().updateLineWithHistory);
+
+    expect(getLine("a1").words?.[1].text).toBe("LOVE ");
+  });
+
+  it("nudgeLineBegin on one line-synced instance leaves the sibling's bounds untouched", () => {
+    useProjectStore.setState({
+      groups: [seedGroup("g1")],
+      lines: [
+        {
+          id: "a0",
+          text: "I love you",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          begin: 30,
+          end: 32,
+        },
+        {
+          id: "a1",
+          text: "I love you",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          begin: 60,
+          end: 62,
+        },
+      ],
+      isDirtySinceHistory: true,
+    });
+
+    nudgeLineBegin(useProjectStore.getState().lines, 0, 0.5, useProjectStore.getState().updateLineWithHistory);
+
+    expect(getLine("a1").begin).toBe(60);
+    expect(getLine("a1").end).toBe(62);
+  });
+});

--- a/src/stores/project/lines-slice.ts
+++ b/src/stores/project/lines-slice.ts
@@ -52,8 +52,9 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
 
   updateLineWithHistory: (id, updates, options = {}) =>
     set((state) => {
+      const { propagateToSiblings = true, ...historyOptions } = options;
       const target = state.lines.find((l) => l.id === id);
-      const linkScope = target ? getLinkScope(target) : null;
+      const linkScope = propagateToSiblings && target ? getLinkScope(target) : null;
       const linkedUpdates = linkScope ? extractLinkedFields(updates) : null;
       const sourceWordsBefore = target?.words;
       const sourceWordsAfter = updates.words;
@@ -77,11 +78,12 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
         return line;
       });
 
-      return commitHistory(state, { lines: newLines }, options);
+      return commitHistory(state, { lines: newLines }, historyOptions);
     }),
 
   updateLinesWithHistory: (updates, options = {}) =>
     set((state) => {
+      const { propagateToSiblings = true, ...historyOptions } = options;
       const newLines = [...state.lines];
       const indexById = new Map<string, number>();
       for (let i = 0; i < newLines.length; i++) indexById.set(newLines[i].id, i);
@@ -89,7 +91,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
       for (const { id, updates: lineUpdates } of updates) {
         const targetIdx = indexById.get(id);
         const target = targetIdx !== undefined ? newLines[targetIdx] : undefined;
-        const linkScope = target ? getLinkScope(target) : null;
+        const linkScope = propagateToSiblings && target ? getLinkScope(target) : null;
         const sourceWordsBefore = target?.words;
         const sourceWordsAfter = lineUpdates.words;
         const sourceBgBefore = target?.backgroundWords;
@@ -115,7 +117,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
         }
       }
 
-      return commitHistory(state, { lines: newLines }, options);
+      return commitHistory(state, { lines: newLines }, historyOptions);
     }),
 
   moveWordToBg: (lineId, wordIndices, timeDelta, duration) =>

--- a/src/stores/project/types.ts
+++ b/src/stores/project/types.ts
@@ -112,10 +112,14 @@ interface LineActions {
   setLines: (lines: LyricLine[]) => void;
   setLinesWithHistory: (lines: LyricLine[], groups?: LinkGroup[]) => void;
   updateLine: (id: string, updates: Partial<LyricLine>, options?: { deriveText?: boolean }) => void;
-  updateLineWithHistory: (id: string, updates: Partial<LyricLine>, options?: { deriveText?: boolean }) => void;
+  updateLineWithHistory: (
+    id: string,
+    updates: Partial<LyricLine>,
+    options?: { deriveText?: boolean; propagateToSiblings?: boolean },
+  ) => void;
   updateLinesWithHistory: (
     updates: Array<{ id: string; updates: Partial<LyricLine> }>,
-    options?: { deriveText?: boolean },
+    options?: { deriveText?: boolean; propagateToSiblings?: boolean },
   ) => void;
   moveWordToBg: (lineId: string, wordIndices: number[], timeDelta: number, duration: number) => void;
   moveWordFromBg: (lineId: string, wordIndices: number[], timeDelta: number, duration: number) => void;

--- a/src/utils/timing/line-timing.ts
+++ b/src/utils/timing/line-timing.ts
@@ -1,6 +1,10 @@
 import type { LyricLine } from "@/domain/line/model";
 
-type UpdateLineWithHistory = (id: string, updates: Partial<LyricLine>) => void;
+type UpdateLineWithHistory = (
+  id: string,
+  updates: Partial<LyricLine>,
+  options?: { propagateToSiblings?: boolean },
+) => void;
 
 function nudgeLineBegin(
   lines: LyricLine[],
@@ -13,10 +17,7 @@ function nudgeLineBegin(
 
   const newBegin = Math.max(0, line.begin + delta);
   const duration = line.end - line.begin;
-  updateLineWithHistory(line.id, {
-    begin: newBegin,
-    end: newBegin + duration,
-  });
+  updateLineWithHistory(line.id, { begin: newBegin, end: newBegin + duration }, { propagateToSiblings: false });
 }
 
 function setLineBegin(
@@ -29,10 +30,7 @@ function setLineBegin(
   if (line?.begin === undefined) return;
 
   const duration = line.end - line.begin;
-  updateLineWithHistory(line.id, {
-    begin: newBegin,
-    end: newBegin + duration,
-  });
+  updateLineWithHistory(line.id, { begin: newBegin, end: newBegin + duration }, { propagateToSiblings: false });
 }
 
 export { nudgeLineBegin, setLineBegin };

--- a/src/utils/timing/word-timing-ops.ts
+++ b/src/utils/timing/word-timing-ops.ts
@@ -3,7 +3,11 @@ import type { WordTiming } from "@/domain/word/timing";
 
 // -- Types --------------------------------------------------------------------
 
-type UpdateLineWithHistory = (id: string, updates: Partial<LyricLine>) => void;
+type UpdateLineWithHistory = (
+  id: string,
+  updates: Partial<LyricLine>,
+  options?: { propagateToSiblings?: boolean },
+) => void;
 
 interface WordFieldConfig {
   getWords: (line: LyricLine) => WordTiming[] | undefined;
@@ -34,7 +38,9 @@ function createWordTimingOps(config: WordFieldConfig) {
     const newBegin = Math.min(word.end, Math.max(minBegin, word.begin + delta));
 
     updatedWords[wordIdx] = { ...word, begin: newBegin };
-    updateLineWithHistory(line.id, { [updateKey]: updatedWords } as Partial<LyricLine>);
+    updateLineWithHistory(line.id, { [updateKey]: updatedWords } as Partial<LyricLine>, {
+      propagateToSiblings: false,
+    });
   }
 
   function setBegin(
@@ -55,7 +61,9 @@ function createWordTimingOps(config: WordFieldConfig) {
     const minBegin = prevWord?.end ?? 0;
     const clampedBegin = Math.min(word.end, Math.max(minBegin, newBegin));
     updatedWords[wordIdx] = { ...word, begin: clampedBegin };
-    updateLineWithHistory(line.id, { [updateKey]: updatedWords } as Partial<LyricLine>);
+    updateLineWithHistory(line.id, { [updateKey]: updatedWords } as Partial<LyricLine>, {
+      propagateToSiblings: false,
+    });
   }
 
   function nudgeEnd(
@@ -77,7 +85,9 @@ function createWordTimingOps(config: WordFieldConfig) {
     const newEnd = Math.min(maxEnd, Math.max(word.begin, word.end + delta));
 
     updatedWords[wordIdx] = { ...word, end: newEnd };
-    updateLineWithHistory(line.id, { [updateKey]: updatedWords } as Partial<LyricLine>);
+    updateLineWithHistory(line.id, { [updateKey]: updatedWords } as Partial<LyricLine>, {
+      propagateToSiblings: false,
+    });
   }
 
   function setEnd(
@@ -98,7 +108,9 @@ function createWordTimingOps(config: WordFieldConfig) {
     const maxEnd = nextWord?.begin ?? Number.POSITIVE_INFINITY;
     const clampedEnd = Math.min(maxEnd, Math.max(word.begin, newEnd));
     updatedWords[wordIdx] = { ...word, end: clampedEnd };
-    updateLineWithHistory(line.id, { [updateKey]: updatedWords } as Partial<LyricLine>);
+    updateLineWithHistory(line.id, { [updateKey]: updatedWords } as Partial<LyricLine>, {
+      propagateToSiblings: false,
+    });
   }
 
   return { nudgeBegin, setBegin, nudgeEnd, setEnd };

--- a/src/views/timeline/timeline-info-panel.tsx
+++ b/src/views/timeline/timeline-info-panel.tsx
@@ -184,9 +184,9 @@ const TimelineInfoPanel: React.FC = () => {
     updatedWords[wordIndex] = { ...word, begin: clampedBegin };
 
     if (selectedWord.type === "word") {
-      updateLineWithHistory(line.id, { words: updatedWords });
+      updateLineWithHistory(line.id, { words: updatedWords }, { propagateToSiblings: false });
     } else {
-      updateLineWithHistory(line.id, manualBackgroundWordEdit(updatedWords));
+      updateLineWithHistory(line.id, manualBackgroundWordEdit(updatedWords), { propagateToSiblings: false });
     }
   }, [selectedWord, lines, updateLineWithHistory]);
 
@@ -213,9 +213,9 @@ const TimelineInfoPanel: React.FC = () => {
     updatedWords[wordIndex] = { ...word, end: clampedEnd };
 
     if (selectedWord.type === "word") {
-      updateLineWithHistory(line.id, { words: updatedWords });
+      updateLineWithHistory(line.id, { words: updatedWords }, { propagateToSiblings: false });
     } else {
-      updateLineWithHistory(line.id, manualBackgroundWordEdit(updatedWords));
+      updateLineWithHistory(line.id, manualBackgroundWordEdit(updatedWords), { propagateToSiblings: false });
     }
   }, [selectedWord, lines, duration, updateLineWithHistory]);
 

--- a/src/views/timeline/timeline-rows.tsx
+++ b/src/views/timeline/timeline-rows.tsx
@@ -90,7 +90,7 @@ const TimelineRows: React.FC<TimelineRowsProps> = ({ scrollContainerRef }) => {
         const lineUpdates: Partial<LyricLine> = {};
         if (updates.begin !== undefined) lineUpdates.begin = updates.begin;
         if (updates.end !== undefined) lineUpdates.end = updates.end;
-        updateLineWithHistory(lineId, lineUpdates);
+        updateLineWithHistory(lineId, lineUpdates, { propagateToSiblings: false });
         return;
       }
 
@@ -102,7 +102,7 @@ const TimelineRows: React.FC<TimelineRowsProps> = ({ scrollContainerRef }) => {
         adjacentIndex !== undefined && adjacentUpdates ? { index: adjacentIndex, updates: adjacentUpdates } : undefined,
       );
       if (!updatedWords) return;
-      updateLineWithHistory(lineId, { words: updatedWords });
+      updateLineWithHistory(lineId, { words: updatedWords }, { propagateToSiblings: false });
     },
     [lines, updateLineWithHistory],
   );
@@ -125,7 +125,7 @@ const TimelineRows: React.FC<TimelineRowsProps> = ({ scrollContainerRef }) => {
         adjacentIndex !== undefined && adjacentUpdates ? { index: adjacentIndex, updates: adjacentUpdates } : undefined,
       );
       if (!updatedWords) return;
-      updateLineWithHistory(lineId, manualBackgroundWordEdit(updatedWords));
+      updateLineWithHistory(lineId, manualBackgroundWordEdit(updatedWords), { propagateToSiblings: false });
     },
     [lines, updateLineWithHistory],
   );

--- a/src/views/timeline/use-timeline-dnd.ts
+++ b/src/views/timeline/use-timeline-dnd.ts
@@ -141,7 +141,7 @@ function handleAltDuplicate(event: DragEndEvent, lines: LyricLine[], zoom: numbe
   }
 
   if (updates.length > 0) {
-    useProjectStore.getState().updateLinesWithHistory(updates);
+    useProjectStore.getState().updateLinesWithHistory(updates, { propagateToSiblings: false });
   }
 }
 
@@ -307,7 +307,7 @@ function useTimelineDnd(lines: LyricLine[]) {
         }
 
         if (updates.length > 0) {
-          useProjectStore.getState().updateLinesWithHistory(updates);
+          useProjectStore.getState().updateLinesWithHistory(updates, { propagateToSiblings: false });
         }
       } else {
         const wordsArray = activeData.trackType === "word" ? line.words : line.backgroundWords;
@@ -318,9 +318,11 @@ function useTimelineDnd(lines: LyricLine[]) {
 
         const normalized = reorderWordTrack(wordsArray, new Set([wordIndex]), timeDelta, duration);
         if (activeData.trackType === "word") {
-          updateLineWithHistory(activeData.lineId, { words: normalized });
+          updateLineWithHistory(activeData.lineId, { words: normalized }, { propagateToSiblings: false });
         } else {
-          updateLineWithHistory(activeData.lineId, manualBackgroundWordEdit(normalized));
+          updateLineWithHistory(activeData.lineId, manualBackgroundWordEdit(normalized), {
+            propagateToSiblings: false,
+          });
         }
       }
     },

--- a/src/views/timeline/use-timeline-keyboard.ts
+++ b/src/views/timeline/use-timeline-keyboard.ts
@@ -166,9 +166,9 @@ function useTimelineKeyboard(
 
       const updateLineWithHistory = useProjectStore.getState().updateLineWithHistory;
       if (targetWord.type === "word") {
-        updateLineWithHistory(line.id, { words: updatedWords });
+        updateLineWithHistory(line.id, { words: updatedWords }, { propagateToSiblings: false });
       } else {
-        updateLineWithHistory(line.id, manualBackgroundWordEdit(updatedWords));
+        updateLineWithHistory(line.id, manualBackgroundWordEdit(updatedWords), { propagateToSiblings: false });
       }
     },
     [lines, duration, scrollContainerRef],
@@ -634,9 +634,11 @@ function useTimelineKeyboard(
           const result = shiftSelectionsTogether(rawLines, partitioned, requestedDelta, duration);
           if (result.updates.length === 0) break;
           if (result.updates.length === 1) {
-            useProjectStore.getState().updateLineWithHistory(result.updates[0].id, result.updates[0].updates);
+            useProjectStore.getState().updateLineWithHistory(result.updates[0].id, result.updates[0].updates, {
+              propagateToSiblings: false,
+            });
           } else {
-            useProjectStore.getState().updateLinesWithHistory(result.updates);
+            useProjectStore.getState().updateLinesWithHistory(result.updates, { propagateToSiblings: false });
           }
           break;
         }


### PR DESCRIPTION
## Overview

- Fixes #96 - Add `propagateToSiblings` opt-out to `updateLineWithHistory` / `updateLinesWithHistory`; per-instance timing edits no longer propagate to linked siblings


