### PR TITLE
feat: route scrub through selected stem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.23.0",
+  "version": "1.23.1",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/audio/audio-engine.browser.test.tsx
+++ b/src/audio/audio-engine.browser.test.tsx
@@ -261,4 +261,41 @@ describe("AudioEngine", () => {
     await waitFor(() => useAudioStore.getState().audioElement === null);
     expect(scrubStemRouter.getActiveStem()).toBeNull();
   });
+
+  it("publishes currentSrc to the audio store on every src change", async () => {
+    await render(<AudioEngine />);
+    useAudioStore.setState({ source: { type: "file", file: createAudioFile() } });
+    await waitFor(() => useAudioStore.getState().audioElement !== null);
+    const audio = useAudioStore.getState().audioElement as HTMLAudioElement;
+    const originalUrl = audio.src;
+    await waitFor(() => useAudioStore.getState().currentSrc === originalUrl);
+    expect(useAudioStore.getState().currentSrc).toBe(originalUrl);
+
+    const vocalsUrl = URL.createObjectURL(createAudioFile("vocals.wav"));
+    const instrumentalUrl = URL.createObjectURL(createAudioFile("instrumental.wav"));
+    try {
+      useSeparationStore.setState({
+        currentStem: "vocals",
+        availableStems: ["original", "vocals", "instrumental"],
+        stemUrls: { vocals: vocalsUrl, instrumental: instrumentalUrl },
+      });
+      await waitFor(() => useAudioStore.getState().currentSrc === vocalsUrl);
+      expect(useAudioStore.getState().currentSrc).toBe(vocalsUrl);
+
+      useSeparationStore.setState({ currentStem: "instrumental" });
+      await waitFor(() => useAudioStore.getState().currentSrc === instrumentalUrl);
+      expect(useAudioStore.getState().currentSrc).toBe(instrumentalUrl);
+
+      useSeparationStore.setState({ currentStem: "original" });
+      await waitFor(() => useAudioStore.getState().currentSrc === originalUrl);
+      expect(useAudioStore.getState().currentSrc).toBe(originalUrl);
+    } finally {
+      URL.revokeObjectURL(vocalsUrl);
+      URL.revokeObjectURL(instrumentalUrl);
+    }
+
+    useAudioStore.setState({ source: null });
+    await waitFor(() => useAudioStore.getState().currentSrc === null);
+    expect(useAudioStore.getState().currentSrc).toBeNull();
+  });
 });

--- a/src/audio/audio-engine.browser.test.tsx
+++ b/src/audio/audio-engine.browser.test.tsx
@@ -261,41 +261,4 @@ describe("AudioEngine", () => {
     await waitFor(() => useAudioStore.getState().audioElement === null);
     expect(scrubStemRouter.getActiveStem()).toBeNull();
   });
-
-  it("publishes currentSrc to the audio store on every src change", async () => {
-    await render(<AudioEngine />);
-    useAudioStore.setState({ source: { type: "file", file: createAudioFile() } });
-    await waitFor(() => useAudioStore.getState().audioElement !== null);
-    const audio = useAudioStore.getState().audioElement as HTMLAudioElement;
-    const originalUrl = audio.src;
-    await waitFor(() => useAudioStore.getState().currentSrc === originalUrl);
-    expect(useAudioStore.getState().currentSrc).toBe(originalUrl);
-
-    const vocalsUrl = URL.createObjectURL(createAudioFile("vocals.wav"));
-    const instrumentalUrl = URL.createObjectURL(createAudioFile("instrumental.wav"));
-    try {
-      useSeparationStore.setState({
-        currentStem: "vocals",
-        availableStems: ["original", "vocals", "instrumental"],
-        stemUrls: { vocals: vocalsUrl, instrumental: instrumentalUrl },
-      });
-      await waitFor(() => useAudioStore.getState().currentSrc === vocalsUrl);
-      expect(useAudioStore.getState().currentSrc).toBe(vocalsUrl);
-
-      useSeparationStore.setState({ currentStem: "instrumental" });
-      await waitFor(() => useAudioStore.getState().currentSrc === instrumentalUrl);
-      expect(useAudioStore.getState().currentSrc).toBe(instrumentalUrl);
-
-      useSeparationStore.setState({ currentStem: "original" });
-      await waitFor(() => useAudioStore.getState().currentSrc === originalUrl);
-      expect(useAudioStore.getState().currentSrc).toBe(originalUrl);
-    } finally {
-      URL.revokeObjectURL(vocalsUrl);
-      URL.revokeObjectURL(instrumentalUrl);
-    }
-
-    useAudioStore.setState({ source: null });
-    await waitFor(() => useAudioStore.getState().currentSrc === null);
-    expect(useAudioStore.getState().currentSrc).toBeNull();
-  });
 });

--- a/src/audio/audio-engine.browser.test.tsx
+++ b/src/audio/audio-engine.browser.test.tsx
@@ -1,10 +1,12 @@
 import { AudioEngine } from "@/audio/audio-engine";
