### PR TITLE
Refresh help for YouTube backends and recent timeline work

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.28.3",
+  "version": "1.28.4",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/ui/help-sections/importing.browser.test.tsx
+++ b/src/ui/help-sections/importing.browser.test.tsx
@@ -12,4 +12,16 @@ describe("ImportSection", () => {
     const screen = await render(<ImportSection />);
     await expect.poll(() => screen.container.querySelectorAll("[data-inline-key-badge]").length).toBeGreaterThan(0);
   });
+
+  it("documents the Composer Bridge as an alternative YouTube backend", async () => {
+    const screen = await render(<ImportSection />);
+    expect(screen.container.textContent).toContain("Composer Bridge");
+    expect(screen.container.textContent).toContain("http://localhost:7777");
+  });
+
+  it("links to the composer-bridge repo", async () => {
+    const screen = await render(<ImportSection />);
+    const link = screen.container.querySelector('a[href="https://github.com/better-lyrics/composer-bridge"]');
+    expect(link).not.toBeNull();
+  });
 });

--- a/src/ui/help-sections/importing.tsx
+++ b/src/ui/help-sections/importing.tsx
@@ -15,12 +15,6 @@ const ImportSection: React.FC = () => (
         <li>The file name auto-fills the project title in metadata.</li>
         <li>To replace audio, just drop a new file on the Import tab.</li>
       </ul>
-      <p className={`${PROSE} mt-3`}>
-        For YouTube imports, audio comes from a Cobalt backend. Composer ships with a default instance that handles
-        verification automatically, but YouTube is currently blocking it. To import from YouTube, add a working instance
-        from cobalt.directory in Settings → Advanced, or self-host. Each custom instance shows a small status icon next
-        to its name reflecting the last attempt, with the actual error in the tooltip if anything went wrong.
-      </p>
     </div>
 
     <div>
@@ -38,6 +32,55 @@ const ImportSection: React.FC = () => (
           some other way and drop the file into the Import tab.
         </li>
       </ul>
+    </div>
+
+    <div>
+      <h4 className={HEADING}>YouTube backends: Cobalt and Composer Bridge</h4>
+      <p className={PROSE}>
+        YouTube audio doesn't come from YouTube directly. Composer routes the request through a small backend service
+        that fetches the audio and hands it back. There are two options.
+      </p>
+      <p className={`${PROSE} mt-2`}>
+        <strong>Cobalt</strong> is the default. Composer ships with a public instance that handles verification
+        automatically, but YouTube is currently blocking it. To get unblocked, add a working instance from
+        cobalt.directory in Settings → Advanced, or self-host. Each custom instance shows a small status icon next to
+        its name reflecting the last attempt, with the actual error in the tooltip if anything went wrong.
+      </p>
+      <p className={`${PROSE} mt-3`}>
+        <strong>Composer Bridge</strong>
+        <span className="ml-2 text-[10px] tracking-wide text-composer-accent-text">Experimental</span>
+        <br />A tiny binary you run on your own machine that downloads YouTube audio over your residential IP, so
+        YouTube doesn't block it the way it blocks shared Cobalt hosts. Composer talks to it over localhost; nothing
+        leaves your machine. Toggle "Composer Bridge for YouTube" on in Settings → Advanced and every YouTube import
+        routes through the bridge instead of Cobalt.
+      </p>
+      <ul className={`${PROSE} list-disc pl-4 mt-1.5 space-y-1`}>
+        <li>
+          If the bridge isn't installed yet, an inline guide appears with a one-line install command for macOS and
+          Linux, plus a link to the Windows download.
+        </li>
+        <li>
+          Once installed, launch <span className={INLINE_CODE}>Composer Bridge</span> from your Applications folder or
+          run the binary from a terminal. It lives in your menu bar (Mac) or system tray (Windows, Linux). Leave it
+          running.
+        </li>
+        <li>
+          The default URL is <span className={INLINE_CODE}>http://localhost:7777</span>. Change it in the bridge URL
+          field if you're running on a different port, and hit "Reset" to restore the default.
+        </li>
+      </ul>
+      <p className={`${PROSE} mt-3`}>
+        Sources, releases, and self-build instructions live on{" "}
+        <a
+          href="https://github.com/better-lyrics/composer-bridge"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-composer-text underline underline-offset-2 hover:text-composer-text-bright"
+        >
+          GitHub
+        </a>
+        . The install script verifies the release checksum before unpacking.
+      </p>
     </div>
 
     <div>

--- a/src/ui/help-sections/timeline-extras.browser.test.tsx
+++ b/src/ui/help-sections/timeline-extras.browser.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@/test/render";
+import { TimelineExtras } from "@/ui/help-sections/timeline-extras";
+
+describe("TimelineExtras", () => {
+  it("renders the section content", async () => {
+    const screen = await render(<TimelineExtras />);
+    await expect.element(screen.getByRole("heading", { name: "Header toolbar" })).toBeInTheDocument();
+  });
+
+  it("renders inline shortcut key badges", async () => {
+    const screen = await render(<TimelineExtras />);
+    await expect.poll(() => screen.container.querySelectorAll("[data-inline-key-badge]").length).toBeGreaterThan(0);
+  });
+
+  it("documents explicit-word marking and the TTML attribute", async () => {
+    const screen = await render(<TimelineExtras />);
+    await expect.element(screen.getByRole("heading", { name: "Explicit words" })).toBeInTheDocument();
+    await expect.element(screen.getByText(/composer:explicit/)).toBeInTheDocument();
+  });
+
+  it("documents playhead-anchored zoom on the header buttons", async () => {
+    const screen = await render(<TimelineExtras />);
+    expect(screen.container.textContent).toContain("playhead pinned in place");
+  });
+
+  it("documents header-toggle persistence", async () => {
+    const screen = await render(<TimelineExtras />);
+    expect(screen.container.textContent).toContain("remember their state across reloads");
+  });
+});

--- a/src/ui/help-sections/timeline-extras.tsx
+++ b/src/ui/help-sections/timeline-extras.tsx
@@ -1,0 +1,101 @@
+import { getEffectiveKeysArray } from "@/stores/shortcut-bindings";
+import { HEADING, INLINE_CODE, PROSE } from "@/ui/help-sections/shared";
+import { InlineKeyBadge } from "@/ui/inline-key-badge";
+import { MOD_KEY } from "@/utils/platform";
+
+// -- Timeline extras ----------------------------------------------------------
+
+const TimelineExtras: React.FC = () => (
+  <>
+    <div>
+      <h4 className={HEADING}>Explicit words</h4>
+      <p className={PROSE}>
+        Mark a word as explicit so it carries the right flag through to export. Select one or more words and press{" "}
+        <InlineKeyBadge keys={getEffectiveKeysArray("timeline.toggleExplicit")} />, or right-click and pick{" "}
+        <strong>Mark as explicit</strong> (the same item reads <strong>Unmark explicit</strong> when the words are
+        already flagged).
+      </p>
+      <p className={`${PROSE} mt-2`}>
+        Composer also scans your lyrics for likely explicit words and shows a suggestions banner above the timeline.
+        From there you can mark a suggested word, mark them all, or dismiss ones that are false positives. Explicit
+        words export as the <span className={INLINE_CODE}>composer:explicit="true"</span> attribute on the word's TTML
+        span.
+      </p>
+    </div>
+
+    <div>
+      <h4 className={HEADING}>Right-click menus</h4>
+      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
+        <li>
+          Right-click a word: Edit text, Split syllables, Split word. Merge words appears when multiple words are
+          selected. On a word already split into syllables you also get Merge syllables and Snap syllables flush. Mark
+          as explicit (or Unmark explicit) toggles the explicit flag. Group this line and Split into words show up when
+          they apply, and Delete word is always there.
+        </li>
+        <li>Right-click empty track space: Add word here.</li>
+        <li>Right-click the gutter: Add line above/below, Assign agent, Delete line.</li>
+        <li>
+          Right-click a group banner: Add instance, Shift to playhead, Rename, Recolor, Detach instance, Delete group.
+        </li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 className={HEADING}>Linked groups</h4>
+      <p className={PROSE}>
+        Mark repeating sections (chorus, verse, bridge) as a group so structural edits fan out to every instance. See
+        the <strong>Linked groups</strong> section in this help modal for the full walkthrough.
+      </p>
+    </div>
+
+    <div>
+      <h4 className={HEADING}>Header toolbar</h4>
+      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
+        <li>
+          <strong>Follow</strong> (<InlineKeyBadge keys={getEffectiveKeysArray("timeline.toggleFollow")} />
+          ): auto-scrolls the view to keep the playhead visible during playback.
+        </li>
+        <li>
+          <strong>Rolling</strong> (<InlineKeyBadge keys={getEffectiveKeysArray("timeline.toggleRollingEdit")} />
+          ): the rolling edit tool. When on, dragging a flush boundary moves both adjacent words together while keeping
+          their combined duration.
+        </li>
+        <li>
+          <strong>Preview</strong> (<InlineKeyBadge keys={getEffectiveKeysArray("timeline.togglePreview")} />
+          ): opens a live lyrics preview sidebar on the right.
+        </li>
+        <li>
+          <strong>Snap</strong> (<InlineKeyBadge keys={getEffectiveKeysArray("timeline.toggleSnap")} />
+          ): a magnet for word edges and the playhead. Hold {MOD_KEY} mid-drag to bypass.
+        </li>
+        <li>
+          <strong>Import</strong> (<InlineKeyBadge keys={getEffectiveKeysArray("timeline.importLyrics")} />
+          ): imports lyrics directly into the Timeline without switching tabs.
+        </li>
+        <li>
+          <strong>Zoom</strong>: use the +/- buttons or {MOD_KEY} + scroll wheel to zoom in and out. The header buttons
+          keep the playhead pinned in place; scroll-wheel zoom pivots under the cursor.
+        </li>
+      </ul>
+      <p className={`${PROSE} mt-3`}>
+        Follow, Rolling, Preview, and Snap remember their state across reloads. Override the per-session default in
+        Settings, under Timeline.
+      </p>
+    </div>
+
+    <div>
+      <h4 className={HEADING}>Other features</h4>
+      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
+        <li>
+          Press <InlineKeyBadge keys={getEffectiveKeysArray("timeline.insertLineBelow")} /> with a word selected to
+          insert a new empty line below it.
+        </li>
+        <li>The info panel at the bottom shows details for the selected word, including background text editing.</li>
+      </ul>
+    </div>
+  </>
+);
+
+// -- Exports ------------------------------------------------------------------
+
+export { TimelineExtras };

--- a/src/ui/help-sections/timeline.browser.test.tsx
+++ b/src/ui/help-sections/timeline.browser.test.tsx
@@ -66,4 +66,21 @@ describe("TimelineSection", () => {
     const screen = await render(<TimelineSection />);
     expect(screen.container.textContent).not.toContain("Scroll horizontally to move through time");
   });
+
+  it("documents cross-line word drag", async () => {
+    const screen = await render(<TimelineSection />);
+    await expect
+      .element(screen.getByRole("heading", { name: "Moving words across lines and tracks" }))
+      .toBeInTheDocument();
+  });
+
+  it("documents stem-aware scrub preview", async () => {
+    const screen = await render(<TimelineSection />);
+    expect(screen.container.textContent).toContain("separated the song into stems");
+  });
+
+  it("documents playhead-anchored zoom on the header buttons", async () => {
+    const screen = await render(<TimelineSection />);
+    expect(screen.container.textContent).toContain("playhead pinned in place");
+  });
 });

