### PR TITLE
fix: preserve sync on unchanged split-character lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.19.0",
+  "version": "1.19.2",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/domain/line/reconcile-text.test.ts
+++ b/src/domain/line/reconcile-text.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import type { LyricLine } from "@/domain/line/model";
+import { reconcileMatchedTiming } from "@/domain/line/reconcile-text";
+
+describe("reconcileMatchedTiming", () => {
+  it("returns the same reference when the typed text is identical", () => {
+    const line: LyricLine = {
+      id: "L1",
+      text: "Dengar|lah rindu yang menyik|sa i|ni",
+      agentId: "v1",
+      words: [
+        { text: "Dengar", begin: 1, end: 1.2 },
+        { text: "lah ", begin: 1.2, end: 1.4 },
+        { text: "rindu ", begin: 1.4, end: 1.6 },
+        { text: "yang ", begin: 1.6, end: 1.8 },
+        { text: "menyik", begin: 1.8, end: 2 },
+        { text: "sa ", begin: 2, end: 2.2 },
+        { text: "i", begin: 2.2, end: 2.4 },
+        { text: "ni", begin: 2.4, end: 2.6 },
+      ],
+    };
+    const result = reconcileMatchedTiming(line, "Dengar|lah rindu yang menyik|sa i|ni");
+    expect(result).toBe(line);
+  });
+
+  it("preserves begin/end on an untouched line-synced line that contains split characters", () => {
+    const line: LyricLine = {
+      id: "L0",
+      text: "Dengar|lah rindu",
+      agentId: "v1",
+      begin: 1,
+      end: 2,
+    };
+    const result = reconcileMatchedTiming(line, "Dengar|lah rindu");
+    expect(result).toBe(line);
+  });
+
+  it("remaps words when split positions move but the syllable count is unchanged", () => {
+    const line: LyricLine = {
+      id: "L0",
+      text: "Den|garlah rin|du",
+      agentId: "v1",
+      words: [
+        { text: "Den", begin: 0, end: 0.5 },
+        { text: "garlah ", begin: 0.5, end: 1 },
+        { text: "rin", begin: 1, end: 1.5 },
+        { text: "du", begin: 1.5, end: 2 },
+      ],
+    };
+    const result = reconcileMatchedTiming(line, "Dengar|lah rin|du");
+    expect(result.text).toBe("Dengar|lah rin|du");
+    expect(result.words?.map((w) => w.begin)).toEqual([0, 0.5, 1, 1.5]);
+    expect(result.words?.map((w) => w.end)).toEqual([0.5, 1, 1.5, 2]);
+    expect(result.words?.map((w) => w.text)).toEqual(["Dengar", "lah ", "rin", "du"]);
+  });
+
+  it("clears word timing when the syllable count actually changes", () => {
+    const line: LyricLine = {
+      id: "L0",
+      text: "Dengar|lah",
+      agentId: "v1",
+      words: [
+        { text: "Dengar", begin: 0, end: 0.5 },
+        { text: "lah", begin: 0.5, end: 1 },
+      ],
+    };
+    const result = reconcileMatchedTiming(line, "Dengar|lah|extra");
+    expect(result.text).toBe("Dengar|lah|extra");
+    expect(result.words).toBeUndefined();
+  });
+
+  it("clears begin/end on a line-synced line whose text content actually changed", () => {
+    const line: LyricLine = {
+      id: "L0",
+      text: "Dengarlah rindu",
+      agentId: "v1",
+      begin: 1,
+      end: 2,
+    };
+    const result = reconcileMatchedTiming(line, "Dengarlah rindu sayang");
+    expect(result.text).toBe("Dengarlah rindu sayang");
+    expect(result.begin).toBeUndefined();
+    expect(result.end).toBeUndefined();
+  });
+});
+
+describe("reconcileMatchedTiming · edge cases", () => {
+  it("returns the same reference for an untimed line whose text is identical", () => {
+    const line: LyricLine = { id: "L0", text: "no timing here", agentId: "v1" };
+    const result = reconcileMatchedTiming(line, "no timing here");
+    expect(result).toBe(line);
+  });
+
+  it("updates text on an untimed line whose text changed", () => {
+    const line: LyricLine = { id: "L0", text: "old", agentId: "v1" };
+    const result = reconcileMatchedTiming(line, "new");
+    expect(result.text).toBe("new");
+    expect(result.words).toBeUndefined();
+    expect(result.begin).toBeUndefined();
+    expect(result.end).toBeUndefined();
+  });
+
+  it("treats an empty words array as no timing and clears on text change", () => {
+    const line: LyricLine = {
+      id: "L0",
+      text: "Dengar|lah",
+      agentId: "v1",
+      words: [],
+    };
+    const result = reconcileMatchedTiming(line, "Dengar|lah|extra");
+    expect(result.text).toBe("Dengar|lah|extra");
+    expect(result.words).toBeUndefined();
+    expect(result.begin).toBeUndefined();
+    expect(result.end).toBeUndefined();
+  });
+
+  it("does not mutate the input line or its words array", () => {
+    const originalWords = [
+      { text: "Den", begin: 0, end: 0.5 },
+      { text: "garlah ", begin: 0.5, end: 1 },
+      { text: "rin", begin: 1, end: 1.5 },
+      { text: "du", begin: 1.5, end: 2 },
+    ];
+    const line: LyricLine = {
+      id: "L0",
+      text: "Den|garlah rin|du",
+      agentId: "v1",
+      words: originalWords,
+    };
+    const beforeText = line.text;
+    const beforeWords = line.words;
+    const beforeWordsSnapshot = JSON.parse(JSON.stringify(line.words));
+    reconcileMatchedTiming(line, "Dengar|lah rin|du");
+    expect(line.text).toBe(beforeText);
+    expect(line.words).toBe(beforeWords);
+    expect(line.words).toEqual(beforeWordsSnapshot);
+  });
+
+  it("preserves background-vocal fields on the remap path", () => {
+    const line: LyricLine = {
+      id: "L0",
+      text: "Den|garlah rin|du",
+      agentId: "v1",
+      words: [
+        { text: "Den", begin: 0, end: 0.5 },
+        { text: "garlah ", begin: 0.5, end: 1 },
+        { text: "rin", begin: 1, end: 1.5 },
+        { text: "du", begin: 1.5, end: 2 },
+      ],
+      backgroundText: "ooh",
+      backgroundWords: [{ text: "ooh", begin: 0.2, end: 0.8 }],
+      backgroundTextSource: "manual",
+    };
+    const result = reconcileMatchedTiming(line, "Dengar|lah rin|du");
+    expect(result.backgroundText).toBe("ooh");
+    expect(result.backgroundWords).toEqual([{ text: "ooh", begin: 0.2, end: 0.8 }]);
+    expect(result.backgroundTextSource).toBe("manual");
+  });
+
+  it("preserves background-vocal fields on the clear path", () => {
+    const line: LyricLine = {
+      id: "L0",
+      text: "Dengar|lah",
+      agentId: "v1",
+      words: [
+        { text: "Dengar", begin: 0, end: 0.5 },
+        { text: "lah", begin: 0.5, end: 1 },
+      ],
+      backgroundText: "ooh",
+      backgroundWords: [{ text: "ooh", begin: 0.2, end: 0.8 }],
+      backgroundTextSource: "extraction",
+    };
+    const result = reconcileMatchedTiming(line, "Dengar|lah|extra");
+    expect(result.backgroundText).toBe("ooh");
+    expect(result.backgroundWords).toEqual([{ text: "ooh", begin: 0.2, end: 0.8 }]);
+    expect(result.backgroundTextSource).toBe("extraction");
+  });
+
+  it("preserves group fields (groupId, instanceIdx, templateLineIdx) on both paths", () => {
+    const wordSynced: LyricLine = {
+      id: "L0",
+      text: "Den|garlah rin|du",
+      agentId: "v1",
+      words: [
+        { text: "Den", begin: 0, end: 0.5 },
+        { text: "garlah ", begin: 0.5, end: 1 },
+        { text: "rin", begin: 1, end: 1.5 },
+        { text: "du", begin: 1.5, end: 2 },
+      ],
+      groupId: "g1",
+      instanceIdx: 0,
+      templateLineIdx: 0,
+    };
+    const remapped = reconcileMatchedTiming(wordSynced, "Dengar|lah rin|du");
+    expect(remapped.groupId).toBe("g1");
+    expect(remapped.instanceIdx).toBe(0);
+    expect(remapped.templateLineIdx).toBe(0);
+
+    const cleared = reconcileMatchedTiming(wordSynced, "totally different content here now");
+    expect(cleared.groupId).toBe("g1");
+    expect(cleared.instanceIdx).toBe(0);
+    expect(cleared.templateLineIdx).toBe(0);
+  });
+});