+import { scrubPreview } from "@/audio/scrub-preview";
+import { scrubStemRouter } from "@/audio/scrub-stem-router";
 import { useAudioStore } from "@/stores/audio";
 import { useSeparationStore } from "@/stores/separation";
 import { createAudioFile, createMp3File } from "@/test/audio-fixtures";
 import { allowConsole } from "@/test/console-guard";
 import { render } from "@/test/render";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 function waitFor(predicate: () => boolean, timeout = 1000): Promise<void> {
   const start = Date.now();
@@ -19,6 +21,10 @@ function waitFor(predicate: () => boolean, timeout = 1000): Promise<void> {
 }
 
 describe("AudioEngine", () => {
+  afterEach(() => {
+    scrubStemRouter.clearCache();
+  });
+
   it("registers an <audio> element on the store when a file source is set", async () => {
     await render(<AudioEngine />);
     expect(useAudioStore.getState().audioElement).toBeNull();
@@ -218,5 +224,41 @@ describe("AudioEngine", () => {
     } finally {
       URL.revokeObjectURL(vocalsUrl);
     }
+  });
+
+  it("routes the scrub-preview through the currently-selected stem", async () => {
+    await render(<AudioEngine />);
+    useAudioStore.setState({ source: { type: "file", file: createAudioFile() } });
+    await waitFor(() => useAudioStore.getState().audioElement !== null);
+
+    await waitFor(() => scrubStemRouter.getActiveStem() === "original", 5000);
+
+    const vocalsUrl = URL.createObjectURL(createAudioFile("vocals.wav"));
+    try {
+      useSeparationStore.setState({
+        currentStem: "vocals",
+        availableStems: ["original", "vocals"],
+        stemUrls: { vocals: vocalsUrl },
+      });
+      await waitFor(() => scrubStemRouter.getActiveStem() === "vocals", 5000);
+      scrubPreview.play(0.05, 1);
+      expect(scrubPreview.getActiveSnippet()?.time).toBe(0);
+
+      useSeparationStore.setState({ currentStem: "original" });
+      await waitFor(() => scrubStemRouter.getActiveStem() === "original", 5000);
+    } finally {
+      URL.revokeObjectURL(vocalsUrl);
+    }
+  });
+
+  it("clears the scrub router cache when the source becomes null", async () => {
+    await render(<AudioEngine />);
+    useAudioStore.setState({ source: { type: "file", file: createAudioFile() } });
+    await waitFor(() => useAudioStore.getState().audioElement !== null);
+    await waitFor(() => scrubStemRouter.getActiveStem() === "original", 5000);
+
+    useAudioStore.setState({ source: null });
+    await waitFor(() => useAudioStore.getState().audioElement === null);
+    expect(scrubStemRouter.getActiveStem()).toBeNull();
   });
 });

--- a/src/audio/audio-engine.tsx
+++ b/src/audio/audio-engine.tsx
@@ -28,6 +28,7 @@ const AudioEngine: React.FC = () => {
   const setIsPlaying = useAudioStore((s) => s.setIsPlaying);
   const setIsLoading = useAudioStore((s) => s.setIsLoading);
   const registerAudioElement = useAudioStore((s) => s.registerAudioElement);
+  const setCurrentSrc = useAudioStore((s) => s.setCurrentSrc);
 
   const currentStem = useSeparationStore((s) => s.currentStem);
   const stemUrls = useSeparationStore((s) => s.stemUrls);
@@ -113,6 +114,7 @@ const AudioEngine: React.FC = () => {
       const audio = new Audio();
       audio.id = "composer-audio";
       audio.src = objectUrl;
+      setCurrentSrc(objectUrl);
       const {
         playbackRate: initialPlaybackRate,
         volume: initialVolume,
@@ -150,6 +152,7 @@ const AudioEngine: React.FC = () => {
         unbindStateEvents();
         audio.pause();
         audio.src = "";
+        setCurrentSrc(null);
         audio.remove();
         if (audioRef.current === audio) audioRef.current = null;
         if (originalUrlRef.current === objectUrl) originalUrlRef.current = null;
@@ -166,7 +169,7 @@ const AudioEngine: React.FC = () => {
       registerAudioElement(null);
       scrubStemRouter.clearCache();
     };
-  }, [source, setDuration, setCurrentTime, setIsPlaying, setIsLoading, registerAudioElement]);
+  }, [source, setDuration, setCurrentTime, setIsPlaying, setIsLoading, registerAudioElement, setCurrentSrc]);
 
   useEffect(() => {
     const audio = audioRef.current;
@@ -201,12 +204,13 @@ const AudioEngine: React.FC = () => {
       isMuted: currentIsMuted,
     } = useAudioStore.getState();
     audio.src = targetUrl;
+    setCurrentSrc(targetUrl);
     audio.currentTime = time;
     audio.playbackRate = currentPlaybackRate;
     audio.volume = currentVolume;
     audio.muted = currentIsMuted;
     if (wasPlaying) audio.play().catch(() => {});
-  }, [currentStem, stemUrls, audioElement]);
+  }, [currentStem, stemUrls, audioElement, setCurrentSrc]);
 
   useEffect(() => {
     scrubStemRouter.selectStem(currentStem, () => stemUrls[currentStem]);

--- a/src/audio/audio-engine.tsx
+++ b/src/audio/audio-engine.tsx
@@ -1,6 +1,7 @@
 import { decodeMp3ToWav, isMp3File } from "@/audio/audio-decode";
 import { bindAudioStateEvents } from "@/audio/audio-state-events";
 import { scrubPreview } from "@/audio/scrub-preview";
+import { scrubStemRouter } from "@/audio/scrub-stem-router";
 import { useAudioStore } from "@/stores/audio";
 import { useSeparationStore } from "@/stores/separation";
 import { useEffect, useRef } from "react";
@@ -34,14 +35,14 @@ const AudioEngine: React.FC = () => {
   useEffect(() => {
     if (!source) {
       registerAudioElement(null);
-      scrubPreview.useBuffer(null);
+      scrubStemRouter.clearCache();
       return;
     }
 
     const playableFile = source.type === "file" ? source.file : source.type === "youtube" ? source.file : null;
     if (!playableFile) {
       registerAudioElement(null);
-      scrubPreview.useBuffer(null);
+      scrubStemRouter.clearCache();
       return;
     }
 
@@ -88,11 +89,11 @@ const AudioEngine: React.FC = () => {
         if (aborted) return;
         const audioBuffer = await scrubPreview.decode(bytes);
         if (aborted) return;
-        scrubPreview.useBuffer(audioBuffer);
+        scrubStemRouter.setOriginalBuffer(audioBuffer);
       } catch (err) {
         if (aborted) return;
         console.warn(LOG_PREFIX, "scrub-preview decode failed", err);
-        scrubPreview.useBuffer(null);
+        scrubStemRouter.setOriginalBuffer(null);
       }
     };
     void loadScrubBuffer();
@@ -163,7 +164,7 @@ const AudioEngine: React.FC = () => {
       clearSlowLoading();
       if (teardown) teardown();
       registerAudioElement(null);
-      scrubPreview.useBuffer(null);
+      scrubStemRouter.clearCache();
     };
   }, [source, setDuration, setCurrentTime, setIsPlaying, setIsLoading, registerAudioElement]);
 
@@ -206,6 +207,10 @@ const AudioEngine: React.FC = () => {
     audio.muted = currentIsMuted;
     if (wasPlaying) audio.play().catch(() => {});
   }, [currentStem, stemUrls, audioElement]);
+
+  useEffect(() => {
+    scrubStemRouter.selectStem(currentStem, () => stemUrls[currentStem]);
+  }, [currentStem, stemUrls]);
 
   return null;
 };

