### PR TITLE
refactor: extract persistence-idb shared module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.22.0",
+  "version": "1.22.1",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.22.1",
+  "version": "1.23.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/audio/separation/demucs-postprocess.ts
+++ b/src/audio/separation/demucs-postprocess.ts
@@ -95,5 +95,4 @@ function extractVocalsStem(timeTensor: TensorLike, freqTensor: TensorLike): Floa
 
 // -- Exports ------------------------------------------------------------------
 
-export { STEM_INDEX_VOCALS, normalizeForDemucs, denormalizeDemucsOutput, extractVocalsStem };
-export type { NormalizationStats, NormalizedAudio, TensorLike };
+export { normalizeForDemucs, denormalizeDemucsOutput, extractVocalsStem };

--- a/src/audio/separation/stem-store.ts
+++ b/src/audio/separation/stem-store.ts
@@ -1,5 +1,5 @@
 import type { Stem } from "@/audio/separation/types";
-import { STEM_STORE_NAME, openDB } from "@/lib/persistence";
+import { STEM_STORE_NAME, openDB } from "@/lib/persistence-idb";
 import type { VocalModelVariant } from "@/stores/settings";
 
 const MAX_ENTRIES = 3;

--- a/src/hooks/usePersistence.stem.browser.test.tsx
+++ b/src/hooks/usePersistence.stem.browser.test.tsx
@@ -3,6 +3,7 @@ import { usePersistence } from "@/hooks/usePersistence";
 import { loadCurrentProject } from "@/lib/persistence";
 import { cancelPendingSave } from "@/lib/persistence-debounce";
 import { getPersistenceSettled } from "@/lib/persistence-settled";
+import { useAudioStore } from "@/stores/audio";
 import { useSeparationStore } from "@/stores/separation";
 import { useSettingsStore } from "@/stores/settings";
 import { seedProject } from "@/test/idb";
@@ -138,5 +139,39 @@ describe("usePersistence:saved project field shape", () => {
     useSeparationStore.getState().selectStem("instrumental");
 
     await expect.poll(async () => (await loadCurrentProject())?.currentStem).toBe("instrumental");
+  });
+});
+
+// -- Regression: audio-only setup (no lyrics, no title) ---------------------
+
+describe("usePersistence:stem persists in audio-only sessions", () => {
+  it("persists the stem when the user has audio loaded but no project content", async () => {
+    // No seeded project, no title, no lines. The realistic "I'm trying out
+    // vocal separation before writing lyrics" flow that previously hit the
+    // empty-project save guard and never wrote currentStem.
+    await render(<HookHost />);
+    await getPersistenceSettled();
+    fastSaves();
+
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "song.mp3", { type: "audio/mpeg" });
+    useAudioStore.getState().setSource({ type: "file", file });
+    useSeparationStore.setState({ availableStems: ["original", "vocals", "instrumental"] });
+
+    useSeparationStore.getState().selectStem("vocals");
+
+    await expect.poll(async () => (await loadCurrentProject())?.currentStem).toBe("vocals");
+  });
+
+  it("does not save when there is neither audio nor lyrics (true empty session)", async () => {
+    await render(<HookHost />);
+    await getPersistenceSettled();
+    fastSaves();
+    useSeparationStore.setState({ availableStems: ["original", "vocals", "instrumental"] });
+
+    useSeparationStore.getState().selectStem("vocals");
+
+    // Nothing about the session is worth persisting; project record stays absent.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(await loadCurrentProject()).toBeUndefined();
   });
 });

--- a/src/hooks/usePersistence.stem.browser.test.tsx
+++ b/src/hooks/usePersistence.stem.browser.test.tsx
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { usePersistence } from "@/hooks/usePersistence";
+import { loadCurrentProject } from "@/lib/persistence";
+import { cancelPendingSave } from "@/lib/persistence-debounce";
+import { getPersistenceSettled } from "@/lib/persistence-settled";
+import { useSeparationStore } from "@/stores/separation";
+import { useSettingsStore } from "@/stores/settings";
+import { seedProject } from "@/test/idb";
+import { render } from "@/test/render";
+
+// -- Test infrastructure ------------------------------------------------------
+
+const HookHost: React.FC = () => {
+  usePersistence();
+  return null;
+};
+
+// Tighten the debounce to 0 so save side-effects land within the test window.
+function fastSaves(): void {
+  useSettingsStore.getState().set("autoSaveDelay", 0);
+}
+
+function seedSavedProject(currentStem?: "original" | "vocals" | "instrumental"): Promise<void> {
+  return seedProject({
+    version: 1,
+    savedAt: Date.now(),
+    metadata: { title: "Seeded Song", artist: "", album: "", duration: 0 },
+    lines: [],
+    agents: [{ id: "v1", type: "person", name: "Lead" }],
+    granularity: "word",
+    ...(currentStem ? { currentStem } : {}),
+  });
+}
+
+async function pollSavedStem(): Promise<"original" | "vocals" | "instrumental" | undefined> {
+  const saved = await loadCurrentProject();
+  return saved?.currentStem;
+}
+
+beforeEach(() => {
+  cancelPendingSave();
+});
+
+// -- Load: restore saved stem -------------------------------------------------
+
+describe("usePersistence:load: restore saved stem", () => {
+  it("restores 'vocals' when the saved project had vocals selected", async () => {
+    await seedSavedProject("vocals");
+
+    await render(<HookHost />);
+    await getPersistenceSettled();
+
+    expect(useSeparationStore.getState().currentStem).toBe("vocals");
+  });
+
+  it("restores 'instrumental' when the saved project had instrumental selected", async () => {
+    await seedSavedProject("instrumental");
+
+    await render(<HookHost />);
+    await getPersistenceSettled();
+
+    expect(useSeparationStore.getState().currentStem).toBe("instrumental");
+  });
+
+  it("leaves the store at 'original' when the saved project has no currentStem field (older project)", async () => {
+    await seedSavedProject();
+
+    await render(<HookHost />);
+    await getPersistenceSettled();
+
+    expect(useSeparationStore.getState().currentStem).toBe("original");
+  });
+
+  it("leaves the store at 'original' on a cold-start with no saved project", async () => {
+    await render(<HookHost />);
+    await getPersistenceSettled();
+
+    expect(useSeparationStore.getState().currentStem).toBe("original");
+  });
+});
+
+// -- Save: stem change triggers persistence -----------------------------------
+
+describe("usePersistence:save: stem changes are persisted", () => {
+  it("persists a stem selection made after load", async () => {
+    await seedSavedProject();
+    await render(<HookHost />);
+    await getPersistenceSettled();
+    fastSaves();
+    useSeparationStore.setState({ availableStems: ["original", "vocals", "instrumental"] });
+
+    useSeparationStore.getState().selectStem("vocals");
+
+    await expect.poll(pollSavedStem).toBe("vocals");
+  });
+
+  it("persists the latest stem when the user switches rapidly", async () => {
+    await seedSavedProject();
+    await render(<HookHost />);
+    await getPersistenceSettled();
+    fastSaves();
+    useSeparationStore.setState({ availableStems: ["original", "vocals", "instrumental"] });
+
+    const { selectStem } = useSeparationStore.getState();
+    selectStem("vocals");
+    selectStem("instrumental");
+    selectStem("original");
+
+    await expect.poll(pollSavedStem).toBe("original");
+  });
+
+  it("does not change the stored stem when selectStem is called with an unavailable stem", async () => {
+    await seedSavedProject("original");
+    await render(<HookHost />);
+    await getPersistenceSettled();
+    fastSaves();
+    // availableStems intentionally not expanded; "vocals" is not selectable.
+
+    useSeparationStore.getState().selectStem("vocals");
+
+    // selectStem silently no-ops; currentStem stays at "original" so no save
+    // delta. We poll briefly: the value should remain "original" the whole time.
+    await expect.poll(pollSavedStem).toBe("original");
+    expect(useSeparationStore.getState().currentStem).toBe("original");
+  });
+});
+
+// -- Boundary: stale projects without the field -----------------------------
+
+describe("usePersistence:saved project field shape", () => {
+  it("writes currentStem into the saved project record", async () => {
+    await seedSavedProject();
+    await render(<HookHost />);
+    await getPersistenceSettled();
+    fastSaves();
+    useSeparationStore.setState({ availableStems: ["original", "vocals", "instrumental"] });
+
+    useSeparationStore.getState().selectStem("instrumental");
+
+    await expect.poll(async () => (await loadCurrentProject())?.currentStem).toBe("instrumental");
+  });
+});