--- a/src/domain/line/reconcile-text.ts
+++ b/src/domain/line/reconcile-text.ts
@@ -1,5 +1,5 @@
 import { reconcileLine, type LyricLine } from "@/domain/line/model";
-import { remapWordTextsPreservingTiming } from "@/utils/lyrics-text";
+import { remapWordTextsPreservingTiming } from "@/domain/word/remap-text";
 
 // The single chokepoint for re-deciding timing-staleness after a text edit:
 // both the exact-match and position-match branches of textToLyricLines route

--- a/src/domain/line/reconcile-text.ts
+++ b/src/domain/line/reconcile-text.ts
@@ -1,0 +1,21 @@
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { remapWordTextsPreservingTiming } from "@/utils/lyrics-text";
+
+// The single chokepoint for re-deciding timing-staleness after a text edit:
+// both the exact-match and position-match branches of textToLyricLines route
+// through here so they cannot drift apart and clear timing on lines the user
+// never touched.
+function reconcileMatchedTiming(line: LyricLine, cleanedText: string): LyricLine {
+  if (line.text === cleanedText) return line;
+
+  if (line.words && line.words.length > 0) {
+    const remapped = remapWordTextsPreservingTiming(line.words, cleanedText);
+    if (remapped) {
+      return reconcileLine({ ...line, text: cleanedText, words: remapped });
+    }
+  }
+
+  return reconcileLine({ ...line, text: cleanedText, words: undefined, begin: undefined, end: undefined });
+}
+
+export { reconcileMatchedTiming };