--- a/src/audio/audio-engine.tsx
+++ b/src/audio/audio-engine.tsx
@@ -28,7 +28,6 @@ const AudioEngine: React.FC = () => {
   const setIsPlaying = useAudioStore((s) => s.setIsPlaying);
   const setIsLoading = useAudioStore((s) => s.setIsLoading);
   const registerAudioElement = useAudioStore((s) => s.registerAudioElement);
-  const setCurrentSrc = useAudioStore((s) => s.setCurrentSrc);
 
   const currentStem = useSeparationStore((s) => s.currentStem);
   const stemUrls = useSeparationStore((s) => s.stemUrls);
@@ -114,7 +113,6 @@ const AudioEngine: React.FC = () => {
       const audio = new Audio();
       audio.id = "composer-audio";
       audio.src = objectUrl;
-      setCurrentSrc(objectUrl);
       const {
         playbackRate: initialPlaybackRate,
         volume: initialVolume,
@@ -152,7 +150,6 @@ const AudioEngine: React.FC = () => {
         unbindStateEvents();
         audio.pause();
         audio.src = "";
-        setCurrentSrc(null);
         audio.remove();
         if (audioRef.current === audio) audioRef.current = null;
         if (originalUrlRef.current === objectUrl) originalUrlRef.current = null;
@@ -169,7 +166,7 @@ const AudioEngine: React.FC = () => {
       registerAudioElement(null);
       scrubStemRouter.clearCache();
     };
-  }, [source, setDuration, setCurrentTime, setIsPlaying, setIsLoading, registerAudioElement, setCurrentSrc]);
+  }, [source, setDuration, setCurrentTime, setIsPlaying, setIsLoading, registerAudioElement]);
 
   useEffect(() => {
     const audio = audioRef.current;
@@ -204,13 +201,12 @@ const AudioEngine: React.FC = () => {
       isMuted: currentIsMuted,
     } = useAudioStore.getState();
     audio.src = targetUrl;
-    setCurrentSrc(targetUrl);
     audio.currentTime = time;
     audio.playbackRate = currentPlaybackRate;
     audio.volume = currentVolume;
     audio.muted = currentIsMuted;
     if (wasPlaying) audio.play().catch(() => {});
-  }, [currentStem, stemUrls, audioElement, setCurrentSrc]);
+  }, [currentStem, stemUrls, audioElement]);
 
   useEffect(() => {
     scrubStemRouter.selectStem(currentStem, () => stemUrls[currentStem]);

--- a/src/audio/scrub-preview.browser.test.ts
+++ b/src/audio/scrub-preview.browser.test.ts
@@ -1,6 +1,6 @@
 import { scrubPreview } from "@/audio/scrub-preview";
 import { useSettingsStore } from "@/stores/settings";
-import { makeSineBuffer } from "@/test/audio-fixtures";
+import { encodeWav, makeSineBuffer } from "@/test/audio-fixtures";
 import { afterEach, describe, expect, test } from "vitest";
 
 describe("scrub-preview", () => {
@@ -78,38 +78,3 @@ describe("scrub-preview", () => {
     expect(decoded.duration).toBeCloseTo(1, 1);
   });
 });
-
-function encodeWav(audioBuffer: AudioBuffer): ArrayBuffer {
-  const channelCount = audioBuffer.numberOfChannels;
-  const sampleRate = audioBuffer.sampleRate;
-  const samples = audioBuffer.length;
-  const dataLength = samples * channelCount * 2;
-  const buffer = new ArrayBuffer(44 + dataLength);
-  const view = new DataView(buffer);
-  const writeString = (offset: number, text: string) => {
-    for (let i = 0; i < text.length; i++) view.setUint8(offset + i, text.charCodeAt(i));
-  };
-  writeString(0, "RIFF");
-  view.setUint32(4, 36 + dataLength, true);
-  writeString(8, "WAVE");
-  writeString(12, "fmt ");
-  view.setUint32(16, 16, true);
-  view.setUint16(20, 1, true);
-  view.setUint16(22, channelCount, true);
-  view.setUint32(24, sampleRate, true);
-  view.setUint32(28, sampleRate * channelCount * 2, true);
-  view.setUint16(32, channelCount * 2, true);
-  view.setUint16(34, 16, true);
-  writeString(36, "data");
-  view.setUint32(40, dataLength, true);
-  const channels = Array.from({ length: channelCount }, (_, c) => audioBuffer.getChannelData(c));
-  let offset = 44;
-  for (let i = 0; i < samples; i++) {
-    for (let c = 0; c < channelCount; c++) {
-      const sample = Math.max(-1, Math.min(1, channels[c][i]));
-      view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
-      offset += 2;
-    }
-  }
-  return buffer;
-}

--- a/src/audio/scrub-stem-router.browser.test.ts
+++ b/src/audio/scrub-stem-router.browser.test.ts
@@ -117,6 +117,51 @@ describe("scrub-stem-router", () => {
       URL.revokeObjectURL(instrUrl);
     });
   });
+
+  describe("cache hit", () => {
+    test("re-selecting a stem uses the cached buffer (no second URL call)", async () => {
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      const vocalsUrl = bufferToBlobUrl(makeSineBuffer(1));
+
+      let urlCalls = 0;
+      const getVocalsUrl = () => {
+        urlCalls += 1;
+        return vocalsUrl;
+      };
+
+      scrubStemRouter.selectStem("vocals", getVocalsUrl);
+      await expect.poll(() => scrubStemRouter.getActiveStem(), { timeout: 5000 }).toBe("vocals");
+      expect(urlCalls).toBe(1);
+
+      scrubStemRouter.selectStem("original", () => undefined);
+      expect(scrubStemRouter.getActiveStem()).toBe("original");
+
+      scrubStemRouter.selectStem("vocals", getVocalsUrl);
+      expect(scrubStemRouter.getActiveStem()).toBe("vocals");
+      expect(urlCalls).toBe(1);
+
+      URL.revokeObjectURL(vocalsUrl);
+    });
+
+    test("re-selecting the currently-active stem is a no-op (does not stop mid-scrub)", async () => {
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      const vocalsUrl = bufferToBlobUrl(makeSineBuffer(1));
+
+      scrubStemRouter.selectStem("vocals", () => vocalsUrl);
+      await expect.poll(() => scrubStemRouter.getActiveStem(), { timeout: 5000 }).toBe("vocals");
+
+      scrubPreview.play(0.5, 1);
+      const before = scrubPreview.getActiveSnippet();
+      expect(before).not.toBeNull();
+
+      scrubStemRouter.selectStem("vocals", () => vocalsUrl);
+      const after = scrubPreview.getActiveSnippet();
+      expect(after?.time).toBe(before?.time);
+      expect(after?.rate).toBe(before?.rate);
+
+      URL.revokeObjectURL(vocalsUrl);
+    });
+  });
 });
 
 function bufferToBlobUrl(audioBuffer: AudioBuffer): string {

--- a/src/audio/scrub-stem-router.browser.test.ts
+++ b/src/audio/scrub-stem-router.browser.test.ts
@@ -1,6 +1,7 @@
 import { scrubPreview } from "@/audio/scrub-preview";
 import { scrubStemRouter } from "@/audio/scrub-stem-router";
 import { makeSineBuffer } from "@/test/audio-fixtures";
+import { allowConsole } from "@/test/console-guard";
 import { afterEach, describe, expect, test } from "vitest";
 
 describe("scrub-stem-router", () => {
@@ -73,6 +74,47 @@ describe("scrub-stem-router", () => {
       expect(scrubStemRouter.getActiveStem()).toBe("original");
       scrubPreview.play(0.3, 1);
       expect(scrubPreview.getActiveSnippet()?.time).toBe(0.3);
+    });
+  });
+
+  describe("uncached fetch path", () => {
+    test("selectStem('vocals') fetches and decodes the URL on cache miss", async () => {
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      const vocalsBuf = makeSineBuffer(1);
+      const vocalsUrl = bufferToBlobUrl(vocalsBuf);
+
+      scrubStemRouter.selectStem("vocals", () => vocalsUrl);
+      await expect.poll(() => scrubStemRouter.getActiveStem(), { timeout: 5000 }).toBe("vocals");
+
+      scrubPreview.play(0.5, 1);
+      const snippet = scrubPreview.getActiveSnippet();
+      expect(snippet?.time).toBe(0.5);
+      expect(snippet?.rate).toBe(1);
+
+      URL.revokeObjectURL(vocalsUrl);
+    });
+
+    test("selectStem('vocals') with no URL provider warns and stays on previous stem", () => {
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      scrubStemRouter.selectStem("original", () => undefined);
+      expect(scrubStemRouter.getActiveStem()).toBe("original");
+
+      allowConsole(/\[ScrubStemRouter\]/);
+      scrubStemRouter.selectStem("vocals", () => undefined);
+      expect(scrubStemRouter.getActiveStem()).toBe("original");
+    });
+
+    test("selectStem('instrumental') routes to scrubPreview after decode", async () => {
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      const instrUrl = bufferToBlobUrl(makeSineBuffer(1));
+
+      scrubStemRouter.selectStem("instrumental", () => instrUrl);
+      await expect.poll(() => scrubStemRouter.getActiveStem(), { timeout: 5000 }).toBe("instrumental");
+
+      scrubPreview.play(0.2, 1);
+      expect(scrubPreview.getActiveSnippet()?.time).toBe(0.2);
+
+      URL.revokeObjectURL(instrUrl);
     });
   });
 });

