### PR TITLE
feat: strip LAME priming on MP3 decode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.24.2",
+  "version": "1.25.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.25.1",
+  "version": "1.25.2",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.25.0",
+  "version": "1.25.1",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/audio/audio-decode.browser.test.ts
+++ b/src/audio/audio-decode.browser.test.ts
@@ -35,8 +35,9 @@ describe("decodeAudioToWav LAME priming strip", () => {
   it("returns a WAV blob whose sample count is reduced by the parsed LAME priming", async () => {
     const file = createMp3File();
     const bytes = await file.arrayBuffer();
-    const priming = parseLamePriming(bytes);
-    expect(priming).toBeGreaterThan(0);
+    const { samples, sampleRate } = parseLamePriming(bytes);
+    expect(samples).toBeGreaterThan(0);
+    expect(sampleRate).toBeGreaterThan(0);
 
     const blob = await decodeAudioToWav(file);
     const wav = await blob.arrayBuffer();
@@ -49,6 +50,7 @@ describe("decodeAudioToWav LAME priming strip", () => {
     const unstripped = await ctx.decodeAudioData(bytes.slice(0));
     await ctx.close();
 
-    expect(wavFrames).toBe(unstripped.length - priming);
+    const expectedStrip = Math.round((samples * unstripped.sampleRate) / sampleRate);
+    expect(wavFrames).toBe(unstripped.length - expectedStrip);
   });
 });

--- a/src/audio/audio-decode.browser.test.ts
+++ b/src/audio/audio-decode.browser.test.ts
@@ -1,4 +1,5 @@
 import { decodeAudioToWav } from "@/audio/audio-decode";
+import { parseLamePriming } from "@/audio/lame-priming";
 import { createMp3File } from "@/test/audio-fixtures";
 import { describe, expect, it } from "vitest";
 
@@ -27,5 +28,27 @@ describe("decodeAudioToWav", () => {
   it("rejects a file that is not decodable audio", async () => {
     const garbage = new File([new Uint8Array([1, 2, 3, 4, 5])], "broken.mp3", { type: "audio/mpeg" });
     await expect(decodeAudioToWav(garbage)).rejects.toBeTruthy();
+  });
+});
+
+describe("decodeAudioToWav LAME priming strip", () => {
+  it("returns a WAV blob whose sample count is reduced by the parsed LAME priming", async () => {
+    const file = createMp3File();
+    const bytes = await file.arrayBuffer();
+    const priming = parseLamePriming(bytes);
+    expect(priming).toBeGreaterThan(0);
+
+    const blob = await decodeAudioToWav(file);
+    const wav = await blob.arrayBuffer();
+    const view = new DataView(wav);
+    const dataSize = view.getUint32(40, true);
+    const channels = view.getUint16(22, true);
+    const wavFrames = dataSize / (channels * 2);
+
+    const ctx = new AudioContext();
+    const unstripped = await ctx.decodeAudioData(bytes.slice(0));
+    await ctx.close();
+
+    expect(wavFrames).toBe(unstripped.length - priming);
   });
 });

--- a/src/audio/audio-decode.ts
+++ b/src/audio/audio-decode.ts
@@ -1,3 +1,5 @@
+import { parseLamePriming } from "@/audio/lame-priming";
+
 // -- Types --------------------------------------------------------------------
 
 interface DecodedAudio {
@@ -69,13 +71,35 @@ function audioBufferToWav(audio: DecodedAudio): Blob {
 // the original file.
 async function decodeAudioToWav(file: File): Promise<Blob> {
   const arrayBuffer = await file.arrayBuffer();
+  const priming = parseLamePriming(arrayBuffer);
   const ctx = new AudioContext();
   try {
     const audioBuffer = await ctx.decodeAudioData(arrayBuffer);
-    return audioBufferToWav(audioBuffer);
+    if (priming === 0) return audioBufferToWav(audioBuffer);
+    const stripped = makeStrippedAudio(audioBuffer, priming);
+    return audioBufferToWav(stripped);
   } finally {
     void ctx.close();
   }
+}
+
+function makeStrippedAudio(audio: AudioBuffer, priming: number): DecodedAudio {
+  const length = Math.max(0, audio.length - priming);
+  const channels: Float32Array[] = [];
+  for (let c = 0; c < audio.numberOfChannels; c++) {
+    const data = audio.getChannelData(c);
+    const out = new Float32Array(length);
+    out.set(data.subarray(priming, priming + length));
+    channels.push(out);
+  }
+  return {
+    sampleRate: audio.sampleRate,
+    numberOfChannels: audio.numberOfChannels,
+    length,
+    getChannelData(channel: number) {
+      return channels[channel];
+    },
+  };
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/src/audio/audio-decode.ts
+++ b/src/audio/audio-decode.ts
@@ -75,7 +75,11 @@ async function decodeAudioToWav(file: File): Promise<Blob> {
   const ctx = new AudioContext();
   try {
     const audioBuffer = await ctx.decodeAudioData(arrayBuffer);
-    return audioBufferToWav(cropAudioBufferHead(audioBuffer, priming, ctx));
+    const startSample =
+      priming.samples > 0 && priming.sampleRate > 0
+        ? Math.round((priming.samples * audioBuffer.sampleRate) / priming.sampleRate)
+        : 0;
+    return audioBufferToWav(cropAudioBufferHead(audioBuffer, startSample, ctx));
   } finally {
     void ctx.close();
   }

--- a/src/audio/audio-decode.ts
+++ b/src/audio/audio-decode.ts
@@ -1,4 +1,4 @@
-import { parseLamePriming } from "@/audio/lame-priming";
+import { cropAudioBufferHead, parseLamePriming } from "@/audio/lame-priming";
 
 // -- Types --------------------------------------------------------------------
 
@@ -75,31 +75,10 @@ async function decodeAudioToWav(file: File): Promise<Blob> {
   const ctx = new AudioContext();
   try {
     const audioBuffer = await ctx.decodeAudioData(arrayBuffer);
-    if (priming === 0) return audioBufferToWav(audioBuffer);
-    const stripped = makeStrippedAudio(audioBuffer, priming);
-    return audioBufferToWav(stripped);
+    return audioBufferToWav(cropAudioBufferHead(audioBuffer, priming, ctx));
   } finally {
     void ctx.close();
   }
-}
-
-function makeStrippedAudio(audio: AudioBuffer, priming: number): DecodedAudio {
-  const length = Math.max(0, audio.length - priming);
-  const channels: Float32Array[] = [];
-  for (let c = 0; c < audio.numberOfChannels; c++) {
-    const data = audio.getChannelData(c);
-    const out = new Float32Array(length);
-    out.set(data.subarray(priming, priming + length));
-    channels.push(out);
-  }
-  return {
-    sampleRate: audio.sampleRate,
-    numberOfChannels: audio.numberOfChannels,
-    length,
-    getChannelData(channel: number) {
-      return channels[channel];
-    },
-  };
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/src/audio/audio-engine.browser.test.tsx
+++ b/src/audio/audio-engine.browser.test.tsx
@@ -261,4 +261,30 @@ describe("AudioEngine", () => {
     await waitFor(() => useAudioStore.getState().audioElement === null);
     expect(scrubStemRouter.getActiveStem()).toBeNull();
   });
+
+  it("sets primingStripped to true after the audio element is registered for a wav source", async () => {
+    await render(<AudioEngine />);
+    expect(useAudioStore.getState().primingStripped).toBe(false);
+    useAudioStore.setState({ source: { type: "file", file: createAudioFile() } });
+    await waitFor(() => useAudioStore.getState().audioElement !== null);
+    await waitFor(() => useAudioStore.getState().primingStripped === true);
+    expect(useAudioStore.getState().primingStripped).toBe(true);
+  });
+
+  it("sets primingStripped to true after the audio element is registered for an mp3 source", async () => {
+    await render(<AudioEngine />);
+    useAudioStore.setState({ source: { type: "file", file: createMp3File() } });
+    await waitFor(() => useAudioStore.getState().audioElement !== null, 5000);
+    await waitFor(() => useAudioStore.getState().primingStripped === true, 5000);
+    expect(useAudioStore.getState().primingStripped).toBe(true);
+  });
+
+  it("resets primingStripped to false when the source changes via setSource", async () => {
+    await render(<AudioEngine />);
+    useAudioStore.getState().setSource({ type: "file", file: createAudioFile() });
+    await waitFor(() => useAudioStore.getState().primingStripped === true);
+    useAudioStore.getState().setSource({ type: "file", file: createAudioFile("second.wav") });
+    await waitFor(() => useAudioStore.getState().primingStripped === true);
+    expect(useAudioStore.getState().primingStripped).toBe(true);
+  });
 });

--- a/src/audio/audio-engine.browser.test.tsx
+++ b/src/audio/audio-engine.browser.test.tsx
@@ -284,6 +284,7 @@ describe("AudioEngine", () => {
     useAudioStore.getState().setSource({ type: "file", file: createAudioFile() });
     await waitFor(() => useAudioStore.getState().primingStripped === true);
     useAudioStore.getState().setSource({ type: "file", file: createAudioFile("second.wav") });
+    expect(useAudioStore.getState().primingStripped).toBe(false);
     await waitFor(() => useAudioStore.getState().primingStripped === true);
     expect(useAudioStore.getState().primingStripped).toBe(true);
   });

--- a/src/audio/audio-engine.browser.test.tsx
+++ b/src/audio/audio-engine.browser.test.tsx
@@ -288,4 +288,16 @@ describe("AudioEngine", () => {
     await waitFor(() => useAudioStore.getState().primingStripped === true);
     expect(useAudioStore.getState().primingStripped).toBe(true);
   });
+
+  it("regression: preserves primingStripped when mp3 decode fails so the migrated flag survives", async () => {
+    allowConsole(/audio decode failed/);
+    allowConsole(/scrub-preview decode failed/);
+    allowConsole(/Audio error/);
+    await render(<AudioEngine />);
+    useAudioStore.setState({ primingStripped: true });
+    const garbage = new File([new Uint8Array([1, 2, 3, 4, 5])], "broken.mp3", { type: "audio/mpeg" });
+    useAudioStore.setState({ source: { type: "file", file: garbage } });
+    await waitFor(() => useAudioStore.getState().audioElement !== null, 5000);
+    expect(useAudioStore.getState().primingStripped).toBe(true);
+  });
 });

--- a/src/audio/audio-engine.browser.test.tsx
+++ b/src/audio/audio-engine.browser.test.tsx
@@ -2,6 +2,7 @@ import { AudioEngine } from "@/audio/audio-engine";
 import { scrubPreview } from "@/audio/scrub-preview";
 import { scrubStemRouter } from "@/audio/scrub-stem-router";
 import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
 import { useSeparationStore } from "@/stores/separation";
 import { createAudioFile, createMp3File } from "@/test/audio-fixtures";
 import { allowConsole } from "@/test/console-guard";
@@ -264,29 +265,19 @@ describe("AudioEngine", () => {
 
   it("sets primingStripped to true after the audio element is registered for a wav source", async () => {
     await render(<AudioEngine />);
-    expect(useAudioStore.getState().primingStripped).toBe(false);
+    expect(useProjectStore.getState().primingStripped).toBe(false);
     useAudioStore.setState({ source: { type: "file", file: createAudioFile() } });
     await waitFor(() => useAudioStore.getState().audioElement !== null);
-    await waitFor(() => useAudioStore.getState().primingStripped === true);
-    expect(useAudioStore.getState().primingStripped).toBe(true);
+    await waitFor(() => useProjectStore.getState().primingStripped === true);
+    expect(useProjectStore.getState().primingStripped).toBe(true);
   });
 
   it("sets primingStripped to true after the audio element is registered for an mp3 source", async () => {
     await render(<AudioEngine />);
     useAudioStore.setState({ source: { type: "file", file: createMp3File() } });
     await waitFor(() => useAudioStore.getState().audioElement !== null, 5000);
-    await waitFor(() => useAudioStore.getState().primingStripped === true, 5000);
-    expect(useAudioStore.getState().primingStripped).toBe(true);
-  });
-
-  it("resets primingStripped to false when the source changes via setSource", async () => {
-    await render(<AudioEngine />);
-    useAudioStore.getState().setSource({ type: "file", file: createAudioFile() });
-    await waitFor(() => useAudioStore.getState().primingStripped === true);
-    useAudioStore.getState().setSource({ type: "file", file: createAudioFile("second.wav") });
-    expect(useAudioStore.getState().primingStripped).toBe(false);
-    await waitFor(() => useAudioStore.getState().primingStripped === true);
-    expect(useAudioStore.getState().primingStripped).toBe(true);
+    await waitFor(() => useProjectStore.getState().primingStripped === true, 5000);
+    expect(useProjectStore.getState().primingStripped).toBe(true);
   });
 
   it("regression: preserves primingStripped when mp3 decode fails so the migrated flag survives", async () => {
@@ -294,10 +285,10 @@ describe("AudioEngine", () => {
     allowConsole(/scrub-preview decode failed/);
     allowConsole(/Audio error/);
     await render(<AudioEngine />);
-    useAudioStore.setState({ primingStripped: true });
+    useProjectStore.setState({ primingStripped: true });
     const garbage = new File([new Uint8Array([1, 2, 3, 4, 5])], "broken.mp3", { type: "audio/mpeg" });
     useAudioStore.setState({ source: { type: "file", file: garbage } });
     await waitFor(() => useAudioStore.getState().audioElement !== null, 5000);
-    expect(useAudioStore.getState().primingStripped).toBe(true);
+    expect(useProjectStore.getState().primingStripped).toBe(true);
   });
 });

--- a/src/audio/audio-engine.tsx
+++ b/src/audio/audio-engine.tsx
@@ -3,6 +3,7 @@ import { bindAudioStateEvents } from "@/audio/audio-state-events";
 import { scrubPreview } from "@/audio/scrub-preview";
 import { scrubStemRouter } from "@/audio/scrub-stem-router";
 import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
 import { useSeparationStore } from "@/stores/separation";
 import { useEffect, useRef } from "react";
 
@@ -129,7 +130,7 @@ const AudioEngine: React.FC = () => {
       audioRef.current = audio;
       originalUrlRef.current = objectUrl;
       registerAudioElement(audio);
-      if (stripped !== null) useAudioStore.getState().setPrimingStripped(stripped);
+      if (stripped !== null) useProjectStore.getState().setPrimingStripped(stripped);
       if (initialIsPlaying) audio.play().catch(() => undefined);
 
       const handleLoadedMetadata = () => setDuration(audio.duration);

--- a/src/audio/audio-engine.tsx
+++ b/src/audio/audio-engine.tsx
@@ -66,7 +66,7 @@ const AudioEngine: React.FC = () => {
     // reliable frame index. Decoding to uncompressed WAV up front gives the
     // <audio> element an O(1)-seekable source. Other inputs (opus, webm,
     // m4a-with-mp4-container, ogg) already seek fine.
-    const resolvePlaybackUrl = async (): Promise<{ url: string; stripped: boolean }> => {
+    const resolvePlaybackUrl = async (): Promise<{ url: string; stripped: boolean | null }> => {
       if (!needsWavConversion(playableFile)) {
         return { url: URL.createObjectURL(playableFile), stripped: true };
       }
@@ -80,7 +80,7 @@ const AudioEngine: React.FC = () => {
         return { url: URL.createObjectURL(wavBlob), stripped: true };
       } catch (err) {
         console.warn(LOG_PREFIX, "audio decode failed, using original file", err);
-        return { url: URL.createObjectURL(playableFile), stripped: false };
+        return { url: URL.createObjectURL(playableFile), stripped: null };
       }
     };
 
@@ -101,7 +101,7 @@ const AudioEngine: React.FC = () => {
 
     const setup = async () => {
       let objectUrl: string;
-      let stripped: boolean;
+      let stripped: boolean | null;
       try {
         ({ url: objectUrl, stripped } = await resolvePlaybackUrl());
       } finally {
@@ -129,7 +129,7 @@ const AudioEngine: React.FC = () => {
       audioRef.current = audio;
       originalUrlRef.current = objectUrl;
       registerAudioElement(audio);
-      useAudioStore.getState().setPrimingStripped(stripped);
+      if (stripped !== null) useAudioStore.getState().setPrimingStripped(stripped);
       if (initialIsPlaying) audio.play().catch(() => undefined);
 
       const handleLoadedMetadata = () => setDuration(audio.duration);

--- a/src/audio/audio-engine.tsx
+++ b/src/audio/audio-engine.tsx
@@ -128,6 +128,7 @@ const AudioEngine: React.FC = () => {
       audioRef.current = audio;
       originalUrlRef.current = objectUrl;
       registerAudioElement(audio);
+      useAudioStore.getState().setPrimingStripped(true);
       if (initialIsPlaying) audio.play().catch(() => undefined);
 
       const handleLoadedMetadata = () => setDuration(audio.duration);

--- a/src/audio/audio-engine.tsx
+++ b/src/audio/audio-engine.tsx
@@ -66,9 +66,9 @@ const AudioEngine: React.FC = () => {
     // reliable frame index. Decoding to uncompressed WAV up front gives the
     // <audio> element an O(1)-seekable source. Other inputs (opus, webm,
     // m4a-with-mp4-container, ogg) already seek fine.
-    const resolvePlaybackUrl = async (): Promise<string> => {
+    const resolvePlaybackUrl = async (): Promise<{ url: string; stripped: boolean }> => {
       if (!needsWavConversion(playableFile)) {
-        return URL.createObjectURL(playableFile);
+        return { url: URL.createObjectURL(playableFile), stripped: true };
       }
       slowTimer = window.setTimeout(() => {
         slowTimer = null;
@@ -77,10 +77,10 @@ const AudioEngine: React.FC = () => {
       }, SLOW_DECODE_MS);
       try {
         const wavBlob = await decodeAudioToWav(playableFile);
-        return URL.createObjectURL(wavBlob);
+        return { url: URL.createObjectURL(wavBlob), stripped: true };
       } catch (err) {
         console.warn(LOG_PREFIX, "audio decode failed, using original file", err);
-        return URL.createObjectURL(playableFile);
+        return { url: URL.createObjectURL(playableFile), stripped: false };
       }
     };
 
@@ -101,8 +101,9 @@ const AudioEngine: React.FC = () => {
 
     const setup = async () => {
       let objectUrl: string;
+      let stripped: boolean;
       try {
-        objectUrl = await resolvePlaybackUrl();
+        ({ url: objectUrl, stripped } = await resolvePlaybackUrl());
       } finally {
         clearSlowLoading();
       }
@@ -128,7 +129,7 @@ const AudioEngine: React.FC = () => {
       audioRef.current = audio;
       originalUrlRef.current = objectUrl;
       registerAudioElement(audio);
-      useAudioStore.getState().setPrimingStripped(true);
+      useAudioStore.getState().setPrimingStripped(stripped);
       if (initialIsPlaying) audio.play().catch(() => undefined);
 
       const handleLoadedMetadata = () => setDuration(audio.duration);

--- a/src/audio/lame-priming.test.ts
+++ b/src/audio/lame-priming.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { findFirstMp3FrameOffset, parseLamePriming, stripLeading } from "@/audio/lame-priming";
+
+// -- Fixtures ------------------------------------------------------------------
+
+function buildMp3FrameHeader(): Uint8Array {
+  return new Uint8Array([0xff, 0xfb, 0x90, 0x40]);
+}
+
+function buildXingTagFrame(encoderDelay: number, tag: "Xing" | "Info" = "Info"): Uint8Array {
+  const frame = new Uint8Array(417);
+  frame.set(buildMp3FrameHeader(), 0);
+  const tagOffset = 0x24;
+  const tagBytes = new TextEncoder().encode(tag);
+  frame.set(tagBytes, tagOffset);
+  const lameOffset = tagOffset + 0x78;
+  const delayHigh = (encoderDelay >> 4) & 0xff;
+  const mixed = ((encoderDelay & 0x0f) << 4) | 0;
+  frame[lameOffset + 0x15] = delayHigh;
+  frame[lameOffset + 0x16] = mixed;
+  return frame;
+}
+
+function withId3v2Prefix(payload: Uint8Array, sizeBytes = 100): Uint8Array {
+  const header = new Uint8Array(10 + sizeBytes);
+  header.set(new TextEncoder().encode("ID3"), 0);
+  header[3] = 3;
+  header[6] = (sizeBytes >> 21) & 0x7f;
+  header[7] = (sizeBytes >> 14) & 0x7f;
+  header[8] = (sizeBytes >> 7) & 0x7f;
+  header[9] = sizeBytes & 0x7f;
+  const out = new Uint8Array(header.length + payload.length);
+  out.set(header, 0);
+  out.set(payload, header.length);
+  return out;
+}
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("parseLamePriming", () => {
+  it("returns 1105 + 528 for a CBR Info tag with encoder delay 1105", () => {
+    const frame = buildXingTagFrame(1105, "Info");
+    expect(parseLamePriming(frame.buffer)).toBe(1105 + 528);
+  });
+
+  it("returns 2257 + 528 for a VBR Xing tag with encoder delay 2257", () => {
+    const frame = buildXingTagFrame(2257, "Xing");
+    expect(parseLamePriming(frame.buffer)).toBe(2257 + 528);
+  });
+
+  it("skips an ID3v2 header before locating the frame", () => {
+    const frame = buildXingTagFrame(1105, "Info");
+    const withHeader = withId3v2Prefix(frame, 100);
+    expect(parseLamePriming(withHeader.buffer)).toBe(1105 + 528);
+  });
+});
+
+describe("parseLamePriming edge cases", () => {
+  it("returns 0 for non-MP3 bytes", () => {
+    const bytes = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05]);
+    expect(parseLamePriming(bytes.buffer)).toBe(0);
+  });
+
+  it("returns 0 when an MP3 frame header is present but no Xing/Info tag follows", () => {
+    const frame = new Uint8Array(417);
+    frame.set(buildMp3FrameHeader(), 0);
+    expect(parseLamePriming(frame.buffer)).toBe(0);
+  });
+
+  it("returns 0 for a truncated buffer (first 20 bytes of a valid frame)", () => {
+    const frame = buildXingTagFrame(1105, "Info");
+    const truncated = frame.slice(0, 20);
+    expect(parseLamePriming(truncated.buffer)).toBe(0);
+  });
+
+  it("accepts the maximum valid 12-bit encoder delay without tripping the hard cap", () => {
+    const frame = buildXingTagFrame(0, "Info");
+    const tagOffset = 0x24;
+    const lameOffset = tagOffset + 0x78;
+    frame[lameOffset + 0x15] = 0xff;
+    frame[lameOffset + 0x16] = 0xf0;
+    expect(parseLamePriming(frame.buffer)).toBe(4095 + 528);
+  });
+
+  it("accepts a Uint8Array directly", () => {
+    const frame = buildXingTagFrame(1105, "Info");
+    expect(parseLamePriming(frame)).toBe(1105 + 528);
+  });
+
+  it("returns 0 for an empty buffer", () => {
+    expect(parseLamePriming(new ArrayBuffer(0))).toBe(0);
+  });
+});
+
+describe("findFirstMp3FrameOffset", () => {
+  it("returns 0 when no ID3 header is present", () => {
+    const frame = buildXingTagFrame(1105, "Info");
+    expect(findFirstMp3FrameOffset(frame)).toBe(0);
+  });
+
+  it("returns 10 + sizeBytes past an ID3v2 header", () => {
+    const sizeBytes = 200;
+    const frame = buildXingTagFrame(1105, "Info");
+    const withHeader = withId3v2Prefix(frame, sizeBytes);
+    expect(findFirstMp3FrameOffset(withHeader)).toBe(10 + sizeBytes);
+  });
+});
+
+describe("stripLeading", () => {
+  it("returns the same array references when n is 0", () => {
+    const left = new Float32Array([0.1, 0.2, 0.3, 0.4]);
+    const right = new Float32Array([0.5, 0.6, 0.7, 0.8]);
+    const channels = [left, right];
+    const result = stripLeading(channels, 0);
+    expect(result[0]).toBe(left);
+    expect(result[1]).toBe(right);
+  });
+
+  it("slices first 2 samples off each channel when n is 2", () => {
+    const left = new Float32Array([0.1, 0.2, 0.3, 0.4]);
+    const right = new Float32Array([0.5, 0.6, 0.7, 0.8]);
+    const result = stripLeading([left, right], 2);
+    expect(Array.from(result[0])).toEqual(Array.from(new Float32Array([0.3, 0.4])));
+    expect(Array.from(result[1])).toEqual(Array.from(new Float32Array([0.7, 0.8])));
+  });
+
+  it("is a no-op when n is negative", () => {
+    const left = new Float32Array([0.1, 0.2, 0.3]);
+    const right = new Float32Array([0.4, 0.5, 0.6]);
+    const channels = [left, right];
+    const result = stripLeading(channels, -5);
+    expect(result[0]).toBe(left);
+    expect(result[1]).toBe(right);
+  });
+
+  it("returns empty channels when n equals channel length", () => {
+    const left = new Float32Array([0.1, 0.2, 0.3]);
+    const right = new Float32Array([0.4, 0.5, 0.6]);
+    const result = stripLeading([left, right], 3);
+    expect(result[0].length).toBe(0);
+    expect(result[1].length).toBe(0);
+  });
+});

--- a/src/audio/lame-priming.test.ts
+++ b/src/audio/lame-priming.test.ts
@@ -3,14 +3,36 @@ import { findFirstMp3FrameOffset, parseLamePriming, stripLeading } from "@/audio
 
 // -- Fixtures ------------------------------------------------------------------
 
-function buildMp3FrameHeader(): Uint8Array {
-  return new Uint8Array([0xff, 0xfb, 0x90, 0x40]);
+type Mode =
+  | { version: "mpeg1"; channels: "stereo" | "mono" }
+  | { version: "mpeg2"; channels: "stereo" | "mono" }
+  | { version: "mpeg25"; channels: "stereo" | "mono" };
+
+function versionBitsFor(mode: Mode): number {
+  if (mode.version === "mpeg1") return 0x03;
+  if (mode.version === "mpeg2") return 0x02;
+  return 0x00;
 }
 
-function buildXingTagFrame(encoderDelay: number, tag: "Xing" | "Info" = "Info"): Uint8Array {
+function channelBitsFor(mode: Mode): number {
+  return mode.channels === "mono" ? 0x03 : 0x01;
+}
+
+function tagOffsetFor(mode: Mode): number {
+  if (mode.version === "mpeg1" && mode.channels === "stereo") return 0x24;
+  if (mode.version === "mpeg1") return 0x15;
+  if (mode.channels === "stereo") return 0x15;
+  return 0x0d;
+}
+
+function buildFrame(mode: Mode, encoderDelay: number, tag: "Xing" | "Info" = "Info"): Uint8Array {
   const frame = new Uint8Array(417);
-  frame.set(buildMp3FrameHeader(), 0);
-  const tagOffset = 0x24;
+  const sync = 0xe0 | (versionBitsFor(mode) << 3) | (0x01 << 1) | 0x01;
+  frame[0] = 0xff;
+  frame[1] = sync;
+  frame[2] = 0x90;
+  frame[3] = channelBitsFor(mode) << 6;
+  const tagOffset = tagOffsetFor(mode);
   const tagBytes = new TextEncoder().encode(tag);
   frame.set(tagBytes, tagOffset);
   const lameOffset = tagOffset + 0x78;
@@ -19,6 +41,15 @@ function buildXingTagFrame(encoderDelay: number, tag: "Xing" | "Info" = "Info"):
   frame[lameOffset + 0x15] = delayHigh;
   frame[lameOffset + 0x16] = mixed;
   return frame;
+}
+
+function buildMp3FrameHeader(): Uint8Array {
+  const frame = buildFrame({ version: "mpeg1", channels: "stereo" }, 0);
+  return frame.slice(0, 4);
+}
+
+function buildXingTagFrame(encoderDelay: number, tag: "Xing" | "Info" = "Info"): Uint8Array {
+  return buildFrame({ version: "mpeg1", channels: "stereo" }, encoderDelay, tag);
 }
 
 function withId3v2Prefix(payload: Uint8Array, sizeBytes = 100): Uint8Array {
@@ -38,39 +69,61 @@ function withId3v2Prefix(payload: Uint8Array, sizeBytes = 100): Uint8Array {
 // -- Tests ---------------------------------------------------------------------
 
 describe("parseLamePriming", () => {
-  it("returns 1105 + 528 for a CBR Info tag with encoder delay 1105", () => {
+  it("returns samples 1105 + 528 and sampleRate 44100 for a CBR Info tag", () => {
     const frame = buildXingTagFrame(1105, "Info");
-    expect(parseLamePriming(frame.buffer)).toBe(1105 + 528);
+    expect(parseLamePriming(frame.buffer)).toEqual({ samples: 1105 + 528, sampleRate: 44_100 });
   });
 
-  it("returns 2257 + 528 for a VBR Xing tag with encoder delay 2257", () => {
+  it("returns samples 2257 + 528 and sampleRate 44100 for a VBR Xing tag", () => {
     const frame = buildXingTagFrame(2257, "Xing");
-    expect(parseLamePriming(frame.buffer)).toBe(2257 + 528);
+    expect(parseLamePriming(frame.buffer)).toEqual({ samples: 2257 + 528, sampleRate: 44_100 });
   });
 
   it("skips an ID3v2 header before locating the frame", () => {
     const frame = buildXingTagFrame(1105, "Info");
     const withHeader = withId3v2Prefix(frame, 100);
-    expect(parseLamePriming(withHeader.buffer)).toBe(1105 + 528);
+    expect(parseLamePriming(withHeader.buffer)).toEqual({ samples: 1105 + 528, sampleRate: 44_100 });
+  });
+});
+
+describe("parseLamePriming across MPEG versions and channel modes", () => {
+  it("parses MPEG-1 mono with the Xing tag at offset 0x15", () => {
+    const frame = buildFrame({ version: "mpeg1", channels: "mono" }, 576);
+    expect(parseLamePriming(frame.buffer)).toEqual({ samples: 576 + 528, sampleRate: 44_100 });
+  });
+
+  it("parses MPEG-2 stereo at 22050 Hz with the Xing tag at offset 0x15", () => {
+    const frame = buildFrame({ version: "mpeg2", channels: "stereo" }, 480);
+    expect(parseLamePriming(frame.buffer)).toEqual({ samples: 480 + 528, sampleRate: 22_050 });
+  });
+
+  it("parses MPEG-2 mono at 22050 Hz with the Xing tag at offset 0x0D", () => {
+    const frame = buildFrame({ version: "mpeg2", channels: "mono" }, 320);
+    expect(parseLamePriming(frame.buffer)).toEqual({ samples: 320 + 528, sampleRate: 22_050 });
+  });
+
+  it("parses MPEG-2.5 stereo at 11025 Hz with the Xing tag at offset 0x15", () => {
+    const frame = buildFrame({ version: "mpeg25", channels: "stereo" }, 480);
+    expect(parseLamePriming(frame.buffer)).toEqual({ samples: 480 + 528, sampleRate: 11_025 });
   });
 });
 
 describe("parseLamePriming edge cases", () => {
-  it("returns 0 for non-MP3 bytes", () => {
+  it("returns zero priming for non-MP3 bytes", () => {
     const bytes = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05]);
-    expect(parseLamePriming(bytes.buffer)).toBe(0);
+    expect(parseLamePriming(bytes.buffer)).toEqual({ samples: 0, sampleRate: 0 });
   });
 
-  it("returns 0 when an MP3 frame header is present but no Xing/Info tag follows", () => {
+  it("returns zero priming when an MP3 frame header is present but no Xing/Info tag follows", () => {
     const frame = new Uint8Array(417);
     frame.set(buildMp3FrameHeader(), 0);
-    expect(parseLamePriming(frame.buffer)).toBe(0);
+    expect(parseLamePriming(frame.buffer)).toEqual({ samples: 0, sampleRate: 0 });
   });
 
-  it("returns 0 for a truncated buffer (first 20 bytes of a valid frame)", () => {
+  it("returns zero priming for a truncated buffer", () => {
     const frame = buildXingTagFrame(1105, "Info");
     const truncated = frame.slice(0, 20);
-    expect(parseLamePriming(truncated.buffer)).toBe(0);
+    expect(parseLamePriming(truncated.buffer)).toEqual({ samples: 0, sampleRate: 0 });
   });
 
   it("accepts the maximum valid 12-bit encoder delay without tripping the hard cap", () => {
@@ -79,16 +132,16 @@ describe("parseLamePriming edge cases", () => {
     const lameOffset = tagOffset + 0x78;
     frame[lameOffset + 0x15] = 0xff;
     frame[lameOffset + 0x16] = 0xf0;
-    expect(parseLamePriming(frame.buffer)).toBe(4095 + 528);
+    expect(parseLamePriming(frame.buffer)).toEqual({ samples: 4095 + 528, sampleRate: 44_100 });
   });
 
   it("accepts a Uint8Array directly", () => {
     const frame = buildXingTagFrame(1105, "Info");
-    expect(parseLamePriming(frame)).toBe(1105 + 528);
+    expect(parseLamePriming(frame)).toEqual({ samples: 1105 + 528, sampleRate: 44_100 });
   });
 
-  it("returns 0 for an empty buffer", () => {
-    expect(parseLamePriming(new ArrayBuffer(0))).toBe(0);
+  it("returns zero priming for an empty buffer", () => {
+    expect(parseLamePriming(new ArrayBuffer(0))).toEqual({ samples: 0, sampleRate: 0 });
   });
 });
 
@@ -103,6 +156,21 @@ describe("findFirstMp3FrameOffset", () => {
     const frame = buildXingTagFrame(1105, "Info");
     const withHeader = withId3v2Prefix(frame, sizeBytes);
     expect(findFirstMp3FrameOffset(withHeader)).toBe(10 + sizeBytes);
+  });
+
+  it("masks the high bit of each ID3v2 size byte per syncsafe spec", () => {
+    const payload = buildXingTagFrame(1105, "Info");
+    const header = new Uint8Array(10 + payload.length);
+    header.set(new TextEncoder().encode("ID3"), 0);
+    header[3] = 3;
+    header[6] = 0x80;
+    header[7] = 0x80;
+    header[8] = 0x80;
+    header[9] = 0x80;
+    const out = new Uint8Array(header.length + payload.length);
+    out.set(header, 0);
+    out.set(payload, header.length);
+    expect(findFirstMp3FrameOffset(out)).toBe(10);
   });
 });
 

--- a/src/audio/lame-priming.ts
+++ b/src/audio/lame-priming.ts
@@ -4,42 +4,91 @@ const DECODER_DELAY_SAMPLES = 528;
 const PRIMING_HARD_CAP = 8192;
 const LOG_PREFIX = "[Composer]";
 
+const MPEG1_SAMPLE_RATES: readonly number[] = [44_100, 48_000, 32_000];
+const MPEG2_SAMPLE_RATES: readonly number[] = [22_050, 24_000, 16_000];
+const MPEG25_SAMPLE_RATES: readonly number[] = [11_025, 12_000, 8_000];
+
+const TAG_OFFSET_MPEG1_STEREO = 0x24;
+const TAG_OFFSET_MPEG1_MONO = 0x15;
+const TAG_OFFSET_MPEG2_STEREO = 0x15;
+const TAG_OFFSET_MPEG2_MONO = 0x0d;
+
+const MPEG_VERSION_2_5 = 0;
+const MPEG_VERSION_2 = 2;
+const MPEG_VERSION_1 = 3;
+const CHANNEL_MODE_MONO = 3;
+
+// -- Types ---------------------------------------------------------------------
+
+interface LamePriming {
+  samples: number;
+  sampleRate: number;
+}
+
 // -- Functions -----------------------------------------------------------------
 
 function findFirstMp3FrameOffset(bytes: Uint8Array): number {
   if (bytes.length >= 10 && bytes[0] === 0x49 && bytes[1] === 0x44 && bytes[2] === 0x33) {
-    const size = (bytes[6] << 21) | (bytes[7] << 14) | (bytes[8] << 7) | bytes[9];
+    const size = ((bytes[6] & 0x7f) << 21) | ((bytes[7] & 0x7f) << 14) | ((bytes[8] & 0x7f) << 7) | (bytes[9] & 0x7f);
     return 10 + size;
   }
   return 0;
 }
 
-function parseLamePriming(input: ArrayBuffer | Uint8Array): number {
+function readSampleRate(versionBits: number, rateIdx: number): number {
+  if (rateIdx === 3) return 0;
+  if (versionBits === MPEG_VERSION_1) return MPEG1_SAMPLE_RATES[rateIdx] ?? 0;
+  if (versionBits === MPEG_VERSION_2) return MPEG2_SAMPLE_RATES[rateIdx] ?? 0;
+  if (versionBits === MPEG_VERSION_2_5) return MPEG25_SAMPLE_RATES[rateIdx] ?? 0;
+  return 0;
+}
+
+function readTagOffset(versionBits: number, channelMode: number): number {
+  const mono = channelMode === CHANNEL_MODE_MONO;
+  if (versionBits === MPEG_VERSION_1) return mono ? TAG_OFFSET_MPEG1_MONO : TAG_OFFSET_MPEG1_STEREO;
+  if (versionBits === MPEG_VERSION_2 || versionBits === MPEG_VERSION_2_5) {
+    return mono ? TAG_OFFSET_MPEG2_MONO : TAG_OFFSET_MPEG2_STEREO;
+  }
+  return 0;
+}
+
+function parseLamePriming(input: ArrayBuffer | Uint8Array): LamePriming {
+  const empty: LamePriming = { samples: 0, sampleRate: 0 };
   const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
   const frameOffset = findFirstMp3FrameOffset(bytes);
-  if (frameOffset + 4 > bytes.length) return 0;
+  if (frameOffset + 4 > bytes.length) return empty;
   const syncHigh = bytes[frameOffset];
   const syncLow = bytes[frameOffset + 1];
-  if (syncHigh !== 0xff || (syncLow & 0xe0) !== 0xe0) return 0;
-  const tagOffset = frameOffset + 0x24;
-  if (tagOffset + 4 > bytes.length) return 0;
+  if (syncHigh !== 0xff || (syncLow & 0xe0) !== 0xe0) return empty;
+
+  const versionBits = (syncLow >> 3) & 0x03;
+  const rateIdx = (bytes[frameOffset + 2] >> 2) & 0x03;
+  const channelMode = (bytes[frameOffset + 3] >> 6) & 0x03;
+  const sampleRate = readSampleRate(versionBits, rateIdx);
+  if (sampleRate === 0) return empty;
+  const tagFrameOffset = readTagOffset(versionBits, channelMode);
+  if (tagFrameOffset === 0) return empty;
+
+  const tagOffset = frameOffset + tagFrameOffset;
+  if (tagOffset + 4 > bytes.length) return empty;
   const tag =
     String.fromCharCode(bytes[tagOffset]) +
     String.fromCharCode(bytes[tagOffset + 1]) +
     String.fromCharCode(bytes[tagOffset + 2]) +
     String.fromCharCode(bytes[tagOffset + 3]);
-  if (tag !== "Xing" && tag !== "Info") return 0;
+  if (tag !== "Xing" && tag !== "Info") return empty;
+
   const lameOffset = tagOffset + 0x78;
-  if (lameOffset + 0x18 > bytes.length) return 0;
+  if (lameOffset + 0x18 > bytes.length) return empty;
   const high = bytes[lameOffset + 0x15];
   const mixed = bytes[lameOffset + 0x16];
   const encoderDelay = (high << 4) | (mixed >> 4);
-  const priming = encoderDelay + DECODER_DELAY_SAMPLES;
-  if (priming > PRIMING_HARD_CAP) {
-    console.warn(`${LOG_PREFIX} LAME priming over cap:`, priming);
-    return 0;
+  const samples = encoderDelay + DECODER_DELAY_SAMPLES;
+  if (samples > PRIMING_HARD_CAP) {
+    console.warn(`${LOG_PREFIX} LAME priming over cap:`, samples);
+    return empty;
   }
-  return priming;
+  return { samples, sampleRate };
 }
 
 function stripLeading<T extends Float32Array>(channels: T[], n: number): T[] {
@@ -49,7 +98,11 @@ function stripLeading<T extends Float32Array>(channels: T[], n: number): T[] {
 
 function cropAudioBufferHead(audio: AudioBuffer, startSample: number, ctx: BaseAudioContext): AudioBuffer {
   if (startSample <= 0) return audio;
-  const length = Math.max(0, audio.length - startSample);
+  if (startSample >= audio.length) {
+    console.warn(`${LOG_PREFIX} priming meets or exceeds buffer length; skipping crop:`, startSample, audio.length);
+    return audio;
+  }
+  const length = audio.length - startSample;
   const out = ctx.createBuffer(audio.numberOfChannels, length, audio.sampleRate);
   for (let c = 0; c < audio.numberOfChannels; c++) {
     const src = audio.getChannelData(c);
@@ -61,3 +114,4 @@ function cropAudioBufferHead(audio: AudioBuffer, startSample: number, ctx: BaseA
 // -- Exports -------------------------------------------------------------------
 
 export { cropAudioBufferHead, findFirstMp3FrameOffset, parseLamePriming, stripLeading };
+export type { LamePriming };

--- a/src/audio/lame-priming.ts
+++ b/src/audio/lame-priming.ts
@@ -47,6 +47,17 @@ function stripLeading<T extends Float32Array>(channels: T[], n: number): T[] {
   return channels.map((c) => c.slice(n) as T);
 }
 
+function cropAudioBufferHead(audio: AudioBuffer, startSample: number, ctx: BaseAudioContext): AudioBuffer {
+  if (startSample <= 0) return audio;
+  const length = Math.max(0, audio.length - startSample);
+  const out = ctx.createBuffer(audio.numberOfChannels, length, audio.sampleRate);
+  for (let c = 0; c < audio.numberOfChannels; c++) {
+    const src = audio.getChannelData(c);
+    out.getChannelData(c).set(src.subarray(startSample, startSample + length));
+  }
+  return out;
+}
+
 // -- Exports -------------------------------------------------------------------
 
-export { findFirstMp3FrameOffset, parseLamePriming, stripLeading };
+export { cropAudioBufferHead, findFirstMp3FrameOffset, parseLamePriming, stripLeading };

--- a/src/audio/lame-priming.ts
+++ b/src/audio/lame-priming.ts
@@ -2,7 +2,7 @@
 
 const DECODER_DELAY_SAMPLES = 528;
 const PRIMING_HARD_CAP = 8192;
-const LOG_PREFIX = "[Composer]";
+const LOG_PREFIX = "[LamePriming]";
 
 const MPEG1_SAMPLE_RATES: readonly number[] = [44_100, 48_000, 32_000];
 const MPEG2_SAMPLE_RATES: readonly number[] = [22_050, 24_000, 16_000];

--- a/src/audio/lame-priming.ts
+++ b/src/audio/lame-priming.ts
@@ -1,0 +1,52 @@
+// -- Constants -----------------------------------------------------------------
+
+const DECODER_DELAY_SAMPLES = 528;
+const PRIMING_HARD_CAP = 8192;
+const LOG_PREFIX = "[Composer]";
+
+// -- Functions -----------------------------------------------------------------
+
+function findFirstMp3FrameOffset(bytes: Uint8Array): number {
+  if (bytes.length >= 10 && bytes[0] === 0x49 && bytes[1] === 0x44 && bytes[2] === 0x33) {
+    const size = (bytes[6] << 21) | (bytes[7] << 14) | (bytes[8] << 7) | bytes[9];
+    return 10 + size;
+  }
+  return 0;
+}
+
+function parseLamePriming(input: ArrayBuffer | Uint8Array): number {
+  const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
+  const frameOffset = findFirstMp3FrameOffset(bytes);
+  if (frameOffset + 4 > bytes.length) return 0;
+  const syncHigh = bytes[frameOffset];
+  const syncLow = bytes[frameOffset + 1];
+  if (syncHigh !== 0xff || (syncLow & 0xe0) !== 0xe0) return 0;
+  const tagOffset = frameOffset + 0x24;
+  if (tagOffset + 4 > bytes.length) return 0;
+  const tag =
+    String.fromCharCode(bytes[tagOffset]) +
+    String.fromCharCode(bytes[tagOffset + 1]) +
+    String.fromCharCode(bytes[tagOffset + 2]) +
+    String.fromCharCode(bytes[tagOffset + 3]);
+  if (tag !== "Xing" && tag !== "Info") return 0;
+  const lameOffset = tagOffset + 0x78;
+  if (lameOffset + 0x18 > bytes.length) return 0;
+  const high = bytes[lameOffset + 0x15];
+  const mixed = bytes[lameOffset + 0x16];
+  const encoderDelay = (high << 4) | (mixed >> 4);
+  const priming = encoderDelay + DECODER_DELAY_SAMPLES;
+  if (priming > PRIMING_HARD_CAP) {
+    console.warn(`${LOG_PREFIX} LAME priming over cap:`, priming);
+    return 0;
+  }
+  return priming;
+}
+
+function stripLeading<T extends Float32Array>(channels: T[], n: number): T[] {
+  if (n <= 0) return channels;
+  return channels.map((c) => c.slice(n) as T);
+}
+
+// -- Exports -------------------------------------------------------------------
+
+export { findFirstMp3FrameOffset, parseLamePriming, stripLeading };

--- a/src/audio/scrub-preview.browser.test.ts
+++ b/src/audio/scrub-preview.browser.test.ts
@@ -82,14 +82,16 @@ describe("scrub-preview", () => {
   test("decode strips LAME priming from an MP3 source", async () => {
     const mp3 = createMp3File();
     const bytes = await mp3.arrayBuffer();
-    const priming = parseLamePriming(bytes);
-    expect(priming).toBeGreaterThan(0);
+    const { samples, sampleRate } = parseLamePriming(bytes);
+    expect(samples).toBeGreaterThan(0);
+    expect(sampleRate).toBeGreaterThan(0);
 
     const ctx = new AudioContext();
     const unstripped = await ctx.decodeAudioData(bytes.slice(0));
     await ctx.close();
 
     const decoded = await scrubPreview.decode(bytes);
-    expect(decoded.length).toBe(unstripped.length - priming);
+    const expectedStrip = Math.round((samples * unstripped.sampleRate) / sampleRate);
+    expect(decoded.length).toBe(unstripped.length - expectedStrip);
   });
 });

--- a/src/audio/scrub-preview.browser.test.ts
+++ b/src/audio/scrub-preview.browser.test.ts
@@ -1,6 +1,7 @@
+import { parseLamePriming } from "@/audio/lame-priming";
 import { scrubPreview } from "@/audio/scrub-preview";
 import { useSettingsStore } from "@/stores/settings";
-import { encodeWav, makeSineBuffer } from "@/test/audio-fixtures";
+import { createMp3File, encodeWav, makeSineBuffer } from "@/test/audio-fixtures";
 import { afterEach, describe, expect, test } from "vitest";
 
 describe("scrub-preview", () => {
@@ -76,5 +77,19 @@ describe("scrub-preview", () => {
     const wavBytes = encodeWav(rendered);
     const decoded = await scrubPreview.decode(wavBytes);
     expect(decoded.duration).toBeCloseTo(1, 1);
+  });
+
+  test("decode strips LAME priming from an MP3 source", async () => {
+    const mp3 = createMp3File();
+    const bytes = await mp3.arrayBuffer();
+    const priming = parseLamePriming(bytes);
+    expect(priming).toBeGreaterThan(0);
+
+    const ctx = new AudioContext();
+    const unstripped = await ctx.decodeAudioData(bytes.slice(0));
+    await ctx.close();
+
+    const decoded = await scrubPreview.decode(bytes);
+    expect(decoded.length).toBe(unstripped.length - priming);
   });
 });

--- a/src/audio/scrub-preview.ts
+++ b/src/audio/scrub-preview.ts
@@ -1,4 +1,4 @@
-import { parseLamePriming } from "@/audio/lame-priming";
+import { cropAudioBufferHead, parseLamePriming } from "@/audio/lame-priming";
 import { useAudioStore } from "@/stores/audio";
 import { useSettingsStore } from "@/stores/settings";
 
@@ -26,14 +26,7 @@ async function decode(bytes: ArrayBuffer): Promise<AudioBuffer> {
   const ctx = getContext();
   const priming = parseLamePriming(bytes);
   const decoded = await ctx.decodeAudioData(bytes.slice(0));
-  if (priming <= 0 || priming >= decoded.length) return decoded;
-  const trimmedLength = decoded.length - priming;
-  const trimmed = ctx.createBuffer(decoded.numberOfChannels, trimmedLength, decoded.sampleRate);
-  for (let c = 0; c < decoded.numberOfChannels; c++) {
-    const src = decoded.getChannelData(c);
-    trimmed.getChannelData(c).set(src.subarray(priming, priming + trimmedLength));
-  }
-  return trimmed;
+  return cropAudioBufferHead(decoded, priming, ctx);
 }
 
 function useBuffer(next: AudioBuffer | null): void {

--- a/src/audio/scrub-preview.ts
+++ b/src/audio/scrub-preview.ts
@@ -25,8 +25,13 @@ function getContext(): AudioContext {
 async function decode(bytes: ArrayBuffer): Promise<AudioBuffer> {
   const ctx = getContext();
   const priming = parseLamePriming(bytes);
+  // decodeAudioData detaches its input ArrayBuffer in some browsers; copy first
   const decoded = await ctx.decodeAudioData(bytes.slice(0));
-  return cropAudioBufferHead(decoded, priming, ctx);
+  const startSample =
+    priming.samples > 0 && priming.sampleRate > 0
+      ? Math.round((priming.samples * decoded.sampleRate) / priming.sampleRate)
+      : 0;
+  return cropAudioBufferHead(decoded, startSample, ctx);
 }
 
 function useBuffer(next: AudioBuffer | null): void {

--- a/src/audio/scrub-preview.ts
+++ b/src/audio/scrub-preview.ts
@@ -1,3 +1,4 @@
+import { parseLamePriming } from "@/audio/lame-priming";
 import { useAudioStore } from "@/stores/audio";
 import { useSettingsStore } from "@/stores/settings";
 
@@ -23,8 +24,16 @@ function getContext(): AudioContext {
 
 async function decode(bytes: ArrayBuffer): Promise<AudioBuffer> {
   const ctx = getContext();
-  // decodeAudioData detaches its input ArrayBuffer in some browsers; copy first
-  return await ctx.decodeAudioData(bytes.slice(0));
+  const priming = parseLamePriming(bytes);
+  const decoded = await ctx.decodeAudioData(bytes.slice(0));
+  if (priming <= 0 || priming >= decoded.length) return decoded;
+  const trimmedLength = decoded.length - priming;
+  const trimmed = ctx.createBuffer(decoded.numberOfChannels, trimmedLength, decoded.sampleRate);
+  for (let c = 0; c < decoded.numberOfChannels; c++) {
+    const src = decoded.getChannelData(c);
+    trimmed.getChannelData(c).set(src.subarray(priming, priming + trimmedLength));
+  }
+  return trimmed;
 }
 
 function useBuffer(next: AudioBuffer | null): void {

--- a/src/audio/separation/audio-codec.browser.test.ts
+++ b/src/audio/separation/audio-codec.browser.test.ts
@@ -1,5 +1,5 @@
 import { parseLamePriming } from "@/audio/lame-priming";
-import { decodeFileToFloat32 } from "@/audio/separation/audio-codec";
+import { decodeFileToFloat32, TARGET_SAMPLE_RATE } from "@/audio/separation/audio-codec";
 import { createAudioFile, createMp3File } from "@/test/audio-fixtures";
 import { describe, expect, it } from "vitest";
 
@@ -7,12 +7,14 @@ describe("decodeFileToFloat32 LAME priming", () => {
   it("strips LAME priming from the head of the decoded channels for an MP3", async () => {
     const file = createMp3File();
     const bytes = await file.arrayBuffer();
-    const priming = parseLamePriming(bytes);
-    expect(priming).toBeGreaterThan(0);
+    const { samples, sampleRate } = parseLamePriming(bytes);
+    expect(samples).toBeGreaterThan(0);
+    expect(sampleRate).toBeGreaterThan(0);
 
     const decoded = await decodeFileToFloat32(file);
     const undecorated = await decodeFileToFloat32(file, { stripPriming: false });
-    expect(decoded.numFrames).toBe(undecorated.numFrames - priming);
+    const expectedStrip = Math.round((samples * TARGET_SAMPLE_RATE) / sampleRate);
+    expect(decoded.numFrames).toBe(undecorated.numFrames - expectedStrip);
     expect(decoded.channels[0].length).toBe(decoded.numFrames);
     expect(decoded.channels[1].length).toBe(decoded.numFrames);
   });

--- a/src/audio/separation/audio-codec.browser.test.ts
+++ b/src/audio/separation/audio-codec.browser.test.ts
@@ -1,0 +1,33 @@
+import { parseLamePriming } from "@/audio/lame-priming";
+import { decodeFileToFloat32 } from "@/audio/separation/audio-codec";
+import { createAudioFile, createMp3File } from "@/test/audio-fixtures";
+import { describe, expect, it } from "vitest";
+
+describe("decodeFileToFloat32 LAME priming", () => {
+  it("strips LAME priming from the head of the decoded channels for an MP3", async () => {
+    const file = createMp3File();
+    const bytes = await file.arrayBuffer();
+    const priming = parseLamePriming(bytes);
+    expect(priming).toBeGreaterThan(0);
+
+    const decoded = await decodeFileToFloat32(file);
+    const undecorated = await decodeFileToFloat32(file, { stripPriming: false });
+    expect(decoded.numFrames).toBe(undecorated.numFrames - priming);
+    expect(decoded.channels[0].length).toBe(decoded.numFrames);
+    expect(decoded.channels[1].length).toBe(decoded.numFrames);
+  });
+
+  it("is a no-op for a WAV file", async () => {
+    const wav = createAudioFile();
+    const decoded = await decodeFileToFloat32(wav);
+    const undecorated = await decodeFileToFloat32(wav, { stripPriming: false });
+    expect(decoded.numFrames).toBe(undecorated.numFrames);
+  });
+
+  it("returns 2 channels and the correct sample rate", async () => {
+    const file = createMp3File();
+    const decoded = await decodeFileToFloat32(file);
+    expect(decoded.channels.length).toBe(2);
+    expect(decoded.sampleRate).toBe(44100);
+  });
+});

--- a/src/audio/separation/audio-codec.ts
+++ b/src/audio/separation/audio-codec.ts
@@ -16,8 +16,12 @@ interface DecodeOptions {
 async function decodeFileToFloat32(file: File | Blob, opts: DecodeOptions = {}): Promise<DecodedAudio> {
   const buf = await file.arrayBuffer();
   const shouldStrip = opts.stripPriming !== false;
-  const priming = shouldStrip ? parseLamePriming(buf) : 0;
-  const applyStrip = (channels: Float32Array[]): Float32Array[] => stripLeading(channels, priming);
+  const priming = shouldStrip ? parseLamePriming(buf) : { samples: 0, sampleRate: 0 };
+  const trimAtTarget =
+    priming.samples > 0 && priming.sampleRate > 0
+      ? Math.round((priming.samples * TARGET_SAMPLE_RATE) / priming.sampleRate)
+      : 0;
+  const applyStrip = (channels: Float32Array[]): Float32Array[] => stripLeading(channels, trimAtTarget);
 
   const ctx = new OfflineAudioContext(TARGET_CHANNELS, 1, TARGET_SAMPLE_RATE);
   const decoded = await ctx.decodeAudioData(buf);

--- a/src/audio/separation/audio-codec.ts
+++ b/src/audio/separation/audio-codec.ts
@@ -1,3 +1,5 @@
+import { parseLamePriming, stripLeading } from "@/audio/lame-priming";
+
 const TARGET_SAMPLE_RATE = 44_100;
 const TARGET_CHANNELS = 2;
 
@@ -7,8 +9,16 @@ interface DecodedAudio {
   numFrames: number;
 }
 
-async function decodeFileToFloat32(file: File | Blob): Promise<DecodedAudio> {
+interface DecodeOptions {
+  stripPriming?: boolean;
+}
+
+async function decodeFileToFloat32(file: File | Blob, opts: DecodeOptions = {}): Promise<DecodedAudio> {
   const buf = await file.arrayBuffer();
+  const shouldStrip = opts.stripPriming !== false;
+  const priming = shouldStrip ? parseLamePriming(buf) : 0;
+  const applyStrip = (channels: Float32Array[]): Float32Array[] => stripLeading(channels, priming);
+
   const ctx = new OfflineAudioContext(TARGET_CHANNELS, 1, TARGET_SAMPLE_RATE);
   const decoded = await ctx.decodeAudioData(buf);
 
@@ -19,7 +29,8 @@ async function decodeFileToFloat32(file: File | Blob): Promise<DecodedAudio> {
       decoded.copyFromChannel(out, c);
       channels.push(out);
     }
-    return { channels, sampleRate: TARGET_SAMPLE_RATE, numFrames: decoded.length };
+    const stripped = applyStrip(channels);
+    return { channels: stripped, sampleRate: TARGET_SAMPLE_RATE, numFrames: stripped[0]?.length ?? 0 };
   }
 
   const durationSec = decoded.length / decoded.sampleRate;
@@ -46,7 +57,8 @@ async function decodeFileToFloat32(file: File | Blob): Promise<DecodedAudio> {
     rendered.copyFromChannel(out, c);
     channels.push(out);
   }
-  return { channels, sampleRate: TARGET_SAMPLE_RATE, numFrames: rendered.length };
+  const stripped = applyStrip(channels);
+  return { channels: stripped, sampleRate: TARGET_SAMPLE_RATE, numFrames: stripped[0]?.length ?? 0 };
 }
 
 function floatChannelsToWavBlob(channels: Float32Array[], sampleRate: number): Blob {

--- a/src/hooks/usePersistence.priming-migration.browser.test.tsx
+++ b/src/hooks/usePersistence.priming-migration.browser.test.tsx
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parseLamePriming } from "@/audio/lame-priming";
+import { TARGET_SAMPLE_RATE } from "@/audio/separation/audio-codec";
+import { DEFAULT_AGENTS } from "@/domain/agent/colors";
+import type { WordTiming } from "@/domain/word/timing";
+import { clearCurrentProject, saveAudioFile, saveCurrentProject } from "@/lib/persistence";
+import { loadCurrentProjectWithPrimingMigration } from "@/lib/priming-migration";
+import { createMp3File } from "@/test/audio-fixtures";
+
+// -- Helpers ------------------------------------------------------------------
+
+function seedSavedProject(opts: { primingStripped: boolean }): Promise<void> {
+  return saveCurrentProject(
+    { title: "t", artist: "", album: "", duration: 0 },
+    DEFAULT_AGENTS,
+    [
+      {
+        id: "L1",
+        text: "hello world",
+        agentId: DEFAULT_AGENTS[0].id,
+        words: [
+          { text: "hello", begin: 1.0, end: 1.5 },
+          { text: "world", begin: 1.5, end: 2.0 },
+        ],
+      },
+    ],
+    [],
+    "word",
+    { applyToAll: false, caseInsensitive: false },
+    { kind: "file", name: "silence.mp3" },
+    [],
+    [],
+    "original",
+    opts.primingStripped,
+  );
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("loadCurrentProjectWithPrimingMigration", () => {
+  beforeEach(async () => {
+    await clearCurrentProject();
+  });
+  afterEach(async () => {
+    await clearCurrentProject();
+  });
+
+  it("shifts saved line/word timings when project lacks primingStripped and audio has LAME priming", async () => {
+    const mp3 = createMp3File();
+    const priming = parseLamePriming(await mp3.arrayBuffer());
+    expect(priming).toBeGreaterThan(0);
+    await saveAudioFile(mp3);
+    await seedSavedProject({ primingStripped: false });
+
+    const migrated = await loadCurrentProjectWithPrimingMigration();
+    expect(migrated).toBeDefined();
+    const shiftSec = priming / TARGET_SAMPLE_RATE;
+    const words = (migrated!.lines[0] as { words: WordTiming[] }).words;
+    expect(words[0].begin).toBeCloseTo(1.0 - shiftSec);
+    expect(words[0].end).toBeCloseTo(1.5 - shiftSec);
+    expect(words[1].begin).toBeCloseTo(1.5 - shiftSec);
+    expect(words[1].end).toBeCloseTo(2.0 - shiftSec);
+    expect(migrated!.primingStripped).toBe(true);
+  });
+
+  it("does not shift when primingStripped is already true", async () => {
+    const mp3 = createMp3File();
+    await saveAudioFile(mp3);
+    await seedSavedProject({ primingStripped: true });
+
+    const loaded = await loadCurrentProjectWithPrimingMigration();
+    const words = (loaded!.lines[0] as { words: WordTiming[] }).words;
+    expect(words[0].begin).toBeCloseTo(1.0);
+    expect(words[1].end).toBeCloseTo(2.0);
+    expect(loaded!.primingStripped).toBe(true);
+  });
+
+  it("leaves timings unchanged and does not set the flag when audio bytes are missing", async () => {
+    await seedSavedProject({ primingStripped: false });
+
+    const loaded = await loadCurrentProjectWithPrimingMigration();
+    expect(loaded!.primingStripped).toBe(false);
+    const words = (loaded!.lines[0] as { words: WordTiming[] }).words;
+    expect(words[0].begin).toBeCloseTo(1.0);
+    expect(words[1].end).toBeCloseTo(2.0);
+  });
+
+  it("returns undefined when there is no saved project", async () => {
+    const loaded = await loadCurrentProjectWithPrimingMigration();
+    expect(loaded).toBeUndefined();
+  });
+
+  it("sets primingStripped to true even when audio has zero priming", async () => {
+    const noPrimingMp3 = new File([new Uint8Array([0, 1, 2, 3])], "not-mp3.bin", { type: "audio/mpeg" });
+    expect(parseLamePriming(await noPrimingMp3.arrayBuffer())).toBe(0);
+    await saveAudioFile(noPrimingMp3);
+    await seedSavedProject({ primingStripped: false });
+
+    const loaded = await loadCurrentProjectWithPrimingMigration();
+    expect(loaded!.primingStripped).toBe(true);
+    const words = (loaded!.lines[0] as { words: WordTiming[] }).words;
+    expect(words[0].begin).toBeCloseTo(1.0);
+  });
+});

--- a/src/hooks/usePersistence.priming-migration.browser.test.tsx
+++ b/src/hooks/usePersistence.priming-migration.browser.test.tsx
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { renderHook } from "vitest-browser-react";
 import { parseLamePriming } from "@/audio/lame-priming";
 import { DEFAULT_AGENTS } from "@/domain/agent/colors";
 import type { WordTiming } from "@/domain/word/timing";
-import { clearCurrentProject, saveAudioFile, saveCurrentProject } from "@/lib/persistence";
+import { usePersistence } from "@/hooks/usePersistence";
+import { clearCurrentProject, loadCurrentProject, saveAudioFile, saveCurrentProject } from "@/lib/persistence";
 import { loadCurrentProjectWithPrimingMigration } from "@/lib/priming-migration";
+import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
 import { createMp3File } from "@/test/audio-fixtures";
 
 // -- Helpers ------------------------------------------------------------------
@@ -100,5 +104,77 @@ describe("loadCurrentProjectWithPrimingMigration", () => {
     expect(loaded!.primingStripped).toBe(true);
     const words = (loaded!.lines[0] as { words: WordTiming[] }).words;
     expect(words[0].begin).toBeCloseTo(1.0);
+  });
+});
+
+describe("usePersistence priming-stripped flag survives the post-load debounced save", () => {
+  const initialAutoSaveDelay = useSettingsStore.getState().autoSaveDelay;
+
+  beforeEach(async () => {
+    useSettingsStore.setState({ autoSaveDelay: 30 });
+    await clearCurrentProject();
+  });
+  afterEach(async () => {
+    useSettingsStore.setState({ autoSaveDelay: initialAutoSaveDelay });
+    await clearCurrentProject();
+  });
+
+  async function waitForProjectHydration(): Promise<void> {
+    for (let i = 0; i < 200; i++) {
+      if (useProjectStore.getState().lines.length > 0) return;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    throw new Error("project store never hydrated");
+  }
+
+  it("regression: post-migration debounced save does not overwrite primingStripped with false", async () => {
+    const mp3 = createMp3File();
+    expect(parseLamePriming(await mp3.arrayBuffer()).samples).toBeGreaterThan(0);
+    await saveAudioFile(mp3);
+    await saveCurrentProject(
+      { title: "race", artist: "", album: "", duration: 0 },
+      DEFAULT_AGENTS,
+      [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
+      [],
+      "word",
+      { applyToAll: false, caseInsensitive: false },
+      { kind: "file", name: "silence.mp3" },
+      [],
+      [],
+      "original",
+      false,
+    );
+
+    await renderHook(() => usePersistence());
+    await waitForProjectHydration();
+    await new Promise((r) => setTimeout(r, 150));
+
+    const reloaded = await loadCurrentProject();
+    expect(reloaded?.primingStripped).toBe(true);
+  });
+
+  it("flag stays true after debounced save even when audio has zero priming", async () => {
+    const noPrimingMp3 = new File([new Uint8Array([0, 1, 2, 3])], "not-mp3.bin", { type: "audio/mpeg" });
+    await saveAudioFile(noPrimingMp3);
+    await saveCurrentProject(
+      { title: "race-zero", artist: "", album: "", duration: 0 },
+      DEFAULT_AGENTS,
+      [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
+      [],
+      "word",
+      { applyToAll: false, caseInsensitive: false },
+      { kind: "file", name: "not-mp3.bin" },
+      [],
+      [],
+      "original",
+      false,
+    );
+
+    await renderHook(() => usePersistence());
+    await waitForProjectHydration();
+    await new Promise((r) => setTimeout(r, 150));
+
+    const reloaded = await loadCurrentProject();
+    expect(reloaded?.primingStripped).toBe(true);
   });
 });

--- a/src/hooks/usePersistence.priming-migration.browser.test.tsx
+++ b/src/hooks/usePersistence.priming-migration.browser.test.tsx
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { parseLamePriming } from "@/audio/lame-priming";
-import { TARGET_SAMPLE_RATE } from "@/audio/separation/audio-codec";
 import { DEFAULT_AGENTS } from "@/domain/agent/colors";
 import type { WordTiming } from "@/domain/word/timing";
 import { clearCurrentProject, saveAudioFile, saveCurrentProject } from "@/lib/persistence";
@@ -47,14 +46,15 @@ describe("loadCurrentProjectWithPrimingMigration", () => {
 
   it("shifts saved line/word timings when project lacks primingStripped and audio has LAME priming", async () => {
     const mp3 = createMp3File();
-    const priming = parseLamePriming(await mp3.arrayBuffer());
-    expect(priming).toBeGreaterThan(0);
+    const { samples, sampleRate } = parseLamePriming(await mp3.arrayBuffer());
+    expect(samples).toBeGreaterThan(0);
+    expect(sampleRate).toBeGreaterThan(0);
     await saveAudioFile(mp3);
     await seedSavedProject({ primingStripped: false });
 
     const migrated = await loadCurrentProjectWithPrimingMigration();
     expect(migrated).toBeDefined();
-    const shiftSec = priming / TARGET_SAMPLE_RATE;
+    const shiftSec = samples / sampleRate;
     const words = (migrated!.lines[0] as { words: WordTiming[] }).words;
     expect(words[0].begin).toBeCloseTo(1.0 - shiftSec);
     expect(words[0].end).toBeCloseTo(1.5 - shiftSec);
@@ -92,7 +92,7 @@ describe("loadCurrentProjectWithPrimingMigration", () => {
 
   it("sets primingStripped to true even when audio has zero priming", async () => {
     const noPrimingMp3 = new File([new Uint8Array([0, 1, 2, 3])], "not-mp3.bin", { type: "audio/mpeg" });
-    expect(parseLamePriming(await noPrimingMp3.arrayBuffer())).toBe(0);
+    expect(parseLamePriming(await noPrimingMp3.arrayBuffer()).samples).toBe(0);
     await saveAudioFile(noPrimingMp3);
     await seedSavedProject({ primingStripped: false });
 

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -1,13 +1,13 @@
 import {
   clearAudioFile,
   loadAudioFile,
-  loadCurrentProject,
   saveAudioFile,
   saveCurrentProject,
   type SavedAudioSource,
 } from "@/lib/persistence";
 import { cancelPendingSave, debouncedSave, flushPendingSave } from "@/lib/persistence-debounce";
 import { markPersistenceSettled } from "@/lib/persistence-settled";
+import { loadCurrentProjectWithPrimingMigration } from "@/lib/priming-migration";
 import { type AudioSource, useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { DEFAULT_SYLLABLE_SPLIT_DEFAULTS } from "@/stores/project/types";
@@ -82,7 +82,7 @@ function commitProjectSaveNow(): void {
 
 function usePersistence(): void {
   useEffect(() => {
-    Promise.all([loadCurrentProject(), loadAudioFile()])
+    Promise.all([loadCurrentProjectWithPrimingMigration(), loadAudioFile()])
       .then(([project, file]) => {
         if (project) {
           const issues: string[] = [];

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -98,6 +98,22 @@ function usePersistence(): void {
             );
           }
 
+          // Restore the saved stem selection BEFORE setting the audio source.
+          // useAutoSeparate's source subscription will then run refreshForCurrentSource
+          // which preserves currentStem when the cached stems are still available, and
+          // falls back to "original" when they aren't (LRU eviction or variant change).
+          if (project.currentStem) {
+            useSeparationStore.getState().restoreCurrentStem(project.currentStem);
+          }
+
+          const savedSource = project.audioSource;
+          if (savedSource?.kind === "youtube") {
+            useAudioStore.getState().setYouTubeSource(savedSource.videoId, file);
+          } else if (file) {
+            useAudioStore.getState().setSource({ type: "file", file });
+          }
+          useAudioStore.getState().setPrimingStripped(project.primingStripped ?? false);
+
           const state = useProjectStore.getState();
           state.setMetadata(project.metadata);
           state.setLines(safeLines);
@@ -108,24 +124,8 @@ function usePersistence(): void {
           state.setDismissedSuggestions(project.dismissedSuggestions ?? []);
           state.setDismissedExplicitSuggestions(project.dismissedExplicitSuggestions ?? []);
           state.markClean();
-        }
-
-        // Restore the saved stem selection BEFORE setting the audio source.
-        // useAutoSeparate's source subscription will then run refreshForCurrentSource
-        // which preserves currentStem when the cached stems are still available, and
-        // falls back to "original" when they aren't (LRU eviction or variant change).
-        if (project?.currentStem) {
-          useSeparationStore.getState().restoreCurrentStem(project.currentStem);
-        }
-
-        const savedSource = project?.audioSource;
-        if (savedSource?.kind === "youtube") {
-          useAudioStore.getState().setYouTubeSource(savedSource.videoId, file);
         } else if (file) {
           useAudioStore.getState().setSource({ type: "file", file });
-        }
-        if (project) {
-          useAudioStore.getState().setPrimingStripped(project.primingStripped ?? false);
         }
       })
       .catch((err) => {

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -58,7 +58,7 @@ function buildSaveArgs(): ProjectSaveArgs | null {
     projectState.dismissedSuggestions,
     projectState.dismissedExplicitSuggestions,
     useSeparationStore.getState().currentStem,
-    useAudioStore.getState().primingStripped,
+    projectState.primingStripped,
   ];
 }
 
@@ -112,7 +112,6 @@ function usePersistence(): void {
           } else if (file) {
             useAudioStore.getState().setSource({ type: "file", file });
           }
-          useAudioStore.getState().setPrimingStripped(project.primingStripped ?? false);
 
           const state = useProjectStore.getState();
           state.setMetadata(project.metadata);
@@ -123,6 +122,7 @@ function usePersistence(): void {
           state.setAgents(safeAgents);
           state.setDismissedSuggestions(project.dismissedSuggestions ?? []);
           state.setDismissedExplicitSuggestions(project.dismissedExplicitSuggestions ?? []);
+          state.setPrimingStripped(project.primingStripped ?? false);
           state.markClean();
         } else if (file) {
           useAudioStore.getState().setSource({ type: "file", file });

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -124,6 +124,9 @@ function usePersistence(): void {
         } else if (file) {
           useAudioStore.getState().setSource({ type: "file", file });
         }
+        if (project) {
+          useAudioStore.getState().setPrimingStripped(project.primingStripped ?? false);
+        }
       })
       .catch((err) => {
         console.error(`${LOG_PREFIX} initial load failed:`, err);

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -58,6 +58,7 @@ function buildSaveArgs(): ProjectSaveArgs | null {
     projectState.dismissedSuggestions,
     projectState.dismissedExplicitSuggestions,
     useSeparationStore.getState().currentStem,
+    useAudioStore.getState().primingStripped,
   ];
 }
 

--- a/src/lib/persistence-debounce.ts
+++ b/src/lib/persistence-debounce.ts
@@ -25,6 +25,7 @@ type SaveArgs = [
   string[],
   string[],
   Stem,
+  boolean,
 ];
 
 let saveTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -43,6 +44,7 @@ function debouncedSave(
   dismissedSuggestions: string[],
   dismissedExplicitSuggestions: string[],
   currentStem: Stem,
+  primingStripped: boolean,
 ): void {
   pendingSaveArgs = [
     metadata,
@@ -55,6 +57,7 @@ function debouncedSave(
     dismissedSuggestions,
     dismissedExplicitSuggestions,
     currentStem,
+    primingStripped,
   ];
   if (saveTimeout) {
     clearTimeout(saveTimeout);

--- a/src/lib/persistence.test.ts
+++ b/src/lib/persistence.test.ts
@@ -40,3 +40,62 @@ describe("persistence: syllableSplitDefaults", () => {
     expect(parsed.syllableSplitDefaults).toEqual({ applyToAll: false, caseInsensitive: false });
   });
 });
+
+describe("persistence: primingStripped round-trip", () => {
+  it("persists and reads back primingStripped through importProjectFromFile", async () => {
+    const metadata = { title: "Song", artist: "", album: "", duration: 0 };
+    const payload = {
+      version: 1 as const,
+      savedAt: Date.now(),
+      metadata,
+      agents: DEFAULT_AGENTS,
+      lines: [],
+      groups: [],
+      granularity: "word" as const,
+      syllableSplitDefaults: { applyToAll: false, caseInsensitive: false },
+      primingStripped: true,
+    };
+    const file = new File([JSON.stringify(payload)], "song.ttml-project.json", { type: "application/json" });
+
+    const parsed = await importProjectFromFile(file);
+
+    expect(parsed.primingStripped).toBe(true);
+  });
+
+  it("leaves primingStripped undefined when importing a pre-strip project", async () => {
+    const metadata = { title: "Old", artist: "", album: "", duration: 0 };
+    const legacy = {
+      version: 1 as const,
+      savedAt: Date.now(),
+      metadata,
+      agents: DEFAULT_AGENTS,
+      lines: [],
+      groups: [],
+      granularity: "word" as const,
+    };
+    const file = new File([JSON.stringify(legacy)], "legacy.ttml-project.json", { type: "application/json" });
+
+    const parsed = await importProjectFromFile(file);
+
+    expect(parsed.primingStripped).toBeUndefined();
+  });
+
+  it("preserves primingStripped=false explicitly", async () => {
+    const metadata = { title: "Mid", artist: "", album: "", duration: 0 };
+    const payload = {
+      version: 1 as const,
+      savedAt: Date.now(),
+      metadata,
+      agents: DEFAULT_AGENTS,
+      lines: [],
+      groups: [],
+      granularity: "word" as const,
+      primingStripped: false,
+    };
+    const file = new File([JSON.stringify(payload)], "mid.ttml-project.json", { type: "application/json" });
+
+    const parsed = await importProjectFromFile(file);
+
+    expect(parsed.primingStripped).toBe(false);
+  });
+});

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -167,4 +167,4 @@ export {
   loadAudioFile,
   clearAudioFile,
 };
-export type { SavedAudioSource };
+export type { SavedAudioSource, SavedProject };

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -25,6 +25,7 @@ interface SavedProject {
   dismissedSuggestions?: string[];
   dismissedExplicitSuggestions?: string[];
   currentStem?: Stem;
+  primingStripped?: boolean;
 }
 
 // -- Constants ----------------------------------------------------------------
@@ -45,6 +46,7 @@ async function saveCurrentProject(
   dismissedSuggestions: string[],
   dismissedExplicitSuggestions: string[],
   currentStem: Stem,
+  primingStripped: boolean,
 ): Promise<void> {
   const audioFileName = audioSource?.kind === "file" ? audioSource.name : undefined;
   const project: SavedProject = {
@@ -61,6 +63,7 @@ async function saveCurrentProject(
     dismissedSuggestions,
     dismissedExplicitSuggestions,
     currentStem,
+    primingStripped,
   };
   await setInStore(PROJECT_STORE_NAME, CURRENT_PROJECT_KEY, project);
 }

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -72,6 +72,10 @@ async function loadCurrentProject(): Promise<SavedProject | undefined> {
   return getFromStore<SavedProject>(PROJECT_STORE_NAME, CURRENT_PROJECT_KEY);
 }
 
+async function replaceCurrentProject(project: SavedProject): Promise<void> {
+  await setInStore(PROJECT_STORE_NAME, CURRENT_PROJECT_KEY, project);
+}
+
 async function clearCurrentProject(): Promise<void> {
   await deleteFromStore(PROJECT_STORE_NAME, CURRENT_PROJECT_KEY);
   await clearAudioFile();
@@ -160,6 +164,7 @@ async function importProjectFromFile(file: File): Promise<SavedProject> {
 export {
   saveCurrentProject,
   loadCurrentProject,
+  replaceCurrentProject,
   clearCurrentProject,
   exportProjectToFile,
   importProjectFromFile,

--- a/src/lib/priming-migration.test.ts
+++ b/src/lib/priming-migration.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+import { shiftAllTimings } from "@/lib/priming-migration";
+import type { LyricLine } from "@/domain/line/model";
+import type { WordTiming } from "@/domain/word/timing";
+
+// -- Helpers ------------------------------------------------------------------
+
+function lineSynced(id: string, begin: number, end: number): LyricLine {
+  return { id, text: "x", agentId: "a", begin, end };
+}
+
+function wordSynced(id: string, words: WordTiming[]): LyricLine {
+  return { id, text: words.map((w) => w.text).join(" "), agentId: "a", words };
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("shiftAllTimings", () => {
+  it("subtracts the shift from line begin and end", () => {
+    const out = shiftAllTimings([lineSynced("L", 1.0, 2.0)], 0.5);
+    const line = out[0] as { begin: number; end: number };
+    expect(line.begin).toBeCloseTo(0.5);
+    expect(line.end).toBeCloseTo(1.5);
+  });
+
+  it("subtracts the shift from every word begin and end", () => {
+    const out = shiftAllTimings(
+      [
+        wordSynced("L", [
+          { text: "hi", begin: 1.0, end: 1.5 },
+          { text: "you", begin: 1.5, end: 2.0 },
+        ]),
+      ],
+      0.5,
+    );
+    const words = (out[0] as { words: WordTiming[] }).words;
+    expect(words[0].begin).toBeCloseTo(0.5);
+    expect(words[0].end).toBeCloseTo(1.0);
+    expect(words[1].begin).toBeCloseTo(1.0);
+    expect(words[1].end).toBeCloseTo(1.5);
+  });
+
+  it("subtracts the shift from background words", () => {
+    const lines: LyricLine[] = [
+      {
+        id: "L",
+        text: "main",
+        agentId: "a",
+        words: [{ text: "main", begin: 1.0, end: 2.0 }],
+        backgroundText: "bg",
+        backgroundWords: [{ text: "bg", begin: 1.2, end: 1.8 }],
+      },
+    ];
+    const out = shiftAllTimings(lines, 0.5);
+    const bg = (out[0] as { backgroundWords: WordTiming[] }).backgroundWords;
+    expect(bg[0].begin).toBeCloseTo(0.7);
+    expect(bg[0].end).toBeCloseTo(1.3);
+  });
+
+  it("leaves untimed lines untouched", () => {
+    const lines: LyricLine[] = [{ id: "L", text: "no timing", agentId: "a" }];
+    const out = shiftAllTimings(lines, 0.5);
+    expect(out[0]).toEqual(lines[0]);
+  });
+
+  it("is a no-op for shift = 0", () => {
+    const lines = [lineSynced("L", 1.0, 2.0)];
+    const out = shiftAllTimings(lines, 0);
+    expect(out).toEqual(lines);
+  });
+
+  it("preserves WordTiming extras like explicit and syllableGroupId", () => {
+    const lines: LyricLine[] = [
+      {
+        id: "L",
+        text: "x",
+        agentId: "a",
+        words: [{ text: "x", begin: 1.0, end: 1.5, explicit: true, syllableGroupId: "g1" }],
+      },
+    ];
+    const shifted = shiftAllTimings(lines, 0.5);
+    const w = (shifted[0] as { words: WordTiming[] }).words[0];
+    expect(w.explicit).toBe(true);
+    expect(w.syllableGroupId).toBe("g1");
+    expect(w.begin).toBeCloseTo(0.5);
+    expect(w.end).toBeCloseTo(1.0);
+  });
+
+  it("preserves background word extras", () => {
+    const lines: LyricLine[] = [
+      {
+        id: "L",
+        text: "main",
+        agentId: "a",
+        backgroundText: "bg",
+        backgroundWords: [{ text: "bg", begin: 1.0, end: 1.5, explicit: true, syllableGroupId: "g2" }],
+      },
+    ];
+    const out = shiftAllTimings(lines, 0.5);
+    const bg = (out[0] as { backgroundWords: WordTiming[] }).backgroundWords[0];
+    expect(bg.explicit).toBe(true);
+    expect(bg.syllableGroupId).toBe("g2");
+    expect(bg.begin).toBeCloseTo(0.5);
+  });
+
+  it("preserves LineFields like agentId, text, groupId, instanceIdx across all variants", () => {
+    const lines: LyricLine[] = [
+      {
+        id: "wsl",
+        text: "hi",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 2,
+        templateLineIdx: 0,
+        words: [{ text: "hi", begin: 1.0, end: 1.5 }],
+      },
+      {
+        id: "lsl",
+        text: "world",
+        agentId: "v2",
+        groupId: "g2",
+        instanceIdx: 1,
+        begin: 2.0,
+        end: 3.0,
+      },
+    ];
+    const out = shiftAllTimings(lines, 0.5);
+    expect(out[0].agentId).toBe("v1");
+    expect(out[0].groupId).toBe("g1");
+    expect(out[0].instanceIdx).toBe(2);
+    expect(out[0].templateLineIdx).toBe(0);
+    expect(out[0].text).toBe("hi");
+    expect(out[1].agentId).toBe("v2");
+    expect(out[1].groupId).toBe("g2");
+    expect(out[1].instanceIdx).toBe(1);
+  });
+});
+
+describe("shiftAllTimings: edge cases", () => {
+  it("clamps negative line timings to 0", () => {
+    const out = shiftAllTimings([lineSynced("L", 0.1, 0.4)], 0.5);
+    const line = out[0] as { begin: number; end: number };
+    expect(line.begin).toBe(0);
+    expect(line.end).toBe(0);
+  });
+
+  it("clamps negative word timings to 0", () => {
+    const out = shiftAllTimings(
+      [
+        wordSynced("L", [
+          { text: "early", begin: 0.1, end: 0.2 },
+          { text: "later", begin: 0.6, end: 1.0 },
+        ]),
+      ],
+      0.5,
+    );
+    const words = (out[0] as { words: WordTiming[] }).words;
+    expect(words[0].begin).toBe(0);
+    expect(words[0].end).toBe(0);
+    expect(words[1].begin).toBeCloseTo(0.1);
+    expect(words[1].end).toBeCloseTo(0.5);
+  });
+
+  it("clamps negative background word timings to 0", () => {
+    const lines: LyricLine[] = [
+      {
+        id: "L",
+        text: "main",
+        agentId: "a",
+        backgroundText: "bg",
+        backgroundWords: [{ text: "bg", begin: 0.1, end: 0.3 }],
+      },
+    ];
+    const out = shiftAllTimings(lines, 0.5);
+    const bg = (out[0] as { backgroundWords: WordTiming[] }).backgroundWords[0];
+    expect(bg.begin).toBe(0);
+    expect(bg.end).toBe(0);
+  });
+
+  it("handles an empty lines array", () => {
+    const out = shiftAllTimings([], 0.5);
+    expect(out).toEqual([]);
+  });
+
+  it("handles a word-synced line with no words", () => {
+    const lines: LyricLine[] = [{ id: "L", text: "", agentId: "a", words: [] }];
+    const out = shiftAllTimings(lines, 0.5);
+    expect((out[0] as { words: WordTiming[] }).words).toEqual([]);
+  });
+});
+
+describe("shiftAllTimings: invariants", () => {
+  it("does not mutate the input array or its elements", () => {
+    const lines: LyricLine[] = [
+      lineSynced("L1", 1.0, 2.0),
+      wordSynced("L2", [{ text: "x", begin: 1.0, end: 1.5 }]),
+      {
+        id: "L3",
+        text: "main",
+        agentId: "a",
+        backgroundText: "bg",
+        backgroundWords: [{ text: "bg", begin: 1.0, end: 1.5 }],
+      },
+    ];
+    const snapshot = JSON.parse(JSON.stringify(lines));
+    shiftAllTimings(lines, 0.5);
+    expect(JSON.parse(JSON.stringify(lines))).toEqual(snapshot);
+  });
+
+  it("returns the same length output", () => {
+    const lines: LyricLine[] = [
+      lineSynced("L1", 1.0, 2.0),
+      { id: "L2", text: "untimed", agentId: "a" },
+      wordSynced("L3", [{ text: "x", begin: 1.0, end: 1.5 }]),
+    ];
+    const out = shiftAllTimings(lines, 0.5);
+    expect(out.length).toBe(lines.length);
+  });
+
+  it("preserves line ids and order", () => {
+    const lines: LyricLine[] = [lineSynced("L1", 1.0, 2.0), lineSynced("L2", 3.0, 4.0), lineSynced("L3", 5.0, 6.0)];
+    const out = shiftAllTimings(lines, 0.5);
+    expect(out.map((l) => l.id)).toEqual(["L1", "L2", "L3"]);
+  });
+
+  it("returns the same reference when shift is 0 (no-op fast path)", () => {
+    const lines = [lineSynced("L", 1.0, 2.0)];
+    const out = shiftAllTimings(lines, 0);
+    expect(out).toBe(lines);
+  });
+});

--- a/src/lib/priming-migration.ts
+++ b/src/lib/priming-migration.ts
@@ -1,0 +1,57 @@
+import { parseLamePriming } from "@/audio/lame-priming";
+import { TARGET_SAMPLE_RATE } from "@/audio/separation/audio-codec";
+import type { LyricLine } from "@/domain/line/model";
+import type { WordTiming } from "@/domain/word/timing";
+import { loadAudioFile, loadCurrentProject, type SavedProject } from "@/lib/persistence";
+
+// -- Helpers ------------------------------------------------------------------
+
+function shiftWord(word: WordTiming, shiftSec: number): WordTiming {
+  return {
+    ...word,
+    begin: Math.max(0, word.begin - shiftSec),
+    end: Math.max(0, word.end - shiftSec),
+  };
+}
+
+function shiftLine(line: LyricLine, shiftSec: number): LyricLine {
+  const next = { ...line } as LyricLine;
+  if ("words" in next && next.words) {
+    (next as { words: WordTiming[] }).words = next.words.map((w) => shiftWord(w, shiftSec));
+  }
+  if ("begin" in next && next.begin !== undefined && "end" in next && next.end !== undefined) {
+    (next as { begin: number; end: number }).begin = Math.max(0, next.begin - shiftSec);
+    (next as { begin: number; end: number }).end = Math.max(0, next.end - shiftSec);
+  }
+  if (next.backgroundWords) {
+    next.backgroundWords = next.backgroundWords.map((w) => shiftWord(w, shiftSec));
+  }
+  return next;
+}
+
+// -- Public API ---------------------------------------------------------------
+
+function shiftAllTimings(lines: LyricLine[], shiftSec: number): LyricLine[] {
+  if (shiftSec === 0) return lines;
+  return lines.map((line) => shiftLine(line, shiftSec));
+}
+
+async function loadCurrentProjectWithPrimingMigration(): Promise<SavedProject | undefined> {
+  const project = await loadCurrentProject();
+  if (!project) return project;
+  if (project.primingStripped === true) return project;
+  const audioFile = await loadAudioFile();
+  if (!audioFile) return project;
+  const buf = await audioFile.arrayBuffer();
+  const priming = parseLamePriming(buf);
+  if (priming > 0) {
+    const shiftSec = priming / TARGET_SAMPLE_RATE;
+    project.lines = shiftAllTimings(project.lines ?? [], shiftSec);
+  }
+  project.primingStripped = true;
+  return project;
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { shiftAllTimings, loadCurrentProjectWithPrimingMigration };

--- a/src/lib/priming-migration.ts
+++ b/src/lib/priming-migration.ts
@@ -1,5 +1,5 @@
 import { parseLamePriming } from "@/audio/lame-priming";
-import { isLineSynced } from "@/domain/line/predicates";
+import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
 import type { LyricLine } from "@/domain/line/model";
 import type { WordTiming } from "@/domain/word/timing";
 import { loadAudioFile, loadCurrentProject, replaceCurrentProject, type SavedProject } from "@/lib/persistence";
@@ -16,8 +16,8 @@ function shiftWord(word: WordTiming, shiftSec: number): WordTiming {
 
 function shiftLine(line: LyricLine, shiftSec: number): LyricLine {
   const next = { ...line } as LyricLine;
-  if ("words" in next && next.words) {
-    (next as { words: WordTiming[] }).words = next.words.map((w) => shiftWord(w, shiftSec));
+  if (isWordSynced(next)) {
+    (next as { words: WordTiming[] }).words = next.words!.map((w) => shiftWord(w, shiftSec));
   }
   if (isLineSynced(next)) {
     (next as { begin: number; end: number }).begin = Math.max(0, next.begin - shiftSec);

--- a/src/lib/priming-migration.ts
+++ b/src/lib/priming-migration.ts
@@ -1,8 +1,8 @@
 import { parseLamePriming } from "@/audio/lame-priming";
-import { TARGET_SAMPLE_RATE } from "@/audio/separation/audio-codec";
+import { isLineSynced } from "@/domain/line/predicates";
 import type { LyricLine } from "@/domain/line/model";
 import type { WordTiming } from "@/domain/word/timing";
-import { loadAudioFile, loadCurrentProject, type SavedProject } from "@/lib/persistence";
+import { loadAudioFile, loadCurrentProject, replaceCurrentProject, type SavedProject } from "@/lib/persistence";
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -19,7 +19,7 @@ function shiftLine(line: LyricLine, shiftSec: number): LyricLine {
   if ("words" in next && next.words) {
     (next as { words: WordTiming[] }).words = next.words.map((w) => shiftWord(w, shiftSec));
   }
-  if ("begin" in next && next.begin !== undefined && "end" in next && next.end !== undefined) {
+  if (isLineSynced(next)) {
     (next as { begin: number; end: number }).begin = Math.max(0, next.begin - shiftSec);
     (next as { begin: number; end: number }).end = Math.max(0, next.end - shiftSec);
   }
@@ -43,12 +43,13 @@ async function loadCurrentProjectWithPrimingMigration(): Promise<SavedProject | 
   const audioFile = await loadAudioFile();
   if (!audioFile) return project;
   const buf = await audioFile.arrayBuffer();
-  const priming = parseLamePriming(buf);
-  if (priming > 0) {
-    const shiftSec = priming / TARGET_SAMPLE_RATE;
+  const { samples, sampleRate } = parseLamePriming(buf);
+  if (samples > 0 && sampleRate > 0) {
+    const shiftSec = samples / sampleRate;
     project.lines = shiftAllTimings(project.lines ?? [], shiftSec);
   }
   project.primingStripped = true;
+  await replaceCurrentProject(project);
   return project;
 }
 

--- a/src/stores/audio.test.ts
+++ b/src/stores/audio.test.ts
@@ -109,49 +109,6 @@ describe("useAudioStore - seekTo", () => {
   });
 });
 
-describe("useAudioStore - primingStripped", () => {
-  it("defaults to false", () => {
-    expect(useAudioStore.getState().primingStripped).toBe(false);
-  });
-
-  it("can be set true via setPrimingStripped", () => {
-    useAudioStore.getState().setPrimingStripped(true);
-    expect(useAudioStore.getState().primingStripped).toBe(true);
-  });
-
-  it("can be set back to false via setPrimingStripped", () => {
-    useAudioStore.getState().setPrimingStripped(true);
-    useAudioStore.getState().setPrimingStripped(false);
-    expect(useAudioStore.getState().primingStripped).toBe(false);
-  });
-
-  it("resets to false when setSource is called", () => {
-    useAudioStore.getState().setPrimingStripped(true);
-    const file = new File([], "x.wav", { type: "audio/wav" });
-    useAudioStore.getState().setSource({ type: "file", file });
-    expect(useAudioStore.getState().primingStripped).toBe(false);
-  });
-
-  it("resets to false when setSource(null) is called", () => {
-    useAudioStore.getState().setPrimingStripped(true);
-    useAudioStore.getState().setSource(null);
-    expect(useAudioStore.getState().primingStripped).toBe(false);
-  });
-
-  it("resets to false on reset()", () => {
-    useAudioStore.getState().setPrimingStripped(true);
-    useAudioStore.getState().reset();
-    expect(useAudioStore.getState().primingStripped).toBe(false);
-  });
-
-  it("does not affect other audio state when toggling", () => {
-    useAudioStore.setState({ currentTime: 5, duration: 100 });
-    useAudioStore.getState().setPrimingStripped(true);
-    expect(useAudioStore.getState().currentTime).toBe(5);
-    expect(useAudioStore.getState().duration).toBe(100);
-  });
-});
-
 describe("useAudioStore - setPlaybackRate", () => {
   it("persists the selected playback rate as the default", () => {
     useAudioStore.getState().setPlaybackRate(1.5);

--- a/src/stores/audio.test.ts
+++ b/src/stores/audio.test.ts
@@ -109,6 +109,49 @@ describe("useAudioStore - seekTo", () => {
   });
 });
 
+describe("useAudioStore - primingStripped", () => {
+  it("defaults to false", () => {
+    expect(useAudioStore.getState().primingStripped).toBe(false);
+  });
+
+  it("can be set true via setPrimingStripped", () => {
+    useAudioStore.getState().setPrimingStripped(true);
+    expect(useAudioStore.getState().primingStripped).toBe(true);
+  });
+
+  it("can be set back to false via setPrimingStripped", () => {
+    useAudioStore.getState().setPrimingStripped(true);
+    useAudioStore.getState().setPrimingStripped(false);
+    expect(useAudioStore.getState().primingStripped).toBe(false);
+  });
+
+  it("resets to false when setSource is called", () => {
+    useAudioStore.getState().setPrimingStripped(true);
+    const file = new File([], "x.wav", { type: "audio/wav" });
+    useAudioStore.getState().setSource({ type: "file", file });
+    expect(useAudioStore.getState().primingStripped).toBe(false);
+  });
+
+  it("resets to false when setSource(null) is called", () => {
+    useAudioStore.getState().setPrimingStripped(true);
+    useAudioStore.getState().setSource(null);
+    expect(useAudioStore.getState().primingStripped).toBe(false);
+  });
+
+  it("resets to false on reset()", () => {
+    useAudioStore.getState().setPrimingStripped(true);
+    useAudioStore.getState().reset();
+    expect(useAudioStore.getState().primingStripped).toBe(false);
+  });
+
+  it("does not affect other audio state when toggling", () => {
+    useAudioStore.setState({ currentTime: 5, duration: 100 });
+    useAudioStore.getState().setPrimingStripped(true);
+    expect(useAudioStore.getState().currentTime).toBe(5);
+    expect(useAudioStore.getState().duration).toBe(100);
+  });
+});
+
 describe("useAudioStore - setPlaybackRate", () => {
   it("persists the selected playback rate as the default", () => {
     useAudioStore.getState().setPlaybackRate(1.5);

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -16,6 +16,7 @@ interface AudioState {
   isLoading: boolean;
   audioElement: HTMLAudioElement | null;
   youtubeLoadError: string | null;
+  primingStripped: boolean;
 }
 
 interface AudioActions {
@@ -31,6 +32,7 @@ interface AudioActions {
   setIsLoading: (isLoading: boolean) => void;
   setYouTubeLoadError: (error: string | null) => void;
   registerAudioElement: (element: HTMLAudioElement | null) => void;
+  setPrimingStripped: (value: boolean) => void;
   seekTo: (time: number) => void;
   reset: () => void;
 }
@@ -50,6 +52,7 @@ function createInitialState(): AudioState {
     isLoading: false,
     audioElement: null,
     youtubeLoadError: null,
+    primingStripped: false,
   };
 }
 
@@ -60,7 +63,15 @@ const INITIAL_STATE: AudioState = createInitialState();
 const useAudioStore = create<AudioState & AudioActions>((set, get) => ({
   ...INITIAL_STATE,
 
-  setSource: (source) => set({ source, currentTime: 0, duration: 0, isPlaying: false, youtubeLoadError: null }),
+  setSource: (source) =>
+    set({
+      source,
+      currentTime: 0,
+      duration: 0,
+      isPlaying: false,
+      youtubeLoadError: null,
+      primingStripped: false,
+    }),
   setYouTubeSource: (videoId, file) =>
     set({
       source: { type: "youtube", videoId, file },
@@ -68,6 +79,7 @@ const useAudioStore = create<AudioState & AudioActions>((set, get) => ({
       duration: 0,
       isPlaying: false,
       youtubeLoadError: null,
+      primingStripped: false,
     }),
   setYouTubeFile: (file) =>
     set((s) => {
@@ -89,6 +101,7 @@ const useAudioStore = create<AudioState & AudioActions>((set, get) => ({
   setIsLoading: (isLoading) => set({ isLoading }),
   setYouTubeLoadError: (youtubeLoadError) => set({ youtubeLoadError }),
   registerAudioElement: (audioElement) => set({ audioElement }),
+  setPrimingStripped: (primingStripped) => set({ primingStripped }),
   seekTo: (time: number) => {
     if (!Number.isFinite(time) || time < 0) return;
     const audio = get().audioElement;

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -16,7 +16,6 @@ interface AudioState {
   isLoading: boolean;
   audioElement: HTMLAudioElement | null;
   youtubeLoadError: string | null;
-  primingStripped: boolean;
 }
 
 interface AudioActions {
@@ -32,7 +31,6 @@ interface AudioActions {
   setIsLoading: (isLoading: boolean) => void;
   setYouTubeLoadError: (error: string | null) => void;
   registerAudioElement: (element: HTMLAudioElement | null) => void;
-  setPrimingStripped: (value: boolean) => void;
   seekTo: (time: number) => void;
   reset: () => void;
 }
@@ -52,7 +50,6 @@ function createInitialState(): AudioState {
     isLoading: false,
     audioElement: null,
     youtubeLoadError: null,
-    primingStripped: false,
   };
 }
 
@@ -70,7 +67,6 @@ const useAudioStore = create<AudioState & AudioActions>((set, get) => ({
       duration: 0,
       isPlaying: false,
       youtubeLoadError: null,
-      primingStripped: false,
     }),
   setYouTubeSource: (videoId, file) =>
     set({
@@ -79,7 +75,6 @@ const useAudioStore = create<AudioState & AudioActions>((set, get) => ({
       duration: 0,
       isPlaying: false,
       youtubeLoadError: null,
-      primingStripped: false,
     }),
   setYouTubeFile: (file) =>
     set((s) => {
@@ -101,7 +96,6 @@ const useAudioStore = create<AudioState & AudioActions>((set, get) => ({
   setIsLoading: (isLoading) => set({ isLoading }),
   setYouTubeLoadError: (youtubeLoadError) => set({ youtubeLoadError }),
   registerAudioElement: (audioElement) => set({ audioElement }),
-  setPrimingStripped: (primingStripped) => set({ primingStripped }),
   seekTo: (time: number) => {
     if (!Number.isFinite(time) || time < 0) return;
     const audio = get().audioElement;

--- a/src/stores/project/types.ts
+++ b/src/stores/project/types.ts
@@ -49,6 +49,7 @@ interface UiState {
   editorMode: EditorMode;
   activeTab: SimpleTab;
   syllableSplitDefaults: SyllableSplitDefaults;
+  primingStripped: boolean;
 }
 
 interface DismissalsState {
@@ -86,6 +87,7 @@ interface UiActions {
   setEditorMode: (mode: EditorMode) => void;
   setActiveTab: (tab: SimpleTab) => void;
   setSyllableSplitDefaults: (defaults: SyllableSplitDefaults) => void;
+  setPrimingStripped: (value: boolean) => void;
 }
 
 interface DismissalActions {

--- a/src/stores/project/ui-slice.ts
+++ b/src/stores/project/ui-slice.ts
@@ -16,6 +16,7 @@ function createUiInitialState(): UiState {
     editorMode: "simple",
     activeTab: "import",
     syllableSplitDefaults: DEFAULT_SYLLABLE_SPLIT_DEFAULTS,
+    primingStripped: false,
   };
 }
 
@@ -36,6 +37,8 @@ const createUiSlice: StateCreator<ProjectStore, [], [], UiState & UiActions> = (
   },
 
   setSyllableSplitDefaults: (syllableSplitDefaults) => set({ syllableSplitDefaults, isDirty: true }),
+
+  setPrimingStripped: (primingStripped) => set({ primingStripped, isDirty: true }),
 });
 
 // -- Exports ------------------------------------------------------------------

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -114,4 +114,3 @@ describe("cobalt instance helpers", () => {
     expect(getActiveCobaltInstance().url).toBe("https://example.test");
   });
 });
-

--- a/src/utils/background-vocal-brackets.ts
+++ b/src/utils/background-vocal-brackets.ts
@@ -33,11 +33,6 @@ function bracketWordList(words: WordTiming[]): WordTiming[] {
 
 // -- Seam-aware concatenation -------------------------------------------------
 
-// Peels the trailing ')' off the base's last word and the leading '(' off the
-// carried first word so the two arrays land inside one outer pair. Reinserts a
-// space at the seam to keep token boundaries intact. Falls back to plain
-// concatenation when either side lacks the matching bracket at the seam,
-// which is how manual base words stay untouched next to a bracketed carry.
 function joinBracketedCarriedWords(
   baseWords: WordTiming[],
   carried: WordTiming[],

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -230,11 +230,6 @@ function mergeStandaloneInto(
 
 function extractBackgroundVocals(lines: LyricLine[], options: ExtractOptions): LyricLine[] {
   const result: LyricLine[] = [];
-  // Result indices whose bg was written or appended to during this pass. Used
-  // for two decisions: (a) the extraction-source bg is fresh, not stale prior
-  // output to discard on re-paste, and (b) a trailing ')' is safe to peel when
-  // grouping a later standalone inside. Pre-existing prev bg is never in the
-  // set, so manual text typed by the user is left intact.
   const sameSessionWriteIndices = new Set<number>();
   for (const line of lines) {
     const classified = classifyLine(line.text);


### PR DESCRIPTION
Chrome's decodeAudioData leaves ~1900 samples of LAME priming at the head of MP3 buffers, causing a ~43ms shift between Composer's downloaded stems and externally-decoded references. The parser reads the encoder delay from the LAME tag and trims it at decode; old projects auto-shift their saved timings on next load.