--- a/src/domain/word/remap-text.ts
+++ b/src/domain/word/remap-text.ts
@@ -1,0 +1,14 @@
+import type { WordTiming } from "@/domain/word/timing";
+import { splitIntoWordsWithMeta } from "@/utils/sync-helpers";
+
+// Maps the new typed text onto an existing words array by tokenising the same
+// way the sync pipeline does (whitespace + split character). Returns null when
+// the syllable count differs, so callers know to clear timing rather than
+// silently shift word boundaries.
+function remapWordTextsPreservingTiming(oldWords: WordTiming[], newText: string): WordTiming[] | null {
+  const { parts, trailingSpace } = splitIntoWordsWithMeta(newText);
+  if (parts.length !== oldWords.length) return null;
+  return oldWords.map((oldWord, i) => ({ ...oldWord, text: parts[i] + (trailingSpace[i] ? " " : "") }));
+}
+
+export { remapWordTextsPreservingTiming };

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -5,8 +5,8 @@ import type { LyricLine } from "@/domain/line/model";
 import { reconcileLine } from "@/domain/line/model";
 import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
 import { reconstructLineText, wordContentSpans } from "@/domain/line/reconstruct-text";
+import { remapWordTextsPreservingTiming } from "@/domain/word/remap-text";
 import type { WordTiming } from "@/domain/word/timing";
-import { remapWordTextsPreservingTiming } from "@/utils/lyrics-text";
 import { getSplitCharacter } from "@/utils/split-character";
 import { createInitialBgWords } from "@/utils/sync-helpers";
 

--- a/src/utils/lyrics-text.test.ts
+++ b/src/utils/lyrics-text.test.ts
@@ -365,3 +365,39 @@ describe("textToLyricLines · group attrs preservation", () => {
     expect(result[1].words).toEqual(existing[1].words);
   });
 });
+
+describe("textToLyricLines · split-character timing preservation", () => {
+  it("preserves word timing on untouched split-character lines when a blank line is appended", () => {
+    const existing: LyricLine[] = [
+      {
+        id: "L0",
+        text: "Suara hujan",
+        agentId: "v1",
+        words: [
+          { text: "Suara ", begin: 0, end: 0.5 },
+          { text: "hujan", begin: 0.5, end: 1 },
+        ],
+      },
+      {
+        id: "L1",
+        text: "Dengar|lah rindu yang menyik|sa i|ni",
+        agentId: "v1",
+        words: [
+          { text: "Dengar", begin: 1, end: 1.2 },
+          { text: "lah ", begin: 1.2, end: 1.4 },
+          { text: "rindu ", begin: 1.4, end: 1.6 },
+          { text: "yang ", begin: 1.6, end: 1.8 },
+          { text: "menyik", begin: 1.8, end: 2 },
+          { text: "sa ", begin: 2, end: 2.2 },
+          { text: "i", begin: 2.2, end: 2.4 },
+          { text: "ni", begin: 2.4, end: 2.6 },
+        ],
+      },
+    ];
+    const result = textToLyricLines("Suara hujan\nDengar|lah rindu yang menyik|sa i|ni\n", "v1", existing);
+    expect(result).toHaveLength(3);
+    expect(result[1].id).toBe("L1");
+    expect(result[1].text).toBe("Dengar|lah rindu yang menyik|sa i|ni");
+    expect(result[1].words).toEqual(existing[1].words);
+  });
+});