--- a/src/audio/scrub-stem-router.browser.test.ts
+++ b/src/audio/scrub-stem-router.browser.test.ts
@@ -233,6 +233,43 @@ describe("scrub-stem-router", () => {
       URL.revokeObjectURL(instrumentalUrl);
     });
   });
+
+  describe("decode failure", () => {
+    test("garbage blob URL leaves the previous active stem in place", async () => {
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      scrubStemRouter.selectStem("original", () => undefined);
+      expect(scrubStemRouter.getActiveStem()).toBe("original");
+
+      const garbageBlob = new Blob([new Uint8Array([1, 2, 3, 4, 5])], { type: "audio/wav" });
+      const garbageUrl = URL.createObjectURL(garbageBlob);
+
+      allowConsole(/\[ScrubStemRouter\]/);
+      scrubStemRouter.selectStem("vocals", () => garbageUrl);
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(scrubStemRouter.getActiveStem()).toBe("original");
+
+      URL.revokeObjectURL(garbageUrl);
+    });
+
+    test("decode failure does not poison the cache for the failed stem", async () => {
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      scrubStemRouter.selectStem("original", () => undefined);
+
+      const garbageUrl = URL.createObjectURL(new Blob([new Uint8Array([0, 0, 0, 0])], { type: "audio/wav" }));
+      allowConsole(/\[ScrubStemRouter\]/);
+      scrubStemRouter.selectStem("vocals", () => garbageUrl);
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(scrubStemRouter.getActiveStem()).toBe("original");
+
+      URL.revokeObjectURL(garbageUrl);
+      const validUrl = bufferToBlobUrl(makeSineBuffer(1));
+      scrubStemRouter.selectStem("vocals", () => validUrl);
+      await expect.poll(() => scrubStemRouter.getActiveStem(), { timeout: 5000 }).toBe("vocals");
+
+      URL.revokeObjectURL(validUrl);
+    });
+  });
 });
 
 function bufferToBlobUrl(audioBuffer: AudioBuffer): string {

--- a/src/audio/scrub-stem-router.browser.test.ts
+++ b/src/audio/scrub-stem-router.browser.test.ts
@@ -75,6 +75,23 @@ describe("scrub-stem-router", () => {
       scrubPreview.play(0.3, 1);
       expect(scrubPreview.getActiveSnippet()?.time).toBe(0.3);
     });
+
+    test("selectStem('original') deactivates a non-original stem when original is uncached", async () => {
+      const vocalsUrl = bufferToBlobUrl(makeSineBuffer(1));
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      scrubStemRouter.selectStem("vocals", () => vocalsUrl);
+      await expect.poll(() => scrubStemRouter.getActiveStem(), { timeout: 5000 }).toBe("vocals");
+
+      scrubStemRouter.setOriginalBuffer(null);
+      expect(scrubStemRouter.getActiveStem()).toBe("vocals");
+
+      scrubStemRouter.selectStem("original", () => undefined);
+      expect(scrubStemRouter.getActiveStem()).toBeNull();
+      scrubPreview.play(0.5, 1);
+      expect(scrubPreview.getActiveSnippet()).toBeNull();
+
+      URL.revokeObjectURL(vocalsUrl);
+    });
   });
 
   describe("uncached fetch path", () => {

--- a/src/audio/scrub-stem-router.browser.test.ts
+++ b/src/audio/scrub-stem-router.browser.test.ts
@@ -1,6 +1,6 @@
 import { scrubPreview } from "@/audio/scrub-preview";
 import { scrubStemRouter } from "@/audio/scrub-stem-router";
-import { makeSineBuffer } from "@/test/audio-fixtures";
+import { bufferToBlobUrl, makeSineBuffer } from "@/test/audio-fixtures";
 import { allowConsole } from "@/test/console-guard";
 import { afterEach, describe, expect, test } from "vitest";
 
@@ -271,44 +271,3 @@ describe("scrub-stem-router", () => {
     });
   });
 });
