### PR TITLE
fix: point tutorial video to new walkthrough

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.28.2",
+  "version": "1.28.3",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.28.1",
+  "version": "1.28.2",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/tour/guide-card.browser.test.tsx
+++ b/src/tour/guide-card.browser.test.tsx
@@ -10,7 +10,10 @@ describe("GuideCard", () => {
 
   it("renders the current task and step label when state is provided", async () => {
     const screen = await render(
-      <GuideCard state={{ task: "Click Import", stepLabel: "Step 1 of 3", isComplete: false }} onSkip={() => {}} />,
+      <GuideCard
+        state={{ task: "Click Import", stepLabel: "Step 1 of 3", stepIndex: 0, isComplete: false }}
+        onSkip={() => {}}
+      />,
     );
     expect(screen.container.textContent).toContain("Click Import");
     expect(screen.container.textContent).toContain("Step 1 of 3");
@@ -19,7 +22,10 @@ describe("GuideCard", () => {
   it("calls onSkip when the Skip button is clicked", async () => {
     let skipped = 0;
     const screen = await render(
-      <GuideCard state={{ task: "Do thing", stepLabel: "Step 1", isComplete: false }} onSkip={() => skipped++} />,
+      <GuideCard
+        state={{ task: "Do thing", stepLabel: "Step 1", stepIndex: 0, isComplete: false }}
+        onSkip={() => skipped++}
+      />,
     );
     await screen.getByRole("button", { name: "Skip" }).click();
     expect(skipped).toBe(1);

--- a/src/tour/guide-card.tsx
+++ b/src/tour/guide-card.tsx
@@ -8,6 +8,7 @@ import { AnimatePresence, m, useReducedMotion } from "motion/react";
 interface GuideCardState {
   task: string;
   stepLabel: string;
+  stepIndex: number;
   isComplete: boolean;
 }
 

--- a/src/tour/tour-steps.ts
+++ b/src/tour/tour-steps.ts
@@ -18,7 +18,7 @@ function switchTab(tabId: string) {
   useProjectStore.getState().setActiveTab(tabId as "import" | "edit" | "sync" | "timeline" | "preview" | "export");
 }
 
-const YOUTUBE_EMBED_HTML = `<div class="composer-tour-video-embed"><iframe src="https://www.youtube.com/embed/IEA0W4qpRIs?rel=0" title="Composer demo" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" allowfullscreen></iframe></div>`;
+const YOUTUBE_EMBED_HTML = `<div class="composer-tour-video-embed"><iframe src="https://www.youtube.com/embed/to138zXZ0nc?rel=0" title="Composer demo" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" allowfullscreen></iframe></div>`;
 
 // -- Gate checks --------------------------------------------------------------
 

--- a/src/tour/use-tour.browser.test.tsx
+++ b/src/tour/use-tour.browser.test.tsx
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { GuideCard } from "@/tour/guide-card";
+import { useTour } from "@/tour/use-tour";
+import { render } from "@/test/render";
+import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
+import { createLine } from "@/test/factories";
+
+// -- Harness ------------------------------------------------------------------
+
+function TourHarness() {
+  const { startTour, guideCard, skipGuideCard } = useTour();
+  return (
+    <div>
+      <button type="button" data-testid="start" onClick={() => startTour()}>
+        Start
+      </button>
+      <GuideCard state={guideCard} onSkip={skipGuideCard} />
+    </div>
+  );
+}
+
+// -- Driver popover helpers ---------------------------------------------------
+
+const driverNextBtn = () => document.querySelector(".driver-popover-next-btn") as HTMLButtonElement | null;
+const driverProgress = () => document.querySelector(".driver-popover-progress-text")?.textContent ?? "";
+const driverTitle = () => document.querySelector(".driver-popover-title")?.textContent ?? "";
+
+async function clickNext() {
+  await expect.poll(() => driverNextBtn() !== null).toBe(true);
+  driverNextBtn()?.click();
+}
+
+function setAudioLoaded() {
+  useAudioStore.setState({ source: { type: "file", file: new File([], "x.mp3", { type: "audio/mpeg" }) } });
+}
+
+function setLyrics() {
+  useProjectStore.setState({ lines: [createLine({ text: "hello world" })] });
+}
+
+function setLyricsSynced() {
+  useProjectStore.setState({
+    lines: [createLine({ text: "hello", begin: 0, end: 1, words: [{ text: "hello", begin: 0, end: 1 }] })],
+  });
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("useTour skipGuideCard", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("advances from the lyrics guide card to the Sync step even when the audio gate is also failing", async () => {
+    const screen = await render(<TourHarness />);
+
+    await screen.getByTestId("start").click();
+    await expect.poll(driverProgress).toBe("1 / 11");
+    await clickNext();
+    await expect.poll(driverProgress).toBe("2 / 11");
+    await clickNext();
+    // Audio gate fails -> guide card replaces the popover.
+    await expect.poll(() => screen.container.textContent).toContain("Step 3 / 11");
+
+    // Skip audio guide -> step 3 Edit "Type or paste lyrics" (4/11).
+    await screen.getByRole("button", { name: "Skip" }).click();
+    await expect.poll(driverProgress).toBe("4 / 11");
+    await expect.poll(driverTitle).toBe("Type or paste lyrics");
+
+    // Step 3 -> step 4 gated lyrics -> guide card.
+    await clickNext();
+    await expect.poll(() => screen.container.textContent).toContain("Step 5 / 11");
+
+    // BUG: skip jumps back to step 3 (4/11) because the skip logic re-scans gates
+    // and picks the first failing one (audio), not the one the user is currently on.
+    // FIX: skip advances to step 5 Sync (6/11).
+    await screen.getByRole("button", { name: "Skip" }).click();
+    await expect.poll(driverProgress).toBe("6 / 11");
+    await expect.poll(driverTitle).toBe("Sync your lyrics");
+  });
+
+  it("skipping the audio guide card lands on the Edit step", async () => {
+    const screen = await render(<TourHarness />);
+
+    await screen.getByTestId("start").click();
+    await clickNext();
+    await clickNext();
+    await expect.poll(() => screen.container.textContent).toContain("Step 3 / 11");
+
+    await screen.getByRole("button", { name: "Skip" }).click();
+    await expect.poll(driverProgress).toBe("4 / 11");
+    await expect.poll(driverTitle).toBe("Type or paste lyrics");
+  });
+
+  it("skipping the lyrics guide card with audio loaded lands on the Sync step", async () => {
+    setAudioLoaded();
+    const screen = await render(<TourHarness />);
+
+    await screen.getByTestId("start").click();
+    await clickNext();
+    await clickNext();
+    // Audio gate passes -> driver auto-advances past step 2 to step 3 (Edit, 4/11).
+    await expect.poll(driverProgress).toBe("4 / 11");
+
+    await clickNext();
+    await expect.poll(() => screen.container.textContent).toContain("Step 5 / 11");
+
+    await screen.getByRole("button", { name: "Skip" }).click();
+    await expect.poll(driverProgress).toBe("6 / 11");
+    await expect.poll(driverTitle).toBe("Sync your lyrics");
+  });
+
+  it("skipping the sync guide card lands on the Timeline step", async () => {
+    setAudioLoaded();
+    setLyrics();
+    const screen = await render(<TourHarness />);
+
+    await screen.getByTestId("start").click();
+    await clickNext();
+    await clickNext();
+    await expect.poll(driverProgress).toBe("4 / 11");
+    await clickNext();
+    // Lyrics gate passes -> auto-advance to step 5 Sync (6/11).
+    await expect.poll(driverProgress).toBe("6 / 11");
+    await clickNext();
+    // Sync gate fails -> guide card replaces the popover.
+    await expect.poll(() => screen.container.textContent).toContain("Step 7 / 11");
+
+    await screen.getByRole("button", { name: "Skip" }).click();
+    await expect.poll(driverProgress).toBe("8 / 11");
+    await expect.poll(driverTitle).toBe("Fine-tune on the timeline");
+  });
+
+  it("transitions from the lyrics guide card to the Sync step when lyrics get added", async () => {
+    setAudioLoaded();
+    const screen = await render(<TourHarness />);
+
+    await screen.getByTestId("start").click();
+    await clickNext();
+    await clickNext();
+    await expect.poll(driverProgress).toBe("4 / 11");
+    await clickNext();
+    await expect.poll(() => screen.container.textContent).toContain("Step 5 / 11");
+
+    // Populate lyrics. The gate poll detects the pass, flashes "Done!", then advances.
+    setLyrics();
+
+    await expect.poll(() => screen.container.textContent).toContain("Done!");
+    await expect.poll(driverProgress).toBe("6 / 11");
+  });
+
+  it("does not show the sync guide card when the sync gate already passes", async () => {
+    setAudioLoaded();
+    setLyricsSynced();
+    const screen = await render(<TourHarness />);
+
+    await screen.getByTestId("start").click();
+    await clickNext();
+    await clickNext();
+    await expect.poll(driverProgress).toBe("4 / 11");
+    await clickNext();
+    await expect.poll(driverProgress).toBe("6 / 11");
+    await clickNext();
+    // Sync gate passes -> driver auto-advances past step 6. Guide card never appears.
+    await expect.poll(() => screen.container.textContent?.includes("Step 7 / 11") ?? false).toBe(false);
+  });
+});

--- a/src/tour/use-tour.ts
+++ b/src/tour/use-tour.ts
@@ -1,7 +1,7 @@
 import { type GatedStep, TOUR_GATED_STEPS, createTourSteps } from "@/tour/tour-steps";
 import type { GuideCardState } from "@/tour/guide-card";
 import { driver, type Driver, type DriveStep } from "driver.js";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useReducedMotion } from "motion/react";
 
 // -- Constants ----------------------------------------------------------------
@@ -97,7 +97,7 @@ function useTour() {
       const nextStepIndex = gatedStep.stepIndex + 1;
       const stepLabel = `Step ${gatedStep.stepIndex + 1} / ${totalSteps}`;
 
-      setGuideCard({ task: gatedStep.task, stepLabel, isComplete: false });
+      setGuideCard({ task: gatedStep.task, stepLabel, stepIndex: gatedStep.stepIndex, isComplete: false });
       saveResumeState(gatedStep.stepIndex);
 
       gateIntervalRef.current = setInterval(() => {
@@ -152,20 +152,13 @@ function useTour() {
 
   const skipGuideCard = useCallback(() => {
     clearGateInterval();
+    const currentIdx = guideCard?.stepIndex;
     setGuideCard(null);
+    if (currentIdx === undefined) return;
 
     const steps = createTourSteps();
     const gatedIndices = new Set(TOUR_GATED_STEPS.map((g) => g.stepIndex));
-
-    let currentGatedIdx = 0;
-    for (const gs of TOUR_GATED_STEPS) {
-      if (!gs.gateCheck()) {
-        currentGatedIdx = gs.stepIndex;
-        break;
-      }
-    }
-
-    let nextIdx = currentGatedIdx + 1;
+    let nextIdx = currentIdx + 1;
     while (nextIdx < steps.length && gatedIndices.has(nextIdx)) {
       nextIdx++;
     }
@@ -176,7 +169,7 @@ function useTour() {
       driverRef.current = d;
       d.drive(nextIdx);
     }
-  }, [clearGateInterval, createDriverInstance, patchStepsWithGates]);
+  }, [guideCard, clearGateInterval, createDriverInstance, patchStepsWithGates]);
 
   const driveTour = useCallback(
     (startIndex?: number) => {
@@ -199,6 +192,13 @@ function useTour() {
     clearResumeState();
     driveTour();
   }, [markTourSeen, driveTour]);
+
+  useEffect(() => {
+    return () => {
+      destroyDriver();
+      clearGateInterval();
+    };
+  }, [destroyDriver, clearGateInterval]);
 
   const resumeOrStartTour = useCallback(() => {
     const isActive = driverRef.current?.isActive() || guideCard !== null;

--- a/src/ui/help-sections/getting-started.tsx
+++ b/src/ui/help-sections/getting-started.tsx
@@ -84,7 +84,7 @@ const GettingStartedSection: React.FC = () => (
 
     <div className="aspect-video w-full rounded-lg overflow-hidden border border-composer-border">
       <iframe
-        src="https://www.youtube.com/embed/IEA0W4qpRIs?rel=0"
+        src="https://www.youtube.com/embed/to138zXZ0nc?rel=0"
         title="Composer tutorial"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
         sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"


### PR DESCRIPTION
Swap the embedded YouTube ID in the Getting Started help section and the onboarding tour to the new walkthrough.