--- a/src/utils/lyrics-text.ts
+++ b/src/utils/lyrics-text.ts
@@ -1,15 +1,7 @@
 import { CLEARED_BACKGROUND } from "@/domain/line/background";
 import type { LyricLine } from "@/domain/line/model";
 import { reconcileMatchedTiming } from "@/domain/line/reconcile-text";
-import type { WordTiming } from "@/domain/word/timing";
 import { cleanSplitCharacters, stripSplitCharacter } from "@/utils/split-character";
-import { splitIntoWordsWithMeta } from "@/utils/sync-helpers";
-
-function remapWordTextsPreservingTiming(oldWords: WordTiming[], newText: string): WordTiming[] | null {
-  const { parts, trailingSpace } = splitIntoWordsWithMeta(newText);
-  if (parts.length !== oldWords.length) return null;
-  return oldWords.map((oldWord, i) => ({ ...oldWord, text: parts[i] + (trailingSpace[i] ? " " : "") }));
-}
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -67,4 +59,4 @@ function textToLyricLines(text: string, defaultAgentId: string, existingLines: L
 
 // -- Exports ------------------------------------------------------------------
 
-export { remapWordTextsPreservingTiming, textToLyricLines };
+export { textToLyricLines };

--- a/src/utils/lyrics-text.ts
+++ b/src/utils/lyrics-text.ts
@@ -1,7 +1,8 @@
 import { CLEARED_BACKGROUND } from "@/domain/line/background";
 import type { LyricLine } from "@/domain/line/model";
+import { reconcileMatchedTiming } from "@/domain/line/reconcile-text";
 import type { WordTiming } from "@/domain/word/timing";
-import { cleanSplitCharacters, getSplitCharacter, stripSplitCharacter } from "@/utils/split-character";
+import { cleanSplitCharacters, stripSplitCharacter } from "@/utils/split-character";
 import { splitIntoWordsWithMeta } from "@/utils/sync-helpers";
 
 function remapWordTextsPreservingTiming(oldWords: WordTiming[], newText: string): WordTiming[] | null {
@@ -41,37 +42,14 @@ function textToLyricLines(text: string, defaultAgentId: string, existingLines: L
     const exactMatch = candidates?.find((line) => !usedExistingIds.has(line.id));
     if (exactMatch) {
       usedExistingIds.add(exactMatch.id);
-      if (cleanedText.includes(getSplitCharacter())) {
-        return {
-          ...exactMatch,
-          text: cleanedText,
-          words: undefined,
-          begin: undefined,
-          end: undefined,
-        };
-      }
-      return { ...exactMatch };
+      return reconcileMatchedTiming(exactMatch, cleanedText);
     }
 
     if (allowPositionMatch) {
       const positionMatch = existingLines[index];
       if (positionMatch && !usedExistingIds.has(positionMatch.id)) {
         usedExistingIds.add(positionMatch.id);
-
-        if (positionMatch.words?.length) {
-          const remapped = remapWordTextsPreservingTiming(positionMatch.words, cleanedText);
-          if (remapped) {
-            return { ...positionMatch, text: cleanedText, words: remapped };
-          }
-        }
-
-        return {
-          ...positionMatch,
-          text: cleanedText,
-          words: undefined,
-          begin: undefined,
-          end: undefined,
-        };
+        return reconcileMatchedTiming(positionMatch, cleanedText);
       }
     }
 

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -14,7 +14,7 @@ import { Popover } from "@/ui/popover";
 import { Scroll } from "@/ui/scroll";
 import { classifyLine, extractBackgroundVocals, extractInlineFromLine } from "@/utils/background-vocal-extraction";
 import { type ParseResult, parseLyricsFile } from "@/utils/lyrics-parsers";
-import { remapWordTextsPreservingTiming } from "@/utils/lyrics-text";
+import { remapWordTextsPreservingTiming } from "@/domain/word/remap-text";
 import { stripSplitCharacter } from "@/utils/split-character";
 import { AgentManager } from "@/views/edit/agent-manager";
 import { decideEditTextAction } from "@/views/edit/decide-edit-text-action";


### PR DESCRIPTION
## Overview

- `textToLyricLines` cleared `words`/`begin`/`end` on every matched line whose text contained `|`, so any unrelated keystroke dropped sync across the song.