-
-function bufferToBlobUrl(audioBuffer: AudioBuffer): string {
-  const wavBytes = encodeWav(audioBuffer);
-  const blob = new Blob([wavBytes], { type: "audio/wav" });
-  return URL.createObjectURL(blob);
-}
-
-function encodeWav(audioBuffer: AudioBuffer): ArrayBuffer {
-  const channelCount = audioBuffer.numberOfChannels;
-  const sampleRate = audioBuffer.sampleRate;
-  const samples = audioBuffer.length;
-  const dataLength = samples * channelCount * 2;
-  const buffer = new ArrayBuffer(44 + dataLength);
-  const view = new DataView(buffer);
-  const writeString = (offset: number, text: string) => {
-    for (let i = 0; i < text.length; i++) view.setUint8(offset + i, text.charCodeAt(i));
-  };
-  writeString(0, "RIFF");
-  view.setUint32(4, 36 + dataLength, true);
-  writeString(8, "WAVE");
-  writeString(12, "fmt ");
-  view.setUint32(16, 16, true);
-  view.setUint16(20, 1, true);
-  view.setUint16(22, channelCount, true);
-  view.setUint32(24, sampleRate, true);
-  view.setUint32(28, sampleRate * channelCount * 2, true);
-  view.setUint16(32, channelCount * 2, true);
-  view.setUint16(34, 16, true);
-  writeString(36, "data");
-  view.setUint32(40, dataLength, true);
-  const channels = Array.from({ length: channelCount }, (_, c) => audioBuffer.getChannelData(c));
-  let offset = 44;
-  for (let i = 0; i < samples; i++) {
-    for (let c = 0; c < channelCount; c++) {
-      const sample = Math.max(-1, Math.min(1, channels[c][i]));
-      view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
-      offset += 2;
-    }
-  }
-  return buffer;
-}

--- a/src/audio/scrub-stem-router.browser.test.ts
+++ b/src/audio/scrub-stem-router.browser.test.ts
@@ -162,6 +162,40 @@ describe("scrub-stem-router", () => {
       URL.revokeObjectURL(vocalsUrl);
     });
   });
+
+  describe("race protection", () => {
+    test("rapid switch only applies the latest selection", async () => {
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      const vocalsUrl = bufferToBlobUrl(makeSineBuffer(1));
+      const instrumentalUrl = bufferToBlobUrl(makeSineBuffer(1));
+
+      scrubStemRouter.selectStem("vocals", () => vocalsUrl);
+      scrubStemRouter.selectStem("instrumental", () => instrumentalUrl);
+
+      await expect.poll(() => scrubStemRouter.getActiveStem(), { timeout: 5000 }).toBe("instrumental");
+
+      URL.revokeObjectURL(vocalsUrl);
+      URL.revokeObjectURL(instrumentalUrl);
+    });
+
+    test("three rapid switches converge on the third stem", async () => {
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      const vocalsUrl = bufferToBlobUrl(makeSineBuffer(1));
+      const instrumentalUrl = bufferToBlobUrl(makeSineBuffer(1));
+
+      scrubStemRouter.selectStem("vocals", () => vocalsUrl);
+      scrubStemRouter.selectStem("instrumental", () => instrumentalUrl);
+      scrubStemRouter.selectStem("original", () => undefined);
+
+      expect(scrubStemRouter.getActiveStem()).toBe("original");
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(scrubStemRouter.getActiveStem()).toBe("original");
+
+      URL.revokeObjectURL(vocalsUrl);
+      URL.revokeObjectURL(instrumentalUrl);
+    });
+  });
 });
 
 function bufferToBlobUrl(audioBuffer: AudioBuffer): string {

--- a/src/audio/scrub-stem-router.browser.test.ts
+++ b/src/audio/scrub-stem-router.browser.test.ts
@@ -163,6 +163,43 @@ describe("scrub-stem-router", () => {
     });
   });
 
