### PR TITLE
Preserve brackets on background-vocal extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.24.2",
+  "version": "1.25.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/hooks/useDualClickImport.tsx
+++ b/src/hooks/useDualClickImport.tsx
@@ -26,6 +26,7 @@ function useDualClickImport(openModal: () => void): DualClickImportHandlers {
   const audioDuration = useAudioStore((s) => s.duration);
   const autoExtract = useSettingsStore((s) => s.autoExtractBackgroundVocals);
   const mergeStandalone = useSettingsStore((s) => s.mergeStandaloneBackgroundLines);
+  const preserveBrackets = useSettingsStore((s) => s.preserveBracketsOnExtraction);
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const clickTimerRef = useRef<number | null>(null);
@@ -63,13 +64,14 @@ function useDualClickImport(openModal: () => void): DualClickImportHandlers {
         audioDuration,
         applyBackgroundExtraction: autoExtract,
         backgroundExtractionMergeStandalone: mergeStandalone,
+        backgroundExtractionPreserveBrackets: preserveBrackets,
         source: { label: "File", filename: file.name },
         onResult: (parsedResult, source) => {
           useImportModalStore.getState().recordImportResult(parsedResult, source);
         },
       });
     },
-    [agents, audioDuration, autoExtract, confirm, mergeStandalone],
+    [agents, audioDuration, autoExtract, confirm, mergeStandalone, preserveBrackets],
   );
 
   const fileInput = (

--- a/src/stores/project.background-extraction.test.ts
+++ b/src/stores/project.background-extraction.test.ts
@@ -30,7 +30,7 @@ describe("project store · background extraction on linked lines", () => {
   function applyPullFromParens(lineId: string) {
     const target = useProjectStore.getState().lines.find((l) => l.id === lineId);
     if (!target) throw new Error(`line ${lineId} not found`);
-    const extracted = extractInlineFromLine(target);
+    const extracted = extractInlineFromLine(target, { mergeStandaloneLines: false, preserveBrackets: false });
     useProjectStore.getState().updateLineWithHistory(target.id, {
       text: extracted.text,
       words: extracted.words,

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -114,4 +114,3 @@ describe("cobalt instance helpers", () => {
     expect(getActiveCobaltInstance().url).toBe("https://example.test");
   });
 });
-

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -57,6 +57,18 @@ describe("background vocal extraction settings", () => {
     expect(useSettingsStore.getState().mergeStandaloneBackgroundLines).toBe(true);
   });
 
+  it("defaults preserveBracketsOnExtraction to false", () => {
+    expect(DEFAULTS.preserveBracketsOnExtraction).toBe(false);
+    expect(useSettingsStore.getState().preserveBracketsOnExtraction).toBe(false);
+  });
+
+  it("allows toggling preserveBracketsOnExtraction via set()", () => {
+    useSettingsStore.getState().set("preserveBracketsOnExtraction", true);
+    expect(useSettingsStore.getState().preserveBracketsOnExtraction).toBe(true);
+    useSettingsStore.getState().set("preserveBracketsOnExtraction", false);
+    expect(useSettingsStore.getState().preserveBracketsOnExtraction).toBe(false);
+  });
+
   it("allows toggling autoExtractBackgroundVocals via set()", () => {
     useSettingsStore.getState().set("autoExtractBackgroundVocals", false);
     expect(useSettingsStore.getState().autoExtractBackgroundVocals).toBe(false);

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -52,6 +52,7 @@ interface SettingsState {
   splitCharacter: string;
   autoExtractBackgroundVocals: boolean;
   mergeStandaloneBackgroundLines: boolean;
+  preserveBracketsOnExtraction: boolean;
 
   confirmReplaceProjectFromHash: boolean;
   confirmReplaceLyrics: boolean;
@@ -113,6 +114,7 @@ const DEFAULTS: SettingsState = {
   splitCharacter: "|",
   autoExtractBackgroundVocals: true,
   mergeStandaloneBackgroundLines: true,
+  preserveBracketsOnExtraction: false,
 
   confirmReplaceProjectFromHash: true,
   confirmReplaceLyrics: true,

--- a/src/ui/settings/general-section.browser.test.tsx
+++ b/src/ui/settings/general-section.browser.test.tsx
@@ -6,13 +6,21 @@ import { GeneralSection } from "@/ui/settings/general-section";
 describe("GeneralSection", () => {
   it("renders a switch for each toggle setting", async () => {
     const screen = await render(<GeneralSection onResetTour={() => {}} onClose={() => {}} />);
-    expect(screen.container.querySelectorAll('[role="switch"]').length).toBe(4);
+    expect(screen.container.querySelectorAll('[role="switch"]').length).toBe(5);
   });
 
   it("renders the background vocal toggles", async () => {
     const screen = await render(<GeneralSection onResetTour={() => {}} onClose={() => {}} />);
     await expect.element(screen.getByRole("switch", { name: "Auto-extract background vocals" })).toBeInTheDocument();
     await expect.element(screen.getByRole("switch", { name: "Merge standalone background lines" })).toBeInTheDocument();
+    await expect.element(screen.getByRole("switch", { name: "Preserve brackets when extracting" })).toBeInTheDocument();
+  });
+
+  it("flips preserveBracketsOnExtraction when its switch is clicked", async () => {
+    useSettingsStore.setState({ preserveBracketsOnExtraction: false });
+    const screen = await render(<GeneralSection onResetTour={() => {}} onClose={() => {}} />);
+    await screen.getByRole("switch", { name: "Preserve brackets when extracting" }).click();
+    await expect.poll(() => useSettingsStore.getState().preserveBracketsOnExtraction).toBe(true);
   });
 
   it("flips autoExtractBackgroundVocals when its switch is clicked", async () => {

--- a/src/ui/settings/general-section.tsx
+++ b/src/ui/settings/general-section.tsx
@@ -46,6 +46,11 @@ const GeneralSection: React.FC<{
         description="When a whole line is in parentheses, attach it to the line above instead of keeping it as its own line."
         settingKey="mergeStandaloneBackgroundLines"
       />
+      <ToggleSetting
+        label="Preserve brackets when extracting"
+        description="Keep parentheses around extracted background vocals. Multiple snippets share one outer pair."
+        settingKey="preserveBracketsOnExtraction"
+      />
       <div className="flex items-center justify-between py-3">
         <div className="flex flex-col gap-0.5">
           <span className="text-sm font-medium text-composer-text">Reset product tour</span>

--- a/src/utils/background-vocal-brackets.ts
+++ b/src/utils/background-vocal-brackets.ts
@@ -1,0 +1,68 @@
+import type { WordTiming } from "@/domain/word/timing";
+
+// -- Trailing space accessors -------------------------------------------------
+
+function stripTrailingSpace(s: string): string {
+  return s.replace(/ +$/, "");
+}
+
+function trailingSpaceOf(s: string): string {
+  const m = s.match(/ +$/);
+  return m ? m[0] : "";
+}
+
+// -- Word-list bracket wrapping -----------------------------------------------
+
+function bracketWordList(words: WordTiming[]): WordTiming[] {
+  if (words.length === 0) return words;
+  if (words.length === 1) {
+    const only = words[0];
+    const core = stripTrailingSpace(only.text);
+    const trail = trailingSpaceOf(only.text);
+    return [{ ...only, text: `(${core})${trail}` }];
+  }
+  const first = words[0];
+  const last = words[words.length - 1];
+  const lastCore = stripTrailingSpace(last.text);
+  const lastTrail = trailingSpaceOf(last.text);
+  const out = [...words];
+  out[0] = { ...first, text: `(${first.text}` };
+  out[out.length - 1] = { ...last, text: `${lastCore})${lastTrail}` };
+  return out;
+}
+
+// -- Seam-aware concatenation -------------------------------------------------
+
+// Peels the trailing ')' off the base's last word and the leading '(' off the
+// carried first word so the two arrays land inside one outer pair. Reinserts a
+// space at the seam to keep token boundaries intact. Falls back to plain
+// concatenation when either side lacks the matching bracket at the seam,
+// which is how manual base words stay untouched next to a bracketed carry.
+function joinBracketedCarriedWords(
+  baseWords: WordTiming[],
+  carried: WordTiming[],
+  canSeamStrip: boolean,
+): WordTiming[] {
+  if (!canSeamStrip) return [...baseWords, ...carried];
+  if (baseWords.length === 0) return carried;
+  if (carried.length === 0) return baseWords;
+  const lastBase = baseWords[baseWords.length - 1];
+  const firstCarry = carried[0];
+  const lastBaseStripped = stripTrailingSpace(lastBase.text);
+  const lastBaseTrail = trailingSpaceOf(lastBase.text);
+  const lastEndsBracket = lastBaseStripped.endsWith(")");
+  const firstStartsBracket = firstCarry.text.startsWith("(");
+  if (!lastEndsBracket || !firstStartsBracket) return [...baseWords, ...carried];
+  const lastBaseText = `${lastBaseStripped.slice(0, -1)}${lastBaseTrail.length > 0 ? lastBaseTrail : " "}`;
+  const firstCarryText = firstCarry.text.slice(1);
+  return [
+    ...baseWords.slice(0, -1),
+    { ...lastBase, text: lastBaseText },
+    { ...firstCarry, text: firstCarryText },
+    ...carried.slice(1),
+  ];
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { bracketWordList, joinBracketedCarriedWords };

--- a/src/utils/background-vocal-extraction.test.ts
+++ b/src/utils/background-vocal-extraction.test.ts
@@ -1711,3 +1711,189 @@ describe("preserveBrackets: invariants", () => {
     expect(bg).toBe("(ooh yeah la)");
   });
 });
+
+describe("preserveBrackets: word-synced bg", () => {
+  it("brackets a multi-word standalone carried into prev with no existing bg", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line" }),
+      createLine({
+        id: "2",
+        text: "(ooh yeah)",
+        words: [
+          { text: "(ooh ", begin: 5.0, end: 5.6 },
+          { text: "yeah)", begin: 5.6, end: 6.2 },
+        ],
+      }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].backgroundWords).toEqual([
+      { text: "(ooh ", begin: 5.0, end: 5.6 },
+      { text: "yeah)", begin: 5.6, end: 6.2 },
+    ]);
+    expect(result[0].backgroundText).toBe("(ooh yeah)");
+  });
+
+  it("brackets a single-word standalone", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line" }),
+      createLine({
+        id: "2",
+        text: "(ooh)",
+        words: [{ text: "(ooh)", begin: 5.0, end: 5.6 }],
+      }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result[0].backgroundWords).toEqual([{ text: "(ooh)", begin: 5.0, end: 5.6 }]);
+    expect(result[0].backgroundText).toBe("(ooh)");
+  });
+
+  it("merges a second standalone into the same outer pair, stripping seam brackets", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line" }),
+      createLine({
+        id: "2",
+        text: "(ooh)",
+        words: [{ text: "(ooh)", begin: 5.0, end: 5.5 }],
+      }),
+      createLine({
+        id: "3",
+        text: "(yeah)",
+        words: [{ text: "(yeah)", begin: 5.6, end: 6.1 }],
+      }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].backgroundWords).toEqual([
+      { text: "(ooh ", begin: 5.0, end: 5.5 },
+      { text: "yeah)", begin: 5.6, end: 6.1 },
+    ]);
+    expect(result[0].backgroundText).toBe("(ooh yeah)");
+  });
+
+  it("appends bracketed carry next to existing manual bg words without merging into manual pair", () => {
+    const lines = [
+      createLine({
+        id: "1",
+        text: "Real line",
+        backgroundText: "ah ",
+        backgroundWords: [{ text: "ah ", begin: 1.0, end: 1.5 }],
+        backgroundTextSource: "manual",
+      }),
+      createLine({
+        id: "2",
+        text: "(ooh)",
+        words: [{ text: "(ooh)", begin: 5.0, end: 5.5 }],
+      }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].backgroundWords).toEqual([
+      { text: "ah ", begin: 1.0, end: 1.5 },
+      { text: "(ooh)", begin: 5.0, end: 5.5 },
+    ]);
+  });
+
+  it("falls back to text-only addition when standalone has no words", () => {
+    const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh)" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result[0].backgroundWords).toBeUndefined();
+    expect(result[0].backgroundText).toBe("(ooh)");
+  });
+
+  it("off-state: word carry is unchanged (regression guard)", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line" }),
+      createLine({
+        id: "2",
+        text: "(ooh yeah)",
+        words: [
+          { text: "(ooh ", begin: 5.0, end: 5.6 },
+          { text: "yeah)", begin: 5.6, end: 6.2 },
+        ],
+      }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
+    expect(result[0].backgroundWords).toEqual([
+      { text: "ooh ", begin: 5.0, end: 5.6 },
+      { text: "yeah", begin: 5.6, end: 6.2 },
+    ]);
+    expect(result[0].backgroundText).toBe("ooh yeah");
+  });
+
+  it("does not fuse a manually-bracketed bg with a fresh bracketed carry", () => {
+    const lines = [
+      createLine({
+        id: "1",
+        text: "Real line",
+        backgroundText: "(clap)",
+        backgroundWords: [{ text: "(clap)", begin: 1.0, end: 1.5 }],
+        backgroundTextSource: "manual",
+      }),
+      createLine({
+        id: "2",
+        text: "(ooh)",
+        words: [{ text: "(ooh)", begin: 5.0, end: 5.5 }],
+      }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].backgroundWords).toEqual([
+      { text: "(clap)", begin: 1.0, end: 1.5 },
+      { text: "(ooh)", begin: 5.0, end: 5.5 },
+    ]);
+  });
+});
+
+describe("preserveBrackets: word-synced invariants", () => {
+  it("preserves timing values exactly across bracket wrapping", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line" }),
+      createLine({
+        id: "2",
+        text: "(ooh yeah)",
+        words: [
+          { text: "(ooh ", begin: 5.123, end: 5.617 },
+          { text: "yeah)", begin: 5.617, end: 6.234 },
+        ],
+      }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    const w = result[0].backgroundWords ?? [];
+    expect(w[0].begin).toBe(5.123);
+    expect(w[0].end).toBe(5.617);
+    expect(w[1].begin).toBe(5.617);
+    expect(w[1].end).toBe(6.234);
+  });
+
+  it("reconstructed backgroundText stays consistent with bracketed words", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line" }),
+      createLine({
+        id: "2",
+        text: "(ooh)",
+        words: [{ text: "(ooh)", begin: 5.0, end: 5.5 }],
+      }),
+      createLine({
+        id: "3",
+        text: "(yeah)",
+        words: [{ text: "(yeah)", begin: 5.6, end: 6.1 }],
+      }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result[0].backgroundText).toBe("(ooh yeah)");
+  });
+
+  it("does not introduce parens in the main line text", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line" }),
+      createLine({
+        id: "2",
+        text: "(ooh)",
+        words: [{ text: "(ooh)", begin: 5.0, end: 5.5 }],
+      }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result[0].text).toBe("Real line");
+  });
+});

--- a/src/utils/background-vocal-extraction.test.ts
+++ b/src/utils/background-vocal-extraction.test.ts
@@ -1553,3 +1553,161 @@ describe("lineHasInlineParens", () => {
     expect(lineHasInlineParens(createLine({ id: "1", text: "Hello (ooh" }))).toBe(false);
   });
 });
+
+// -- preserveBrackets: text-only bg -------------------------------------------
+
+describe("preserveBrackets: text-only bg", () => {
+  it("wraps a single inline group in one outer pair", () => {
+    const lines = [createLine({ id: "1", text: "A (ooh) B" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("A B");
+    expect(result[0].backgroundText).toBe("(ooh)");
+  });
+
+  it("wraps multiple inline groups on the same line in one outer pair", () => {
+    const lines = [createLine({ id: "1", text: "A (ooh) (yeah) B" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result[0].text).toBe("A B");
+    expect(result[0].backgroundText).toBe("(ooh yeah)");
+  });
+
+  it("merges a standalone into prev with one outer pair", () => {
+    const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh yeah)" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].backgroundText).toBe("(ooh yeah)");
+  });
+
+  it("merges multiple consecutive standalones into one outer pair", () => {
+    const lines = [
+      createLine({ id: "1", text: "Real line" }),
+      createLine({ id: "2", text: "(ooh)" }),
+      createLine({ id: "3", text: "(yeah)" }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].backgroundText).toBe("(ooh yeah)");
+  });
+
+  it("merges inline-then-standalone same-pass into one outer pair", () => {
+    const lines = [createLine({ id: "1", text: "A (ooh) B" }), createLine({ id: "2", text: "(yeah)" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("A B");
+    expect(result[0].backgroundText).toBe("(ooh yeah)");
+  });
+
+  it("appends a bracketed addition next to existing manual bg text", () => {
+    const lines = [
+      createLine({
+        id: "1",
+        text: "Real line",
+        backgroundText: "ah",
+        backgroundTextSource: "manual",
+      }),
+      createLine({ id: "2", text: "(ooh)" }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].backgroundText).toBe("ah (ooh)");
+  });
+
+  it("groups multiple bracketed additions inside one pair after manual bg", () => {
+    const lines = [
+      createLine({
+        id: "1",
+        text: "Real line",
+        backgroundText: "ah",
+        backgroundTextSource: "manual",
+      }),
+      createLine({ id: "2", text: "(ooh)" }),
+      createLine({ id: "3", text: "(yeah)" }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].backgroundText).toBe("ah (ooh yeah)");
+  });
+
+  it("preserves backgroundTextSource as extraction for fresh additions", () => {
+    const lines = [createLine({ id: "1", text: "A (ooh) B" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result[0].backgroundTextSource).toBe("extraction");
+  });
+
+  it("is idempotent on already-bracketed extracted bg (no double wrap)", () => {
+    const lines = [createLine({ id: "1", text: "A (ooh) B" })];
+    const once = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    const twice = extractBackgroundVocals(once, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(twice[0].backgroundText).toBe("(ooh)");
+    expect(twice[0].text).toBe("A B");
+  });
+
+  it("does not change main text under preserveBrackets", () => {
+    const lines = [createLine({ id: "1", text: "A (ooh) (yeah) B" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result[0].text).toBe("A B");
+  });
+
+  it("does not peel a trailing ')' from manual bg text", () => {
+    const lines = [
+      createLine({
+        id: "1",
+        text: "Real line",
+        backgroundText: "my note)",
+        backgroundTextSource: "manual",
+      }),
+      createLine({ id: "2", text: "(ooh)" }),
+    ];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].backgroundText).toBe("my note) (ooh)");
+  });
+});
+
+// -- preserveBrackets: invariants ---------------------------------------------
+
+describe("preserveBrackets: invariants", () => {
+  it("regression: off-state inline single group matches pre-task output", () => {
+    const lines = [createLine({ id: "1", text: "A (ooh) B" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("A B");
+    expect(result[0].backgroundText).toBe("ooh");
+  });
+
+  it("regression: off-state standalone merge matches pre-task output", () => {
+    const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh yeah)" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("Real line");
+    expect(result[0].backgroundText).toBe("ooh yeah");
+  });
+
+  it("off-state and on-state produce different bg text for inline parens", () => {
+    const lines = [createLine({ id: "1", text: "A (ooh) B" })];
+    const off = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
+    const on = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(off[0].backgroundText).toBe("ooh");
+    expect(on[0].backgroundText).toBe("(ooh)");
+    expect(off[0].backgroundText).not.toBe(on[0].backgroundText);
+  });
+
+  it("paren-free line is reference-equality pass-through regardless of flag", () => {
+    const lines = [createLine({ id: "1", text: "Plain line" })];
+    const off = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
+    const on = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(off[0]).toBe(lines[0]);
+    expect(on[0]).toBe(lines[0]);
+  });
+
+  it("inline groups plus same-pass standalone merge yield exactly one outer pair", () => {
+    const lines = [createLine({ id: "1", text: "A (ooh) (yeah) B" }), createLine({ id: "2", text: "(la)" })];
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
+    expect(result).toHaveLength(1);
+    const bg = result[0].backgroundText ?? "";
+    expect((bg.match(/\(/g) ?? []).length).toBe(1);
+    expect((bg.match(/\)/g) ?? []).length).toBe(1);
+    expect(bg).toBe("(ooh yeah la)");
+  });
+});

--- a/src/utils/background-vocal-extraction.test.ts
+++ b/src/utils/background-vocal-extraction.test.ts
@@ -354,7 +354,7 @@ describe("classifyLine: returned shape", () => {
 describe("extractInlineFromLine", () => {
   it("extracts an inline group from an untimed line", () => {
     const line: LyricLine = { id: "1", text: "Hello (ooh) world", agentId: "v1" };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.text).toBe("Hello world");
     expect(result.backgroundText).toBe("ooh");
   });
@@ -366,7 +366,7 @@ describe("extractInlineFromLine", () => {
       agentId: "v1",
       backgroundText: "ah",
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.text).toBe("Hello");
     expect(result.backgroundText).toBe("ah ooh");
   });
@@ -378,23 +378,23 @@ describe("extractInlineFromLine", () => {
       agentId: "v1",
       backgroundText: undefined,
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.backgroundText).toBe("ooh");
   });
 
   it("returns the same reference for a line with no parentheses", () => {
     const line: LyricLine = { id: "1", text: "Hello world", agentId: "v1" };
-    expect(extractInlineFromLine(line)).toBe(line);
+    expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 
   it("returns the same reference for a standalone line", () => {
     const line: LyricLine = { id: "1", text: "(ooh yeah)", agentId: "v1" };
-    expect(extractInlineFromLine(line)).toBe(line);
+    expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 
   it("returns the same reference for a skip line", () => {
     const line: LyricLine = { id: "1", text: "Hello (ooh", agentId: "v1" };
-    expect(extractInlineFromLine(line)).toBe(line);
+    expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 
   it("preserves begin and end on a line-synced line", () => {
@@ -405,7 +405,7 @@ describe("extractInlineFromLine", () => {
       begin: 1,
       end: 3,
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.text).toBe("Hi there");
     expect(result.backgroundText).toBe("ooh");
     expect(result.begin).toBe(1);
@@ -424,7 +424,7 @@ describe("extractInlineFromLine", () => {
         { text: "there", begin: 2, end: 3 },
       ],
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result).not.toBe(line);
     expect(result.text).toBe("Hi there");
     expect(result.backgroundText).toBe("ooh");
@@ -442,7 +442,7 @@ describe("extractInlineFromLine", () => {
       agentId: "v1",
       backgroundText: "ah",
     };
-    extractInlineFromLine(line);
+    extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(line.text).toBe("Hello (ooh) world");
     expect(line.backgroundText).toBe("ah");
   });
@@ -456,7 +456,7 @@ describe("extractInlineFromLine", () => {
       end: 3,
       backgroundWords: [{ text: "clap", begin: 1.2, end: 1.8 }],
     };
-    expect(extractInlineFromLine(line)).toBe(line);
+    expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 
   it("returns the same reference for an untimed line carrying manual background words", () => {
@@ -466,7 +466,7 @@ describe("extractInlineFromLine", () => {
       agentId: "v1",
       backgroundWords: [{ text: "clap", begin: 1.2, end: 1.8 }],
     };
-    expect(extractInlineFromLine(line)).toBe(line);
+    expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 
   it("still extracts a line-synced line when backgroundWords is an empty array", () => {
@@ -478,7 +478,7 @@ describe("extractInlineFromLine", () => {
       end: 3,
       backgroundWords: [],
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.text).toBe("Hi there");
     expect(result.backgroundText).toBe("ooh");
   });
@@ -498,7 +498,7 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "world", begin: 1.9, end: 2.7 },
       ],
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result).not.toBe(line);
     expect(result.text).toBe("Hello world");
     expect(result.backgroundText).toBe("ooh");
@@ -519,7 +519,7 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "(ooh)", begin: 1, end: 2 },
       ],
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result).not.toBe(line);
     expect(result.text).toBe("Hello");
     expect(result.backgroundText).toBe("ooh");
@@ -538,7 +538,7 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "world", begin: 2, end: 3 },
       ],
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result).not.toBe(line);
     expect(result.text).toBe("Hello world");
     expect(result.backgroundText).toBe("ooh yeah");
@@ -558,7 +558,7 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "world", begin: 1, end: 2 },
       ],
     };
-    expect(extractInlineFromLine(line)).toBe(line);
+    expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 
   it("preserves explicit and syllableGroupId fields on survivors", () => {
@@ -572,7 +572,7 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "world", begin: 2, end: 3, explicit: true, syllableGroupId: "g2" },
       ],
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.words).toEqual([
       { text: "Hello ", begin: 0, end: 1, explicit: true, syllableGroupId: "g1" },
       { text: "world", begin: 2, end: 3, explicit: true, syllableGroupId: "g2" },
@@ -591,7 +591,7 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "world", begin: 2, end: 3 },
       ],
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result).not.toBe(line);
     expect(result.text).toBe("Hel|lo world");
     expect(result.backgroundText).toBe("ooh");
@@ -614,7 +614,7 @@ describe("extractInlineFromLine: word-synced extraction", () => {
       ],
       backgroundWords: [{ text: "ah", begin: 0, end: 1 }],
     };
-    expect(extractInlineFromLine(line)).toBe(line);
+    expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 
   it("appends to existing backgroundText on a word-synced line", () => {
@@ -629,7 +629,7 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "world", begin: 2, end: 3 },
       ],
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.backgroundText).toBe("ah ooh");
   });
 
@@ -640,7 +640,7 @@ describe("extractInlineFromLine: word-synced extraction", () => {
       { text: "world", begin: 2, end: 3 },
     ];
     const line: LyricLine = { id: "1", text: "Hello (ooh) world", agentId: "v1", words };
-    extractInlineFromLine(line);
+    extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(line.text).toBe("Hello (ooh) world");
     expect(line.words).toBe(words);
     expect(line.words).toEqual([
@@ -660,7 +660,7 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "yeah)", begin: 1, end: 2 },
       ],
     };
-    expect(extractInlineFromLine(line)).toBe(line);
+    expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 });
 
@@ -670,7 +670,7 @@ describe("extractBackgroundVocals: specification table", () => {
   it("extracts an inline line regardless of mergeStandaloneLines", () => {
     for (const mergeStandaloneLines of [true, false]) {
       const lines = [createLine({ id: "1", text: "A (ooh) B" })];
-      const result = extractBackgroundVocals(lines, { mergeStandaloneLines });
+      const result = extractBackgroundVocals(lines, { mergeStandaloneLines, preserveBrackets: false });
       expect(result).toHaveLength(1);
       expect(result[0].text).toBe("A B");
       expect(result[0].backgroundText).toBe("ooh");
@@ -679,7 +679,7 @@ describe("extractBackgroundVocals: specification table", () => {
 
   it("merges a standalone line into the previous line when merge is enabled", () => {
     const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh yeah)" })];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("1");
     expect(result[0].text).toBe("Real line");
@@ -688,7 +688,7 @@ describe("extractBackgroundVocals: specification table", () => {
 
   it("leaves a standalone line in place when merge is disabled", () => {
     const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh yeah)" })];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: false });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result).toHaveLength(2);
     expect(result[0]).toBe(lines[0]);
     expect(result[1]).toBe(lines[1]);
@@ -700,7 +700,7 @@ describe("extractBackgroundVocals: specification table", () => {
       createLine({ id: "2", text: "(ooh)" }),
       createLine({ id: "3", text: "(yeah)" }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("1");
     expect(result[0].text).toBe("Real line");
@@ -709,7 +709,7 @@ describe("extractBackgroundVocals: specification table", () => {
 
   it("does not merge a leading standalone line with no valid predecessor", () => {
     const lines = [createLine({ id: "1", text: "(ooh)" }), createLine({ id: "2", text: "Real line" })];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(2);
     expect(result[0]).toBe(lines[0]);
     expect(result[1]).toBe(lines[1]);
@@ -721,7 +721,7 @@ describe("extractBackgroundVocals: specification table", () => {
       createLine({ id: "2", text: "" }),
       createLine({ id: "3", text: "(ooh)" }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(3);
     expect(result[0]).toBe(lines[0]);
     expect(result[1]).toBe(lines[1]);
@@ -733,7 +733,7 @@ describe("extractBackgroundVocals: specification table", () => {
       createLine({ id: "1", text: "Chorus", groupId: "g1", instanceIdx: 0 }),
       createLine({ id: "2", text: "(ooh)" }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(2);
     expect(result[0]).toBe(lines[0]);
     expect(result[1]).toBe(lines[1]);
@@ -744,7 +744,7 @@ describe("extractBackgroundVocals: specification table", () => {
       createLine({ id: "1", text: "Real" }),
       createLine({ id: "2", text: "(ooh)", groupId: "g1", instanceIdx: 0 }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(2);
     expect(result[0]).toBe(lines[0]);
     expect(result[1]).toBe(lines[1]);
@@ -752,7 +752,7 @@ describe("extractBackgroundVocals: specification table", () => {
 
   it("merges a standalone line into a predecessor that was itself inline-extracted", () => {
     const lines = [createLine({ id: "1", text: "A (ooh) B" }), createLine({ id: "2", text: "(yeah)" })];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("1");
     expect(result[0].text).toBe("A B");
@@ -765,21 +765,21 @@ describe("extractBackgroundVocals: specification table", () => {
 describe("extractBackgroundVocals: none and skip lines", () => {
   it("pushes a none line by reference", () => {
     const lines = [createLine({ id: "1", text: "Plain line" })];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0]).toBe(lines[0]);
   });
 
   it("pushes a skip line by reference", () => {
     const lines = [createLine({ id: "1", text: "Hello (ooh" })];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0]).toBe(lines[0]);
   });
 
   it("does not merge a standalone line into a skip predecessor", () => {
     const lines = [createLine({ id: "1", text: "Hello (ooh" }), createLine({ id: "2", text: "(yeah)" })];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(2);
     expect(result[0]).toBe(lines[0]);
     expect(result[1]).toBe(lines[1]);
@@ -791,7 +791,7 @@ describe("extractBackgroundVocals: none and skip lines", () => {
 describe("extractBackgroundVocals: timing-aware standalone merge", () => {
   it("merges an untimed standalone line into an untimed predecessor as text only", () => {
     const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh yeah)" })];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("1");
     expect(result[0].backgroundText).toBe("ooh yeah");
@@ -810,7 +810,7 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
         ],
       }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("1");
     expect(result[0].backgroundWords).toEqual([
@@ -837,7 +837,7 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
         ],
       }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].backgroundWords).toEqual([
       { text: "ah ", begin: 1.0, end: 1.5 },
@@ -859,7 +859,7 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
         ],
       }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].backgroundText).toBe("ah ooh yeah");
     expect(result[0].backgroundWords).toBeUndefined();
@@ -870,7 +870,7 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
       createLine({ id: "1", text: "Real line" }),
       createLine({ id: "2", text: "(ooh)", begin: 4.0, end: 6.0 }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].backgroundText).toBe("ooh");
     const bgWords = result[0].backgroundWords;
@@ -885,7 +885,7 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
       createLine({ id: "1", text: "Real line" }),
       createLine({ id: "2", text: "(ooh yeah)", begin: 4.0, end: 6.0 }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     const bgWords = result[0].backgroundWords;
     expect(bgWords).toHaveLength(2);
     expect(bgWords?.[0].begin).toBe(4.0);
@@ -902,7 +902,7 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
       }),
       createLine({ id: "2", text: "(ooh)" }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(2);
     expect(result[0]).toBe(lines[0]);
     expect(result[1]).toBe(lines[1]);
@@ -923,7 +923,7 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
         ],
       }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].backgroundText).toBe("ooh yeah");
     expect(result[0].backgroundWords).toBeUndefined();
@@ -935,7 +935,7 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
 describe("extractBackgroundVocals: merge gate", () => {
   it("does not merge a standalone line into a standalone predecessor", () => {
     const lines = [createLine({ id: "1", text: "(ooh)" }), createLine({ id: "2", text: "(yeah)" })];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(2);
     expect(result[0]).toBe(lines[0]);
     expect(result[1]).toBe(lines[1]);
@@ -947,7 +947,7 @@ describe("extractBackgroundVocals: merge gate", () => {
       createLine({ id: "2", text: "(ooh)" }),
       createLine({ id: "3", text: "(yeah)" }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("1");
     expect(result[0].text).toBe("Real");
@@ -965,7 +965,7 @@ describe("extractBackgroundVocals: reference stability", () => {
         createLine({ id: "2", text: "Second line" }),
         createLine({ id: "3", text: "Third line" }),
       ];
-      const result = extractBackgroundVocals(lines, { mergeStandaloneLines });
+      const result = extractBackgroundVocals(lines, { mergeStandaloneLines, preserveBrackets: false });
       expect(result).toHaveLength(lines.length);
       for (let i = 0; i < lines.length; i++) {
         expect(result[i]).toBe(lines[i]);
@@ -982,7 +982,7 @@ describe("extractBackgroundVocals: existing backgroundText", () => {
       createLine({ id: "1", text: "Real line", backgroundText: "ah" }),
       createLine({ id: "2", text: "(ooh)" }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].backgroundText).toBe("ah ooh");
   });
@@ -998,7 +998,7 @@ describe("extractBackgroundVocals: input not mutated", () => {
       createLine({ id: "3", text: "Plain" }),
     ];
     const originalLength = lines.length;
-    extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(lines).toHaveLength(originalLength);
     expect(lines[0].text).toBe("A (ooh) B");
     expect(lines[0].backgroundText).toBe("ah");
@@ -1016,7 +1016,7 @@ describe("extractBackgroundVocals: input not mutated", () => {
       createLine({ id: "2", text: "(ooh yeah)", words: standaloneWords }),
     ];
     const standaloneWordsRef = lines[1].words;
-    extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(lines).toHaveLength(2);
     expect(lines[1].text).toBe("(ooh yeah)");
     expect(lines[1].words).toBe(standaloneWordsRef);
@@ -1038,8 +1038,8 @@ describe("extractBackgroundVocals: idempotence", () => {
       createLine({ id: "3", text: "Plain line" }),
       createLine({ id: "4", text: "C (ah) D" }),
     ];
-    const first = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
-    const second = extractBackgroundVocals(first, { mergeStandaloneLines: true });
+    const first = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
+    const second = extractBackgroundVocals(first, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(second).toHaveLength(first.length);
     for (let i = 0; i < first.length; i++) {
       expect(second[i]).toBe(first[i]);
@@ -1068,8 +1068,8 @@ describe("extractBackgroundVocals: idempotence", () => {
       }),
       createLine({ id: "3", text: "Plain line" }),
     ];
-    const first = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
-    const second = extractBackgroundVocals(first, { mergeStandaloneLines: true });
+    const first = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
+    const second = extractBackgroundVocals(first, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(second).toHaveLength(first.length);
     for (let i = 0; i < first.length; i++) {
       expect(second[i]).toBe(first[i]);
@@ -1088,7 +1088,7 @@ describe("re-paste doubling", () => {
         { id: "a", text: "hello", agentId: "v1" },
         { id: "b", text: "(ooh)", agentId: "v1" },
       ],
-      { mergeStandaloneLines: true },
+      { mergeStandaloneLines: true, preserveBrackets: false },
     );
     expect(first).toHaveLength(1);
     expect(first[0].backgroundText).toBe("ooh");
@@ -1096,6 +1096,7 @@ describe("re-paste doubling", () => {
 
     const second = extractBackgroundVocals([first[0], { id: "b", text: "(ooh)", agentId: "v1" }], {
       mergeStandaloneLines: true,
+      preserveBrackets: false,
     });
     expect(second).toHaveLength(1);
     expect(second[0].backgroundText).toBe("ooh");
@@ -1107,7 +1108,7 @@ describe("re-paste doubling", () => {
         { id: "a", text: "hello", agentId: "v1", backgroundText: "clap", backgroundTextSource: "manual" },
         { id: "b", text: "(ooh)", agentId: "v1" },
       ],
-      { mergeStandaloneLines: true },
+      { mergeStandaloneLines: true, preserveBrackets: false },
     );
     expect(merged[0].backgroundText).toBe("clap ooh");
     expect(merged[0].backgroundTextSource).toBe("manual");
@@ -1119,7 +1120,7 @@ describe("re-paste doubling", () => {
 describe("extractInlineFromLine: provenance", () => {
   it("stamps extraction source on a freshly extracted untimed line", () => {
     const line: LyricLine = { id: "1", text: "Hello (ooh) world", agentId: "v1" };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.backgroundText).toBe("ooh");
     expect(result.backgroundTextSource).toBe("extraction");
   });
@@ -1132,7 +1133,7 @@ describe("extractInlineFromLine: provenance", () => {
       backgroundText: "ooh",
       backgroundTextSource: "extraction",
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.text).toBe("Hello");
     expect(result.backgroundText).toBe("ooh");
     expect(result.backgroundTextSource).toBe("extraction");
@@ -1146,7 +1147,7 @@ describe("extractInlineFromLine: provenance", () => {
       backgroundText: "clap",
       backgroundTextSource: "manual",
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.backgroundText).toBe("clap ooh");
     expect(result.backgroundTextSource).toBe("manual");
   });
@@ -1158,7 +1159,7 @@ describe("extractInlineFromLine: provenance", () => {
       agentId: "v1",
       backgroundText: "clap",
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.backgroundText).toBe("clap ooh");
     expect(result.backgroundTextSource).toBe("manual");
   });
@@ -1174,7 +1175,7 @@ describe("extractInlineFromLine: provenance", () => {
         { text: "world", begin: 2, end: 3 },
       ],
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.backgroundText).toBe("ooh");
     expect(result.backgroundTextSource).toBe("extraction");
   });
@@ -1192,7 +1193,7 @@ describe("extractInlineFromLine: provenance", () => {
         { text: "world", begin: 2, end: 3 },
       ],
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.backgroundText).toBe("ooh");
     expect(result.backgroundTextSource).toBe("extraction");
   });
@@ -1210,7 +1211,7 @@ describe("extractInlineFromLine: provenance", () => {
         { text: "world", begin: 2, end: 3 },
       ],
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.backgroundText).toBe("clap ooh");
     expect(result.backgroundTextSource).toBe("manual");
   });
@@ -1221,7 +1222,7 @@ describe("extractInlineFromLine: provenance", () => {
 describe("extractBackgroundVocals: standalone merge provenance", () => {
   it("stamps extraction source when an untimed standalone merges into a clean predecessor", () => {
     const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh)" })];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result[0].backgroundText).toBe("ooh");
     expect(result[0].backgroundTextSource).toBe("extraction");
   });
@@ -1231,7 +1232,7 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
       createLine({ id: "1", text: "Real line", backgroundText: "ah", backgroundTextSource: "manual" }),
       createLine({ id: "2", text: "(ooh)" }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result[0].backgroundText).toBe("ah ooh");
     expect(result[0].backgroundTextSource).toBe("manual");
   });
@@ -1241,7 +1242,7 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
       createLine({ id: "1", text: "Real line", backgroundText: "ah" }),
       createLine({ id: "2", text: "(ooh)" }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result[0].backgroundText).toBe("ah ooh");
     expect(result[0].backgroundTextSource).toBe("manual");
   });
@@ -1251,7 +1252,7 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
       createLine({ id: "1", text: "Real line", backgroundText: "ooh", backgroundTextSource: "extraction" }),
       createLine({ id: "2", text: "(ooh)" }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result[0].backgroundText).toBe("ooh");
     expect(result[0].backgroundTextSource).toBe("extraction");
   });
@@ -1262,7 +1263,7 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
       createLine({ id: "2", text: "(ooh)" }),
       createLine({ id: "3", text: "(ah)" }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].backgroundText).toBe("ooh ah");
     expect(result[0].backgroundTextSource).toBe("extraction");
@@ -1280,7 +1281,7 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
         ],
       }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result[0].backgroundWords).toEqual([
       { text: "ooh ", begin: 5.0, end: 5.6 },
       { text: "yeah", begin: 5.6, end: 6.2 },
@@ -1306,7 +1307,7 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
         ],
       }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result[0].backgroundWords).toEqual([
       { text: "ah ", begin: 1.0, end: 1.5 },
       { text: "ooh ", begin: 5.0, end: 5.6 },
@@ -1336,7 +1337,7 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
         ],
       }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].backgroundWords).toEqual([
       { text: "ooh ", begin: 5.0, end: 5.6 },
@@ -1357,7 +1358,7 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
         ],
       }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result[0].backgroundText).toBe("ooh yeah");
     expect(result[0].backgroundWords).toEqual([
       { text: "ooh ", begin: 5.0, end: 5.6 },
@@ -1377,7 +1378,7 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
       }),
       createLine({ id: "2", text: "(ooh)" }),
     ];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].backgroundText).toBe("ooh");
     expect(result[0].backgroundWords).toBeUndefined();
@@ -1390,7 +1391,7 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
 describe("extractBackgroundVocals: standalone merge disabled", () => {
   it("leaves standalone all-parens lines untouched but still extracts inline lines", () => {
     const lines = [createLine({ id: "1", text: "A (ooh) B" }), createLine({ id: "2", text: "(yeah)" })];
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: false });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result).toHaveLength(2);
     expect(result[0].text).toBe("A B");
     expect(result[0].backgroundText).toBe("ooh");
@@ -1404,8 +1405,8 @@ describe("extractBackgroundVocals: standalone merge disabled", () => {
 describe("extractBackgroundVocals: re-paste idempotence with provenance", () => {
   it("is a no-op on its own already-extracted standalone-merge output", () => {
     const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh)" })];
-    const first = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
-    const second = extractBackgroundVocals(first, { mergeStandaloneLines: true });
+    const first = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
+    const second = extractBackgroundVocals(first, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(second).toHaveLength(first.length);
     for (let i = 0; i < first.length; i++) {
       expect(second[i]).toBe(first[i]);
@@ -1414,8 +1415,8 @@ describe("extractBackgroundVocals: re-paste idempotence with provenance", () => 
 
   it("is a no-op on its own already-extracted inline output", () => {
     const lines = [createLine({ id: "1", text: "Hello (ooh) world" })];
-    const first = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
-    const second = extractBackgroundVocals(first, { mergeStandaloneLines: true });
+    const first = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
+    const second = extractBackgroundVocals(first, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(second[0]).toBe(first[0]);
     expect(second[0].backgroundText).toBe(first[0].backgroundText);
     expect(second[0].backgroundTextSource).toBe("extraction");
@@ -1440,7 +1441,7 @@ describe("extractInlineFromLine: linked lines", () => {
       instanceIdx: 0,
       templateLineIdx: 0,
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.text).toBe("Hello");
     expect(result.backgroundText).toBe("ooh");
     expect(result.groupId).toBe("g1");
@@ -1461,7 +1462,7 @@ describe("extractInlineFromLine: linked lines", () => {
         { text: "(ooh)", begin: 31, end: 32 },
       ],
     };
-    const result = extractInlineFromLine(line);
+    const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result.text).toBe("Hello");
     expect(result.backgroundText).toBe("ooh");
     expect(result.words).toEqual([{ text: "Hello", begin: 30, end: 31 }]);
@@ -1478,7 +1479,7 @@ describe("extractBackgroundVocals: linked sibling lines", () => {
       createLine({ id: "s1", text: "Hello (ooh)", groupId: "g1", instanceIdx: 1 }),
     ].map((line, idx) => ({ ...line, templateLineIdx: 0, instanceIdx: idx }));
 
-    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
 
     expect(result).toHaveLength(2);
     for (const line of result) {
@@ -1517,7 +1518,7 @@ describe("extractBackgroundVocals: linked sibling lines", () => {
       ],
     };
 
-    const result = extractBackgroundVocals([s0, s1], { mergeStandaloneLines: true });
+    const result = extractBackgroundVocals([s0, s1], { mergeStandaloneLines: true, preserveBrackets: false });
 
     expect(result).toHaveLength(2);
     expect(result[0].text).toBe("Hello");

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -34,6 +34,11 @@ interface LineClassification {
   mainText: string;
 }
 
+interface ExtractOptions {
+  mergeStandaloneLines: boolean;
+  preserveBrackets: boolean;
+}
+
 // -- Scanner ------------------------------------------------------------------
 
 function scanParenGroups(text: string): ParenScan {
@@ -90,7 +95,7 @@ function classifyLine(text: string): LineClassification {
 
 // -- Extraction ---------------------------------------------------------------
 
-function extractInlineWordSynced(line: LyricLine, classified: LineClassification): LyricLine {
+function extractInlineWordSynced(line: LyricLine, classified: LineClassification, _options: ExtractOptions): LyricLine {
   const words = line.words;
   if (!words || words.length === 0) return line;
   if (line.backgroundWords && line.backgroundWords.length > 0) return line;
@@ -127,10 +132,10 @@ function extractInlineWordSynced(line: LyricLine, classified: LineClassification
   );
 }
 
-function extractInlineFromLine(line: LyricLine): LyricLine {
+function extractInlineFromLine(line: LyricLine, options: ExtractOptions): LyricLine {
   const classified = classifyLine(line.text);
   if (classified.kind !== "inline") return line;
-  if (isWordSynced(line)) return extractInlineWordSynced(line, classified);
+  if (isWordSynced(line)) return extractInlineWordSynced(line, classified, options);
   if (line.backgroundWords && line.backgroundWords.length > 0) return line;
   const base = line.backgroundTextSource === "extraction" ? undefined : line.backgroundText;
   return applyBackground(
@@ -140,10 +145,6 @@ function extractInlineFromLine(line: LyricLine): LyricLine {
 }
 
 // -- Whole-list transform -----------------------------------------------------
-
-interface ExtractOptions {
-  mergeStandaloneLines: boolean;
-}
 
 function carriedBackgroundWords(standalone: LyricLine, bgText: string): WordTiming[] | null {
   const words = standalone.words;
@@ -209,7 +210,7 @@ function extractBackgroundVocals(lines: LyricLine[], options: ExtractOptions): L
   for (const line of lines) {
     const classified = classifyLine(line.text);
     if (classified.kind === "inline") {
-      const extracted = extractInlineFromLine(line);
+      const extracted = extractInlineFromLine(line, options);
       result.push(extracted);
       // extracted === line means nothing was extracted; such a pass-through
       // line may carry stale prior-pass provenance and must not count as fresh.

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -7,6 +7,7 @@ import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
 import { reconstructLineText, wordContentSpans } from "@/domain/line/reconstruct-text";
 import { remapWordTextsPreservingTiming } from "@/domain/word/remap-text";
 import type { WordTiming } from "@/domain/word/timing";
+import { bracketWordList, joinBracketedCarriedWords } from "@/utils/background-vocal-brackets";
 import { getSplitCharacter } from "@/utils/split-character";
 import { createInitialBgWords } from "@/utils/sync-helpers";
 
@@ -160,11 +161,19 @@ function extractInlineFromLine(line: LyricLine, options: ExtractOptions): LyricL
 
 // -- Whole-list transform -----------------------------------------------------
 
-function carriedBackgroundWords(standalone: LyricLine, bgText: string): WordTiming[] | null {
+function carriedBackgroundWords(standalone: LyricLine, bgText: string, preserveBrackets: boolean): WordTiming[] | null {
   const words = standalone.words;
-  if (words && words.length > 0) return remapWordTextsPreservingTiming(words, bgText);
-  if (isLineSynced(standalone)) return createInitialBgWords(bgText, standalone.begin, standalone.end);
-  return null;
+  let carry: WordTiming[] | null;
+  if (words && words.length > 0) {
+    carry = remapWordTextsPreservingTiming(words, bgText);
+  } else if (isLineSynced(standalone)) {
+    carry = createInitialBgWords(bgText, standalone.begin, standalone.end);
+  } else {
+    carry = null;
+  }
+  if (!preserveBrackets) return carry;
+  if (!carry || carry.length === 0) return carry;
+  return bracketWordList(carry);
 }
 
 function mergeStandaloneInto(
@@ -182,7 +191,7 @@ function mergeStandaloneInto(
   const prevIsStaleExtraction = prevIsExtraction && !prevTrailingBracketFromSamePass;
   const baseText = prevIsStaleExtraction ? undefined : prev.backgroundText;
   const baseWords = prevIsStaleExtraction ? undefined : prev.backgroundWords;
-  const carried = carriedBackgroundWords(standalone, bgText);
+  const carried = carriedBackgroundWords(standalone, bgText, options.preserveBrackets);
 
   // Source for a result that keeps the prev base: a surviving extraction base
   // is necessarily fresh same-pass output (stale extraction was dropped above),
@@ -191,7 +200,8 @@ function mergeStandaloneInto(
 
   if (carried && carried.length > 0) {
     if (baseWords && baseWords.length > 0) {
-      const combined = [...baseWords, ...carried];
+      const canSeamStrip = options.preserveBrackets && prevTrailingBracketFromSamePass;
+      const combined = joinBracketedCarriedWords(baseWords, carried, canSeamStrip);
       return applyBackground(prev, {
         words: combined,
         text: reconstructLineText(combined, getSplitCharacter()),

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -75,9 +75,17 @@ function collapseSpaces(text: string): string {
   return text.replace(/ {2,}/g, " ").trim();
 }
 
-function joinBackgroundText(existing: string | undefined, addition: string): string {
+function joinBackgroundText(
+  existing: string | undefined,
+  addition: string,
+  preserveBrackets: boolean,
+  trailingBracketFromSamePass: boolean,
+): string {
   const base = existing?.trim() ?? "";
-  return base.length > 0 ? `${base} ${addition}` : addition;
+  if (!preserveBrackets) return base.length > 0 ? `${base} ${addition}` : addition;
+  if (base.length === 0) return `(${addition})`;
+  if (trailingBracketFromSamePass && base.endsWith(")")) return `${base.slice(0, -1)} ${addition})`;
+  return `${base} (${addition})`;
 }
 
 function classifyLine(text: string): LineClassification {
@@ -95,7 +103,7 @@ function classifyLine(text: string): LineClassification {
 
 // -- Extraction ---------------------------------------------------------------
 
-function extractInlineWordSynced(line: LyricLine, classified: LineClassification, _options: ExtractOptions): LyricLine {
+function extractInlineWordSynced(line: LyricLine, classified: LineClassification, options: ExtractOptions): LyricLine {
   const words = line.words;
   if (!words || words.length === 0) return line;
   if (line.backgroundWords && line.backgroundWords.length > 0) return line;
@@ -128,7 +136,10 @@ function extractInlineWordSynced(line: LyricLine, classified: LineClassification
       words: trimmedSurvivors,
       text: reconstructLineText(trimmedSurvivors, splitChar),
     }),
-    { text: joinBackgroundText(base, classified.bgText), source: base ? "manual" : "extraction" },
+    {
+      text: joinBackgroundText(base, classified.bgText, options.preserveBrackets, false),
+      source: base ? "manual" : "extraction",
+    },
   );
 }
 
@@ -140,7 +151,10 @@ function extractInlineFromLine(line: LyricLine, options: ExtractOptions): LyricL
   const base = line.backgroundTextSource === "extraction" ? undefined : line.backgroundText;
   return applyBackground(
     { ...line, text: classified.mainText },
-    { text: joinBackgroundText(base, classified.bgText), source: base ? "manual" : "extraction" },
+    {
+      text: joinBackgroundText(base, classified.bgText, options.preserveBrackets, false),
+      source: base ? "manual" : "extraction",
+    },
   );
 }
 
@@ -157,14 +171,15 @@ function mergeStandaloneInto(
   prev: LyricLine,
   standalone: LyricLine,
   bgText: string,
-  prevMergedThisPass: boolean,
+  prevTrailingBracketFromSamePass: boolean,
+  options: ExtractOptions,
 ): LyricLine | null {
   // On re-paste, prev's extraction-sourced background is stale output from a
   // prior pass, so the standalone line replaces it. Manual background is kept.
   // Extraction-sourced background produced earlier in this same pass (an
   // already-merged standalone) is fresh, so further standalones append to it.
   const prevIsExtraction = prev.backgroundTextSource === "extraction";
-  const prevIsStaleExtraction = prevIsExtraction && !prevMergedThisPass;
+  const prevIsStaleExtraction = prevIsExtraction && !prevTrailingBracketFromSamePass;
   const baseText = prevIsStaleExtraction ? undefined : prev.backgroundText;
   const baseWords = prevIsStaleExtraction ? undefined : prev.backgroundWords;
   const carried = carriedBackgroundWords(standalone, bgText);
@@ -190,33 +205,33 @@ function mergeStandaloneInto(
         source: "extraction",
       });
     }
-    return applyBackground(prev, { text: joinBackgroundText(baseText, bgText), source: keptBaseSource });
+    return applyBackground(prev, {
+      text: joinBackgroundText(baseText, bgText, options.preserveBrackets, prevTrailingBracketFromSamePass),
+      source: keptBaseSource,
+    });
   }
 
   if (baseWords && baseWords.length > 0) return null;
   return applyBackground(prev, {
-    text: joinBackgroundText(baseText, bgText),
+    text: joinBackgroundText(baseText, bgText, options.preserveBrackets, prevTrailingBracketFromSamePass),
     source: baseText ? keptBaseSource : "extraction",
   });
 }
 
 function extractBackgroundVocals(lines: LyricLine[], options: ExtractOptions): LyricLine[] {
   const result: LyricLine[] = [];
-  // Result indices whose extraction-sourced background was written during this
-  // pass. Such content is fresh, so a later standalone appends to it; an
-  // extraction-sourced background carried in unchanged is stale prior output
-  // that a standalone replaces instead.
-  const freshExtractionIndices = new Set<number>();
+  // Result indices whose bg was written or appended to during this pass. Used
+  // for two decisions: (a) the extraction-source bg is fresh, not stale prior
+  // output to discard on re-paste, and (b) a trailing ')' is safe to peel when
+  // grouping a later standalone inside. Pre-existing prev bg is never in the
+  // set, so manual text typed by the user is left intact.
+  const sameSessionWriteIndices = new Set<number>();
   for (const line of lines) {
     const classified = classifyLine(line.text);
     if (classified.kind === "inline") {
       const extracted = extractInlineFromLine(line, options);
       result.push(extracted);
-      // extracted === line means nothing was extracted; such a pass-through
-      // line may carry stale prior-pass provenance and must not count as fresh.
-      if (extracted !== line && extracted.backgroundTextSource === "extraction") {
-        freshExtractionIndices.add(result.length - 1);
-      }
+      if (extracted !== line) sameSessionWriteIndices.add(result.length - 1);
       continue;
     }
     if (classified.kind === "standalone" && options.mergeStandaloneLines) {
@@ -229,10 +244,16 @@ function extractBackgroundVocals(lines: LyricLine[], options: ExtractOptions): L
         !isLinked(prev) &&
         !isLinked(line)
       ) {
-        const merged = mergeStandaloneInto(prev, line, classified.bgText, freshExtractionIndices.has(prevIndex));
+        const merged = mergeStandaloneInto(
+          prev,
+          line,
+          classified.bgText,
+          sameSessionWriteIndices.has(prevIndex),
+          options,
+        );
         if (merged) {
           result[prevIndex] = merged;
-          if (merged.backgroundTextSource === "extraction") freshExtractionIndices.add(prevIndex);
+          sameSessionWriteIndices.add(prevIndex);
           continue;
         }
       }

--- a/src/utils/lyrics-text.test.ts
+++ b/src/utils/lyrics-text.test.ts
@@ -327,7 +327,7 @@ describe("textToLyricLines · group attrs preservation", () => {
   it("re-pasting parenthesised lyrics over an already-extracted line does not double the background text", () => {
     const existing: LyricLine[] = [{ id: "L1", text: "Hello world", agentId: "v1", backgroundText: "ooh" }];
     const reparsed = textToLyricLines("Hello (ooh) world", "v1", existing);
-    const extracted = extractBackgroundVocals(reparsed, { mergeStandaloneLines: false });
+    const extracted = extractBackgroundVocals(reparsed, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(extracted).toHaveLength(1);
     expect(extracted[0].text).toBe("Hello world");
     expect(extracted[0].backgroundText).toBe("ooh");

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -297,6 +297,7 @@ const EditPanel: React.FC = () => {
   const lastImportResult = useLastImportResult();
   const autoExtractBackgroundVocals = useSettingsStore((s) => s.autoExtractBackgroundVocals);
   const mergeStandaloneBackgroundLines = useSettingsStore((s) => s.mergeStandaloneBackgroundLines);
+  const preserveBracketsOnExtraction = useSettingsStore((s) => s.preserveBracketsOnExtraction);
 
   const [rawText, setRawText] = useState(() => (lines.length > 0 ? lines.map((l) => l.text).join("\n") : ""));
   const rawTextRef = useRef(rawText);
@@ -341,10 +342,12 @@ const EditPanel: React.FC = () => {
     return counts;
   }, [lines]);
 
-  const mergeStandalone = useSettingsStore((s) => s.mergeStandaloneBackgroundLines);
   const extractOptions = useMemo(
-    () => ({ mergeStandaloneLines: mergeStandalone, preserveBrackets: false }),
-    [mergeStandalone],
+    () => ({
+      mergeStandaloneLines: mergeStandaloneBackgroundLines,
+      preserveBrackets: preserveBracketsOnExtraction,
+    }),
+    [mergeStandaloneBackgroundLines, preserveBracketsOnExtraction],
   );
   const canExtractBackgroundVocals = useMemo(() => {
     const extracted = extractBackgroundVocals(lines, extractOptions);
@@ -386,7 +389,10 @@ const EditPanel: React.FC = () => {
   const handleExtractLine = useCallback((lineId: string) => {
     const target = useProjectStore.getState().lines.find((line) => line.id === lineId);
     if (!target) return;
-    const extracted = extractInlineFromLine(target, { mergeStandaloneLines: false, preserveBrackets: false });
+    const extracted = extractInlineFromLine(target, {
+      mergeStandaloneLines: false,
+      preserveBrackets: useSettingsStore.getState().preserveBracketsOnExtraction,
+    });
     if (extracted === target) return;
     useProjectStore.getState().updateLineWithHistory(lineId, {
       text: extracted.text,
@@ -490,7 +496,7 @@ const EditPanel: React.FC = () => {
     const current = useProjectStore.getState().lines;
     const next = extractBackgroundVocals(current, {
       mergeStandaloneLines: useSettingsStore.getState().mergeStandaloneBackgroundLines,
-      preserveBrackets: false,
+      preserveBrackets: useSettingsStore.getState().preserveBracketsOnExtraction,
     });
     if (next.length === current.length && next.every((line, i) => line === current[i])) return;
     commitLinesWithHistory(next);
@@ -589,7 +595,7 @@ const EditPanel: React.FC = () => {
         if (useSettingsStore.getState().autoExtractBackgroundVocals) {
           finalLines = extractBackgroundVocals(finalLines, {
             mergeStandaloneLines: useSettingsStore.getState().mergeStandaloneBackgroundLines,
-            preserveBrackets: false,
+            preserveBrackets: useSettingsStore.getState().preserveBracketsOnExtraction,
           });
         }
         finalizeRun();
@@ -619,6 +625,7 @@ const EditPanel: React.FC = () => {
         audioDuration,
         applyBackgroundExtraction: autoExtractBackgroundVocals,
         backgroundExtractionMergeStandalone: mergeStandaloneBackgroundLines,
+        backgroundExtractionPreserveBrackets: preserveBracketsOnExtraction,
         source: { label: "Drop", filename: file.name },
         onResult: (result, source) => {
           useImportModalStore.getState().recordImportResult(result, source);
@@ -626,7 +633,7 @@ const EditPanel: React.FC = () => {
       };
       await importParsedLyrics(parsed, context);
     },
-    [agents, autoExtractBackgroundVocals, confirm, mergeStandaloneBackgroundLines],
+    [agents, autoExtractBackgroundVocals, confirm, mergeStandaloneBackgroundLines, preserveBracketsOnExtraction],
   );
 
   const importTriggers = useDualClickImport(openImportModal);

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -342,7 +342,10 @@ const EditPanel: React.FC = () => {
   }, [lines]);
 
   const mergeStandalone = useSettingsStore((s) => s.mergeStandaloneBackgroundLines);
-  const extractOptions = useMemo(() => ({ mergeStandaloneLines: mergeStandalone }), [mergeStandalone]);
+  const extractOptions = useMemo(
+    () => ({ mergeStandaloneLines: mergeStandalone, preserveBrackets: false }),
+    [mergeStandalone],
+  );
   const canExtractBackgroundVocals = useMemo(() => {
     const extracted = extractBackgroundVocals(lines, extractOptions);
     return extracted.length !== lines.length || extracted.some((line, i) => line !== lines[i]);
@@ -383,7 +386,7 @@ const EditPanel: React.FC = () => {
   const handleExtractLine = useCallback((lineId: string) => {
     const target = useProjectStore.getState().lines.find((line) => line.id === lineId);
     if (!target) return;
-    const extracted = extractInlineFromLine(target);
+    const extracted = extractInlineFromLine(target, { mergeStandaloneLines: false, preserveBrackets: false });
     if (extracted === target) return;
     useProjectStore.getState().updateLineWithHistory(lineId, {
       text: extracted.text,
@@ -487,6 +490,7 @@ const EditPanel: React.FC = () => {
     const current = useProjectStore.getState().lines;
     const next = extractBackgroundVocals(current, {
       mergeStandaloneLines: useSettingsStore.getState().mergeStandaloneBackgroundLines,
+      preserveBrackets: false,
     });
     if (next.length === current.length && next.every((line, i) => line === current[i])) return;
     commitLinesWithHistory(next);
@@ -585,6 +589,7 @@ const EditPanel: React.FC = () => {
         if (useSettingsStore.getState().autoExtractBackgroundVocals) {
           finalLines = extractBackgroundVocals(finalLines, {
             mergeStandaloneLines: useSettingsStore.getState().mergeStandaloneBackgroundLines,
+            preserveBrackets: false,
           });
         }
         finalizeRun();

--- a/src/views/lyrics-import-modal/lyrics-import-modal.tsx
+++ b/src/views/lyrics-import-modal/lyrics-import-modal.tsx
@@ -41,6 +41,7 @@ const LyricsImportModalShell: React.FC = () => {
   const audioDuration = useAudioStore((s) => s.duration);
   const autoExtractBackgroundVocals = useSettingsStore((s) => s.autoExtractBackgroundVocals);
   const mergeStandaloneBackgroundLines = useSettingsStore((s) => s.mergeStandaloneBackgroundLines);
+  const preserveBracketsOnExtraction = useSettingsStore((s) => s.preserveBracketsOnExtraction);
 
   const [currentSection, setCurrentSection] = useState<ImportModalSection>(initialSection ?? "search");
   const [pasteText, setPasteText] = useState("");
@@ -70,12 +71,20 @@ const LyricsImportModalShell: React.FC = () => {
       audioDuration,
       applyBackgroundExtraction: autoExtractBackgroundVocals,
       backgroundExtractionMergeStandalone: mergeStandaloneBackgroundLines,
+      backgroundExtractionPreserveBrackets: preserveBracketsOnExtraction,
       source,
       onResult: (parsed, src) => {
         useImportModalStore.getState().recordImportResult(parsed, src);
       },
     }),
-    [agents, audioDuration, autoExtractBackgroundVocals, confirm, mergeStandaloneBackgroundLines],
+    [
+      agents,
+      audioDuration,
+      autoExtractBackgroundVocals,
+      confirm,
+      mergeStandaloneBackgroundLines,
+      preserveBracketsOnExtraction,
+    ],
   );
 
   const handleImportPaste = useCallback(async () => {

--- a/src/views/lyrics-import-modal/use-import-modal-actions.test.ts
+++ b/src/views/lyrics-import-modal/use-import-modal-actions.test.ts
@@ -34,6 +34,7 @@ function buildContext(overrides: Partial<ImportParsedLyricsContext> = {}): Impor
     audioDuration: 0,
     applyBackgroundExtraction: false,
     backgroundExtractionMergeStandalone: false,
+    backgroundExtractionPreserveBrackets: false,
     source: { label: "Test", filename: "test.lrc" },
     ...overrides,
   };

--- a/src/views/lyrics-import-modal/use-import-modal-actions.ts
+++ b/src/views/lyrics-import-modal/use-import-modal-actions.ts
@@ -62,6 +62,7 @@ async function importParsedLyrics(parsed: ParseResult, ctx: ImportParsedLyricsCo
   let workingLines = ctx.applyBackgroundExtraction
     ? extractBackgroundVocals(parsed.lines, {
         mergeStandaloneLines: ctx.backgroundExtractionMergeStandalone,
+        preserveBrackets: false,
       })
     : parsed.lines;
 

--- a/src/views/lyrics-import-modal/use-import-modal-actions.ts
+++ b/src/views/lyrics-import-modal/use-import-modal-actions.ts
@@ -20,6 +20,7 @@ interface ImportParsedLyricsContext {
   audioDuration: number;
   applyBackgroundExtraction: boolean;
   backgroundExtractionMergeStandalone: boolean;
+  backgroundExtractionPreserveBrackets: boolean;
   source: ImportSourceInfo;
   onResult?: (parsed: ParseResult, source: ImportSourceInfo) => void;
 }
@@ -62,7 +63,7 @@ async function importParsedLyrics(parsed: ParseResult, ctx: ImportParsedLyricsCo
   let workingLines = ctx.applyBackgroundExtraction
     ? extractBackgroundVocals(parsed.lines, {
         mergeStandaloneLines: ctx.backgroundExtractionMergeStandalone,
-        preserveBrackets: false,
+        preserveBrackets: ctx.backgroundExtractionPreserveBrackets,
       })
     : parsed.lines;
 


### PR DESCRIPTION
## Summary

- Adds a Settings → General toggle "Preserve brackets when extracting" (default off).
- When on, parens stick to the extracted background vocals instead of getting stripped: `A (oh) (yeah) B` becomes main `A B` with bg `(oh yeah)`. One outer pair, regardless of how many groups merge in.
- Works for both text-only and word-synced extraction. Same-pass merges strip the seam so two standalones share one pair across their word arrays. Manual bg stays untouched alongside.

## Test plan

- [ ] Toggle on in Settings, paste `Hello (oh) world (yeah)`, confirm bg is `(oh yeah)`
- [ ] Paste a line with a `(...)` line below it, confirm the standalone merges into the same bracket pair
- [ ] With existing manual bg text on a line, confirm the bracketed addition appends as `manual (extracted)`
- [ ] Toggle off, confirm old behavior (bare `oh yeah`) is unchanged
- [ ] Word-synced: import a line with word timing and a `(...)` standalone, confirm the first carried word gets `(` and last gets `)`