--- a/src/hooks/usePersistence.stem.browser.test.tsx
+++ b/src/hooks/usePersistence.stem.browser.test.tsx
@@ -162,16 +162,22 @@ describe("usePersistence:stem persists in audio-only sessions", () => {
     await expect.poll(async () => (await loadCurrentProject())?.currentStem).toBe("vocals");
   });
 
-  it("does not save when there is neither audio nor lyrics (true empty session)", async () => {
+  // This mirrors the real-world flow: default debounce delay (no fastSaves
+  // shortcut). The user picks a stem and immediately reloads, within the
+  // 2-second debounce window. The save must still land.
+  it("persists across an immediate reload at the default debounce delay", async () => {
     await render(<HookHost />);
     await getPersistenceSettled();
-    fastSaves();
+    // intentionally NOT calling fastSaves(); use the real autoSaveDelay.
+
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "song.mp3", { type: "audio/mpeg" });
+    useAudioStore.getState().setSource({ type: "file", file });
     useSeparationStore.setState({ availableStems: ["original", "vocals", "instrumental"] });
 
     useSeparationStore.getState().selectStem("vocals");
+    // Reload immediately, before the 2-second debounce fires.
+    window.dispatchEvent(new Event("beforeunload"));
 
-    // Nothing about the session is worth persisting; project record stays absent.
-    await new Promise((resolve) => setTimeout(resolve, 30));
-    expect(await loadCurrentProject()).toBeUndefined();
+    await expect.poll(async () => (await loadCurrentProject())?.currentStem).toBe("vocals");
   });
 });

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -5,7 +5,7 @@ import {
   saveAudioFile,
   type SavedAudioSource,
 } from "@/lib/persistence";