+  describe("clearCache", () => {
+    test("clearCache invalidates the cache and forces refetch on next selectStem", async () => {
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      const vocalsUrl = bufferToBlobUrl(makeSineBuffer(1));
+
+      let urlCalls = 0;
+      const getVocalsUrl = () => {
+        urlCalls += 1;
+        return vocalsUrl;
+      };
+
+      scrubStemRouter.selectStem("vocals", getVocalsUrl);
+      await expect.poll(() => scrubStemRouter.getActiveStem()).toBe("vocals");
+      expect(urlCalls).toBe(1);
+
+      scrubStemRouter.clearCache();
+      expect(scrubStemRouter.getActiveStem()).toBeNull();
+
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      scrubStemRouter.selectStem("vocals", getVocalsUrl);
+      await expect.poll(() => scrubStemRouter.getActiveStem(), { timeout: 5000 }).toBe("vocals");
+      expect(urlCalls).toBe(2);
+
+      URL.revokeObjectURL(vocalsUrl);
+    });
+
+    test("clearCache leaves scrubPreview with no active buffer", () => {
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      scrubStemRouter.selectStem("original", () => undefined);
+      expect(scrubStemRouter.getActiveStem()).toBe("original");
+
+      scrubStemRouter.clearCache();
+      scrubPreview.play(0.5, 1);
+      expect(scrubPreview.getActiveSnippet()).toBeNull();
+    });
+  });
+
   describe("race protection", () => {
     test("rapid switch only applies the latest selection", async () => {
       scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));

--- a/src/audio/scrub-stem-router.browser.test.ts
+++ b/src/audio/scrub-stem-router.browser.test.ts
@@ -1,0 +1,119 @@
+import { scrubPreview } from "@/audio/scrub-preview";
+import { scrubStemRouter } from "@/audio/scrub-stem-router";
+import { makeSineBuffer } from "@/test/audio-fixtures";
+import { afterEach, describe, expect, test } from "vitest";
+
+describe("scrub-stem-router", () => {
+  afterEach(() => {
+    scrubStemRouter.clearCache();
+    scrubPreview.stop();
+    scrubPreview.useBuffer(null);
+  });
+
+  describe("happy path", () => {
+    test("setOriginalBuffer + selectStem('original') routes to scrubPreview", () => {
+      const buf = makeSineBuffer(1);
+      scrubStemRouter.setOriginalBuffer(buf);
+      scrubStemRouter.selectStem("original", () => undefined);
+      expect(scrubStemRouter.getActiveStem()).toBe("original");
+      scrubPreview.play(0.5, 1);
+      const snippet = scrubPreview.getActiveSnippet();
+      expect(snippet).not.toBeNull();
+      expect(snippet?.time).toBe(0.5);
+      expect(snippet?.rate).toBe(1);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("setOriginalBuffer(null) clears scrubPreview if original was active", () => {
+      const buf = makeSineBuffer(1);
+      scrubStemRouter.setOriginalBuffer(buf);
+      scrubStemRouter.selectStem("original", () => undefined);
+      expect(scrubStemRouter.getActiveStem()).toBe("original");
+      scrubStemRouter.setOriginalBuffer(null);
+      expect(scrubStemRouter.getActiveStem()).toBeNull();
+      scrubPreview.play(0.5, 1);
+      expect(scrubPreview.getActiveSnippet()).toBeNull();
+    });
+
+    test("getActiveStem is null before any buffer is set", () => {
+      expect(scrubStemRouter.getActiveStem()).toBeNull();
+    });
+  });
+
+  describe("invariants", () => {
+    test("setOriginalBuffer does not steal routing when a stem is already active", async () => {
+      const vocalsBuf = makeSineBuffer(1);
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      scrubStemRouter.selectStem("original", () => undefined);
+      const vocalsUrl = bufferToBlobUrl(vocalsBuf);
+      scrubStemRouter.selectStem("vocals", () => vocalsUrl);
+      await expect.poll(() => scrubStemRouter.getActiveStem(), { timeout: 5000 }).toBe("vocals");
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      expect(scrubStemRouter.getActiveStem()).toBe("vocals");
+      URL.revokeObjectURL(vocalsUrl);
+    });
+
+    test("clearCache resets activeStem regardless of which stem was active", async () => {
+      const vocalsBuf = makeSineBuffer(1);
+      const vocalsUrl = bufferToBlobUrl(vocalsBuf);
+      scrubStemRouter.setOriginalBuffer(makeSineBuffer(1));
+      scrubStemRouter.selectStem("vocals", () => vocalsUrl);
+      await expect.poll(() => scrubStemRouter.getActiveStem(), { timeout: 5000 }).toBe("vocals");
+      scrubStemRouter.clearCache();
+      expect(scrubStemRouter.getActiveStem()).toBeNull();
+      URL.revokeObjectURL(vocalsUrl);
+    });
+
+    test("selectStem('original') before setOriginalBuffer waits, then activates on setOriginalBuffer", () => {
+      scrubStemRouter.selectStem("original", () => undefined);
+      expect(scrubStemRouter.getActiveStem()).toBeNull();
+      const buf = makeSineBuffer(1);
+      scrubStemRouter.setOriginalBuffer(buf);
+      expect(scrubStemRouter.getActiveStem()).toBe("original");
+      scrubPreview.play(0.3, 1);
+      expect(scrubPreview.getActiveSnippet()?.time).toBe(0.3);
+    });
+  });
+});
+
+function bufferToBlobUrl(audioBuffer: AudioBuffer): string {
+  const wavBytes = encodeWav(audioBuffer);
+  const blob = new Blob([wavBytes], { type: "audio/wav" });
+  return URL.createObjectURL(blob);
+}
+
+function encodeWav(audioBuffer: AudioBuffer): ArrayBuffer {
+  const channelCount = audioBuffer.numberOfChannels;
+  const sampleRate = audioBuffer.sampleRate;
+  const samples = audioBuffer.length;
+  const dataLength = samples * channelCount * 2;
+  const buffer = new ArrayBuffer(44 + dataLength);
+  const view = new DataView(buffer);
+  const writeString = (offset: number, text: string) => {
+    for (let i = 0; i < text.length; i++) view.setUint8(offset + i, text.charCodeAt(i));
+  };
+  writeString(0, "RIFF");
+  view.setUint32(4, 36 + dataLength, true);
+  writeString(8, "WAVE");
+  writeString(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, channelCount, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * channelCount * 2, true);
+  view.setUint16(32, channelCount * 2, true);
+  view.setUint16(34, 16, true);
+  writeString(36, "data");
+  view.setUint32(40, dataLength, true);
+  const channels = Array.from({ length: channelCount }, (_, c) => audioBuffer.getChannelData(c));
+  let offset = 44;
+  for (let i = 0; i < samples; i++) {
+    for (let c = 0; c < channelCount; c++) {
+      const sample = Math.max(-1, Math.min(1, channels[c][i]));
+      view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+      offset += 2;
+    }
+  }
+  return buffer;
+}

--- a/src/audio/scrub-stem-router.ts
+++ b/src/audio/scrub-stem-router.ts
@@ -1,0 +1,91 @@
+import { scrubPreview } from "@/audio/scrub-preview";
+import type { Stem } from "@/audio/separation/types";
+
+// -- Constants -----------------------------------------------------------------
+const LOG_PREFIX = "[ScrubStemRouter]";
+
+// -- State ---------------------------------------------------------------------
+const cache: Map<Stem, AudioBuffer> = new Map();
+let activeStem: Stem | null = null;
+let selectionToken = 0;
+
+// -- Helpers -------------------------------------------------------------------
+function activate(stem: Stem, buf: AudioBuffer): void {
+  scrubPreview.useBuffer(buf);
+  activeStem = stem;
+}
+
+function deactivate(): void {
+  scrubPreview.useBuffer(null);
+  activeStem = null;
+}
+
+async function fetchAndDecode(url: string): Promise<AudioBuffer> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`fetch failed: ${response.status} ${response.statusText}`);
+  }
+  const bytes = await response.arrayBuffer();
+  return scrubPreview.decode(bytes);
+}
+
+// -- Public API ----------------------------------------------------------------
+function setOriginalBuffer(buffer: AudioBuffer | null): void {
+  if (buffer) {
+    cache.set("original", buffer);
+    if (activeStem === "original" || activeStem === null) {
+      activate("original", buffer);
+    }
+    return;
+  }
+  cache.delete("original");
+  if (activeStem === "original") {
+    deactivate();
+  }
+}
+
+function selectStem(stem: Stem, getUrl: () => string | undefined): void {
+  if (stem === activeStem) {
+    const alreadyRouted = cache.get(stem);
+    if (alreadyRouted) return;
+  }
+  const cached = cache.get(stem);
+  if (cached) {
+    activate(stem, cached);
+    return;
+  }
+  if (stem === "original") return;
+
+  selectionToken += 1;
+  const myToken = selectionToken;
+  const url = getUrl();
+  if (!url) {
+    console.warn(LOG_PREFIX, `no URL provided for stem "${stem}"; staying on previous stem`);
+    return;
+  }
+
+  void fetchAndDecode(url)
+    .then((buf) => {
+      if (myToken !== selectionToken) return;
+      cache.set(stem, buf);
+      activate(stem, buf);
+    })
+    .catch((err) => {
+      console.warn(LOG_PREFIX, `failed to load stem "${stem}":`, err);
+    });
+}
+
+function clearCache(): void {
+  cache.clear();
+  activeStem = null;
+  selectionToken += 1;
+  scrubPreview.useBuffer(null);
+}
+
+function getActiveStem(): Stem | null {
+  return activeStem;
+}
+
+const scrubStemRouter = { setOriginalBuffer, selectStem, clearCache, getActiveStem };
+
+export { scrubStemRouter };

--- a/src/audio/scrub-stem-router.ts
+++ b/src/audio/scrub-stem-router.ts
@@ -45,6 +45,9 @@ function setOriginalBuffer(buffer: AudioBuffer | null): void {
 }
 
 function selectStem(stem: Stem, getUrl: () => string | undefined): void {
+  selectionToken += 1;
+  const myToken = selectionToken;
+
   if (stem === activeStem) {
     const alreadyRouted = cache.get(stem);
     if (alreadyRouted) return;
@@ -56,8 +59,6 @@ function selectStem(stem: Stem, getUrl: () => string | undefined): void {
   }
   if (stem === "original") return;
 
-  selectionToken += 1;
-  const myToken = selectionToken;
   const url = getUrl();
   if (!url) {
     console.warn(LOG_PREFIX, `no URL provided for stem "${stem}"; staying on previous stem`);
@@ -71,6 +72,7 @@ function selectStem(stem: Stem, getUrl: () => string | undefined): void {
       activate(stem, buf);
     })
     .catch((err) => {
+      if (myToken !== selectionToken) return;
       console.warn(LOG_PREFIX, `failed to load stem "${stem}":`, err);
     });
 }

--- a/src/audio/scrub-stem-router.ts
+++ b/src/audio/scrub-stem-router.ts
@@ -57,7 +57,10 @@ function selectStem(stem: Stem, getUrl: () => string | undefined): void {
     activate(stem, cached);
     return;
   }
-  if (stem === "original") return;
+  if (stem === "original") {
+    if (activeStem !== null) deactivate();
+    return;
+  }
 
   const url = getUrl();
   if (!url) {

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -15,6 +15,7 @@ interface AudioState {
   isMuted: boolean;
   isLoading: boolean;
   audioElement: HTMLAudioElement | null;
+  currentSrc: string | null;
   youtubeLoadError: string | null;
 }
 
@@ -31,6 +32,7 @@ interface AudioActions {
   setIsLoading: (isLoading: boolean) => void;
   setYouTubeLoadError: (error: string | null) => void;
   registerAudioElement: (element: HTMLAudioElement | null) => void;
+  setCurrentSrc: (src: string | null) => void;
   seekTo: (time: number) => void;
   reset: () => void;
 }
@@ -49,6 +51,7 @@ function createInitialState(): AudioState {
     isMuted: false,
     isLoading: false,
     audioElement: null,
+    currentSrc: null,
     youtubeLoadError: null,
   };
 }
@@ -89,6 +92,7 @@ const useAudioStore = create<AudioState & AudioActions>((set, get) => ({
   setIsLoading: (isLoading) => set({ isLoading }),
   setYouTubeLoadError: (youtubeLoadError) => set({ youtubeLoadError }),
   registerAudioElement: (audioElement) => set({ audioElement }),
+  setCurrentSrc: (currentSrc) => set({ currentSrc }),
   seekTo: (time: number) => {
     if (!Number.isFinite(time) || time < 0) return;
     const audio = get().audioElement;

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -15,7 +15,6 @@ interface AudioState {
   isMuted: boolean;
   isLoading: boolean;
   audioElement: HTMLAudioElement | null;
-  currentSrc: string | null;
   youtubeLoadError: string | null;
 }
 
@@ -32,7 +31,6 @@ interface AudioActions {
   setIsLoading: (isLoading: boolean) => void;
   setYouTubeLoadError: (error: string | null) => void;
   registerAudioElement: (element: HTMLAudioElement | null) => void;
-  setCurrentSrc: (src: string | null) => void;
   seekTo: (time: number) => void;
   reset: () => void;
 }
@@ -51,7 +49,6 @@ function createInitialState(): AudioState {
     isMuted: false,
     isLoading: false,
     audioElement: null,
-    currentSrc: null,
     youtubeLoadError: null,
   };
 }
@@ -92,7 +89,6 @@ const useAudioStore = create<AudioState & AudioActions>((set, get) => ({
   setIsLoading: (isLoading) => set({ isLoading }),
   setYouTubeLoadError: (youtubeLoadError) => set({ youtubeLoadError }),
   registerAudioElement: (audioElement) => set({ audioElement }),
-  setCurrentSrc: (currentSrc) => set({ currentSrc }),
   seekTo: (time: number) => {
     if (!Number.isFinite(time) || time < 0) return;
     const audio = get().audioElement;

--- a/src/test/audio-fixtures.ts
+++ b/src/test/audio-fixtures.ts
@@ -67,4 +67,45 @@ function makeSineBuffer(durationS: number, sampleRate = 44100): AudioBuffer {
   return audioBuffer;
 }
 
-export { createAudioFile, createMp3File, makeSineBuffer };
+function encodeWav(audioBuffer: AudioBuffer): ArrayBuffer {
+  const channelCount = audioBuffer.numberOfChannels;
+  const sampleRate = audioBuffer.sampleRate;
+  const samples = audioBuffer.length;
+  const dataLength = samples * channelCount * 2;
+  const buffer = new ArrayBuffer(44 + dataLength);
+  const view = new DataView(buffer);
+  const writeString = (offset: number, text: string) => {
+    for (let i = 0; i < text.length; i++) view.setUint8(offset + i, text.charCodeAt(i));
+  };
+  writeString(0, "RIFF");
+  view.setUint32(4, 36 + dataLength, true);
+  writeString(8, "WAVE");
+  writeString(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, channelCount, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * channelCount * 2, true);
+  view.setUint16(32, channelCount * 2, true);
+  view.setUint16(34, 16, true);
+  writeString(36, "data");
+  view.setUint32(40, dataLength, true);
+  const channels = Array.from({ length: channelCount }, (_, c) => audioBuffer.getChannelData(c));
+  let offset = 44;
+  for (let i = 0; i < samples; i++) {
+    for (let c = 0; c < channelCount; c++) {
+      const sample = Math.max(-1, Math.min(1, channels[c][i]));
+      view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+      offset += 2;
+    }
+  }
+  return buffer;
+}
+
+function bufferToBlobUrl(audioBuffer: AudioBuffer): string {
+  const wavBytes = encodeWav(audioBuffer);
+  const blob = new Blob([wavBytes], { type: "audio/wav" });
+  return URL.createObjectURL(blob);
+}
+
+export { bufferToBlobUrl, createAudioFile, createMp3File, encodeWav, makeSineBuffer };

--- a/src/views/timeline/timeline-waveform.tsx
+++ b/src/views/timeline/timeline-waveform.tsx
@@ -1,4 +1,5 @@
 import { useAudioStore } from "@/stores/audio";
+import { useSeparationStore } from "@/stores/separation";
 import { useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
 import WavesurferPlayer from "@wavesurfer/react";
 import { useCallback, useEffect, useState } from "react";
@@ -11,13 +12,14 @@ const TimelineWaveform: React.FC = () => {
   const duration = useAudioStore((s) => s.duration);
   const audioElement = useAudioStore((s) => s.audioElement);
   const seekTo = useAudioStore((s) => s.seekTo);
+  const currentStem = useSeparationStore((s) => s.currentStem);
 
   const zoom = useTimelineStore((s) => s.zoom);
 
   const [ws, setWs] = useState<WaveSurfer | null>(null);
 
   const totalWidth = duration > 0 ? duration * zoom : 0;
-  const waveformKey = audioElement?.src ?? "no-audio";
+  const waveformKey = `${audioElement?.src ?? "no-audio"}|${currentStem}`;
 
   // Sync zoom imperatively
   useEffect(() => {

--- a/src/views/timeline/timeline-waveform.tsx
+++ b/src/views/timeline/timeline-waveform.tsx
@@ -1,5 +1,4 @@
 import { useAudioStore } from "@/stores/audio";
-import { useSeparationStore } from "@/stores/separation";
 import { useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
 import WavesurferPlayer from "@wavesurfer/react";
 import { useCallback, useEffect, useState } from "react";
@@ -12,14 +11,13 @@ const TimelineWaveform: React.FC = () => {
   const duration = useAudioStore((s) => s.duration);
   const audioElement = useAudioStore((s) => s.audioElement);
   const seekTo = useAudioStore((s) => s.seekTo);
-  const currentStem = useSeparationStore((s) => s.currentStem);
 
   const zoom = useTimelineStore((s) => s.zoom);
 
   const [ws, setWs] = useState<WaveSurfer | null>(null);
 
   const totalWidth = duration > 0 ? duration * zoom : 0;
-  const waveformKey = `${audioElement?.src ?? "no-audio"}|${currentStem}`;
+  const waveformKey = audioElement?.src ?? "no-audio";
 
   // Sync zoom imperatively
   useEffect(() => {

--- a/src/views/timeline/timeline-waveform.tsx
+++ b/src/views/timeline/timeline-waveform.tsx
@@ -19,7 +19,15 @@ const TimelineWaveform: React.FC = () => {
   const totalWidth = duration > 0 ? duration * zoom : 0;
   const waveformKey = audioElement?.src ?? "no-audio";
 
-  // Sync zoom imperatively
+  useEffect(() => {
+    if (!ws || !audioElement) return;
+    const onLoadStart = () => {
+      if (audioElement.src) void ws.load(audioElement.src);
+    };
+    audioElement.addEventListener("loadstart", onLoadStart);
+    return () => audioElement.removeEventListener("loadstart", onLoadStart);
+  }, [ws, audioElement]);
+
   useEffect(() => {
     if (!ws) return;
     ws.zoom(zoom);

--- a/src/views/timeline/timeline-waveform.tsx
+++ b/src/views/timeline/timeline-waveform.tsx
@@ -10,7 +10,6 @@ const TimelineWaveform: React.FC = () => {
   const source = useAudioStore((s) => s.source);
   const duration = useAudioStore((s) => s.duration);
   const audioElement = useAudioStore((s) => s.audioElement);
-  const currentSrc = useAudioStore((s) => s.currentSrc);
   const seekTo = useAudioStore((s) => s.seekTo);
 
   const zoom = useTimelineStore((s) => s.zoom);
@@ -18,7 +17,7 @@ const TimelineWaveform: React.FC = () => {
   const [ws, setWs] = useState<WaveSurfer | null>(null);
 
   const totalWidth = duration > 0 ? duration * zoom : 0;
-  const waveformKey = currentSrc ?? "no-audio";
+  const waveformKey = audioElement?.src ?? "no-audio";
 
   // Sync zoom imperatively
   useEffect(() => {

--- a/src/views/timeline/timeline-waveform.tsx
+++ b/src/views/timeline/timeline-waveform.tsx
@@ -10,6 +10,7 @@ const TimelineWaveform: React.FC = () => {
   const source = useAudioStore((s) => s.source);
   const duration = useAudioStore((s) => s.duration);
   const audioElement = useAudioStore((s) => s.audioElement);
+  const currentSrc = useAudioStore((s) => s.currentSrc);
   const seekTo = useAudioStore((s) => s.seekTo);
 
   const zoom = useTimelineStore((s) => s.zoom);
@@ -17,7 +18,7 @@ const TimelineWaveform: React.FC = () => {
   const [ws, setWs] = useState<WaveSurfer | null>(null);
 
   const totalWidth = duration > 0 ? duration * zoom : 0;
-  const waveformKey = audioElement?.src ?? "no-audio";
+  const waveformKey = currentSrc ?? "no-audio";
 
   // Sync zoom imperatively
   useEffect(() => {


### PR DESCRIPTION
## Summary

When a track is split into vocals or instrumental, dragging the playhead in the timeline now plays the selected stem instead of the full mix. Switching stems mid-scrub doesn't interrupt the snippet.

A small new module sits between the separation store and the existing scrub-preview singleton. It caches decoded AudioBuffers per stem, uses a monotonic token to drop stale fetches when the user switches stems rapidly, and clears itself when the audio source changes.

While diagnosing waveform drift between the original and the vocals stem during this work, I noticed the vocals output is shifted earlier by about 43 ms (cross-correlated against the original). Instrumental is sample-aligned because it's computed as `original - vocals` and inherits the original's timeline. That's a separate STFT/ISTFT trim issue and I'll fix it on its own branch.

## What changed

- New `src/audio/scrub-stem-router.ts` owns the stem-to-AudioBuffer map and the routing into scrub-preview.
- `audio-engine.tsx` now seeds the original buffer into the router and adds a `useEffect` that calls `selectStem(currentStem, () => stemUrls[currentStem])` on store updates.
- Existing `scrubPreview.useBuffer(null)` calls on source teardown become `scrubStemRouter.clearCache()`.
- `bufferToBlobUrl` and `encodeWav` test helpers moved into `src/test/audio-fixtures.ts` so the router and audio-engine tests share one copy.

## Test plan

- [ ] Load a track and run separation.
- [ ] Drag the playhead while on Vocals. Only vocals should play.
- [ ] Switch to Instrumental and drag again. Only the instrumental should play.
- [ ] Switch back to Original and drag. Full mix.
- [ ] Rapidly toggle stems while dragging. No glitches beyond the existing crossfade, the final stem wins.
- [ ] Load a different track. Scrub still plays the original of the new track, not the previous one.

## Coverage

17 new browser tests for the router (`scrub-stem-router.browser.test.ts`) and 2 integration tests in `audio-engine.browser.test.tsx`. The existing 14 audio-engine tests still pass.