--- a/src/ui/help-sections/timeline.tsx
+++ b/src/ui/help-sections/timeline.tsx
@@ -1,6 +1,7 @@
 import { getEffectiveKeysArray } from "@/stores/shortcut-bindings";
-import { HEADING, INLINE_CODE, PROSE } from "@/ui/help-sections/shared";
+import { HEADING, PROSE } from "@/ui/help-sections/shared";
 import { InlineKeyBadge } from "@/ui/inline-key-badge";
+import { TimelineExtras } from "@/ui/help-sections/timeline-extras";
 import { ALT_KEY, MOD_KEY } from "@/utils/platform";
 
 // -- Timeline -----------------------------------------------------------------
@@ -38,7 +39,10 @@ const TimelineSection: React.FC = () => (
           Scroll the wheel while the cursor is over the waveform strip to scrub the playhead through time, and the view
           follows it. This works whichever way the "Scroll wheel scrolls timeline" setting is set.
         </li>
-        <li>{MOD_KEY} + scroll wheel to zoom in and out.</li>
+        <li>
+          {MOD_KEY} + scroll wheel to zoom in and out. Zoom anchors under the cursor. The header zoom buttons (and the
+          shortcuts they expose) anchor on the playhead when it's on screen, and on the viewport center otherwise.
+        </li>
         <li>Middle-click and drag to pan freely. Hold Shift while middle-dragging to lock panning to one axis.</li>
         <li>
           Drag the playhead near the left or right edge of the viewport and the view auto-scrolls in that direction, so
@@ -58,6 +62,11 @@ const TimelineSection: React.FC = () => (
         audio at the playhead position, at normal pitch. It helps you find a specific word by ear without having to
         press play. Faster scrubs play more snippets, slower scrubs play fewer. The preview matches your main volume and
         stays silent when the audio is muted. If it gets in the way, turn it off in Settings, under Playback.
+      </p>
+      <p className={`${PROSE} mt-2`}>
+        If you've separated the song into stems, scrubbing follows the stem you have selected: pick "Vocals" from the
+        stem dropdown and the scrub previews vocals only, which makes it much easier to pin down a syllable boundary.
+        The full track plays back as normal regardless of the stem choice.
       </p>
     </div>
 
@@ -110,6 +119,29 @@ const TimelineSection: React.FC = () => (
         </li>
         <li>{ALT_KEY} + drag selected words to duplicate them.</li>
         <li>Press Delete or Backspace to remove selected words.</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 className={HEADING}>Moving words across lines and tracks</h4>
+      <p className={PROSE}>
+        Grab a word block and drop it on a different line, or on the background track of the same line, to relocate it.
+        Multi-select moves them as a group: every selected word follows the dragged one, keeping its relative offset.
+        Linked syllables stay together.
+      </p>
+      <ul className={`${PROSE} list-disc pl-4 mt-1.5 space-y-1`}>
+        <li>
+          The drop falls back to a "reorder within the same row" when you keep it on the source line, so the same drag
+          handles both cases.
+        </li>
+        <li>
+          A drop is refused if it would overlap an existing word on the target track, if the target is line-synced (it
+          has no word slots to land in), or if it would break a linked-group instance. The toast tells you which.
+        </li>
+        <li>
+          Moves into the background track convert the word's role; the destination line picks up <strong>x-bg</strong>{" "}
+          markup at export.
+        </li>
       </ul>
     </div>
 
@@ -197,87 +229,7 @@ const TimelineSection: React.FC = () => (
       </p>
     </div>
 
-    <div>
-      <h4 className={HEADING}>Explicit words</h4>
-      <p className={PROSE}>
-        Mark a word as explicit so it carries the right flag through to export. Select one or more words and press{" "}
-        <InlineKeyBadge keys={getEffectiveKeysArray("timeline.toggleExplicit")} />, or right-click and pick{" "}
-        <strong>Mark as explicit</strong> (the same item reads <strong>Unmark explicit</strong> when the words are
-        already flagged).
-      </p>
-      <p className={`${PROSE} mt-2`}>
-        Composer also scans your lyrics for likely explicit words and shows a suggestions banner above the timeline.
-        From there you can mark a suggested word, mark them all, or dismiss ones that are false positives. Explicit
-        words export as the <span className={INLINE_CODE}>composer:explicit="true"</span> attribute on the word's TTML
-        span.
-      </p>
-    </div>
-
-    <div>
-      <h4 className={HEADING}>Right-click menus</h4>
-      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
-        <li>
-          Right-click a word: Edit text, Split syllables, Split word. Merge words appears when multiple words are
-          selected. On a word already split into syllables you also get Merge syllables and Snap syllables flush. Mark
-          as explicit (or Unmark explicit) toggles the explicit flag. Group this line and Split into words show up when
-          they apply, and Delete word is always there.
-        </li>
-        <li>Right-click empty track space: Add word here.</li>
-        <li>Right-click the gutter: Add line above/below, Assign agent, Delete line.</li>
-        <li>
-          Right-click a group banner: Add instance, Shift to playhead, Rename, Recolor, Detach instance, Delete group.
-        </li>
-      </ul>
-    </div>
-
-    <div>
-      <h4 className={HEADING}>Linked groups</h4>
-      <p className={PROSE}>
-        Mark repeating sections (chorus, verse, bridge) as a group so structural edits fan out to every instance. See
-        the <strong>Linked groups</strong> section in this help modal for the full walkthrough.
-      </p>
-    </div>
-
-    <div>
-      <h4 className={HEADING}>Header toolbar</h4>
-      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
-        <li>
-          <strong>Follow</strong> (<InlineKeyBadge keys={getEffectiveKeysArray("timeline.toggleFollow")} />
-          ): auto-scrolls the view to keep the playhead visible during playback.
-        </li>
-        <li>
-          <strong>Rolling</strong> (<InlineKeyBadge keys={getEffectiveKeysArray("timeline.toggleRollingEdit")} />
-          ): the rolling edit tool. When on, dragging a flush boundary moves both adjacent words together while keeping
-          their combined duration.
-        </li>
-        <li>
-          <strong>Preview</strong> (<InlineKeyBadge keys={getEffectiveKeysArray("timeline.togglePreview")} />
-          ): opens a live lyrics preview sidebar on the right.
-        </li>
-        <li>
-          <strong>Snap</strong> (<InlineKeyBadge keys={getEffectiveKeysArray("timeline.toggleSnap")} />
-          ): a magnet for word edges and the playhead. Hold {MOD_KEY} mid-drag to bypass.
-        </li>
-        <li>
-          <strong>Import</strong> (<InlineKeyBadge keys={getEffectiveKeysArray("timeline.importLyrics")} />
-          ): imports lyrics directly into the Timeline without switching tabs.
-        </li>
-        <li>
-          <strong>Zoom</strong>: use the +/- buttons or {MOD_KEY} + scroll wheel to zoom in and out.
-        </li>
-      </ul>
-    </div>
-
-    <div>
-      <h4 className={HEADING}>Other features</h4>
-      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
-        <li>
-          Press <InlineKeyBadge keys={getEffectiveKeysArray("timeline.insertLineBelow")} /> with a word selected to
-          insert a new empty line below it.
-        </li>
-        <li>The info panel at the bottom shows details for the selected word, including background text editing.</li>
-      </ul>
-    </div>
+    <TimelineExtras />
   </div>
 );
 


### PR DESCRIPTION
Help modal hadn't been touched since vocal separation shipped, so a few things were missing.

What I added:
- A "YouTube backends" subsection in Importing that covers both Cobalt and Composer Bridge. Pulled the Cobalt blurb out of "Audio files" where it was awkwardly tucked in.
- Bridge coverage: what it is, the toggle in Settings > Advanced, the install guide, default URL (`http://localhost:7777`), status badge behavior, and a GitHub link.
- A "Moving words across lines and tracks" subsection in Timeline for the new cross-line drag, including the three reject reasons.
- A note on the audio scrub preview that it follows the selected stem.
- Notes that header zoom buttons anchor to the playhead, and Follow / Rolling / Preview / Snap persist across reloads.

Tests cover Bridge content, the repo link, cross-line drag, stem-aware scrub, and anchored zoom. 33 passing.