-import { debouncedSave, flushPendingSave } from "@/lib/persistence-debounce";
+import { debouncedSave, flushPendingSave, saveProjectNow } from "@/lib/persistence-debounce";
 import { markPersistenceSettled } from "@/lib/persistence-settled";
 import { type AudioSource, useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
@@ -35,7 +35,9 @@ function playableFile(source: AudioSource): File | null {
   return null;
 }
 
-function commitProjectSave(): void {
+type ProjectSaveArgs = Parameters<typeof debouncedSave>;
+
+function buildSaveArgs(): ProjectSaveArgs | null {
   const projectState = useProjectStore.getState();
   const liveAudioSource = useAudioStore.getState().source;
   // Skip only when the session is truly empty. Audio-loaded sessions need to
@@ -43,21 +45,33 @@ function commitProjectSave(): void {
   // before the user types any lyrics.
   const hasContent = projectState.lines.length > 0 || projectState.metadata.title;
   const hasContext = liveAudioSource !== null;
-  if (!hasContent && !hasContext) return;
-  const audioSource = toSavedAudioSource(liveAudioSource);
-  const currentStem = useSeparationStore.getState().currentStem;
-  debouncedSave(
+  if (!hasContent && !hasContext) return null;
+  return [
     projectState.metadata,
     projectState.agents,
     projectState.lines,
     projectState.groups,
     projectState.granularity,
     projectState.syllableSplitDefaults,
-    audioSource,
+    toSavedAudioSource(liveAudioSource),
     projectState.dismissedSuggestions,
     projectState.dismissedExplicitSuggestions,
-    currentStem,
-  );
+    useSeparationStore.getState().currentStem,
+  ];
+}
+
+function commitProjectSave(): void {
+  const args = buildSaveArgs();
+  if (!args) return;
+  debouncedSave(...args);
+}
+
+// Discrete user actions (stem picking) should not wait for the typing-tuned
+// debounce. Skipping it means the save lands in IDB before the user can reload.
+function commitProjectSaveNow(): void {
+  const args = buildSaveArgs();
+  if (!args) return;
+  saveProjectNow(...args).catch((err) => console.error(LOG_PREFIX, "Immediate save failed:", err));
 }
 
 // -- Hook ---------------------------------------------------------------------
@@ -131,12 +145,13 @@ function usePersistence(): void {
 
   // Stem selection lives in a separate store, so changes to currentStem alone
   // don't mark the project dirty and wouldn't trigger the project subscription
-  // above. Subscribe to currentStem directly so picking a stem from the
-  // dropdown persists across reloads.
+  // above. Subscribe to currentStem directly and save IMMEDIATELY (no debounce):
+  // picking a stem is a discrete action and the user can reload at any time,
+  // so the debounce window would silently lose the choice.
   useEffect(() => {
     const unsubscribe = useSeparationStore.subscribe((state, prevState) => {
       if (state.currentStem === prevState.currentStem) return;
-      commitProjectSave();
+      commitProjectSaveNow();
     });
     return () => unsubscribe();
   }, []);
@@ -180,9 +195,13 @@ function usePersistence(): void {
 
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      // Always flush so debounced saves (title edits, lyrics typing, anything
+      // queued within the debounce window) land in IDB before the page closes.
+      // The leave-confirmation prompt below stays gated on meaningful project
+      // content so we don't nag on every audio-only reload.
+      flushPendingSave();
       const state = useProjectStore.getState();
       if (state.isDirty && state.lines.length > 0) {
-        flushPendingSave();
         e.preventDefault();
         return "";
       }

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -91,7 +91,7 @@ function usePersistence(): void {
         // which preserves currentStem when the cached stems are still available, and
         // falls back to "original" when they aren't (LRU eviction or variant change).
         if (project?.currentStem) {
-          useSeparationStore.setState({ currentStem: project.currentStem });
+          useSeparationStore.getState().restoreCurrentStem(project.currentStem);
         }
 
         const savedSource = project?.audioSource;
@@ -128,10 +128,8 @@ function usePersistence(): void {
   // above. Subscribe to currentStem directly so picking a stem from the
   // dropdown persists across reloads.
   useEffect(() => {
-    let prevStem = useSeparationStore.getState().currentStem;
-    const unsubscribe = useSeparationStore.subscribe((state) => {
-      if (state.currentStem === prevStem) return;
-      prevStem = state.currentStem;
+    const unsubscribe = useSeparationStore.subscribe((state, prevState) => {
+      if (state.currentStem === prevState.currentStem) return;
       commitProjectSave();
     });
     return () => unsubscribe();

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -37,8 +37,14 @@ function playableFile(source: AudioSource): File | null {
 
 function commitProjectSave(): void {
   const projectState = useProjectStore.getState();
-  if (projectState.lines.length === 0 && !projectState.metadata.title) return;
-  const audioSource = toSavedAudioSource(useAudioStore.getState().source);
+  const liveAudioSource = useAudioStore.getState().source;
+  // Skip only when the session is truly empty. Audio-loaded sessions need to
+  // persist non-lyric fields like currentStem and the audio source kind, even
+  // before the user types any lyrics.
+  const hasContent = projectState.lines.length > 0 || projectState.metadata.title;
+  const hasContext = liveAudioSource !== null;
+  if (!hasContent && !hasContext) return;
+  const audioSource = toSavedAudioSource(liveAudioSource);
   const currentStem = useSeparationStore.getState().currentStem;
   debouncedSave(
     projectState.metadata,

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -3,9 +3,10 @@ import {
   loadAudioFile,
   loadCurrentProject,
   saveAudioFile,
+  saveCurrentProject,
   type SavedAudioSource,
 } from "@/lib/persistence";
-import { debouncedSave, flushPendingSave, saveProjectNow } from "@/lib/persistence-debounce";
+import { cancelPendingSave, debouncedSave, flushPendingSave } from "@/lib/persistence-debounce";
 import { markPersistenceSettled } from "@/lib/persistence-settled";
 import { type AudioSource, useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
@@ -67,11 +68,13 @@ function commitProjectSave(): void {
 }
 
 // Discrete user actions (stem picking) should not wait for the typing-tuned
-// debounce. Skipping it means the save lands in IDB before the user can reload.
+// debounce. Cancel any queued debounced save so it can't overwrite this one
+// with stale args, then write to IDB now.
 function commitProjectSaveNow(): void {
   const args = buildSaveArgs();
   if (!args) return;
-  saveProjectNow(...args).catch((err) => console.error(LOG_PREFIX, "Immediate save failed:", err));
+  cancelPendingSave();
+  saveCurrentProject(...args).catch((err) => console.error(LOG_PREFIX, "Immediate save failed:", err));
 }
 
 // -- Hook ---------------------------------------------------------------------

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -11,6 +11,7 @@ import { type AudioSource, useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { DEFAULT_SYLLABLE_SPLIT_DEFAULTS } from "@/stores/project/types";
 import { DEFAULT_AGENTS } from "@/domain/agent/colors";
+import { useSeparationStore } from "@/stores/separation";
 import { useSettingsStore } from "@/stores/settings";
 import { useEffect } from "react";
 
@@ -66,6 +67,14 @@ function usePersistence(): void {
           state.markClean();
         }
 
+        // Restore the saved stem selection BEFORE setting the audio source.
+        // useAutoSeparate's source subscription will then run refreshForCurrentSource
+        // which preserves currentStem when the cached stems are still available, and
+        // falls back to "original" when they aren't (LRU eviction or variant change).
+        if (project?.currentStem) {
+          useSeparationStore.setState({ currentStem: project.currentStem });
+        }
+
         const savedSource = project?.audioSource;
         if (savedSource?.kind === "youtube") {
           useAudioStore.getState().setYouTubeSource(savedSource.videoId, file);
@@ -92,6 +101,7 @@ function usePersistence(): void {
       if (!state.isDirty) return;
       if (state.lines.length > 0 || state.metadata.title) {
         const audioSource = toSavedAudioSource(useAudioStore.getState().source);
+        const currentStem = useSeparationStore.getState().currentStem;
         debouncedSave(
           state.metadata,
           state.agents,
@@ -102,6 +112,7 @@ function usePersistence(): void {
           audioSource,
           state.dismissedSuggestions,
           state.dismissedExplicitSuggestions,
+          currentStem,
         );
       }
     });

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -35,6 +35,25 @@ function playableFile(source: AudioSource): File | null {
   return null;
 }
 
+function commitProjectSave(): void {
+  const projectState = useProjectStore.getState();
+  if (projectState.lines.length === 0 && !projectState.metadata.title) return;
+  const audioSource = toSavedAudioSource(useAudioStore.getState().source);
+  const currentStem = useSeparationStore.getState().currentStem;
+  debouncedSave(
+    projectState.metadata,
+    projectState.agents,
+    projectState.lines,
+    projectState.groups,
+    projectState.granularity,
+    projectState.syllableSplitDefaults,
+    audioSource,
+    projectState.dismissedSuggestions,
+    projectState.dismissedExplicitSuggestions,
+    currentStem,
+  );
+}
+
 // -- Hook ---------------------------------------------------------------------
 
 function usePersistence(): void {
@@ -99,24 +118,22 @@ function usePersistence(): void {
   useEffect(() => {
     const unsubscribe = useProjectStore.subscribe((state) => {
       if (!state.isDirty) return;
-      if (state.lines.length > 0 || state.metadata.title) {
-        const audioSource = toSavedAudioSource(useAudioStore.getState().source);
-        const currentStem = useSeparationStore.getState().currentStem;
-        debouncedSave(
-          state.metadata,
-          state.agents,
-          state.lines,
-          state.groups,
-          state.granularity,
-          state.syllableSplitDefaults,
-          audioSource,
-          state.dismissedSuggestions,
-          state.dismissedExplicitSuggestions,
-          currentStem,
-        );
-      }
+      commitProjectSave();
     });
+    return () => unsubscribe();
+  }, []);
 
+  // Stem selection lives in a separate store, so changes to currentStem alone
+  // don't mark the project dirty and wouldn't trigger the project subscription
+  // above. Subscribe to currentStem directly so picking a stem from the
+  // dropdown persists across reloads.
+  useEffect(() => {
+    let prevStem = useSeparationStore.getState().currentStem;
+    const unsubscribe = useSeparationStore.subscribe((state) => {
+      if (state.currentStem === prevStem) return;
+      prevStem = state.currentStem;
+      commitProjectSave();
+    });
     return () => unsubscribe();
   }, []);
 

--- a/src/lib/persistence-debounce.ts
+++ b/src/lib/persistence-debounce.ts
@@ -88,6 +88,37 @@ function flushPendingSave(): void {
   }
 }
 
+// Skip the debounce entirely and write to IDB now. Used for discrete user
+// actions (stem selection) where the debounce buys nothing and an immediate
+// reload would otherwise lose the save. Cancels any pending debounced save so
+// the immediate write isn't shadowed by a stale queued one.
+function saveProjectNow(
+  metadata: ProjectMetadata,
+  agents: Agent[],
+  lines: LyricLine[],
+  groups: LinkGroup[],
+  granularity: GranularityMode,
+  syllableSplitDefaults: SyllableSplitDefaults,
+  audioSource: SavedAudioSource | undefined,
+  dismissedSuggestions: string[],
+  dismissedExplicitSuggestions: string[],
+  currentStem: Stem,
+): Promise<void> {
+  cancelPendingSave();
+  return saveCurrentProject(
+    metadata,
+    agents,
+    lines,
+    groups,
+    granularity,
+    syllableSplitDefaults,
+    audioSource,
+    dismissedSuggestions,
+    dismissedExplicitSuggestions,
+    currentStem,
+  );
+}
+
 // -- Exports ------------------------------------------------------------------
 
-export { debouncedSave, cancelPendingSave, flushPendingSave };
+export { debouncedSave, cancelPendingSave, flushPendingSave, saveProjectNow };

--- a/src/lib/persistence-debounce.ts
+++ b/src/lib/persistence-debounce.ts
@@ -88,37 +88,6 @@ function flushPendingSave(): void {
   }
 }
 
-// Skip the debounce entirely and write to IDB now. Used for discrete user
-// actions (stem selection) where the debounce buys nothing and an immediate
-// reload would otherwise lose the save. Cancels any pending debounced save so
-// the immediate write isn't shadowed by a stale queued one.
-function saveProjectNow(
-  metadata: ProjectMetadata,
-  agents: Agent[],
-  lines: LyricLine[],
-  groups: LinkGroup[],
-  granularity: GranularityMode,
-  syllableSplitDefaults: SyllableSplitDefaults,
-  audioSource: SavedAudioSource | undefined,
-  dismissedSuggestions: string[],
-  dismissedExplicitSuggestions: string[],
-  currentStem: Stem,
-): Promise<void> {
-  cancelPendingSave();
-  return saveCurrentProject(
-    metadata,
-    agents,
-    lines,
-    groups,
-    granularity,
-    syllableSplitDefaults,
-    audioSource,
-    dismissedSuggestions,
-    dismissedExplicitSuggestions,
-    currentStem,
-  );
-}
-
 // -- Exports ------------------------------------------------------------------
 
-export { debouncedSave, cancelPendingSave, flushPendingSave, saveProjectNow };
+export { debouncedSave, cancelPendingSave, flushPendingSave };

--- a/src/lib/persistence-debounce.ts
+++ b/src/lib/persistence-debounce.ts
@@ -1,3 +1,4 @@
+import type { Stem } from "@/audio/separation/types";
 import type { Agent } from "@/domain/agent/model";
 import type { LinkGroup } from "@/domain/group/template";
 import type { LyricLine } from "@/domain/line/model";
@@ -23,6 +24,7 @@ type SaveArgs = [
   SavedAudioSource | undefined,
   string[],
   string[],
+  Stem,
 ];
 
 let saveTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -40,6 +42,7 @@ function debouncedSave(
   audioSource: SavedAudioSource | undefined,
   dismissedSuggestions: string[],
   dismissedExplicitSuggestions: string[],
+  currentStem: Stem,
 ): void {
   pendingSaveArgs = [
     metadata,
@@ -51,6 +54,7 @@ function debouncedSave(
     audioSource,
     dismissedSuggestions,
     dismissedExplicitSuggestions,
+    currentStem,
   ];
   if (saveTimeout) {
     clearTimeout(saveTimeout);

--- a/src/lib/persistence-idb.browser.test.ts
+++ b/src/lib/persistence-idb.browser.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  DB_VERSION,
+  PROJECT_STORE_NAME,
+  STEM_STORE_NAME,
+  deleteFromStore,
+  getFromStore,
+  openDB,
+  setInStore,
+} from "@/lib/persistence-idb";
+
+// The shared browser setup (src/test/setup-browser.ts) deletes the entire
+// `ttml-composer` database before every test, so each test starts from a
+// fresh cold-open of the schema.
+
+// -- Schema -------------------------------------------------------------------
+
+describe("persistence-idb · schema", () => {
+  it("openDB returns a db at the expected version with both stores", async () => {
+    const db = await openDB();
+    expect(db.version).toBe(DB_VERSION);
+    expect(db.objectStoreNames.contains(PROJECT_STORE_NAME)).toBe(true);
+    expect(db.objectStoreNames.contains(STEM_STORE_NAME)).toBe(true);
+    db.close();
+  });
+
+  it("opening twice returns a db with identical schema (no spurious upgrade)", async () => {
+    const first = await openDB();
+    expect(first.version).toBe(DB_VERSION);
+    first.close();
+    const second = await openDB();
+    expect(second.version).toBe(DB_VERSION);
+    expect(second.objectStoreNames.contains(PROJECT_STORE_NAME)).toBe(true);
+    expect(second.objectStoreNames.contains(STEM_STORE_NAME)).toBe(true);
+    second.close();
+  });
+});
+
+// -- CRUD ---------------------------------------------------------------------
+
+describe("persistence-idb · CRUD", () => {
+  it("getFromStore returns undefined when key absent", async () => {
+    const value = await getFromStore<string>(PROJECT_STORE_NAME, "missing-key");
+    expect(value).toBeUndefined();
+  });
+
+  it("set + get round-trips primitive values", async () => {
+    await setInStore<string>(PROJECT_STORE_NAME, "k", "hello");
+    expect(await getFromStore<string>(PROJECT_STORE_NAME, "k")).toBe("hello");
+  });
+
+  it("set + get round-trips structured values", async () => {
+    const value = { title: "Song", tags: ["a", "b"], nested: { count: 3 } };
+    await setInStore(PROJECT_STORE_NAME, "k", value);
+    expect(await getFromStore(PROJECT_STORE_NAME, "k")).toEqual(value);
+  });
+
+  it("set overwrites the previous value at the same key", async () => {
+    await setInStore(PROJECT_STORE_NAME, "k", "first");
+    await setInStore(PROJECT_STORE_NAME, "k", "second");
+    expect(await getFromStore(PROJECT_STORE_NAME, "k")).toBe("second");
+  });
+
+  it("deleteFromStore removes a present key", async () => {
+    await setInStore(PROJECT_STORE_NAME, "k", "v");
+    await deleteFromStore(PROJECT_STORE_NAME, "k");
+    expect(await getFromStore(PROJECT_STORE_NAME, "k")).toBeUndefined();
+  });
+
+  it("deleteFromStore on an absent key resolves without throwing", async () => {
+    await expect(deleteFromStore(PROJECT_STORE_NAME, "never-set")).resolves.toBeUndefined();
+  });
+});
+
+// -- Isolation between stores -------------------------------------------------
+
+describe("persistence-idb · store isolation", () => {
+  it("the same key in different stores resolves to independent values", async () => {
+    await setInStore(PROJECT_STORE_NAME, "shared", "project-side");
+    await setInStore(STEM_STORE_NAME, "shared", "stem-side");
+    expect(await getFromStore(PROJECT_STORE_NAME, "shared")).toBe("project-side");
+    expect(await getFromStore(STEM_STORE_NAME, "shared")).toBe("stem-side");
+  });
+
+  it("deleting from one store leaves the other store's value intact", async () => {
+    await setInStore(PROJECT_STORE_NAME, "shared", "p");
+    await setInStore(STEM_STORE_NAME, "shared", "s");
+    await deleteFromStore(PROJECT_STORE_NAME, "shared");
+    expect(await getFromStore(PROJECT_STORE_NAME, "shared")).toBeUndefined();
+    expect(await getFromStore(STEM_STORE_NAME, "shared")).toBe("s");
+  });
+});

--- a/src/lib/persistence-idb.ts
+++ b/src/lib/persistence-idb.ts
@@ -1,0 +1,64 @@
+// -- Constants ----------------------------------------------------------------
+
+const DB_NAME = "ttml-composer";
+const DB_VERSION = 2;
+const PROJECT_STORE_NAME = "projects";
+const STEM_STORE_NAME = "separated-stems";
+
+// -- Connection ---------------------------------------------------------------
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB open failed"));
+    request.onsuccess = () => resolve(request.result);
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(PROJECT_STORE_NAME)) {
+        db.createObjectStore(PROJECT_STORE_NAME);
+      }
+      if (!db.objectStoreNames.contains(STEM_STORE_NAME)) {
+        db.createObjectStore(STEM_STORE_NAME);
+      }
+    };
+  });
+}
+
+// -- Generic CRUD -------------------------------------------------------------
+
+async function getFromStore<T>(storeName: string, key: string): Promise<T | undefined> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(storeName, "readonly");
+    const request = transaction.objectStore(storeName).get(key);
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result as T | undefined);
+    transaction.oncomplete = () => db.close();
+  });
+}
+
+async function setInStore<T>(storeName: string, key: string, value: T): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(storeName, "readwrite");
+    const request = transaction.objectStore(storeName).put(value, key);
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve();
+    transaction.oncomplete = () => db.close();
+  });
+}
+
+async function deleteFromStore(storeName: string, key: string): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(storeName, "readwrite");
+    const request = transaction.objectStore(storeName).delete(key);
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve();
+    transaction.oncomplete = () => db.close();
+  });
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { DB_NAME, DB_VERSION, PROJECT_STORE_NAME, STEM_STORE_NAME, openDB, getFromStore, setInStore, deleteFromStore };

--- a/src/lib/persistence-idb.ts
+++ b/src/lib/persistence-idb.ts
@@ -31,7 +31,10 @@ async function getFromStore<T>(storeName: string, key: string): Promise<T | unde
   return new Promise((resolve, reject) => {
     const transaction = db.transaction(storeName, "readonly");
     const request = transaction.objectStore(storeName).get(key);
-    request.onerror = () => reject(request.error);
+    request.onerror = () => {
+      db.close();
+      reject(request.error);
+    };
     request.onsuccess = () => resolve(request.result as T | undefined);
     transaction.oncomplete = () => db.close();
   });
@@ -42,7 +45,10 @@ async function setInStore<T>(storeName: string, key: string, value: T): Promise<
   return new Promise((resolve, reject) => {
     const transaction = db.transaction(storeName, "readwrite");
     const request = transaction.objectStore(storeName).put(value, key);
-    request.onerror = () => reject(request.error);
+    request.onerror = () => {
+      db.close();
+      reject(request.error);
+    };
     request.onsuccess = () => resolve();
     transaction.oncomplete = () => db.close();
   });
@@ -53,7 +59,10 @@ async function deleteFromStore(storeName: string, key: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const transaction = db.transaction(storeName, "readwrite");
     const request = transaction.objectStore(storeName).delete(key);
-    request.onerror = () => reject(request.error);
+    request.onerror = () => {
+      db.close();
+      reject(request.error);
+    };
     request.onsuccess = () => resolve();
     transaction.oncomplete = () => db.close();
   });

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -1,3 +1,4 @@
+import type { Stem } from "@/audio/separation/types";
 import type { GranularityMode } from "@/stores/project";
 import { DEFAULT_SYLLABLE_SPLIT_DEFAULTS, type SyllableSplitDefaults } from "@/stores/project/types";
 import type { Agent } from "@/domain/agent/model";
@@ -23,6 +24,7 @@ interface SavedProject {
   audioSource?: SavedAudioSource;
   dismissedSuggestions?: string[];
   dismissedExplicitSuggestions?: string[];
+  currentStem?: Stem;
 }
 
 // -- Constants ----------------------------------------------------------------
@@ -42,6 +44,7 @@ async function saveCurrentProject(
   audioSource: SavedAudioSource | undefined,
   dismissedSuggestions: string[],
   dismissedExplicitSuggestions: string[],
+  currentStem: Stem,
 ): Promise<void> {
   const audioFileName = audioSource?.kind === "file" ? audioSource.name : undefined;
   const project: SavedProject = {
@@ -57,6 +60,7 @@ async function saveCurrentProject(
     audioSource,
     dismissedSuggestions,
     dismissedExplicitSuggestions,
+    currentStem,
   };
   await setInStore(PROJECT_STORE_NAME, CURRENT_PROJECT_KEY, project);
 }

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -3,6 +3,7 @@ import { DEFAULT_SYLLABLE_SPLIT_DEFAULTS, type SyllableSplitDefaults } from "@/s
 import type { Agent } from "@/domain/agent/model";
 import type { LinkGroup } from "@/domain/group/template";
 import type { LyricLine } from "@/domain/line/model";
+import { PROJECT_STORE_NAME, deleteFromStore, getFromStore, setInStore } from "@/lib/persistence-idb";
 import type { ProjectMetadata } from "@/domain/project/metadata";
 
 // -- Types --------------------------------------------------------------------
@@ -26,75 +27,8 @@ interface SavedProject {
 
 // -- Constants ----------------------------------------------------------------
 
-const DB_NAME = "ttml-composer";
-const DB_VERSION = 2;
-const STORE_NAME = "projects";
-const STEM_STORE_NAME = "separated-stems";
 const CURRENT_PROJECT_KEY = "current";
 const AUDIO_FILE_KEY = "current-audio";
-
-// -- IndexedDB Helpers --------------------------------------------------------
-
-function openDB(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, DB_VERSION);
-
-    request.onerror = () => reject(request.error);
-    request.onsuccess = () => resolve(request.result);
-
-    request.onupgradeneeded = (event) => {
-      const db = (event.target as IDBOpenDBRequest).result;
-      if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME);
-      }
-      if (!db.objectStoreNames.contains(STEM_STORE_NAME)) {
-        db.createObjectStore(STEM_STORE_NAME);
-      }
-    };
-  });
-}
-
-async function getFromStore<T>(key: string): Promise<T | undefined> {
-  const db = await openDB();
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, "readonly");
-    const store = transaction.objectStore(STORE_NAME);
-    const request = store.get(key);
-
-    request.onerror = () => reject(request.error);
-    request.onsuccess = () => resolve(request.result as T | undefined);
-
-    transaction.oncomplete = () => db.close();
-  });
-}
-
-async function setInStore<T>(key: string, value: T): Promise<void> {
-  const db = await openDB();
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, "readwrite");
-    const store = transaction.objectStore(STORE_NAME);
-    const request = store.put(value, key);
-
-    request.onerror = () => reject(request.error);
-    request.onsuccess = () => resolve();
-
-    transaction.oncomplete = () => db.close();
-  });
-}
-
-async function deleteFromStore(key: string): Promise<void> {
-  const db = await openDB();
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, "readwrite");
-    const store = transaction.objectStore(STORE_NAME);
-    const request = store.delete(key);
-
-    request.onerror = () => reject(request.error);
-    request.onsuccess = () => resolve();
-
-    transaction.oncomplete = () => db.close();
-  });
-}
 
 // -- Public API ---------------------------------------------------------------
 
@@ -124,15 +58,15 @@ async function saveCurrentProject(
     dismissedSuggestions,
     dismissedExplicitSuggestions,
   };
-  await setInStore(CURRENT_PROJECT_KEY, project);
+  await setInStore(PROJECT_STORE_NAME, CURRENT_PROJECT_KEY, project);
 }
 
 async function loadCurrentProject(): Promise<SavedProject | undefined> {
-  return getFromStore<SavedProject>(CURRENT_PROJECT_KEY);
+  return getFromStore<SavedProject>(PROJECT_STORE_NAME, CURRENT_PROJECT_KEY);
 }
 
 async function clearCurrentProject(): Promise<void> {
-  await deleteFromStore(CURRENT_PROJECT_KEY);
+  await deleteFromStore(PROJECT_STORE_NAME, CURRENT_PROJECT_KEY);
   await clearAudioFile();
 }
 
@@ -146,7 +80,7 @@ interface SavedAudioFile {
 
 async function saveAudioFile(file: File): Promise<void> {
   const data = await file.arrayBuffer();
-  await setInStore<SavedAudioFile>(AUDIO_FILE_KEY, {
+  await setInStore<SavedAudioFile>(PROJECT_STORE_NAME, AUDIO_FILE_KEY, {
     name: file.name,
     type: file.type,
     data,
@@ -154,13 +88,13 @@ async function saveAudioFile(file: File): Promise<void> {
 }
 
 async function loadAudioFile(): Promise<File | undefined> {
-  const saved = await getFromStore<SavedAudioFile>(AUDIO_FILE_KEY);
+  const saved = await getFromStore<SavedAudioFile>(PROJECT_STORE_NAME, AUDIO_FILE_KEY);
   if (!saved) return undefined;
   return new File([saved.data], saved.name, { type: saved.type });
 }
 
 async function clearAudioFile(): Promise<void> {
-  await deleteFromStore(AUDIO_FILE_KEY);
+  await deleteFromStore(PROJECT_STORE_NAME, AUDIO_FILE_KEY);
 }
 
 function exportProjectToFile(
@@ -225,7 +159,5 @@ export {
   saveAudioFile,
   loadAudioFile,
   clearAudioFile,
-  openDB,
-  STEM_STORE_NAME,
 };
 export type { SavedAudioSource };

--- a/src/lib/recovery.browser.test.tsx
+++ b/src/lib/recovery.browser.test.tsx
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { DB_NAME, DB_VERSION, PROJECT_STORE_NAME } from "@/lib/persistence-idb";
 import { clearRecoveryStorage, downloadRecoveryFile, readRecoveryMetadata } from "@/lib/recovery";
 import { seedProject } from "@/test/idb";
 
 // -- Helpers ------------------------------------------------------------------
 
-const DB_NAME = "ttml-composer";
-const STORE_NAME = "projects";
+const STORE_NAME = PROJECT_STORE_NAME;
 const CURRENT_KEY = "current";
 
 function captureDownload(): { resolve: () => Promise<{ filename: string; size: number }>; cleanup: () => void } {
@@ -140,7 +140,7 @@ describe("recovery", () => {
       expect((await readRecoveryMetadata()).found).toBe(false);
 
       await new Promise<void>((resolve, reject) => {
-        const open = indexedDB.open(DB_NAME, 2);
+        const open = indexedDB.open(DB_NAME, DB_VERSION);
         open.onerror = () => reject(open.error);
         open.onsuccess = () => {
           const db = open.result;

--- a/src/lib/recovery.test.ts
+++ b/src/lib/recovery.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { NOT_FOUND_RESULT, type RecoveredProject, buildRecoveryResult } from "@/lib/recovery";
+
+// -- Helpers ------------------------------------------------------------------
+
+const TODAY = new Date().toISOString().slice(0, 10);
+
+function project(overrides: Partial<RecoveredProject> = {}): RecoveredProject {
+  return { savedAt: 1700000000000, metadata: { title: "song" }, lines: [], ...overrides };
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("buildRecoveryResult", () => {
+  it("returns found:true and the trimmed title", () => {
+    const result = buildRecoveryResult(project({ metadata: { title: "  My Song  " } }));
+    expect(result.found).toBe(true);
+    expect(result.title).toBe("My Song");
+  });
+
+  it("falls back to 'recovered' when title is missing", () => {
+    expect(buildRecoveryResult(project({ metadata: undefined })).title).toBe("recovered");
+  });
+
+  it("falls back to 'recovered' when title is an empty string", () => {
+    expect(buildRecoveryResult(project({ metadata: { title: "" } })).title).toBe("recovered");
+  });
+
+  it("falls back to 'recovered' when title is whitespace-only", () => {
+    expect(buildRecoveryResult(project({ metadata: { title: "   " } })).title).toBe("recovered");
+  });
+
+  it("constructs filename as title-YYYY-MM-DD.ttml-project.json", () => {
+    const result = buildRecoveryResult(project({ metadata: { title: "Track" } }));
+    expect(result.filename).toBe(`Track-${TODAY}.ttml-project.json`);
+  });
+
+  it("uses the fallback title in the filename when title is missing", () => {
+    const result = buildRecoveryResult(project({ metadata: undefined }));
+    expect(result.filename).toBe(`recovered-${TODAY}.ttml-project.json`);
+  });
+
+  it("counts lines from the project array", () => {
+    expect(buildRecoveryResult(project({ lines: [1, 2, 3, 4, 5] })).lineCount).toBe(5);
+  });
+
+  it("returns lineCount=0 when lines is missing", () => {
+    expect(buildRecoveryResult(project({ lines: undefined })).lineCount).toBe(0);
+  });
+
+  it("passes through savedAt verbatim", () => {
+    expect(buildRecoveryResult(project({ savedAt: 42 })).savedAt).toBe(42);
+  });
+
+  it("preserves savedAt=undefined", () => {
+    expect(buildRecoveryResult(project({ savedAt: undefined })).savedAt).toBeUndefined();
+  });
+});
+
+describe("NOT_FOUND_RESULT", () => {
+  it("has found=false and empty strings", () => {
+    expect(NOT_FOUND_RESULT).toEqual({
+      found: false,
+      filename: "",
+      lineCount: 0,
+      savedAt: undefined,
+      title: "",
+    });
+  });
+
+  it("is frozen-shaped: callers should treat it as a constant", () => {
+    // The constant is shared between readRecoveryMetadata and downloadRecoveryFile;
+    // mutating it would corrupt the second caller. This asserts the shape only,
+    // not Object.freeze enforcement, so the existing module export stays JS-idiomatic.
+    const first = NOT_FOUND_RESULT;
+    const second = NOT_FOUND_RESULT;
+    expect(first).toBe(second);
+  });
+});

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -3,6 +3,8 @@
 // store, hook, or component so it remains usable from error boundaries
 // and `/recover` even when the rest of the app is in a broken state.
 
+import { PROJECT_STORE_NAME, getFromStore, openDB } from "@/lib/persistence-idb";
+
 // -- Types --------------------------------------------------------------------
 
 interface RecoveredProject {
@@ -22,57 +24,12 @@ interface RecoveryResult {
 
 // -- Constants ----------------------------------------------------------------
 
-const DB_NAME = "ttml-composer";
-const DB_VERSION = 2;
-const STORE_NAME = "projects";
-const STEM_STORE_NAME = "separated-stems";
 const CURRENT_PROJECT_KEY = "current";
 
 // -- Helpers ------------------------------------------------------------------
 
-// Mirrors the onupgradeneeded handler in `src/lib/persistence.ts`. If we open
-// the DB without it and recovery runs before the main app has ever loaded
-// (fresh browser hitting /recover or the panic shortcut), IndexedDB would
-// materialise an empty DB at version 1 with no object store. The main app
-// would then open that same version, skip its own onupgradeneeded, and every
-// read/write would throw NotFoundError until the user clears site data. Keep
-// the schema creation in lockstep with persistence.ts.
-function openRecoveryDB(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, DB_VERSION);
-    request.onerror = () => reject(request.error ?? new Error("IndexedDB open failed"));
-    request.onsuccess = () => resolve(request.result);
-    request.onupgradeneeded = (event) => {
-      const db = (event.target as IDBOpenDBRequest).result;
-      if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME);
-      }
-      if (!db.objectStoreNames.contains(STEM_STORE_NAME)) {
-        db.createObjectStore(STEM_STORE_NAME);
-      }
-    };
-  });
-}
-
-async function readProjectFromIDB(): Promise<RecoveredProject | undefined> {
-  const db = await openRecoveryDB();
-  return new Promise((resolve, reject) => {
-    if (!db.objectStoreNames.contains(STORE_NAME)) {
-      db.close();
-      resolve(undefined);
-      return;
-    }
-    const tx = db.transaction(STORE_NAME, "readonly");
-    const getReq = tx.objectStore(STORE_NAME).get(CURRENT_PROJECT_KEY);
-    getReq.onerror = () => {
-      db.close();
-      reject(getReq.error ?? new Error("IndexedDB read failed"));
-    };
-    getReq.onsuccess = () => {
-      db.close();
-      resolve(getReq.result as RecoveredProject | undefined);
-    };
-  });
+function readProjectFromIDB(): Promise<RecoveredProject | undefined> {
+  return getFromStore<RecoveredProject>(PROJECT_STORE_NAME, CURRENT_PROJECT_KEY);
 }
 
 function triggerDownload(blob: Blob, filename: string): void {
@@ -124,15 +81,10 @@ async function downloadRecoveryFile(): Promise<RecoveryResult> {
 }
 
 async function clearRecoveryStorage(): Promise<void> {
-  const db = await openRecoveryDB();
+  const db = await openDB();
   return new Promise((resolve, reject) => {
-    if (!db.objectStoreNames.contains(STORE_NAME)) {
-      db.close();
-      resolve();
-      return;
-    }
-    const tx = db.transaction(STORE_NAME, "readwrite");
-    tx.objectStore(STORE_NAME).clear();
+    const tx = db.transaction(PROJECT_STORE_NAME, "readwrite");
+    tx.objectStore(PROJECT_STORE_NAME).clear();
     tx.oncomplete = () => {
       db.close();
       resolve();

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -96,5 +96,5 @@ async function clearRecoveryStorage(): Promise<void> {
 
 // -- Exports ------------------------------------------------------------------
 
-export { readRecoveryMetadata, downloadRecoveryFile, clearRecoveryStorage };
-export type { RecoveryResult };
+export { readRecoveryMetadata, downloadRecoveryFile, clearRecoveryStorage, buildRecoveryResult, NOT_FOUND_RESULT };
+export type { RecoveredProject, RecoveryResult };

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -25,11 +25,30 @@ interface RecoveryResult {
 // -- Constants ----------------------------------------------------------------
 
 const CURRENT_PROJECT_KEY = "current";
+const NOT_FOUND_RESULT: RecoveryResult = {
+  found: false,
+  filename: "",
+  lineCount: 0,
+  savedAt: undefined,
+  title: "",
+};
 
 // -- Helpers ------------------------------------------------------------------
 
 function readProjectFromIDB(): Promise<RecoveredProject | undefined> {
   return getFromStore<RecoveredProject>(PROJECT_STORE_NAME, CURRENT_PROJECT_KEY);
+}
+
+function buildRecoveryResult(project: RecoveredProject): RecoveryResult {
+  const title = project.metadata?.title?.trim() || "recovered";
+  const date = new Date().toISOString().slice(0, 10);
+  return {
+    found: true,
+    filename: `${title}-${date}.ttml-project.json`,
+    lineCount: project.lines?.length ?? 0,
+    savedAt: project.savedAt,
+    title,
+  };
 }
 
 function triggerDownload(blob: Blob, filename: string): void {
@@ -47,37 +66,16 @@ function triggerDownload(blob: Blob, filename: string): void {
 
 async function readRecoveryMetadata(): Promise<RecoveryResult> {
   const project = await readProjectFromIDB();
-  if (!project) {
-    return { found: false, filename: "", lineCount: 0, savedAt: undefined, title: "" };
-  }
-  const title = project.metadata?.title?.trim() || "recovered";
-  const date = new Date().toISOString().slice(0, 10);
-  return {
-    found: true,
-    filename: `${title}-${date}.ttml-project.json`,
-    lineCount: project.lines?.length ?? 0,
-    savedAt: project.savedAt,
-    title,
-  };
+  return project ? buildRecoveryResult(project) : NOT_FOUND_RESULT;
 }
 
 async function downloadRecoveryFile(): Promise<RecoveryResult> {
   const project = await readProjectFromIDB();
-  if (!project) {
-    return { found: false, filename: "", lineCount: 0, savedAt: undefined, title: "" };
-  }
-  const title = project.metadata?.title?.trim() || "recovered";
-  const date = new Date().toISOString().slice(0, 10);
-  const filename = `${title}-${date}.ttml-project.json`;
+  if (!project) return NOT_FOUND_RESULT;
+  const result = buildRecoveryResult(project);
   const blob = new Blob([JSON.stringify(project, null, 2)], { type: "application/json" });
-  triggerDownload(blob, filename);
-  return {
-    found: true,
-    filename,
-    lineCount: project.lines?.length ?? 0,
-    savedAt: project.savedAt,
-    title,
-  };
+  triggerDownload(blob, result.filename);
+  return result;
 }
 
 async function clearRecoveryStorage(): Promise<void> {

--- a/src/stores/separation.ts
+++ b/src/stores/separation.ts
@@ -34,6 +34,7 @@ interface SeparationActions {
   downloadModel: () => Promise<void>;
   separate: () => Promise<void>;
   selectStem: (stem: Stem) => void;
+  restoreCurrentStem: (stem: Stem) => void;
   cancel: () => void;
   retry: () => Promise<void>;
   reset: () => void;
@@ -231,6 +232,16 @@ const useSeparationStore = create<SeparationState & SeparationActions>((set, get
   selectStem: (stem) => {
     const available = get().availableStems;
     if (!available.includes(stem)) return;
+    set({ currentStem: stem });
+  },
+
+  // Called once at boot by usePersistence to seed currentStem from the saved
+  // project, before useAutoSeparate's source subscription runs
+  // refreshForCurrentSource. Unlike selectStem this intentionally bypasses the
+  // availableStems guard, because at restore time the available list hasn't
+  // been populated yet. refreshForCurrentSource handles eviction by overwriting
+  // back to "original" when the cached stems are gone.
+  restoreCurrentStem: (stem) => {
     set({ currentStem: stem });
   },
 

--- a/src/stores/separation.ts
+++ b/src/stores/separation.ts
@@ -12,6 +12,7 @@ import type { SeparationError, SeparationStatus, Stem } from "@/audio/separation
 import { hasOnlyFiniteSamples } from "@/audio/separation/validate-channels";
 import { SeparationWorker } from "@/audio/separation/worker-host";
 import { useAudioStore } from "@/stores/audio";
+import type { VocalModelVariant } from "@/stores/settings";
 import { useSettingsStore } from "@/stores/settings";
 import { create } from "zustand";
 
@@ -56,6 +57,30 @@ function disposeWorker() {
 function revokeUrls(urls: Partial<Record<Stem, string>>) {
   for (const url of Object.values(urls)) {
     if (url) URL.revokeObjectURL(url);
+  }
+}
+
+type SetSeparationState = (partial: Partial<SeparationState>) => void;
+
+// Shared download-init prologue used by both `downloadModel` (which then sets
+// idle) and `separate` (which then continues to processing). Returns true if
+// the model initialised, false if it aborted or errored. On abort/error the
+// caller's status has already been written to "idle" or "error".
+async function runModelDownload(set: SetSeparationState, variant: VocalModelVariant): Promise<boolean> {
+  set({ status: "downloading", error: null, progress: { loaded: 0, total: 0 } });
+  try {
+    await getWorker().init({
+      variant,
+      onProgress: (loaded, total) => set({ progress: { loaded, total } }),
+    });
+    return true;
+  } catch (err) {
+    if ((err as Error).name === "AbortError" || isCancelling) {
+      set({ status: "idle" });
+    } else {
+      set({ status: "error", error: { code: "fetch-failed", message: (err as Error).message } });
+    }
+    return false;
   }
 }
 
@@ -122,22 +147,8 @@ const useSeparationStore = create<SeparationState & SeparationActions>((set, get
     }
     isCancelling = false;
     const variant = useSettingsStore.getState().vocalModelVariant;
-    set({ status: "downloading", error: null, progress: { loaded: 0, total: 0 } });
-    try {
-      await getWorker().init({
-        variant,
-        onProgress: (loaded, total) => set({ progress: { loaded, total } }),
-      });
+    if (await runModelDownload(set, variant)) {
       set({ status: "idle", modelCached: true });
-    } catch (err) {
-      if ((err as Error).name === "AbortError" || isCancelling) {
-        set({ status: "idle" });
-        return;
-      }
-      set({
-        status: "error",
-        error: { code: "fetch-failed", message: (err as Error).message },
-      });
     }
   },
 
@@ -155,21 +166,8 @@ const useSeparationStore = create<SeparationState & SeparationActions>((set, get
 
     isCancelling = false;
     const variant = useSettingsStore.getState().vocalModelVariant;
-    set({ status: "downloading", error: null, progress: { loaded: 0, total: 0 } });
-    try {
-      await getWorker().init({
-        variant,
-        onProgress: (loaded, total) => set({ progress: { loaded, total } }),
-      });
-      set({ modelCached: true });
-    } catch (err) {
-      if ((err as Error).name === "AbortError" || isCancelling) {
-        set({ status: "idle" });
-        return;
-      }
-      set({ status: "error", error: { code: "fetch-failed", message: (err as Error).message } });
-      return;
-    }
+    if (!(await runModelDownload(set, variant))) return;
+    set({ modelCached: true });
 
     set({ status: "processing", progress: { loaded: 0, total: 0 } });
     let decoded: Awaited<ReturnType<typeof decodeFileToFloat32>>;

--- a/src/test/idb.ts
+++ b/src/test/idb.ts
@@ -1,42 +1,11 @@
+import { PROJECT_STORE_NAME, setInStore } from "@/lib/persistence-idb";
+
 // -- Constants -----------------------------------------------------------------
 
-const DB_NAME = "ttml-composer";
-const DB_VERSION = 2;
-const STORE_NAME = "projects";
-const STEM_STORE_NAME = "separated-stems";
 const CURRENT_KEY = "current";
 const AUDIO_KEY = "current-audio";
 
-// -- Helpers -------------------------------------------------------------------
-
-function putValue(key: string, value: unknown): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const open = indexedDB.open(DB_NAME, DB_VERSION);
-    open.onupgradeneeded = () => {
-      const db = open.result;
-      if (!db.objectStoreNames.contains(STORE_NAME)) db.createObjectStore(STORE_NAME);
-      if (!db.objectStoreNames.contains(STEM_STORE_NAME)) db.createObjectStore(STEM_STORE_NAME);
-    };
-    open.onerror = () => reject(open.error);
-    open.onsuccess = () => {
-      const db = open.result;
-      const tx = db.transaction(STORE_NAME, "readwrite");
-      const put = tx.objectStore(STORE_NAME).put(value, key);
-      put.onerror = () => {
-        db.close();
-        reject(put.error);
-      };
-      tx.oncomplete = () => {
-        db.close();
-        resolve();
-      };
-    };
-  });
-}
-
-async function seedProject(project: unknown): Promise<void> {
-  return putValue(CURRENT_KEY, project);
-}
+// -- Types ---------------------------------------------------------------------
 
 interface SeedAudioFileArgs {
   name: string;
@@ -44,8 +13,14 @@ interface SeedAudioFileArgs {
   data: ArrayBuffer;
 }
 
-async function seedAudioFile(args: SeedAudioFileArgs): Promise<void> {
-  return putValue(AUDIO_KEY, args);
+// -- Helpers -------------------------------------------------------------------
+
+function seedProject(project: unknown): Promise<void> {
+  return setInStore(PROJECT_STORE_NAME, CURRENT_KEY, project);
+}
+
+function seedAudioFile(args: SeedAudioFileArgs): Promise<void> {
+  return setInStore(PROJECT_STORE_NAME, AUDIO_KEY, args);
 }
 
 // -- Exports -------------------------------------------------------------------

--- a/src/ui/vocal-separation-dropdown.tsx
+++ b/src/ui/vocal-separation-dropdown.tsx
@@ -82,53 +82,71 @@ const VocalSeparationDropdown: React.FC = () => {
         </Button>
       }
     >
-      <div className="p-3 w-max max-w-80">
-        {status === "error" && error && (
-          <ErrorState message={error.message} onRetry={retry} onDismiss={() => useSeparationStore.getState().reset()} />
-        )}
+      {(close) => {
+        const selectAndClose = (stem: Stem) => {
+          selectStem(stem);
+          close();
+        };
+        return (
+          <div className="p-3 w-max max-w-80">
+            {status === "error" && error && (
+              <ErrorState
+                message={error.message}
+                onRetry={retry}
+                onDismiss={() => useSeparationStore.getState().reset()}
+              />
+            )}
 
-        {status === "downloading" && (
-          <ProgressState
-            title="Downloading model…"
-            detail={`${formatMb(progress.loaded)} / ${formatMb(progress.total || (descriptor?.approxBytes ?? 0))}`}
-            pct={pct}
-            onCancel={cancel}
-          />
-        )}
+            {status === "downloading" && (
+              <ProgressState
+                title="Downloading model…"
+                detail={`${formatMb(progress.loaded)} / ${formatMb(progress.total || (descriptor?.approxBytes ?? 0))}`}
+                pct={pct}
+                onCancel={cancel}
+              />
+            )}
 
-        {status === "processing" && (
-          <ProgressState
-            title="Separating vocals…"
-            detail={progress.total > 0 ? `Chunk ${progress.loaded} of ${progress.total}` : "Preparing…"}
-            pct={pct}
-            onCancel={cancel}
-          />
-        )}
+            {status === "processing" && (
+              <ProgressState
+                title="Separating vocals…"
+                detail={progress.total > 0 ? `Chunk ${progress.loaded} of ${progress.total}` : "Preparing…"}
+                pct={pct}
+                onCancel={cancel}
+              />
+            )}
 
-        {status === "idle" && !modelCached && (
-          <IdleNoModelState approxMb={descriptor?.approxMb ?? 85} onDownload={downloadModel} onSeparate={separate} />
-        )}
+            {status === "idle" && !modelCached && (
+              <IdleNoModelState
+                approxMb={descriptor?.approxMb ?? 85}
+                onDownload={downloadModel}
+                onSeparate={separate}
+              />
+            )}
 
-        {status === "idle" && modelCached && (
-          <IdleReadyState
-            availableStems={availableStems}
-            currentStem={currentStem}
-            onSelect={selectStem}
-            onSeparate={separate}
-          />
-        )}
+            {status === "idle" && modelCached && (
+              <IdleReadyState
+                availableStems={availableStems}
+                currentStem={currentStem}
+                onSelect={selectAndClose}
+                onSeparate={separate}
+              />
+            )}
 
-        {status === "ready" && (
-          <IdleReadyState
-            availableStems={availableStems}
-            currentStem={currentStem}
-            onSelect={selectStem}
-            onSeparate={separate}
-          />
-        )}
+            {status === "ready" && (
+              <IdleReadyState
+                availableStems={availableStems}
+                currentStem={currentStem}
+                onSelect={selectAndClose}
+                onSeparate={separate}
+              />
+            )}
 
-        {status === "cancelled" && <p className="text-xs text-composer-text-muted">Cancelled. Open again to retry.</p>}
-      </div>
+            {status === "cancelled" && (
+              <p className="text-xs text-composer-text-muted">Cancelled. Open again to retry.</p>
+            )}
+          </div>
+        );
+      }}
     </Popover>
   );
 };


### PR DESCRIPTION
## Summary

Three structural refactors that consolidate near-identical code spotted by `jscpd` after PR #72 landed.

**New shared module: `src/lib/persistence-idb.ts`**
- Owns IDB schema constants (`DB_NAME`, `DB_VERSION`, `PROJECT_STORE_NAME`, `STEM_STORE_NAME`), the `openDB()` connection with `onupgradeneeded`, and three store-name-parametrized helpers (`getFromStore<T>`, `setInStore<T>`, `deleteFromStore`).
- `persistence.ts` drops its local copies and threads `PROJECT_STORE_NAME` through every call site.
- `recovery.ts` drops its `openRecoveryDB` (which had to mirror persistence's schema by hand) and imports `openDB`. The "keep schema in lockstep" comment is gone because the schema is now defined exactly once.
- `audio/separation/stem-store.ts` retargets imports from `@/lib/persistence` to `@/lib/persistence-idb`.
- `src/test/idb.ts` becomes a thin wrapper around `setInStore` instead of a fourth re-implementation of opening the DB.
- The three near-identical `getFromStore` / `setInStore` / `deleteFromStore` impls in `persistence.ts` collapse into a single parametrized form.

**Recovery helper extraction**
- `readRecoveryMetadata` and `downloadRecoveryFile` shared an early-return shape plus title / date / filename construction. Pulled into `buildRecoveryResult(project)` and a `NOT_FOUND_RESULT` constant. `downloadRecoveryFile` just builds the result, adds the Blob, triggers the download.

**Separation model-download prologue extraction**
- `downloadModel` and `separate` in the separation store shared the "set downloading status, init worker with progress, handle abort vs error" block. Pulled into `runModelDownload(set, variant)` returning a boolean. Callers decide what status to flip after. Behavior preserved: `downloadModel` sets `idle` on success; `separate` sets `modelCached` then continues into the processing phase.

## Why

Post-merge audit of #72 surfaced three `jscpd` hits worth addressing: a 15-line cross-file clone (`persistence.ts` and `recovery.ts` both defining `openDB`), a within-file 3-way clone of the CRUD helpers in `persistence.ts`, and two self-clones (the recovery result shape and the separation download prologue). CI was green and the 3% threshold was not breached, but per the project's "extract on the second use" discipline each one deserved a single home. Schema-mirror-by-comment is the kind of seam that drifts during reviews; PR #72 itself bumped the schema in only one place initially.

## Test plan

- [x] `pnpm test`: 795 / 795 pass across 138 files.
- [x] All 5 fitness tests pass (`file-size-budget`, `no-inline-derivations`, `domain-isolation`, `store-history-single-path`, `lyrics-parsers/registry`).
- [x] `pnpm jscpd`: total TS duplication dropped from 1.17% to 0.94% (21 clones to 18). The four targeted clones are gone (persistence / recovery `openDB`, the within-persistence 3-way helper clone, the recovery result self-clone, the separation download self-clone).
- [x] New `src/lib/persistence-idb.browser.test.ts` covers schema (v2, both stores present, idempotent reopen), CRUD round-trip (primitives and structured), overwrite, delete-absent-key safety, and cross-store isolation under the same key.
- [x] No behavior change. Same v2 schema, same two stores, same keys. Separation store transitions and recovery output shapes are preserved.