### PR TITLE
Snap point overlay and marker mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.29.1",
+  "version": "1.30.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/hooks/useVocalOnsetSnapPoints.browser.test.tsx
+++ b/src/hooks/useVocalOnsetSnapPoints.browser.test.tsx
@@ -55,6 +55,17 @@ describe("useVocalOnsetSnapPoints", () => {
       expect(useTimelineStore.getState().vocalOnsetDetectionStatus).toBe("idle");
     });
 
+    it("regression: clears user-placed custom snap points when the audio source changes", async () => {
+      await render(<HookHarness />);
+
+      useTimelineStore.getState().setCustomSnapPoints([2, 4, 6]);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([2, 4, 6]);
+
+      useAudioStore.setState({ source: { type: "file", file: createAudioFile("another-song.wav") } });
+
+      await expect.poll(() => useTimelineStore.getState().customSnapPoints).toEqual([]);
+    });
+
     it("regression: clears stale onset points when switching between file-less youtube sources", async () => {
       await render(<HookHarness />);
 

--- a/src/hooks/useVocalOnsetSnapPoints.ts
+++ b/src/hooks/useVocalOnsetSnapPoints.ts
@@ -64,6 +64,7 @@ function useVocalOnsetSnapPoints(): void {
       lastVocalsUrl = null;
       const timeline = useTimelineStore.getState();
       timeline.setVocalOnsetSnapPoints([]);
+      timeline.clearCustomSnapPoints();
       timeline.setVocalOnsetDetectionStatus("idle");
     });
 

--- a/src/index.css
+++ b/src/index.css
@@ -98,12 +98,8 @@ body {
 
 @utility snap-custom-line {
   width: 2px;
-  background: linear-gradient(
-    180deg,
-    var(--color-composer-warning) 0%,
-    var(--color-composer-warning) 6%,
-    transparent 88%
-  );
+  background: var(--color-composer-warning);
+  mask: linear-gradient(rgba(0, 0, 0, 0) 0px, rgb(0, 0, 0) 30%, rgb(0, 0, 0) 70%, rgba(0, 0, 0, 0) 100%);
 }
 
 @utility snap-custom-head {

--- a/src/index.css
+++ b/src/index.css
@@ -161,6 +161,14 @@ body {
   }
 }
 
+@utility waveform-armed {
+  cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='28'%3E%3Cpath d='M11 2C7 2 4 5 4 9c0 5 7 16 7 16s7-11 7-16c0-4-3-7-7-7z' fill='%23f5a623' stroke='white' stroke-width='1.6'/%3E%3Ccircle cx='11' cy='9' r='2.6' fill='white'/%3E%3C/svg%3E")
+    11 26, crosshair;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-composer-warning) 18%, transparent), inset 0 0 20px -2px
+    color-mix(in srgb, var(--color-composer-warning) 18%, transparent);
+  transition: box-shadow 180ms ease-out;
+}
+
 /* Timeline panning mode */
 @layer components {
   .is-panning,

--- a/src/index.css
+++ b/src/index.css
@@ -89,7 +89,7 @@ body {
   background: repeating-linear-gradient(180deg, var(--color-composer-onset) 0 5px, transparent 5px 11px);
   -webkit-mask: linear-gradient(180deg, transparent 0, #000 30%, #000 70%, transparent 100%);
   mask: linear-gradient(180deg, transparent 0, #000 30%, #000 70%, transparent 100%);
-  opacity: 0.5;
+  opacity: 0.75;
 }
 
 @utility snap-onset-covered {

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,7 @@
   --color-composer-error-text: #ffe5e5;
   --color-composer-warning: #f5a623;
   --color-composer-explicit: #ff7a85;
+  --color-composer-onset: #4fd6c0;
 
   /* Typography */
   --font-family-sans: "Satoshi", "Avenir", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
@@ -81,6 +82,14 @@ body {
 
 @utility overflow-anchor-none {
   overflow-anchor: none;
+}
+
+@utility snap-onset-line {
+  width: 2px;
+  background: repeating-linear-gradient(180deg, var(--color-composer-onset) 0 5px, transparent 5px 11px);
+  -webkit-mask: linear-gradient(180deg, #000 0, #000 20%, transparent 92%);
+  mask: linear-gradient(180deg, #000 0, #000 20%, transparent 92%);
+  opacity: 0.85;
 }
 
 @utility waveform-loading-dots {

--- a/src/index.css
+++ b/src/index.css
@@ -85,11 +85,11 @@ body {
 }
 
 @utility snap-onset-line {
-  width: 2px;
+  width: 1px;
   background: repeating-linear-gradient(180deg, var(--color-composer-onset) 0 5px, transparent 5px 11px);
   -webkit-mask: linear-gradient(180deg, #000 0, #000 90%, transparent 100%);
   mask: linear-gradient(180deg, #000 0, #000 90%, transparent 100%);
-  opacity: 0.85;
+  opacity: 0.5;
 }
 
 @utility snap-onset-covered {
@@ -111,7 +111,7 @@ body {
   height: 14px;
   background: var(--color-composer-warning);
   border-radius: 50% 50% 50% 0;
-  transform: translateX(-50%) translateY(3px) rotate(45deg);
+  transform: translateX(-50%) rotate(45deg);
   box-shadow: 0 2px 9px rgba(0, 0, 0, 0.5);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -115,6 +115,11 @@ body {
   box-shadow: 0 2px 9px rgba(0, 0, 0, 0.5);
 }
 
+@utility snap-marker-flash {
+  width: 2px;
+  background: #fff;
+}
+
 @utility waveform-loading-dots {
   background-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.1) 1px, transparent 1.5px);
   background-size: 8px 8px;

--- a/src/index.css
+++ b/src/index.css
@@ -87,8 +87,8 @@ body {
 @utility snap-onset-line {
   width: 1px;
   background: repeating-linear-gradient(180deg, var(--color-composer-onset) 0 5px, transparent 5px 11px);
-  -webkit-mask: linear-gradient(180deg, #000 0, #000 90%, transparent 100%);
-  mask: linear-gradient(180deg, #000 0, #000 90%, transparent 100%);
+  -webkit-mask: linear-gradient(180deg, transparent 0, #000 12%, #000 88%, transparent 100%);
+  mask: linear-gradient(180deg, transparent 0, #000 12%, #000 88%, transparent 100%);
   opacity: 0.5;
 }
 
@@ -165,7 +165,6 @@ body {
   cursor: crosshair;
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-composer-warning) 18%, transparent), inset 0 0 20px -2px
     color-mix(in srgb, var(--color-composer-warning) 18%, transparent);
-  transition: box-shadow 180ms ease-out;
 }
 
 /* Timeline panning mode */

--- a/src/index.css
+++ b/src/index.css
@@ -87,8 +87,8 @@ body {
 @utility snap-onset-line {
   width: 1px;
   background: repeating-linear-gradient(180deg, var(--color-composer-onset) 0 5px, transparent 5px 11px);
-  -webkit-mask: linear-gradient(180deg, transparent 0, #000 12%, #000 88%, transparent 100%);
-  mask: linear-gradient(180deg, transparent 0, #000 12%, #000 88%, transparent 100%);
+  -webkit-mask: linear-gradient(180deg, transparent 0, #000 20%, #000 80%, transparent 100%);
+  mask: linear-gradient(180deg, transparent 0, #000 20%, #000 80%, transparent 100%);
   opacity: 0.5;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -87,8 +87,8 @@ body {
 @utility snap-onset-line {
   width: 1px;
   background: repeating-linear-gradient(180deg, var(--color-composer-onset) 0 5px, transparent 5px 11px);
-  -webkit-mask: linear-gradient(180deg, transparent 0, #000 20%, #000 80%, transparent 100%);
-  mask: linear-gradient(180deg, transparent 0, #000 20%, #000 80%, transparent 100%);
+  -webkit-mask: linear-gradient(180deg, transparent 0, #000 30%, #000 70%, transparent 100%);
+  mask: linear-gradient(180deg, transparent 0, #000 30%, #000 70%, transparent 100%);
   opacity: 0.5;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -92,6 +92,29 @@ body {
   opacity: 0.85;
 }
 
+@utility snap-onset-covered {
+  opacity: 0;
+}
+
+@utility snap-custom-line {
+  width: 2px;
+  background: linear-gradient(
+    180deg,
+    var(--color-composer-warning) 0%,
+    var(--color-composer-warning) 6%,
+    transparent 88%
+  );
+}
+
+@utility snap-custom-head {
+  width: 14px;
+  height: 14px;
+  background: var(--color-composer-warning);
+  border-radius: 50% 50% 50% 0;
+  transform: translateX(-50%) rotate(45deg);
+  box-shadow: 0 2px 9px rgba(0, 0, 0, 0.5);
+}
+
 @utility waveform-loading-dots {
   background-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.1) 1px, transparent 1.5px);
   background-size: 8px 8px;

--- a/src/index.css
+++ b/src/index.css
@@ -111,7 +111,7 @@ body {
   height: 14px;
   background: var(--color-composer-warning);
   border-radius: 50% 50% 50% 0;
-  transform: translateX(-50%) rotate(45deg);
+  transform: translateX(-50%) translateY(3px) rotate(45deg);
   box-shadow: 0 2px 9px rgba(0, 0, 0, 0.5);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -87,8 +87,8 @@ body {
 @utility snap-onset-line {
   width: 2px;
   background: repeating-linear-gradient(180deg, var(--color-composer-onset) 0 5px, transparent 5px 11px);
-  -webkit-mask: linear-gradient(180deg, #000 0, #000 20%, transparent 92%);
-  mask: linear-gradient(180deg, #000 0, #000 20%, transparent 92%);
+  -webkit-mask: linear-gradient(180deg, #000 0, #000 90%, transparent 100%);
+  mask: linear-gradient(180deg, #000 0, #000 90%, transparent 100%);
   opacity: 0.85;
 }
 
@@ -162,8 +162,7 @@ body {
 }
 
 @utility waveform-armed {
-  cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='28'%3E%3Cpath d='M11 2C7 2 4 5 4 9c0 5 7 16 7 16s7-11 7-16c0-4-3-7-7-7z' fill='%23f5a623' stroke='white' stroke-width='1.6'/%3E%3Ccircle cx='11' cy='9' r='2.6' fill='white'/%3E%3C/svg%3E")
-    11 26, crosshair;
+  cursor: crosshair;
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-composer-warning) 18%, transparent), inset 0 0 20px -2px
     color-mix(in srgb, var(--color-composer-warning) 18%, transparent);
   transition: box-shadow 180ms ease-out;

--- a/src/stores/shortcut-definitions.test.ts
+++ b/src/stores/shortcut-definitions.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { SHORTCUT_DEFINITIONS, type ShortcutBinding, type ShortcutScope } from "@/stores/shortcut-definitions";
+
+// -- Helpers ------------------------------------------------------------------
+
+const bindingSignature = (binding: ShortcutBinding): string =>
+  [
+    binding.key,
+    binding.shift ? "shift" : "",
+    binding.alt ? "alt" : "",
+    binding.ctrl ? "ctrl" : "",
+    binding.meta ? "meta" : "",
+    binding.mod ? "mod" : "",
+  ].join("|");
+
+const SCOPES: ShortcutScope[] = ["global", "sync", "timeline"];
+
+// -- Tests --------------------------------------------------------------------
+
+describe("SHORTCUT_DEFINITIONS", () => {
+  it("registers the marker-mode toggle with default key 'i' in the timeline scope", () => {
+    const markerMode = SHORTCUT_DEFINITIONS.find((d) => d.id === "timeline.toggleMarkerMode");
+
+    expect(markerMode).toBeDefined();
+    expect(markerMode?.scope).toBe("timeline");
+    expect(markerMode?.defaultBinding.key).toBe("i");
+    expect(markerMode?.defaultBinding.shift).toBeUndefined();
+    expect(markerMode?.defaultBinding.alt).toBeUndefined();
+    expect(markerMode?.defaultBinding.ctrl).toBeUndefined();
+    expect(markerMode?.defaultBinding.meta).toBeUndefined();
+    expect(markerMode?.defaultBinding.mod).toBeUndefined();
+  });
+
+  describe("invariants", () => {
+    it("has a unique id for every definition", () => {
+      const ids = SHORTCUT_DEFINITIONS.map((d) => d.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("ships a non-empty default key for every definition", () => {
+      for (const definition of SHORTCUT_DEFINITIONS) {
+        expect(definition.defaultBinding.key).not.toBe("");
+      }
+    });
+
+    it("ships a non-empty description for every definition", () => {
+      for (const definition of SHORTCUT_DEFINITIONS) {
+        expect(definition.description.trim()).not.toBe("");
+      }
+    });
+
+    it.each(SCOPES)("has no duplicate default binding within the %s scope", (scope) => {
+      const signatures = SHORTCUT_DEFINITIONS.filter((d) => d.scope === scope).map((d) =>
+        bindingSignature(d.defaultBinding),
+      );
+
+      expect(new Set(signatures).size).toBe(signatures.length);
+    });
+  });
+});

--- a/src/stores/shortcut-definitions.ts
+++ b/src/stores/shortcut-definitions.ts
@@ -297,6 +297,12 @@ const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
     description: "Toggle rolling edit tool",
     defaultBinding: { key: "r" },
   },
+  {
+    id: "timeline.toggleMarkerMode",
+    scope: "timeline",
+    description: "Toggle marker mode",
+    defaultBinding: { key: "i" },
+  },
 ];
 
 // -- Exports ------------------------------------------------------------------

--- a/src/ui/help-sections/timeline-extras.browser.test.tsx
+++ b/src/ui/help-sections/timeline-extras.browser.test.tsx
@@ -28,4 +28,9 @@ describe("TimelineExtras", () => {
     const screen = await render(<TimelineExtras />);
     expect(screen.container.textContent).toContain("remember their state across reloads");
   });
+
+  it("documents the marker mode toolbar toggle", async () => {
+    const screen = await render(<TimelineExtras />);
+    expect(screen.container.textContent).toContain("drops a custom snap point");
+  });
 });

--- a/src/ui/help-sections/timeline-extras.tsx
+++ b/src/ui/help-sections/timeline-extras.tsx
@@ -69,6 +69,11 @@ const TimelineExtras: React.FC = () => (
           ): a magnet for word edges and the playhead. Hold {MOD_KEY} mid-drag to bypass.
         </li>
         <li>
+          <strong>Marker</strong> (<InlineKeyBadge keys={getEffectiveKeysArray("timeline.toggleMarkerMode")} />
+          ): arms the waveform so a click drops a custom snap point. See <strong>Snap points and marker mode</strong> in
+          the Timeline section for the full rundown.
+        </li>
+        <li>
           <strong>Import</strong> (<InlineKeyBadge keys={getEffectiveKeysArray("timeline.importLyrics")} />
           ): imports lyrics directly into the Timeline without switching tabs.
         </li>

--- a/src/ui/help-sections/timeline.browser.test.tsx
+++ b/src/ui/help-sections/timeline.browser.test.tsx
@@ -83,4 +83,16 @@ describe("TimelineSection", () => {
     const screen = await render(<TimelineSection />);
     expect(screen.container.textContent).toContain("playhead pinned in place");
   });
+
+  it("documents snap points and marker mode", async () => {
+    const screen = await render(<TimelineSection />);
+    await expect.element(screen.getByRole("heading", { name: "Snap points and marker mode" })).toBeInTheDocument();
+    expect(screen.container.textContent).toContain("vocal onsets");
+    expect(screen.container.textContent).toContain("custom snap points");
+  });
+
+  it("notes that snap points are session-only", async () => {
+    const screen = await render(<TimelineSection />);
+    expect(screen.container.textContent).toContain("clear on reload");
+  });
 });

--- a/src/ui/help-sections/timeline.tsx
+++ b/src/ui/help-sections/timeline.tsx
@@ -192,6 +192,33 @@ const TimelineSection: React.FC = () => (
     </div>
 
     <div>
+      <h4 className={HEADING}>Snap points and marker mode</h4>
+      <p className={PROSE}>
+        Two kinds of snap marker can sit over the waveform. Teal dashed lines are vocal onsets, which Composer detects
+        from the separated vocal stem, so they only show up once you have split out vocals and turned on "Snap to vocal
+        onsets" in the stem dropdown. Amber pins are custom snap points you place yourself. Both pull word edges in the
+        way the magnet does, and custom points keep snapping even when Snap and onset snapping are both off.
+      </p>
+      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
+        <li>
+          Click the pin button in the toolbar or press{" "}
+          <InlineKeyBadge keys={getEffectiveKeysArray("timeline.toggleMarkerMode")} /> to enter marker mode. The
+          waveform cursor turns into a pin, and a single click drops a custom point where you click.
+        </li>
+        <li>With marker mode off, double-click the waveform to drop a point without arming anything.</li>
+        <li>
+          Drag a pin's head to move it. With onset snapping on, releasing near a vocal onset lands the pin right on it,
+          and the onset tucks behind the pin so you do not see two markers stacked.
+        </li>
+        <li>Hover a pin to see its time, with an x button to delete it.</li>
+        <li>
+          Snap points live in the current session. They clear on reload and are not part of the export, so treat them as
+          scratch guides while you work rather than something you save.
+        </li>
+      </ul>
+    </div>
+
+    <div>
       <h4 className={HEADING}>Splitting and merging</h4>
       <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
         <li>

--- a/src/ui/help-sections/timeline.tsx
+++ b/src/ui/help-sections/timeline.tsx
@@ -194,9 +194,9 @@ const TimelineSection: React.FC = () => (
     <div>
       <h4 className={HEADING}>Snap points and marker mode</h4>
       <p className={PROSE}>
-        Two kinds of snap marker can sit over the waveform. Teal dashed lines are vocal onsets, which Composer detects
+        Two kinds of snap marker can sit over the waveform. Dashed guide lines are vocal onsets, which Composer detects
         from the separated vocal stem, so they only show up once you have split out vocals and turned on "Snap to vocal
-        onsets" in the stem dropdown. Amber pins are custom snap points you place yourself. Both pull word edges in the
+        onsets" in the stem dropdown. Solid pins are custom snap points you place yourself. Both pull word edges in the
         way the magnet does, and custom points keep snapping even when Snap and onset snapping are both off.
       </p>
       <ul className={`${PROSE} list-disc pl-4 space-y-1`}>

--- a/src/utils/animationVariants.ts
+++ b/src/utils/animationVariants.ts
@@ -70,6 +70,27 @@ const shimmerVariants: Variants = {
   animate: { backgroundPosition: "-100% 0" },
 };
 
+// -- Snap Markers -------------------------------------------------------------
+
+const pinDropInVariants: Variants = {
+  initial: { opacity: 0, y: -6, scale: 0.4 },
+  animate: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: { type: "spring", stiffness: 700, damping: 18, mass: 0.6 },
+  },
+};
+
+const snapFlashVariants: Variants = {
+  initial: { opacity: 0, boxShadow: "0 0 0px rgba(255, 255, 255, 0)" },
+  animate: {
+    opacity: [0.9, 0],
+    boxShadow: ["0 0 18px rgba(255, 255, 255, 0.9)", "0 0 0px rgba(255, 255, 255, 0)"],
+    transition: { type: "spring", stiffness: 120, damping: 22, mass: 0.7 },
+  },
+};
+
 // -- Stagger Container --------------------------------------------------------
 
 // -- Exports ------------------------------------------------------------------
@@ -82,4 +103,6 @@ export {
   buildGroupPingVariants,
   shimmerTransition,
   shimmerVariants,
+  pinDropInVariants,
+  snapFlashVariants,
 };

--- a/src/utils/animationVariants.ts
+++ b/src/utils/animationVariants.ts
@@ -73,12 +73,12 @@ const shimmerVariants: Variants = {
 // -- Snap Markers -------------------------------------------------------------
 
 const pinDropInVariants: Variants = {
-  initial: { opacity: 0, y: -6, scale: 0.4 },
+  initial: { opacity: 0, y: -4, scale: 0.72 },
   animate: {
     opacity: 1,
     y: 0,
     scale: 1,
-    transition: { type: "spring", stiffness: 700, damping: 18, mass: 0.6 },
+    transition: { type: "spring", stiffness: 500, damping: 32, mass: 0.7 },
   },
 };
 

--- a/src/utils/animationVariants.ts
+++ b/src/utils/animationVariants.ts
@@ -73,12 +73,12 @@ const shimmerVariants: Variants = {
 // -- Snap Markers -------------------------------------------------------------
 
 const pinDropInVariants: Variants = {
-  initial: { opacity: 0, y: -4, scale: 0.72 },
+  initial: { opacity: 0, y: -5, scale: 0.6 },
   animate: {
     opacity: 1,
     y: 0,
     scale: 1,
-    transition: { type: "spring", stiffness: 500, damping: 32, mass: 0.7 },
+    transition: { type: "spring", stiffness: 500, damping: 20, mass: 0.7 },
   },
 };
 

--- a/src/views/timeline/coords.test.ts
+++ b/src/views/timeline/coords.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { GUTTER_WIDTH, timeToX, xToTime } from "@/views/timeline/coords";
+
+describe("timeToX", () => {
+  it("maps seconds to gutter-offset pixels", () => {
+    expect(timeToX(2, 100, 50)).toBe(2 * 100 - 50 + GUTTER_WIDTH);
+  });
+
+  it("subtracts scrollLeft", () => {
+    expect(timeToX(1, 100, 0)).toBe(100 + GUTTER_WIDTH);
+    expect(timeToX(1, 100, 40)).toBe(100 - 40 + GUTTER_WIDTH);
+  });
+
+  it("returns the gutter width at time zero with no scroll", () => {
+    expect(timeToX(0, 100, 0)).toBe(GUTTER_WIDTH);
+  });
+});
+
+describe("xToTime", () => {
+  it("inverts a clientX against a viewport rect", () => {
+    const rect = { left: 10 } as DOMRect;
+    expect(xToTime(10 + GUTTER_WIDTH + 100, rect, 100, 0)).toBeCloseTo(1);
+  });
+
+  it("clamps to >= 0", () => {
+    expect(xToTime(0, { left: 999 } as DOMRect, 100, 0)).toBe(0);
+  });
+
+  it("accounts for scrollLeft", () => {
+    const rect = { left: 0 } as DOMRect;
+    expect(xToTime(GUTTER_WIDTH, rect, 100, 200)).toBeCloseTo(2);
+  });
+});
+
+describe("edge cases", () => {
+  it("handles a negative scrollLeft in timeToX", () => {
+    expect(timeToX(1, 100, -50)).toBe(100 + 50 + GUTTER_WIDTH);
+  });
+
+  it("handles a negative scrollLeft in xToTime", () => {
+    const rect = { left: 0 } as DOMRect;
+    expect(xToTime(GUTTER_WIDTH + 100, rect, 100, -100)).toBeCloseTo(0);
+  });
+
+  it("handles large time and zoom values", () => {
+    expect(timeToX(3600, 500, 0)).toBe(3600 * 500 + GUTTER_WIDTH);
+  });
+
+  it("handles fractional seconds", () => {
+    expect(timeToX(1.5, 80, 0)).toBe(1.5 * 80 + GUTTER_WIDTH);
+  });
+
+  it("clamps when clientX lands left of the gutter", () => {
+    const rect = { left: 0 } as DOMRect;
+    expect(xToTime(GUTTER_WIDTH - 10, rect, 100, 0)).toBe(0);
+  });
+});
+
+describe("invariants", () => {
+  const cases: Array<{ t: number; zoom: number; scrollLeft: number }> = [
+    { t: 0, zoom: 100, scrollLeft: 0 },
+    { t: 1, zoom: 100, scrollLeft: 50 },
+    { t: 2.5, zoom: 80, scrollLeft: 0 },
+    { t: 12.345, zoom: 250, scrollLeft: 400 },
+    { t: 60, zoom: 33, scrollLeft: -120 },
+  ];
+
+  it("round-trips time -> x -> time for representative values", () => {
+    const rect = { left: 17 } as DOMRect;
+    for (const { t, zoom, scrollLeft } of cases) {
+      const x = timeToX(t, zoom, scrollLeft) + rect.left;
+      expect(xToTime(x, rect, zoom, scrollLeft)).toBeCloseTo(t);
+    }
+  });
+
+  it("xToTime is the algebraic inverse of timeToX above the clamp floor", () => {
+    const rect = { left: 0 } as DOMRect;
+    const t = 5;
+    const zoom = 120;
+    const scrollLeft = 30;
+    const x = timeToX(t, zoom, scrollLeft);
+    expect(xToTime(x, rect, zoom, scrollLeft)).toBeCloseTo(t);
+  });
+
+  it("never returns a negative time", () => {
+    const rect = { left: 500 } as DOMRect;
+    for (let clientX = -1000; clientX <= 1000; clientX += 250) {
+      expect(xToTime(clientX, rect, 100, 0)).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/src/views/timeline/coords.ts
+++ b/src/views/timeline/coords.ts
@@ -1,0 +1,9 @@
+import { GUTTER_WIDTH } from "@/views/timeline/timeline-store";
+
+const timeToX = (time: number, zoom: number, scrollLeft: number): number =>
+  time * zoom - scrollLeft + GUTTER_WIDTH;
+
+const xToTime = (clientX: number, rect: DOMRect, zoom: number, scrollLeft: number): number =>
+  Math.max(0, (clientX - rect.left - GUTTER_WIDTH + scrollLeft) / zoom);
+
+export { GUTTER_WIDTH, timeToX, xToTime };

--- a/src/views/timeline/coords.ts
+++ b/src/views/timeline/coords.ts
@@ -1,7 +1,6 @@
 import { GUTTER_WIDTH } from "@/views/timeline/timeline-store";
 
-const timeToX = (time: number, zoom: number, scrollLeft: number): number =>
-  time * zoom - scrollLeft + GUTTER_WIDTH;
+const timeToX = (time: number, zoom: number, scrollLeft: number): number => time * zoom - scrollLeft + GUTTER_WIDTH;
 
 const xToTime = (clientX: number, rect: DOMRect, zoom: number, scrollLeft: number): number =>
   Math.max(0, (clientX - rect.left - GUTTER_WIDTH + scrollLeft) / zoom);

--- a/src/views/timeline/snap-guideline.tsx
+++ b/src/views/timeline/snap-guideline.tsx
@@ -1,4 +1,5 @@
-import { GUTTER_WIDTH, useTimelineStore } from "@/views/timeline/timeline-store";
+import { GUTTER_WIDTH, timeToX } from "@/views/timeline/coords";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
 
 // -- Component ----------------------------------------------------------------
 
@@ -9,7 +10,7 @@ const SnapGuideline: React.FC = () => {
 
   if (snappedAnchorTime === null) return null;
 
-  const position = snappedAnchorTime * zoom - scrollLeft + GUTTER_WIDTH;
+  const position = timeToX(snappedAnchorTime, zoom, scrollLeft);
 
   return (
     <div

--- a/src/views/timeline/snap-marker-math.test.ts
+++ b/src/views/timeline/snap-marker-math.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { computeCoveredOnsets, snapTimeToOnset } from "@/views/timeline/snap-marker-math";
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("snapTimeToOnset", () => {
+  it("snaps to an onset within the pixel threshold", () => {
+    expect(snapTimeToOnset(2.05, [2], 100, 12)).toBe(2);
+  });
+
+  it("leaves the time untouched when no onset is within threshold", () => {
+    expect(snapTimeToOnset(2.5, [2], 100, 12)).toBe(2.5);
+  });
+
+  it("snaps just inside the threshold", () => {
+    expect(snapTimeToOnset(2.11, [2], 100, 12)).toBe(2);
+  });
+
+  it("does not snap just beyond the threshold", () => {
+    expect(snapTimeToOnset(2.13, [2], 100, 12)).toBe(2.13);
+  });
+
+  it("snaps to the nearest of several onsets", () => {
+    expect(snapTimeToOnset(2.04, [2, 2.1], 100, 20)).toBe(2);
+    expect(snapTimeToOnset(2.07, [2, 2.1], 100, 20)).toBe(2.1);
+  });
+
+  it("scales the threshold by zoom (lower zoom = wider time window)", () => {
+    expect(snapTimeToOnset(2.2, [2], 50, 12)).toBe(2);
+    expect(snapTimeToOnset(2.2, [2], 100, 12)).toBe(2.2);
+  });
+
+  describe("edge cases", () => {
+    it("returns the input when there are no onsets", () => {
+      expect(snapTimeToOnset(2, [], 100, 12)).toBe(2);
+    });
+
+    it("handles the timeline origin", () => {
+      expect(snapTimeToOnset(0.05, [0], 100, 12)).toBe(0);
+    });
+  });
+});
+
+describe("computeCoveredOnsets", () => {
+  it("marks an onset covered by a coincident custom point", () => {
+    expect(computeCoveredOnsets([2], [2], 100, 12)).toEqual(new Set([0]));
+  });
+
+  it("marks an onset covered within threshold", () => {
+    expect(computeCoveredOnsets([2], [2.1], 100, 12)).toEqual(new Set([0]));
+  });
+
+  it("does not cover an onset outside threshold", () => {
+    expect(computeCoveredOnsets([2], [2.5], 100, 12)).toEqual(new Set());
+  });
+
+  it("covers by onset index, not value", () => {
+    const covered = computeCoveredOnsets([1, 2, 3], [2], 100, 12);
+    expect(covered.has(1)).toBe(true);
+    expect(covered.has(0)).toBe(false);
+    expect(covered.has(2)).toBe(false);
+  });
+
+  it("covers multiple onsets from multiple covering points", () => {
+    expect(computeCoveredOnsets([1, 2, 3], [1, 3], 100, 12)).toEqual(new Set([0, 2]));
+  });
+
+  describe("edge cases", () => {
+    it("returns empty when there are no covering times", () => {
+      expect(computeCoveredOnsets([1, 2], [], 100, 12)).toEqual(new Set());
+    });
+
+    it("returns empty when there are no onsets", () => {
+      expect(computeCoveredOnsets([], [2], 100, 12)).toEqual(new Set());
+    });
+
+    it("scales coverage window by zoom", () => {
+      expect(computeCoveredOnsets([2], [2.2], 50, 12)).toEqual(new Set([0]));
+      expect(computeCoveredOnsets([2], [2.2], 100, 12)).toEqual(new Set());
+    });
+  });
+});

--- a/src/views/timeline/snap-marker-math.test.ts
+++ b/src/views/timeline/snap-marker-math.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { computeCoveredOnsets, isTimeOnOnset, snapTimeToOnset } from "@/views/timeline/snap-marker-math";
+import {
+  computeCoveredOnsets,
+  findInsertedValue,
+  isTimeOnOnset,
+  snapTimeToOnset,
+} from "@/views/timeline/snap-marker-math";
 
 // -- Tests ---------------------------------------------------------------------
 
@@ -110,6 +115,62 @@ describe("computeCoveredOnsets", () => {
     it("scales coverage window by zoom", () => {
       expect(computeCoveredOnsets([2], [2.2], 50, 12)).toEqual(new Set([0]));
       expect(computeCoveredOnsets([2], [2.2], 100, 12)).toEqual(new Set());
+    });
+  });
+});
+
+describe("findInsertedValue", () => {
+  it("returns the appended value", () => {
+    expect(findInsertedValue([1, 3], [1, 3, 5])).toBe(5);
+  });
+
+  it("returns the middle-inserted value", () => {
+    expect(findInsertedValue([1, 3], [1, 2, 3])).toBe(2);
+  });
+
+  it("returns the prepended value", () => {
+    expect(findInsertedValue([2, 3], [1, 2, 3])).toBe(1);
+  });
+
+  it("returns null on a move (same length, one value changed)", () => {
+    expect(findInsertedValue([2, 4], [4, 6])).toBeNull();
+  });
+
+  it("returns null on a delete (shorter)", () => {
+    expect(findInsertedValue([1, 2, 3], [1, 3])).toBeNull();
+  });
+
+  it("returns null when nothing changed", () => {
+    expect(findInsertedValue([1, 2, 3], [1, 2, 3])).toBeNull();
+  });
+
+  describe("edge cases", () => {
+    it("returns null for empty to empty", () => {
+      expect(findInsertedValue([], [])).toBeNull();
+    });
+
+    it("returns the only value when adding the first point", () => {
+      expect(findInsertedValue([], [4])).toBe(4);
+    });
+
+    it("returns null when the array grows by more than one", () => {
+      expect(findInsertedValue([1], [1, 2, 3])).toBeNull();
+    });
+
+    it("returns null when count rises by one but no value is genuinely new", () => {
+      // A duplicate of an existing value: next-minus-prev is empty, so no fresh value.
+      expect(findInsertedValue([2, 2], [2, 2, 2])).toBeNull();
+    });
+
+    it("returns the inserted value at the timeline origin", () => {
+      expect(findInsertedValue([2], [0, 2])).toBe(0);
+    });
+
+    it("treats a non-trivial first render (prev seeded to current) as no insertion", () => {
+      // When the prev-ref is initialized to the initial array, the first diff is
+      // identical, so nothing is flagged new on mount.
+      const initial = [1, 4, 7];
+      expect(findInsertedValue(initial, initial)).toBeNull();
     });
   });
 });

--- a/src/views/timeline/snap-marker-math.test.ts
+++ b/src/views/timeline/snap-marker-math.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { computeCoveredOnsets, snapTimeToOnset } from "@/views/timeline/snap-marker-math";
+import { computeCoveredOnsets, isTimeOnOnset, snapTimeToOnset } from "@/views/timeline/snap-marker-math";
 
 // -- Tests ---------------------------------------------------------------------
 
@@ -37,6 +37,39 @@ describe("snapTimeToOnset", () => {
 
     it("handles the timeline origin", () => {
       expect(snapTimeToOnset(0.05, [0], 100, 12)).toBe(0);
+    });
+  });
+});
+
+describe("isTimeOnOnset", () => {
+  it("is true when a time sits exactly on an onset", () => {
+    expect(isTimeOnOnset(2, [2], 100, 12)).toBe(true);
+  });
+
+  it("is true within the pixel threshold", () => {
+    expect(isTimeOnOnset(2.1, [2], 100, 12)).toBe(true);
+  });
+
+  it("is false outside the pixel threshold", () => {
+    expect(isTimeOnOnset(2.5, [2], 100, 12)).toBe(false);
+  });
+
+  it("is true if any onset is within threshold", () => {
+    expect(isTimeOnOnset(3, [1, 3, 5], 100, 12)).toBe(true);
+  });
+
+  it("scales the window by zoom (lower zoom = wider time window)", () => {
+    expect(isTimeOnOnset(2.2, [2], 50, 12)).toBe(true);
+    expect(isTimeOnOnset(2.2, [2], 100, 12)).toBe(false);
+  });
+
+  describe("edge cases", () => {
+    it("is false when there are no onsets", () => {
+      expect(isTimeOnOnset(2, [], 100, 12)).toBe(false);
+    });
+
+    it("handles the timeline origin", () => {
+      expect(isTimeOnOnset(0.05, [0], 100, 12)).toBe(true);
     });
   });
 });

--- a/src/views/timeline/snap-marker-math.ts
+++ b/src/views/timeline/snap-marker-math.ts
@@ -13,6 +13,13 @@ function snapTimeToOnset(time: number, onsets: number[], zoom: number, threshold
   return best;
 }
 
+function isTimeOnOnset(time: number, onsets: number[], zoom: number, thresholdPx: number): boolean {
+  for (const onset of onsets) {
+    if (Math.abs(onset - time) * zoom <= thresholdPx) return true;
+  }
+  return false;
+}
+
 function computeCoveredOnsets(
   onsets: number[],
   coveringTimes: number[],
@@ -34,4 +41,4 @@ function computeCoveredOnsets(
 
 // -- Exports -------------------------------------------------------------------
 
-export { snapTimeToOnset, computeCoveredOnsets };
+export { snapTimeToOnset, isTimeOnOnset, computeCoveredOnsets };

--- a/src/views/timeline/snap-marker-math.ts
+++ b/src/views/timeline/snap-marker-math.ts
@@ -39,6 +39,18 @@ function computeCoveredOnsets(
   return covered;
 }
 
+function findInsertedValue(prev: number[], next: number[]): number | null {
+  if (next.length !== prev.length + 1) return null;
+  const prevSet = new Set(prev);
+  let inserted: number | null = null;
+  for (const value of next) {
+    if (prevSet.has(value)) continue;
+    if (inserted !== null) return null;
+    inserted = value;
+  }
+  return inserted;
+}
+
 // -- Exports -------------------------------------------------------------------
 
-export { snapTimeToOnset, isTimeOnOnset, computeCoveredOnsets };
+export { snapTimeToOnset, isTimeOnOnset, computeCoveredOnsets, findInsertedValue };

--- a/src/views/timeline/snap-marker-math.ts
+++ b/src/views/timeline/snap-marker-math.ts
@@ -1,0 +1,37 @@
+// -- Functions -----------------------------------------------------------------
+
+function snapTimeToOnset(time: number, onsets: number[], zoom: number, thresholdPx: number): number {
+  let best = time;
+  let bestDistPx = thresholdPx;
+  for (const onset of onsets) {
+    const distPx = Math.abs(onset - time) * zoom;
+    if (distPx <= bestDistPx) {
+      bestDistPx = distPx;
+      best = onset;
+    }
+  }
+  return best;
+}
+
+function computeCoveredOnsets(
+  onsets: number[],
+  coveringTimes: number[],
+  zoom: number,
+  thresholdPx: number,
+): Set<number> {
+  const covered = new Set<number>();
+  for (let onsetIndex = 0; onsetIndex < onsets.length; onsetIndex++) {
+    const onset = onsets[onsetIndex];
+    for (const covering of coveringTimes) {
+      if (Math.abs(covering - onset) * zoom <= thresholdPx) {
+        covered.add(onsetIndex);
+        break;
+      }
+    }
+  }
+  return covered;
+}
+
+// -- Exports -------------------------------------------------------------------
+
+export { snapTimeToOnset, computeCoveredOnsets };

--- a/src/views/timeline/snap-marker-pin.browser.test.tsx
+++ b/src/views/timeline/snap-marker-pin.browser.test.tsx
@@ -26,8 +26,12 @@ const head = (container: HTMLElement): HTMLElement | null =>
 const line = (container: HTMLElement): HTMLElement | null =>
   container.querySelector<HTMLElement>("[data-snap-marker-line]");
 
-const tooltip = (container: HTMLElement): HTMLElement | null =>
-  container.querySelector<HTMLElement>("[data-snap-marker-tooltip]");
+const tooltip = (): HTMLElement | null => document.body.querySelector<HTMLElement>("[data-snap-marker-tooltip]");
+
+const deleteButton = (): HTMLButtonElement | null =>
+  document.body.querySelector<HTMLButtonElement>("[data-snap-marker-delete]");
+
+const timeLabel = (): HTMLElement | null => document.body.querySelector<HTMLElement>("[data-snap-marker-time-label]");
 
 // -- Tests ---------------------------------------------------------------------
 
@@ -72,22 +76,21 @@ describe("SnapMarkerPin", () => {
   describe("tooltip", () => {
     it("shows a tooltip with the formatted time on hover", async () => {
       const screen = await render(<SnapMarkerPin {...defaultProps} time={2} />);
-      expect(tooltip(screen.container)).toBeNull();
+      expect(tooltip()).toBeNull();
 
       const headEl = head(screen.container);
       if (headEl) await userEvent.hover(headEl);
 
-      await expect.poll(() => tooltip(screen.container)).not.toBeNull();
-      const label = screen.container.querySelector<HTMLElement>("[data-snap-marker-time-label]");
-      expect(label?.textContent).toBe("0:02.000");
-      expect(label?.classList.contains("select-text")).toBe(true);
+      await expect.poll(() => tooltip()).not.toBeNull();
+      await expect.poll(() => timeLabel()?.textContent).toBe("0:02.000");
+      expect(timeLabel()?.classList.contains("select-text")).toBe(true);
     });
 
     it("hides the tooltip while dragging", async () => {
       const screen = await render(<SnapMarkerPin {...defaultProps} isDragging />);
       const headEl = head(screen.container);
       if (headEl) await userEvent.hover(headEl);
-      await expect.poll(() => tooltip(screen.container)).toBeNull();
+      await expect.poll(() => tooltip()).toBeNull();
     });
 
     it("calls onDelete with the index when the delete button is clicked", async () => {
@@ -96,13 +99,34 @@ describe("SnapMarkerPin", () => {
       const headEl = head(screen.container);
       if (headEl) await userEvent.hover(headEl);
 
-      const deleteButton = await vi.waitFor(() => {
-        const button = screen.container.querySelector<HTMLButtonElement>("[data-snap-marker-delete]");
-        if (!button) throw new Error("delete button not yet rendered");
-        return button;
+      const button = await vi.waitFor(() => {
+        const el = deleteButton();
+        if (!el) throw new Error("delete button not yet rendered");
+        return el;
       });
-      await userEvent.click(deleteButton);
+      await userEvent.hover(button);
+      await userEvent.click(button);
       expect(onDelete).toHaveBeenCalledWith(2);
+    });
+
+    it("regression: tooltip stays open while moving from the head onto the delete button", async () => {
+      const onDelete = vi.fn();
+      const screen = await render(<SnapMarkerPin {...defaultProps} index={4} onDelete={onDelete} />);
+      const headEl = head(screen.container);
+      if (headEl) await userEvent.hover(headEl);
+
+      const button = await vi.waitFor(() => {
+        const el = deleteButton();
+        if (!el) throw new Error("delete button not yet rendered");
+        return el;
+      });
+
+      if (headEl) await userEvent.unhover(headEl);
+      await userEvent.hover(button);
+      await expect.poll(() => tooltip()).not.toBeNull();
+
+      await userEvent.click(button);
+      expect(onDelete).toHaveBeenCalledWith(4);
     });
   });
 

--- a/src/views/timeline/snap-marker-pin.browser.test.tsx
+++ b/src/views/timeline/snap-marker-pin.browser.test.tsx
@@ -11,6 +11,7 @@ const defaultProps = {
   zoom: 100,
   fadeExtent: 220,
   isDragging: false,
+  isNew: false,
   isOnOnset: false,
   onHeadPointerDown: () => {},
   onDelete: () => {},
@@ -111,6 +112,18 @@ describe("SnapMarkerPin", () => {
       const wrapper = screen.container.querySelector<HTMLElement>("[data-snap-marker-drop-in]");
       expect(wrapper).not.toBeNull();
       expect(wrapper?.getAttribute("data-snap-marker")).toBe("custom");
+    });
+
+    it("flags the drop-in only when the pin is newly placed", async () => {
+      const screen = await render(<SnapMarkerPin {...defaultProps} isNew />);
+      const wrapper = screen.container.querySelector<HTMLElement>("[data-snap-marker-drop-in]");
+      expect(wrapper?.hasAttribute("data-snap-marker-new")).toBe(true);
+    });
+
+    it("does not flag the drop-in for an existing pin", async () => {
+      const screen = await render(<SnapMarkerPin {...defaultProps} isNew={false} />);
+      const wrapper = screen.container.querySelector<HTMLElement>("[data-snap-marker-drop-in]");
+      expect(wrapper?.hasAttribute("data-snap-marker-new")).toBe(false);
     });
 
     it("renders no flash when the pin is not on an onset", async () => {

--- a/src/views/timeline/snap-marker-pin.browser.test.tsx
+++ b/src/views/timeline/snap-marker-pin.browser.test.tsx
@@ -11,9 +11,13 @@ const defaultProps = {
   zoom: 100,
   fadeExtent: 220,
   isDragging: false,
+  isOnOnset: false,
   onHeadPointerDown: () => {},
   onDelete: () => {},
 };
+
+const flash = (container: HTMLElement): HTMLElement | null =>
+  container.querySelector<HTMLElement>("[data-snap-marker-flash]");
 
 const head = (container: HTMLElement): HTMLElement | null =>
   container.querySelector<HTMLElement>("[data-snap-marker-head]");
@@ -98,6 +102,88 @@ describe("SnapMarkerPin", () => {
       });
       await userEvent.click(deleteButton);
       expect(onDelete).toHaveBeenCalledWith(2);
+    });
+  });
+
+  describe("placement animation", () => {
+    it("mounts the pin inside the drop-in motion wrapper", async () => {
+      const screen = await render(<SnapMarkerPin {...defaultProps} />);
+      const wrapper = screen.container.querySelector<HTMLElement>("[data-snap-marker-drop-in]");
+      expect(wrapper).not.toBeNull();
+      expect(wrapper?.getAttribute("data-snap-marker")).toBe("custom");
+    });
+
+    it("renders no flash when the pin is not on an onset", async () => {
+      const screen = await render(<SnapMarkerPin {...defaultProps} isOnOnset={false} />);
+      expect(flash(screen.container)).toBeNull();
+    });
+
+    it("renders a flash when the pin lands on an onset", async () => {
+      const screen = await render(<SnapMarkerPin {...defaultProps} isOnOnset={false} />);
+      expect(flash(screen.container)).toBeNull();
+
+      await screen.rerender(<SnapMarkerPin {...defaultProps} isOnOnset />);
+
+      await expect.poll(() => flash(screen.container)).not.toBeNull();
+    });
+
+    it("flashes once when a pin is placed directly on an onset", async () => {
+      const screen = await render(<SnapMarkerPin {...defaultProps} isOnOnset />);
+      await expect.poll(() => flash(screen.container)).not.toBeNull();
+    });
+
+    it("does not re-fire the flash while the pin stays on the same onset", async () => {
+      const screen = await render(<SnapMarkerPin {...defaultProps} isOnOnset />);
+      const firstFlash = await vi.waitFor(() => {
+        const el = flash(screen.container);
+        if (!el) throw new Error("flash not yet rendered");
+        return el;
+      });
+      const firstKey = firstFlash.getAttribute("data-flash-key");
+
+      await screen.rerender(<SnapMarkerPin {...defaultProps} isOnOnset time={2.001} />);
+
+      // Same on-onset state across re-render: the flash key must not advance.
+      expect(flash(screen.container)?.getAttribute("data-flash-key")).toBe(firstKey);
+    });
+
+    it("re-fires the flash when the pin leaves and lands on an onset again", async () => {
+      const screen = await render(<SnapMarkerPin {...defaultProps} isOnOnset={false} />);
+
+      await screen.rerender(<SnapMarkerPin {...defaultProps} isOnOnset />);
+      const firstFlash = await vi.waitFor(() => {
+        const el = flash(screen.container);
+        if (!el) throw new Error("flash not yet rendered");
+        return el;
+      });
+      const firstKey = firstFlash.getAttribute("data-flash-key");
+
+      await screen.rerender(<SnapMarkerPin {...defaultProps} isOnOnset={false} />);
+      await screen.rerender(<SnapMarkerPin {...defaultProps} isOnOnset />);
+
+      await expect.poll(() => flash(screen.container)).not.toBeNull();
+      // The flash element identity changes so the animation replays.
+      await expect.poll(() => flash(screen.container)?.getAttribute("data-flash-key")).not.toBe(firstKey);
+    });
+  });
+
+  describe("reduced motion", () => {
+    // The shared render wrapper forces MotionConfig reducedMotion="always",
+    // so useReducedMotion() is true here. This asserts the at-rest fallback:
+    // the pin mounts in place and the flash element still renders on snap.
+    // The animating (non-reduced) path is not reachable through this harness.
+    it("renders the pin at rest and stable under reduced motion", async () => {
+      const screen = await render(<SnapMarkerPin {...defaultProps} time={2} zoom={100} />);
+      const wrapper = screen.container.querySelector<HTMLElement>("[data-snap-marker-drop-in]");
+      expect(wrapper).not.toBeNull();
+      expect(wrapper?.style.left).toBe("200px");
+      await expect.poll(() => wrapper?.style.left).toBe("200px");
+    });
+
+    it("still surfaces a flash element on snap under reduced motion", async () => {
+      const screen = await render(<SnapMarkerPin {...defaultProps} isOnOnset={false} />);
+      await screen.rerender(<SnapMarkerPin {...defaultProps} isOnOnset />);
+      await expect.poll(() => flash(screen.container)).not.toBeNull();
     });
   });
 

--- a/src/views/timeline/snap-marker-pin.browser.test.tsx
+++ b/src/views/timeline/snap-marker-pin.browser.test.tsx
@@ -1,0 +1,111 @@
+import { userEvent } from "vitest/browser";
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@/test/render";
+import { SnapMarkerPin } from "@/views/timeline/snap-marker-pin";
+
+// -- Helpers -------------------------------------------------------------------
+
+const defaultProps = {
+  index: 0,
+  time: 2,
+  zoom: 100,
+  fadeExtent: 220,
+  isDragging: false,
+  onHeadPointerDown: () => {},
+  onDelete: () => {},
+};
+
+const head = (container: HTMLElement): HTMLElement | null =>
+  container.querySelector<HTMLElement>("[data-snap-marker-head]");
+
+const line = (container: HTMLElement): HTMLElement | null =>
+  container.querySelector<HTMLElement>("[data-snap-marker-line]");
+
+const tooltip = (container: HTMLElement): HTMLElement | null =>
+  container.querySelector<HTMLElement>("[data-snap-marker-tooltip]");
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("SnapMarkerPin", () => {
+  it("positions the pin at time * zoom", async () => {
+    const screen = await render(<SnapMarkerPin {...defaultProps} time={2} zoom={100} />);
+    const marker = screen.container.querySelector<HTMLElement>("[data-snap-marker='custom']");
+    expect(marker?.style.left).toBe("200px");
+  });
+
+  it("renders a solid custom line that ignores pointer events", async () => {
+    const screen = await render(<SnapMarkerPin {...defaultProps} />);
+    const lineEl = line(screen.container);
+    expect(lineEl?.classList.contains("snap-custom-line")).toBe(true);
+    expect(lineEl?.classList.contains("pointer-events-none")).toBe(true);
+  });
+
+  it("renders an interactive draggable head with grab cursor", async () => {
+    const screen = await render(<SnapMarkerPin {...defaultProps} />);
+    const headEl = head(screen.container);
+    expect(headEl?.classList.contains("snap-custom-head")).toBe(true);
+    expect(headEl?.classList.contains("pointer-events-auto")).toBe(true);
+    expect(headEl?.classList.contains("cursor-grab")).toBe(true);
+  });
+
+  it("switches the head to grabbing cursor while dragging", async () => {
+    const screen = await render(<SnapMarkerPin {...defaultProps} isDragging />);
+    const headEl = head(screen.container);
+    expect(headEl?.classList.contains("cursor-grabbing")).toBe(true);
+    expect(headEl?.classList.contains("cursor-grab")).toBe(false);
+  });
+
+  it("calls onHeadPointerDown with the index when the head is pressed", async () => {
+    const onHeadPointerDown = vi.fn();
+    const screen = await render(<SnapMarkerPin {...defaultProps} index={3} onHeadPointerDown={onHeadPointerDown} />);
+    const headEl = head(screen.container);
+    headEl?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0 }));
+    expect(onHeadPointerDown).toHaveBeenCalledTimes(1);
+    expect(onHeadPointerDown.mock.calls[0][0]).toBe(3);
+  });
+
+  describe("tooltip", () => {
+    it("shows a tooltip with the formatted time on hover", async () => {
+      const screen = await render(<SnapMarkerPin {...defaultProps} time={2} />);
+      expect(tooltip(screen.container)).toBeNull();
+
+      const headEl = head(screen.container);
+      if (headEl) await userEvent.hover(headEl);
+
+      await expect.poll(() => tooltip(screen.container)).not.toBeNull();
+      const label = screen.container.querySelector<HTMLElement>("[data-snap-marker-time-label]");
+      expect(label?.textContent).toBe("0:02.000");
+      expect(label?.classList.contains("select-text")).toBe(true);
+    });
+
+    it("hides the tooltip while dragging", async () => {
+      const screen = await render(<SnapMarkerPin {...defaultProps} isDragging />);
+      const headEl = head(screen.container);
+      if (headEl) await userEvent.hover(headEl);
+      await expect.poll(() => tooltip(screen.container)).toBeNull();
+    });
+
+    it("calls onDelete with the index when the delete button is clicked", async () => {
+      const onDelete = vi.fn();
+      const screen = await render(<SnapMarkerPin {...defaultProps} index={2} onDelete={onDelete} />);
+      const headEl = head(screen.container);
+      if (headEl) await userEvent.hover(headEl);
+
+      const deleteButton = await vi.waitFor(() => {
+        const button = screen.container.querySelector<HTMLButtonElement>("[data-snap-marker-delete]");
+        if (!button) throw new Error("delete button not yet rendered");
+        return button;
+      });
+      await userEvent.click(deleteButton);
+      expect(onDelete).toHaveBeenCalledWith(2);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("places a pin at the timeline origin", async () => {
+      const screen = await render(<SnapMarkerPin {...defaultProps} time={0} />);
+      const marker = screen.container.querySelector<HTMLElement>("[data-snap-marker='custom']");
+      expect(marker?.style.left).toBe("0px");
+    });
+  });
+});

--- a/src/views/timeline/snap-marker-pin.tsx
+++ b/src/views/timeline/snap-marker-pin.tsx
@@ -88,7 +88,7 @@ const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
       {showTooltip && (
         <div
           data-snap-marker-tooltip
-          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2.5 flex items-center gap-2 whitespace-nowrap rounded-md border border-composer-border-hover bg-composer-bg-elevated px-2 py-1 shadow-lg pointer-events-auto"
+          className="absolute top-4 left-1/2 -translate-x-1/2 flex items-center gap-2 whitespace-nowrap rounded-md border border-composer-border-hover bg-composer-bg-elevated px-2 py-1 shadow-lg pointer-events-auto"
         >
           <span
             data-snap-marker-time-label

--- a/src/views/timeline/snap-marker-pin.tsx
+++ b/src/views/timeline/snap-marker-pin.tsx
@@ -12,6 +12,7 @@ interface SnapMarkerPinProps {
   zoom: number;
   fadeExtent: number;
   isDragging: boolean;
+  isNew: boolean;
   isOnOnset: boolean;
   onHeadPointerDown: (index: number, event: React.PointerEvent<HTMLElement>) => void;
   onDelete: (index: number) => void;
@@ -25,6 +26,7 @@ const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
   zoom,
   fadeExtent,
   isDragging,
+  isNew,
   isOnOnset,
   onHeadPointerDown,
   onDelete,
@@ -43,10 +45,11 @@ const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
       data-snap-marker="custom"
       data-snap-marker-time={time}
       data-snap-marker-drop-in
+      data-snap-marker-new={isNew ? "" : undefined}
       className="absolute top-0"
       style={{ left: time * zoom }}
       variants={pinDropInVariants}
-      initial={reduceMotion ? false : "initial"}
+      initial={isNew && !reduceMotion ? "initial" : false}
       animate="animate"
       onPointerEnter={() => setIsHovered(true)}
       onPointerLeave={() => setIsHovered(false)}

--- a/src/views/timeline/snap-marker-pin.tsx
+++ b/src/views/timeline/snap-marker-pin.tsx
@@ -1,0 +1,88 @@
+import { IconX } from "@tabler/icons-react";
+import { useState } from "react";
+import { formatTime } from "@/utils/format-time";
+
+// -- Types ---------------------------------------------------------------------
+
+interface SnapMarkerPinProps {
+  index: number;
+  time: number;
+  zoom: number;
+  fadeExtent: number;
+  isDragging: boolean;
+  onHeadPointerDown: (index: number, event: React.PointerEvent<HTMLElement>) => void;
+  onDelete: (index: number) => void;
+}
+
+// -- Component -----------------------------------------------------------------
+
+const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
+  index,
+  time,
+  zoom,
+  fadeExtent,
+  isDragging,
+  onHeadPointerDown,
+  onDelete,
+}) => {
+  const [isHovered, setIsHovered] = useState(false);
+  const showTooltip = isHovered && !isDragging;
+
+  return (
+    <div
+      data-snap-marker="custom"
+      data-snap-marker-time={time}
+      className="absolute top-0"
+      style={{ left: time * zoom }}
+      onPointerEnter={() => setIsHovered(true)}
+      onPointerLeave={() => setIsHovered(false)}
+    >
+      <div
+        data-snap-marker-line
+        className="snap-custom-line absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none"
+        style={{ height: fadeExtent }}
+      />
+      <div
+        data-snap-marker-hit
+        className="absolute top-0 left-1/2 -translate-x-1/2 w-3 pointer-events-auto"
+        style={{ height: fadeExtent }}
+      />
+      <button
+        type="button"
+        data-snap-marker-head
+        aria-label={`Custom snap point at ${formatTime(time)}`}
+        className={`snap-custom-head absolute -top-2 left-1/2 pointer-events-auto select-none border-none p-0 ${
+          isDragging ? "cursor-grabbing ring-4 ring-composer-warning/20" : "cursor-grab"
+        }`}
+        onPointerDown={(event) => onHeadPointerDown(index, event)}
+      />
+      {showTooltip && (
+        <div
+          data-snap-marker-tooltip
+          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2.5 flex items-center gap-2 whitespace-nowrap rounded-md border border-composer-border-hover bg-composer-bg-elevated px-2 py-1 shadow-lg pointer-events-auto"
+        >
+          <span
+            data-snap-marker-time-label
+            className="font-mono text-[10.5px] text-composer-text select-text cursor-text"
+          >
+            {formatTime(time)}
+          </span>
+          <button
+            type="button"
+            data-snap-marker-delete
+            aria-label="Delete custom snap point"
+            className="flex items-center text-composer-text-faint hover:text-composer-warning select-none cursor-pointer"
+            onClick={() => onDelete(index)}
+          >
+            <IconX size={12} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// -- Exports -------------------------------------------------------------------
+
+export { SnapMarkerPin };
+export type { SnapMarkerPinProps };

--- a/src/views/timeline/snap-marker-pin.tsx
+++ b/src/views/timeline/snap-marker-pin.tsx
@@ -1,5 +1,7 @@
 import { IconX } from "@tabler/icons-react";
-import { useState } from "react";
+import { m, useReducedMotion } from "motion/react";
+import { useRef, useState } from "react";
+import { pinDropInVariants, snapFlashVariants } from "@/utils/animationVariants";
 import { formatTime } from "@/utils/format-time";
 
 // -- Types ---------------------------------------------------------------------
@@ -10,6 +12,7 @@ interface SnapMarkerPinProps {
   zoom: number;
   fadeExtent: number;
   isDragging: boolean;
+  isOnOnset: boolean;
   onHeadPointerDown: (index: number, event: React.PointerEvent<HTMLElement>) => void;
   onDelete: (index: number) => void;
 }
@@ -22,18 +25,29 @@ const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
   zoom,
   fadeExtent,
   isDragging,
+  isOnOnset,
   onHeadPointerDown,
   onDelete,
 }) => {
+  const reduceMotion = useReducedMotion();
   const [isHovered, setIsHovered] = useState(false);
   const showTooltip = isHovered && !isDragging;
 
+  const wasOnOnsetRef = useRef(false);
+  const [flashKey, setFlashKey] = useState(0);
+  if (isOnOnset && !wasOnOnsetRef.current) setFlashKey((key) => key + 1);
+  wasOnOnsetRef.current = isOnOnset;
+
   return (
-    <div
+    <m.div
       data-snap-marker="custom"
       data-snap-marker-time={time}
+      data-snap-marker-drop-in
       className="absolute top-0"
       style={{ left: time * zoom }}
+      variants={pinDropInVariants}
+      initial={reduceMotion ? false : "initial"}
+      animate="animate"
       onPointerEnter={() => setIsHovered(true)}
       onPointerLeave={() => setIsHovered(false)}
     >
@@ -42,6 +56,18 @@ const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
         className="snap-custom-line absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none"
         style={{ height: fadeExtent }}
       />
+      {flashKey > 0 && (
+        <m.div
+          key={flashKey}
+          data-snap-marker-flash
+          data-flash-key={flashKey}
+          className="snap-marker-flash absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none"
+          style={{ height: fadeExtent }}
+          variants={snapFlashVariants}
+          initial="initial"
+          animate={reduceMotion ? "initial" : "animate"}
+        />
+      )}
       <div
         data-snap-marker-hit
         className="absolute top-0 left-1/2 -translate-x-1/2 w-3 pointer-events-auto"
@@ -78,7 +104,7 @@ const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
           </button>
         </div>
       )}
-    </div>
+    </m.div>
   );
 };
 

--- a/src/views/timeline/snap-marker-pin.tsx
+++ b/src/views/timeline/snap-marker-pin.tsx
@@ -11,7 +11,7 @@ import {
   useInteractions,
   useRole,
 } from "@floating-ui/react";
-import { IconX } from "@tabler/icons-react";
+import { IconTrash } from "@tabler/icons-react";
 import { m, useReducedMotion } from "motion/react";
 import { useRef, useState } from "react";
 import { cn } from "@/utils/cn";
@@ -134,10 +134,10 @@ const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
               type="button"
               data-snap-marker-delete
               aria-label="Delete custom snap point"
-              className="flex items-center text-composer-text-faint hover:text-composer-warning select-none cursor-pointer"
+              className="flex items-center justify-center size-4 text-composer-text-faint hover:text-composer-warning select-none cursor-pointer"
               onClick={() => onDelete(index)}
             >
-              <IconX size={12} />
+              <IconTrash size={13} />
             </button>
           </div>
         </FloatingPortal>

--- a/src/views/timeline/snap-marker-pin.tsx
+++ b/src/views/timeline/snap-marker-pin.tsx
@@ -126,7 +126,7 @@ const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
           >
             <span
               data-snap-marker-time-label
-              className="font-mono text-[10.5px] text-composer-text select-text cursor-text"
+              className="font-mono text-[10.5px] leading-none text-composer-text select-text cursor-text"
             >
               {formatTime(time)}
             </span>

--- a/src/views/timeline/snap-marker-pin.tsx
+++ b/src/views/timeline/snap-marker-pin.tsx
@@ -1,6 +1,20 @@
+import {
+  FloatingPortal,
+  autoUpdate,
+  flip,
+  offset,
+  safePolygon,
+  shift,
+  useDismiss,
+  useFloating,
+  useHover,
+  useInteractions,
+  useRole,
+} from "@floating-ui/react";
 import { IconX } from "@tabler/icons-react";
 import { m, useReducedMotion } from "motion/react";
 import { useRef, useState } from "react";
+import { cn } from "@/utils/cn";
 import { pinDropInVariants, snapFlashVariants } from "@/utils/animationVariants";
 import { formatTime } from "@/utils/format-time";
 
@@ -32,13 +46,32 @@ const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
   onDelete,
 }) => {
   const reduceMotion = useReducedMotion();
-  const [isHovered, setIsHovered] = useState(false);
-  const showTooltip = isHovered && !isDragging;
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { refs, floatingStyles, context } = useFloating({
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    placement: "bottom",
+    middleware: [offset(8), flip(), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
+  });
+
+  const hover = useHover(context, {
+    enabled: !isDragging,
+    handleClose: safePolygon(),
+    delay: { open: 0, close: 60 },
+  });
+  const role = useRole(context, { role: "tooltip" });
+  const dismiss = useDismiss(context);
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([hover, role, dismiss]);
 
   const wasOnOnsetRef = useRef(false);
   const [flashKey, setFlashKey] = useState(0);
   if (isOnOnset && !wasOnOnsetRef.current) setFlashKey((key) => key + 1);
   wasOnOnsetRef.current = isOnOnset;
+
+  const showTooltip = isOpen && !isDragging;
 
   return (
     <m.div
@@ -51,8 +84,6 @@ const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
       variants={pinDropInVariants}
       initial={isNew && !reduceMotion ? "initial" : false}
       animate="animate"
-      onPointerEnter={() => setIsHovered(true)}
-      onPointerLeave={() => setIsHovered(false)}
     >
       <div
         data-snap-marker-line
@@ -71,41 +102,45 @@ const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
           animate={reduceMotion ? "initial" : "animate"}
         />
       )}
-      <div
-        data-snap-marker-hit
-        className="absolute top-0 left-1/2 -translate-x-1/2 w-3 pointer-events-auto"
-        style={{ height: fadeExtent }}
-      />
       <button
+        ref={refs.setReference}
         type="button"
         data-snap-marker-head
         aria-label={`Custom snap point at ${formatTime(time)}`}
-        className={`snap-custom-head absolute top-0 left-1/2 pointer-events-auto select-none border-none p-0 ${
-          isDragging ? "cursor-grabbing ring-4 ring-composer-warning/20" : "cursor-grab"
-        }`}
-        onPointerDown={(event) => onHeadPointerDown(index, event)}
+        className={cn(
+          "snap-custom-head expanded-hit-sm absolute top-0 left-1/2 pointer-events-auto select-none border-none p-0",
+          isDragging ? "cursor-grabbing ring-4 ring-composer-warning/20" : "cursor-grab",
+        )}
+        {...getReferenceProps({
+          onPointerDown: (event: React.PointerEvent<HTMLElement>) => onHeadPointerDown(index, event),
+        })}
       />
       {showTooltip && (
-        <div
-          data-snap-marker-tooltip
-          className="absolute top-6 left-1/2 -translate-x-1/2 flex items-center gap-2 whitespace-nowrap rounded-md border border-composer-border-hover bg-composer-bg-elevated px-2 py-1 shadow-lg pointer-events-auto"
-        >
-          <span
-            data-snap-marker-time-label
-            className="font-mono text-[10.5px] text-composer-text select-text cursor-text"
+        <FloatingPortal>
+          <div
+            ref={refs.setFloating}
+            data-snap-marker-tooltip
+            className="z-100 flex items-center gap-2 whitespace-nowrap rounded-md border border-composer-border-hover bg-composer-bg-elevated px-2 py-1 shadow-lg pointer-events-auto"
+            style={floatingStyles}
+            {...getFloatingProps()}
           >
-            {formatTime(time)}
-          </span>
-          <button
-            type="button"
-            data-snap-marker-delete
-            aria-label="Delete custom snap point"
-            className="flex items-center text-composer-text-faint hover:text-composer-warning select-none cursor-pointer"
-            onClick={() => onDelete(index)}
-          >
-            <IconX size={12} />
-          </button>
-        </div>
+            <span
+              data-snap-marker-time-label
+              className="font-mono text-[10.5px] text-composer-text select-text cursor-text"
+            >
+              {formatTime(time)}
+            </span>
+            <button
+              type="button"
+              data-snap-marker-delete
+              aria-label="Delete custom snap point"
+              className="flex items-center text-composer-text-faint hover:text-composer-warning select-none cursor-pointer"
+              onClick={() => onDelete(index)}
+            >
+              <IconX size={12} />
+            </button>
+          </div>
+        </FloatingPortal>
       )}
     </m.div>
   );

--- a/src/views/timeline/snap-marker-pin.tsx
+++ b/src/views/timeline/snap-marker-pin.tsx
@@ -80,7 +80,7 @@ const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
         type="button"
         data-snap-marker-head
         aria-label={`Custom snap point at ${formatTime(time)}`}
-        className={`snap-custom-head absolute -top-2 left-1/2 pointer-events-auto select-none border-none p-0 ${
+        className={`snap-custom-head absolute top-1 left-1/2 pointer-events-auto select-none border-none p-0 ${
           isDragging ? "cursor-grabbing ring-4 ring-composer-warning/20" : "cursor-grab"
         }`}
         onPointerDown={(event) => onHeadPointerDown(index, event)}
@@ -88,7 +88,7 @@ const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
       {showTooltip && (
         <div
           data-snap-marker-tooltip
-          className="absolute top-4 left-1/2 -translate-x-1/2 flex items-center gap-2 whitespace-nowrap rounded-md border border-composer-border-hover bg-composer-bg-elevated px-2 py-1 shadow-lg pointer-events-auto"
+          className="absolute top-6 left-1/2 -translate-x-1/2 flex items-center gap-2 whitespace-nowrap rounded-md border border-composer-border-hover bg-composer-bg-elevated px-2 py-1 shadow-lg pointer-events-auto"
         >
           <span
             data-snap-marker-time-label

--- a/src/views/timeline/snap-marker-pin.tsx
+++ b/src/views/timeline/snap-marker-pin.tsx
@@ -80,7 +80,7 @@ const SnapMarkerPin: React.FC<SnapMarkerPinProps> = ({
         type="button"
         data-snap-marker-head
         aria-label={`Custom snap point at ${formatTime(time)}`}
-        className={`snap-custom-head absolute top-1 left-1/2 pointer-events-auto select-none border-none p-0 ${
+        className={`snap-custom-head absolute top-0 left-1/2 pointer-events-auto select-none border-none p-0 ${
           isDragging ? "cursor-grabbing ring-4 ring-composer-warning/20" : "cursor-grab"
         }`}
         onPointerDown={(event) => onHeadPointerDown(index, event)}

--- a/src/views/timeline/snap-markers-overlay.animation.browser.test.tsx
+++ b/src/views/timeline/snap-markers-overlay.animation.browser.test.tsx
@@ -1,0 +1,145 @@
+import { useRef } from "react";
+import { describe, expect, it } from "vitest";
+import { useSettingsStore } from "@/stores/settings";
+import { render } from "@/test/render";
+import { SnapMarkersOverlay } from "@/views/timeline/snap-markers-overlay";
+import { GUTTER_WIDTH, useTimelineStore } from "@/views/timeline/timeline-store";
+
+// -- Harness -------------------------------------------------------------------
+
+const Harness: React.FC = () => {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  return (
+    <div ref={scrollContainerRef} style={{ width: 600, height: 200, position: "relative" }}>
+      <SnapMarkersOverlay scrollContainerRef={scrollContainerRef} />
+    </div>
+  );
+};
+
+const customMarkers = (container: HTMLElement): NodeListOf<HTMLElement> =>
+  container.querySelectorAll<HTMLElement>("[data-snap-marker='custom']");
+
+const flashes = (container: HTMLElement): NodeListOf<HTMLElement> =>
+  container.querySelectorAll<HTMLElement>("[data-snap-marker-flash]");
+
+const headOf = (marker: HTMLElement): HTMLElement => {
+  const head = marker.querySelector<HTMLElement>("[data-snap-marker-head]");
+  if (!head) throw new Error("pin head not found");
+  return head;
+};
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("SnapMarkersOverlay placement animation", () => {
+  it("flashes a custom pin that is seeded on top of an onset", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({
+      zoom: 100,
+      scrollLeft: 0,
+      vocalOnsetSnapPoints: [2],
+      customSnapPoints: [2],
+    });
+
+    const screen = await render(<Harness />);
+    await expect.poll(() => flashes(screen.container)).toHaveLength(1);
+  });
+
+  it("does not flash a custom pin placed away from every onset", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({
+      zoom: 100,
+      scrollLeft: 0,
+      vocalOnsetSnapPoints: [2],
+      customSnapPoints: [5],
+    });
+
+    const screen = await render(<Harness />);
+    await expect.poll(() => customMarkers(screen.container)).toHaveLength(1);
+    expect(flashes(screen.container)).toHaveLength(0);
+  });
+
+  it("fires a flash when a dragged pin lands on an onset", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({
+      zoom: 100,
+      scrollLeft: 0,
+      vocalOnsetSnapPoints: [5],
+      customSnapPoints: [2],
+    });
+
+    const screen = await render(<Harness />);
+    await expect.poll(() => flashes(screen.container)).toHaveLength(0);
+
+    const head = headOf(customMarkers(screen.container)[0]);
+    const rect = screen.container.firstElementChild?.getBoundingClientRect();
+    if (!rect) throw new Error("scroll container rect missing");
+
+    head.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerId: 1 }));
+    const onOnsetClientX = rect.left + GUTTER_WIDTH + 5 * 100;
+    head.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX: onOnsetClientX, pointerId: 1 }));
+
+    await expect.poll(() => flashes(screen.container)).toHaveLength(1);
+
+    head.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+  });
+
+  it("keeps a single pin mounted across a drag (no remount/replay)", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: false, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({
+      zoom: 100,
+      scrollLeft: 0,
+      vocalOnsetSnapPoints: [],
+      customSnapPoints: [2],
+    });
+
+    const screen = await render(<Harness />);
+    const pinBefore = customMarkers(screen.container)[0];
+
+    const head = headOf(pinBefore);
+    const rect = screen.container.firstElementChild?.getBoundingClientRect();
+    if (!rect) throw new Error("scroll container rect missing");
+
+    head.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerId: 1 }));
+    for (const targetTime of [3, 4, 5, 6]) {
+      const clientX = rect.left + GUTTER_WIDTH + targetTime * 100;
+      head.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX, pointerId: 1 }));
+    }
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(6, 5);
+    // Positional key keeps the same DOM node mounted: count stays 1 and the
+    // node identity is preserved across every pointermove.
+    expect(customMarkers(screen.container)).toHaveLength(1);
+    expect(customMarkers(screen.container)[0]).toBe(pinBefore);
+
+    head.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+  });
+
+  it("does not flash unrelated pins when the array re-sorts mid-drag", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({
+      zoom: 100,
+      scrollLeft: 0,
+      vocalOnsetSnapPoints: [9],
+      customSnapPoints: [2, 4],
+    });
+
+    const screen = await render(<Harness />);
+    await expect.poll(() => customMarkers(screen.container)).toHaveLength(2);
+    expect(flashes(screen.container)).toHaveLength(0);
+
+    const head = headOf(customMarkers(screen.container)[0]);
+    const rect = screen.container.firstElementChild?.getBoundingClientRect();
+    if (!rect) throw new Error("scroll container rect missing");
+
+    head.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerId: 1 }));
+    // Drag the first pin past the second; the store re-sorts but neither pin
+    // is on an onset, so no flash should ever appear.
+    const clientX = rect.left + GUTTER_WIDTH + 6 * 100;
+    head.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX, pointerId: 1 }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints).toEqual([4, 6]);
+    expect(flashes(screen.container)).toHaveLength(0);
+
+    head.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+  });
+});

--- a/src/views/timeline/snap-markers-overlay.animation.browser.test.tsx
+++ b/src/views/timeline/snap-markers-overlay.animation.browser.test.tsx
@@ -22,6 +22,9 @@ const customMarkers = (container: HTMLElement): NodeListOf<HTMLElement> =>
 const flashes = (container: HTMLElement): NodeListOf<HTMLElement> =>
   container.querySelectorAll<HTMLElement>("[data-snap-marker-flash]");
 
+const newPins = (container: HTMLElement): NodeListOf<HTMLElement> =>
+  container.querySelectorAll<HTMLElement>("[data-snap-marker-new]");
+
 const headOf = (marker: HTMLElement): HTMLElement => {
   const head = marker.querySelector<HTMLElement>("[data-snap-marker-head]");
   if (!head) throw new Error("pin head not found");
@@ -139,6 +142,94 @@ describe("SnapMarkersOverlay placement animation", () => {
 
     await expect.poll(() => useTimelineStore.getState().customSnapPoints).toEqual([4, 6]);
     expect(flashes(screen.container)).toHaveLength(0);
+
+    head.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+  });
+});
+
+describe("SnapMarkersOverlay drop-in freshness", () => {
+  it("does not flag any pin as new on first render of pre-existing points", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: false, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [], customSnapPoints: [1, 4, 7] });
+
+    const screen = await render(<Harness />);
+    await expect.poll(() => customMarkers(screen.container)).toHaveLength(3);
+    expect(newPins(screen.container)).toHaveLength(0);
+  });
+
+  it("drops in the appended pin", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: false, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [], customSnapPoints: [1, 3] });
+
+    const screen = await render(<Harness />);
+    await expect.poll(() => customMarkers(screen.container)).toHaveLength(2);
+
+    useTimelineStore.setState({ customSnapPoints: [1, 3, 5] });
+
+    await expect.poll(() => newPins(screen.container)).toHaveLength(1);
+    expect(newPins(screen.container)[0].getAttribute("data-snap-marker-time")).toBe("5");
+    expect(newPins(screen.container)[0].style.left).toBe("500px");
+  });
+
+  it("drops in the value-2 pin (not value-3) on a middle insert", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: false, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [], customSnapPoints: [1, 3] });
+
+    const screen = await render(<Harness />);
+    await expect.poll(() => customMarkers(screen.container)).toHaveLength(2);
+
+    useTimelineStore.setState({ customSnapPoints: [1, 2, 3] });
+
+    await expect.poll(() => newPins(screen.container)).toHaveLength(1);
+    // The genuinely-new value-2 pin (left = 2 * zoom) animates in, NOT the
+    // shifted value-3 pin that React reuses at the last positional key.
+    expect(newPins(screen.container)[0].getAttribute("data-snap-marker-time")).toBe("2");
+    expect(newPins(screen.container)[0].style.left).toBe("200px");
+  });
+
+  it("does not flag any pin on a move (same count, one value changed)", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: false, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [], customSnapPoints: [2, 4] });
+
+    const screen = await render(<Harness />);
+    await expect.poll(() => customMarkers(screen.container)).toHaveLength(2);
+
+    useTimelineStore.setState({ customSnapPoints: [4, 6] });
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints).toEqual([4, 6]);
+    expect(newPins(screen.container)).toHaveLength(0);
+  });
+
+  it("does not flag any pin on a delete", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: false, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [], customSnapPoints: [1, 2, 3] });
+
+    const screen = await render(<Harness />);
+    await expect.poll(() => customMarkers(screen.container)).toHaveLength(3);
+
+    useTimelineStore.setState({ customSnapPoints: [1, 3] });
+
+    await expect.poll(() => customMarkers(screen.container)).toHaveLength(2);
+    expect(newPins(screen.container)).toHaveLength(0);
+  });
+
+  it("does not flag a dragged pin as new across pointermoves", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: false, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [], customSnapPoints: [2] });
+
+    const screen = await render(<Harness />);
+    const head = headOf(customMarkers(screen.container)[0]);
+    const rect = screen.container.firstElementChild?.getBoundingClientRect();
+    if (!rect) throw new Error("scroll container rect missing");
+
+    head.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerId: 1 }));
+    for (const targetTime of [3, 4, 5]) {
+      const clientX = rect.left + GUTTER_WIDTH + targetTime * 100;
+      head.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX, pointerId: 1 }));
+    }
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(5, 5);
+    expect(newPins(screen.container)).toHaveLength(0);
 
     head.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
   });

--- a/src/views/timeline/snap-markers-overlay.browser.test.tsx
+++ b/src/views/timeline/snap-markers-overlay.browser.test.tsx
@@ -3,8 +3,8 @@ import { userEvent } from "vitest/browser";
 import { describe, expect, it, vi } from "vitest";
 import { useSettingsStore } from "@/stores/settings";
 import { render } from "@/test/render";
-import { MARKER_HEAD_CLEARANCE, SnapMarkersOverlay } from "@/views/timeline/snap-markers-overlay";
-import { GUTTER_WIDTH, useTimelineStore } from "@/views/timeline/timeline-store";
+import { SnapMarkersOverlay } from "@/views/timeline/snap-markers-overlay";
+import { GUTTER_WIDTH, useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
 
 // -- Harness -------------------------------------------------------------------
 
@@ -68,16 +68,27 @@ describe("SnapMarkersOverlay", () => {
     expect(root?.style.clipPath).toBe(`inset(0px 0px 0px ${GUTTER_WIDTH}px)`);
   });
 
-  it("translates the inner layer by GUTTER_WIDTH and head clearance when scrollLeft is 0", async () => {
+  it("renders onset markers at full height and contains custom pins to the waveform", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: true });
+    useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [1], customSnapPoints: [2] });
+
+    const screen = await render(<Harness />);
+    const [onset] = onsetMarkers(screen.container);
+    const [pin] = customMarkers(screen.container);
+    const pinLine = pin.querySelector<HTMLElement>("[data-snap-marker-line]");
+
+    expect(onset.style.height).toBe("100%");
+    expect(pinLine?.style.height).toBe(`${WAVEFORM_HEIGHT}px`);
+  });
+
+  it("translates the inner layer by GUTTER_WIDTH when scrollLeft is 0", async () => {
     useSettingsStore.setState({ vocalOnsetSnap: true });
     useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [1] });
 
     const screen = await render(<Harness />);
     const layer = screen.container.querySelector<HTMLElement>("[data-snap-markers-layer]");
 
-    await expect
-      .poll(() => layer?.style.transform)
-      .toBe(`translate3d(${GUTTER_WIDTH}px, ${MARKER_HEAD_CLEARANCE}px, 0px)`);
+    await expect.poll(() => layer?.style.transform).toBe(`translate3d(${GUTTER_WIDTH}px, 0px, 0px)`);
   });
 
   describe("visibility", () => {

--- a/src/views/timeline/snap-markers-overlay.browser.test.tsx
+++ b/src/views/timeline/snap-markers-overlay.browser.test.tsx
@@ -101,6 +101,20 @@ describe("SnapMarkersOverlay", () => {
       expect(screen.container.querySelector("[data-snap-markers-overlay]")).toBeNull();
     });
 
+    it("renders null when onsets are enabled but there are no points and marker mode is off", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [],
+        customSnapPoints: [],
+        markerMode: false,
+      });
+
+      const screen = await render(<Harness />);
+      expect(screen.container.querySelector("[data-snap-markers-overlay]")).toBeNull();
+    });
+
     it("stays mounted when marker mode is on even with nothing to show", async () => {
       useSettingsStore.setState({ vocalOnsetSnap: false });
       useTimelineStore.setState({

--- a/src/views/timeline/snap-markers-overlay.browser.test.tsx
+++ b/src/views/timeline/snap-markers-overlay.browser.test.tsx
@@ -1,0 +1,123 @@
+import { useRef } from "react";
+import { describe, expect, it } from "vitest";
+import { useSettingsStore } from "@/stores/settings";
+import { render } from "@/test/render";
+import { SnapMarkersOverlay } from "@/views/timeline/snap-markers-overlay";
+import { GUTTER_WIDTH, useTimelineStore } from "@/views/timeline/timeline-store";
+
+// -- Harness -------------------------------------------------------------------
+
+const Harness: React.FC = () => {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  return (
+    <div ref={scrollContainerRef} style={{ width: 600, height: 200, position: "relative" }}>
+      <SnapMarkersOverlay scrollContainerRef={scrollContainerRef} />
+    </div>
+  );
+};
+
+const onsetMarkers = (container: HTMLElement): NodeListOf<HTMLElement> =>
+  container.querySelectorAll<HTMLElement>("[data-snap-marker='onset']");
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("SnapMarkersOverlay", () => {
+  it("renders one onset marker per snap point at left = time * zoom", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: true });
+    useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [1, 2] });
+
+    const screen = await render(<Harness />);
+    const markers = onsetMarkers(screen.container);
+
+    expect(markers).toHaveLength(2);
+    expect(markers[0].style.left).toBe("100px");
+    expect(markers[1].style.left).toBe("200px");
+  });
+
+  it("styles each onset marker with the dashed onset-line utility", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: true });
+    useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [1] });
+
+    const screen = await render(<Harness />);
+    const [marker] = onsetMarkers(screen.container);
+
+    expect(marker.classList.contains("snap-onset-line")).toBe(true);
+  });
+
+  it("clips the overlay root to the right of the gutter", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: true });
+    useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [1] });
+
+    const screen = await render(<Harness />);
+    const root = screen.container.querySelector<HTMLElement>("[data-snap-markers-overlay]");
+
+    expect(root).not.toBeNull();
+    expect(root?.style.clipPath).toBe(`inset(0px 0px 0px ${GUTTER_WIDTH}px)`);
+  });
+
+  it("translates the inner layer by GUTTER_WIDTH when scrollLeft is 0", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: true });
+    useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [1] });
+
+    const screen = await render(<Harness />);
+    const layer = screen.container.querySelector<HTMLElement>("[data-snap-markers-layer]");
+
+    await expect.poll(() => layer?.style.transform).toBe(`translate3d(${GUTTER_WIDTH}px, 0px, 0px)`);
+  });
+
+  describe("visibility", () => {
+    it("renders no onset markers when vocalOnsetSnap is off", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: false });
+      useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [1, 2] });
+
+      const screen = await render(<Harness />);
+      expect(onsetMarkers(screen.container)).toHaveLength(0);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("renders no onset markers when there are no snap points", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true });
+      useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [] });
+
+      const screen = await render(<Harness />);
+      expect(onsetMarkers(screen.container)).toHaveLength(0);
+    });
+
+    it("places a marker at the timeline origin", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true });
+      useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [0] });
+
+      const screen = await render(<Harness />);
+      const [marker] = onsetMarkers(screen.container);
+      expect(marker.style.left).toBe("0px");
+    });
+  });
+
+  describe("reactivity", () => {
+    it("re-lays out markers when zoom changes", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true });
+      useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [1, 2] });
+
+      const screen = await render(<Harness />);
+      await expect.poll(() => onsetMarkers(screen.container)[0]?.style.left).toBe("100px");
+
+      useTimelineStore.setState({ zoom: 50 });
+
+      await expect.poll(() => onsetMarkers(screen.container)[0]?.style.left).toBe("50px");
+      await expect.poll(() => onsetMarkers(screen.container)[1]?.style.left).toBe("100px");
+    });
+
+    it("shows markers when the setting is toggled on", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: false });
+      useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [1] });
+
+      const screen = await render(<Harness />);
+      await expect.poll(() => onsetMarkers(screen.container)).toHaveLength(0);
+
+      useSettingsStore.getState().set("vocalOnsetSnap", true);
+
+      await expect.poll(() => onsetMarkers(screen.container)).toHaveLength(1);
+    });
+  });
+});

--- a/src/views/timeline/snap-markers-overlay.browser.test.tsx
+++ b/src/views/timeline/snap-markers-overlay.browser.test.tsx
@@ -429,10 +429,11 @@ describe("SnapMarkersOverlay", () => {
       await userEvent.hover(headOf(secondPin));
 
       const deleteButton = await vi.waitFor(() => {
-        const button = secondPin.querySelector<HTMLButtonElement>("[data-snap-marker-delete]");
+        const button = document.body.querySelector<HTMLButtonElement>("[data-snap-marker-delete]");
         if (!button) throw new Error("delete button not yet rendered");
         return button;
       });
+      await userEvent.hover(deleteButton);
       await userEvent.click(deleteButton);
 
       await expect.poll(() => useTimelineStore.getState().customSnapPoints).toEqual([1, 3]);

--- a/src/views/timeline/snap-markers-overlay.browser.test.tsx
+++ b/src/views/timeline/snap-markers-overlay.browser.test.tsx
@@ -86,6 +86,62 @@ describe("SnapMarkersOverlay", () => {
       const screen = await render(<Harness />);
       expect(onsetMarkers(screen.container)).toHaveLength(0);
     });
+
+    it("renders null when there is nothing to show and marker mode is off", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: false });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [1, 2],
+        customSnapPoints: [],
+        markerMode: false,
+      });
+
+      const screen = await render(<Harness />);
+      expect(screen.container.querySelector("[data-snap-markers-overlay]")).toBeNull();
+    });
+
+    it("stays mounted when marker mode is on even with nothing to show", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: false });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [],
+        customSnapPoints: [],
+        markerMode: true,
+      });
+
+      const screen = await render(<Harness />);
+      expect(screen.container.querySelector("[data-snap-markers-overlay]")).not.toBeNull();
+    });
+
+    it("stays mounted when custom points exist and marker mode is off", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: false });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [],
+        customSnapPoints: [2],
+        markerMode: false,
+      });
+
+      const screen = await render(<Harness />);
+      expect(screen.container.querySelector("[data-snap-markers-overlay]")).not.toBeNull();
+    });
+
+    it("stays mounted when onsets are visible and marker mode is off", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [1],
+        customSnapPoints: [],
+        markerMode: false,
+      });
+
+      const screen = await render(<Harness />);
+      expect(screen.container.querySelector("[data-snap-markers-overlay]")).not.toBeNull();
+    });
   });
 
   describe("edge cases", () => {

--- a/src/views/timeline/snap-markers-overlay.browser.test.tsx
+++ b/src/views/timeline/snap-markers-overlay.browser.test.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
-import { describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
+import { describe, expect, it, vi } from "vitest";
 import { useSettingsStore } from "@/stores/settings";
 import { render } from "@/test/render";
 import { SnapMarkersOverlay } from "@/views/timeline/snap-markers-overlay";
@@ -18,6 +19,18 @@ const Harness: React.FC = () => {
 
 const onsetMarkers = (container: HTMLElement): NodeListOf<HTMLElement> =>
   container.querySelectorAll<HTMLElement>("[data-snap-marker='onset']");
+
+const customMarkers = (container: HTMLElement): NodeListOf<HTMLElement> =>
+  container.querySelectorAll<HTMLElement>("[data-snap-marker='custom']");
+
+const coveredOnsets = (container: HTMLElement): NodeListOf<HTMLElement> =>
+  container.querySelectorAll<HTMLElement>("[data-snap-marker='onset'][data-covered]");
+
+const headOf = (marker: HTMLElement): HTMLElement => {
+  const head = marker.querySelector<HTMLElement>("[data-snap-marker-head]");
+  if (!head) throw new Error("pin head not found");
+  return head;
+};
 
 // -- Tests ---------------------------------------------------------------------
 
@@ -118,6 +131,228 @@ describe("SnapMarkersOverlay", () => {
       useSettingsStore.getState().set("vocalOnsetSnap", true);
 
       await expect.poll(() => onsetMarkers(screen.container)).toHaveLength(1);
+    });
+  });
+
+  describe("custom pins", () => {
+    it("renders one pin per custom snap point with a draggable head", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [],
+        customSnapPoints: [1, 3],
+      });
+
+      const screen = await render(<Harness />);
+      const pins = customMarkers(screen.container);
+      expect(pins).toHaveLength(2);
+      expect(pins[0].style.left).toBe("100px");
+      expect(pins[1].style.left).toBe("300px");
+      expect(pins[0].querySelector("[data-snap-marker-head]")).not.toBeNull();
+    });
+
+    it("renders pins above the onset layer", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [5],
+        customSnapPoints: [2],
+      });
+
+      const screen = await render(<Harness />);
+      const onsetLayer = screen.container.querySelector<HTMLElement>("[data-snap-marker='onset']")?.parentElement;
+      const customLayer = customMarkers(screen.container)[0]?.parentElement;
+      expect(onsetLayer?.classList.contains("z-10")).toBe(true);
+      expect(customLayer?.classList.contains("z-20")).toBe(true);
+    });
+  });
+
+  describe("covered onsets", () => {
+    it("covers a coincident onset so its line is suppressed", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [2],
+        customSnapPoints: [2],
+      });
+
+      const screen = await render(<Harness />);
+      await expect.poll(() => coveredOnsets(screen.container)).toHaveLength(1);
+      const onset = onsetMarkers(screen.container)[0];
+      expect(onset.classList.contains("snap-onset-covered")).toBe(true);
+    });
+
+    it("leaves an onset visible when no custom point is within threshold", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [2],
+        customSnapPoints: [5],
+      });
+
+      const screen = await render(<Harness />);
+      await expect.poll(() => coveredOnsets(screen.container)).toHaveLength(0);
+    });
+
+    it("reveals the onset again when the custom point moves away", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [2],
+        customSnapPoints: [2],
+      });
+
+      const screen = await render(<Harness />);
+      await expect.poll(() => coveredOnsets(screen.container)).toHaveLength(1);
+
+      useTimelineStore.getState().moveCustomSnapPoint(0, 8);
+
+      await expect.poll(() => coveredOnsets(screen.container)).toHaveLength(0);
+    });
+
+    it("covers only the onset within threshold among several", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [1, 2, 3],
+        customSnapPoints: [2],
+      });
+
+      const screen = await render(<Harness />);
+      await expect.poll(() => coveredOnsets(screen.container)).toHaveLength(1);
+      const onsets = onsetMarkers(screen.container);
+      expect(onsets[1].classList.contains("snap-onset-covered")).toBe(true);
+      expect(onsets[0].classList.contains("snap-onset-covered")).toBe(false);
+      expect(onsets[2].classList.contains("snap-onset-covered")).toBe(false);
+    });
+  });
+
+  describe("drag", () => {
+    it("updates moveCustomSnapPoint as the head is dragged", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: false, timelineSnapThreshold: 12 });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [],
+        customSnapPoints: [2],
+      });
+
+      const screen = await render(<Harness />);
+      const head = headOf(customMarkers(screen.container)[0]);
+      const rect = screen.container.firstElementChild?.getBoundingClientRect();
+      if (!rect) throw new Error("scroll container rect missing");
+
+      head.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerId: 1 }));
+      const targetClientX = rect.left + GUTTER_WIDTH + 5 * 100;
+      head.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX: targetClientX, pointerId: 1 }));
+
+      await expect.poll(() => useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(5, 5);
+
+      head.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+    });
+
+    it("snaps the dragged head onto an onset within threshold", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [5],
+        customSnapPoints: [2],
+      });
+
+      const screen = await render(<Harness />);
+      const head = headOf(customMarkers(screen.container)[0]);
+      const rect = screen.container.firstElementChild?.getBoundingClientRect();
+      if (!rect) throw new Error("scroll container rect missing");
+
+      head.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerId: 1 }));
+      const nearOnsetClientX = rect.left + GUTTER_WIDTH + 5.08 * 100;
+      head.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX: nearOnsetClientX, pointerId: 1 }));
+
+      await expect.poll(() => useTimelineStore.getState().customSnapPoints[0]).toBe(5);
+
+      head.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+    });
+
+    it("does not snap onto an onset outside threshold", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [5],
+        customSnapPoints: [2],
+      });
+
+      const screen = await render(<Harness />);
+      const head = headOf(customMarkers(screen.container)[0]);
+      const rect = screen.container.firstElementChild?.getBoundingClientRect();
+      if (!rect) throw new Error("scroll container rect missing");
+
+      head.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerId: 1 }));
+      const farFromOnsetClientX = rect.left + GUTTER_WIDTH + 5.3 * 100;
+      head.dispatchEvent(
+        new PointerEvent("pointermove", { bubbles: true, clientX: farFromOnsetClientX, pointerId: 1 }),
+      );
+
+      await expect.poll(() => useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(5.3, 5);
+
+      head.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+    });
+
+    it("covers an onset live while a pin is dragged over it", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [5],
+        customSnapPoints: [2],
+      });
+
+      const screen = await render(<Harness />);
+      await expect.poll(() => coveredOnsets(screen.container)).toHaveLength(0);
+
+      const head = headOf(customMarkers(screen.container)[0]);
+      const rect = screen.container.firstElementChild?.getBoundingClientRect();
+      if (!rect) throw new Error("scroll container rect missing");
+
+      head.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerId: 1 }));
+      const onOnsetClientX = rect.left + GUTTER_WIDTH + 5 * 100;
+      head.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX: onOnsetClientX, pointerId: 1 }));
+
+      await expect.poll(() => coveredOnsets(screen.container)).toHaveLength(1);
+
+      head.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+    });
+  });
+
+  describe("delete", () => {
+    it("removes the correct pin when several exist", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: false });
+      useTimelineStore.setState({
+        zoom: 100,
+        scrollLeft: 0,
+        vocalOnsetSnapPoints: [],
+        customSnapPoints: [1, 2, 3],
+      });
+
+      const screen = await render(<Harness />);
+      const secondPin = customMarkers(screen.container)[1];
+      await userEvent.hover(headOf(secondPin));
+
+      const deleteButton = await vi.waitFor(() => {
+        const button = secondPin.querySelector<HTMLButtonElement>("[data-snap-marker-delete]");
+        if (!button) throw new Error("delete button not yet rendered");
+        return button;
+      });
+      await userEvent.click(deleteButton);
+
+      await expect.poll(() => useTimelineStore.getState().customSnapPoints).toEqual([1, 3]);
     });
   });
 });

--- a/src/views/timeline/snap-markers-overlay.browser.test.tsx
+++ b/src/views/timeline/snap-markers-overlay.browser.test.tsx
@@ -3,7 +3,7 @@ import { userEvent } from "vitest/browser";
 import { describe, expect, it, vi } from "vitest";
 import { useSettingsStore } from "@/stores/settings";
 import { render } from "@/test/render";
-import { SnapMarkersOverlay } from "@/views/timeline/snap-markers-overlay";
+import { MARKER_HEAD_CLEARANCE, SnapMarkersOverlay } from "@/views/timeline/snap-markers-overlay";
 import { GUTTER_WIDTH, useTimelineStore } from "@/views/timeline/timeline-store";
 
 // -- Harness -------------------------------------------------------------------
@@ -68,14 +68,16 @@ describe("SnapMarkersOverlay", () => {
     expect(root?.style.clipPath).toBe(`inset(0px 0px 0px ${GUTTER_WIDTH}px)`);
   });
 
-  it("translates the inner layer by GUTTER_WIDTH when scrollLeft is 0", async () => {
+  it("translates the inner layer by GUTTER_WIDTH and head clearance when scrollLeft is 0", async () => {
     useSettingsStore.setState({ vocalOnsetSnap: true });
     useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [1] });
 
     const screen = await render(<Harness />);
     const layer = screen.container.querySelector<HTMLElement>("[data-snap-markers-layer]");
 
-    await expect.poll(() => layer?.style.transform).toBe(`translate3d(${GUTTER_WIDTH}px, 0px, 0px)`);
+    await expect
+      .poll(() => layer?.style.transform)
+      .toBe(`translate3d(${GUTTER_WIDTH}px, ${MARKER_HEAD_CLEARANCE}px, 0px)`);
   });
 
   describe("visibility", () => {

--- a/src/views/timeline/snap-markers-overlay.browser.test.tsx
+++ b/src/views/timeline/snap-markers-overlay.browser.test.tsx
@@ -68,7 +68,7 @@ describe("SnapMarkersOverlay", () => {
     expect(root?.style.clipPath).toBe(`inset(0px 0px 0px ${GUTTER_WIDTH}px)`);
   });
 
-  it("renders onset markers at full height and contains custom pins to the waveform", async () => {
+  it("contains both onset markers and custom pins to the waveform height", async () => {
     useSettingsStore.setState({ vocalOnsetSnap: true });
     useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [1], customSnapPoints: [2] });
 
@@ -77,7 +77,7 @@ describe("SnapMarkersOverlay", () => {
     const [pin] = customMarkers(screen.container);
     const pinLine = pin.querySelector<HTMLElement>("[data-snap-marker-line]");
 
-    expect(onset.style.height).toBe("100%");
+    expect(onset.style.height).toBe(`${WAVEFORM_HEIGHT}px`);
     expect(pinLine?.style.height).toBe(`${WAVEFORM_HEIGHT}px`);
   });
 

--- a/src/views/timeline/snap-markers-overlay.tsx
+++ b/src/views/timeline/snap-markers-overlay.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import { useSettingsStore } from "@/stores/settings";
 import { SnapMarkerPin } from "@/views/timeline/snap-marker-pin";
-import { computeCoveredOnsets, isTimeOnOnset } from "@/views/timeline/snap-marker-math";
+import { computeCoveredOnsets, findInsertedValue, isTimeOnOnset } from "@/views/timeline/snap-marker-math";
 import { useSnapMarkerDrag } from "@/views/timeline/use-snap-marker-drag";
 import { GUTTER_WIDTH, useTimelineStore } from "@/views/timeline/timeline-store";
 
@@ -26,6 +26,10 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
   const thresholdPx = useSettingsStore((s) => s.timelineSnapThreshold);
 
   const { draggingTime, onHeadPointerDown } = useSnapMarkerDrag({ scrollContainerRef });
+
+  const prevCustomSnapPointsRef = useRef(customSnapPoints);
+  const insertedValue = findInsertedValue(prevCustomSnapPointsRef.current, customSnapPoints);
+  prevCustomSnapPointsRef.current = customSnapPoints;
 
   const coveredOnsets = useMemo(() => {
     if (!showOnsets) return new Set<number>();
@@ -90,6 +94,7 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
               zoom={zoom}
               fadeExtent={MARKER_FADE_EXTENT}
               isDragging={draggingTime !== null && time === draggingTime}
+              isNew={insertedValue !== null && time === insertedValue}
               isOnOnset={showOnsets && isTimeOnOnset(time, vocalOnsetSnapPoints, zoom, thresholdPx)}
               onHeadPointerDown={onHeadPointerDown}
               onDelete={removeCustomSnapPoint}

--- a/src/views/timeline/snap-markers-overlay.tsx
+++ b/src/views/timeline/snap-markers-overlay.tsx
@@ -3,7 +3,7 @@ import { useSettingsStore } from "@/stores/settings";
 import { SnapMarkerPin } from "@/views/timeline/snap-marker-pin";
 import { computeCoveredOnsets, findInsertedValue, isTimeOnOnset } from "@/views/timeline/snap-marker-math";
 import { useSnapMarkerDrag } from "@/views/timeline/use-snap-marker-drag";
-import { GUTTER_WIDTH, useTimelineStore } from "@/views/timeline/timeline-store";
+import { GUTTER_WIDTH, useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
 
 // -- Types ---------------------------------------------------------------------
 
@@ -13,8 +13,7 @@ interface SnapMarkersOverlayProps {
 
 // -- Constants -----------------------------------------------------------------
 
-const MARKER_FADE_EXTENT = 220;
-const MARKER_HEAD_CLEARANCE = 16;
+const ONSET_FULL_HEIGHT = "100%";
 
 // -- Component -----------------------------------------------------------------
 
@@ -47,7 +46,7 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
       const layer = layerRef.current;
       if (layer) {
         const scrollLeft = scrollContainerRef.current?.scrollLeft ?? useTimelineStore.getState().scrollLeft;
-        layer.style.transform = `translate3d(${GUTTER_WIDTH - scrollLeft}px, ${MARKER_HEAD_CLEARANCE}px, 0)`;
+        layer.style.transform = `translate3d(${GUTTER_WIDTH - scrollLeft}px, 0, 0)`;
       }
       rafRef.current = requestAnimationFrame(applyTransform);
     };
@@ -71,7 +70,7 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
         ref={layerRef}
         data-snap-markers-layer
         className="absolute inset-0 pointer-events-none"
-        style={{ transform: `translate3d(${GUTTER_WIDTH}px, ${MARKER_HEAD_CLEARANCE}px, 0)` }}
+        style={{ transform: `translate3d(${GUTTER_WIDTH}px, 0, 0)` }}
       >
         {showOnsets && (
           <div className="absolute inset-0 pointer-events-none z-10">
@@ -84,7 +83,7 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
                 className={`snap-onset-line absolute top-0 pointer-events-none ${
                   coveredOnsets.has(index) ? "snap-onset-covered" : ""
                 }`}
-                style={{ left: time * zoom, height: MARKER_FADE_EXTENT }}
+                style={{ left: time * zoom, height: ONSET_FULL_HEIGHT }}
               />
             ))}
           </div>
@@ -97,7 +96,7 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
               index={index}
               time={time}
               zoom={zoom}
-              fadeExtent={MARKER_FADE_EXTENT}
+              fadeExtent={WAVEFORM_HEIGHT}
               isDragging={draggingTime !== null && time === draggingTime}
               isNew={insertedValue !== null && time === insertedValue}
               isOnOnset={showOnsets && isTimeOnOnset(time, vocalOnsetSnapPoints, zoom, thresholdPx)}
@@ -113,4 +112,4 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
 
 // -- Exports -------------------------------------------------------------------
 
-export { SnapMarkersOverlay, MARKER_FADE_EXTENT, MARKER_HEAD_CLEARANCE };
+export { SnapMarkersOverlay };

--- a/src/views/timeline/snap-markers-overlay.tsx
+++ b/src/views/timeline/snap-markers-overlay.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import { useSettingsStore } from "@/stores/settings";
 import { SnapMarkerPin } from "@/views/timeline/snap-marker-pin";
-import { computeCoveredOnsets } from "@/views/timeline/snap-marker-math";
+import { computeCoveredOnsets, isTimeOnOnset } from "@/views/timeline/snap-marker-math";
 import { useSnapMarkerDrag } from "@/views/timeline/use-snap-marker-drag";
 import { GUTTER_WIDTH, useTimelineStore } from "@/views/timeline/timeline-store";
 
@@ -83,13 +83,14 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
         <div className="absolute inset-0 pointer-events-none z-20">
           {customSnapPoints.map((time, index) => (
             <SnapMarkerPin
-              // biome-ignore lint/suspicious/noArrayIndexKey: index tiebreaks identical custom times
-              key={`${time}-${index}`}
+              // biome-ignore lint/suspicious/noArrayIndexKey: positional key keeps a dragged pin mounted while its time changes every frame
+              key={`custom-${index}`}
               index={index}
               time={time}
               zoom={zoom}
               fadeExtent={MARKER_FADE_EXTENT}
               isDragging={draggingTime !== null && time === draggingTime}
+              isOnOnset={showOnsets && isTimeOnOnset(time, vocalOnsetSnapPoints, zoom, thresholdPx)}
               onHeadPointerDown={onHeadPointerDown}
               onDelete={removeCustomSnapPoint}
             />

--- a/src/views/timeline/snap-markers-overlay.tsx
+++ b/src/views/timeline/snap-markers-overlay.tsx
@@ -14,6 +14,7 @@ interface SnapMarkersOverlayProps {
 // -- Constants -----------------------------------------------------------------
 
 const MARKER_FADE_EXTENT = 220;
+const MARKER_HEAD_CLEARANCE = 16;
 
 // -- Component -----------------------------------------------------------------
 
@@ -46,7 +47,7 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
       const layer = layerRef.current;
       if (layer) {
         const scrollLeft = scrollContainerRef.current?.scrollLeft ?? useTimelineStore.getState().scrollLeft;
-        layer.style.transform = `translate3d(${GUTTER_WIDTH - scrollLeft}px, 0, 0)`;
+        layer.style.transform = `translate3d(${GUTTER_WIDTH - scrollLeft}px, ${MARKER_HEAD_CLEARANCE}px, 0)`;
       }
       rafRef.current = requestAnimationFrame(applyTransform);
     };
@@ -70,7 +71,7 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
         ref={layerRef}
         data-snap-markers-layer
         className="absolute inset-0 pointer-events-none"
-        style={{ transform: `translate3d(${GUTTER_WIDTH}px, 0, 0)` }}
+        style={{ transform: `translate3d(${GUTTER_WIDTH}px, ${MARKER_HEAD_CLEARANCE}px, 0)` }}
       >
         {showOnsets && (
           <div className="absolute inset-0 pointer-events-none z-10">
@@ -112,4 +113,4 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
 
 // -- Exports -------------------------------------------------------------------
 
-export { SnapMarkersOverlay, MARKER_FADE_EXTENT };
+export { SnapMarkersOverlay, MARKER_FADE_EXTENT, MARKER_HEAD_CLEARANCE };

--- a/src/views/timeline/snap-markers-overlay.tsx
+++ b/src/views/timeline/snap-markers-overlay.tsx
@@ -1,5 +1,8 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useSettingsStore } from "@/stores/settings";
+import { SnapMarkerPin } from "@/views/timeline/snap-marker-pin";
+import { computeCoveredOnsets } from "@/views/timeline/snap-marker-math";
+import { useSnapMarkerDrag } from "@/views/timeline/use-snap-marker-drag";
 import { GUTTER_WIDTH, useTimelineStore } from "@/views/timeline/timeline-store";
 
 // -- Types ---------------------------------------------------------------------
@@ -17,7 +20,18 @@ const MARKER_FADE_EXTENT = 220;
 const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainerRef }) => {
   const zoom = useTimelineStore((s) => s.zoom);
   const vocalOnsetSnapPoints = useTimelineStore((s) => s.vocalOnsetSnapPoints);
+  const customSnapPoints = useTimelineStore((s) => s.customSnapPoints);
+  const removeCustomSnapPoint = useTimelineStore((s) => s.removeCustomSnapPoint);
   const showOnsets = useSettingsStore((s) => s.vocalOnsetSnap);
+  const thresholdPx = useSettingsStore((s) => s.timelineSnapThreshold);
+
+  const { draggingTime, onHeadPointerDown } = useSnapMarkerDrag({ scrollContainerRef });
+
+  const coveredOnsets = useMemo(() => {
+    if (!showOnsets) return new Set<number>();
+    const coveringTimes = draggingTime === null ? customSnapPoints : [...customSnapPoints, draggingTime];
+    return computeCoveredOnsets(vocalOnsetSnapPoints, coveringTimes, zoom, thresholdPx);
+  }, [showOnsets, vocalOnsetSnapPoints, customSnapPoints, draggingTime, zoom, thresholdPx]);
 
   const layerRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number | null>(null);
@@ -57,12 +71,30 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
                 // biome-ignore lint/suspicious/noArrayIndexKey: index tiebreaks identical onset times
                 key={`${time}-${index}`}
                 data-snap-marker="onset"
-                className="snap-onset-line absolute top-0 pointer-events-none"
+                data-covered={coveredOnsets.has(index) ? "" : undefined}
+                className={`snap-onset-line absolute top-0 pointer-events-none ${
+                  coveredOnsets.has(index) ? "snap-onset-covered" : ""
+                }`}
                 style={{ left: time * zoom, height: MARKER_FADE_EXTENT }}
               />
             ))}
           </div>
         )}
+        <div className="absolute inset-0 pointer-events-none z-20">
+          {customSnapPoints.map((time, index) => (
+            <SnapMarkerPin
+              // biome-ignore lint/suspicious/noArrayIndexKey: index tiebreaks identical custom times
+              key={`${time}-${index}`}
+              index={index}
+              time={time}
+              zoom={zoom}
+              fadeExtent={MARKER_FADE_EXTENT}
+              isDragging={draggingTime !== null && time === draggingTime}
+              onHeadPointerDown={onHeadPointerDown}
+              onDelete={removeCustomSnapPoint}
+            />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/views/timeline/snap-markers-overlay.tsx
+++ b/src/views/timeline/snap-markers-overlay.tsx
@@ -22,6 +22,7 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
   const vocalOnsetSnapPoints = useTimelineStore((s) => s.vocalOnsetSnapPoints);
   const customSnapPoints = useTimelineStore((s) => s.customSnapPoints);
   const removeCustomSnapPoint = useTimelineStore((s) => s.removeCustomSnapPoint);
+  const markerMode = useTimelineStore((s) => s.markerMode);
   const showOnsets = useSettingsStore((s) => s.vocalOnsetSnap);
   const thresholdPx = useSettingsStore((s) => s.timelineSnapThreshold);
 
@@ -55,6 +56,9 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
     };
   }, [scrollContainerRef]);
+
+  const visibleOnsetCount = showOnsets ? vocalOnsetSnapPoints.length : 0;
+  if (visibleOnsetCount === 0 && customSnapPoints.length === 0 && !markerMode) return null;
 
   return (
     <div

--- a/src/views/timeline/snap-markers-overlay.tsx
+++ b/src/views/timeline/snap-markers-overlay.tsx
@@ -11,10 +11,6 @@ interface SnapMarkersOverlayProps {
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
 }
 
-// -- Constants -----------------------------------------------------------------
-
-const ONSET_FULL_HEIGHT = "100%";
-
 // -- Component -----------------------------------------------------------------
 
 const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainerRef }) => {
@@ -83,7 +79,7 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
                 className={`snap-onset-line absolute top-0 pointer-events-none ${
                   coveredOnsets.has(index) ? "snap-onset-covered" : ""
                 }`}
-                style={{ left: time * zoom, height: ONSET_FULL_HEIGHT }}
+                style={{ left: time * zoom, height: WAVEFORM_HEIGHT }}
               />
             ))}
           </div>

--- a/src/views/timeline/snap-markers-overlay.tsx
+++ b/src/views/timeline/snap-markers-overlay.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from "react";
+import { useSettingsStore } from "@/stores/settings";
+import { GUTTER_WIDTH, useTimelineStore } from "@/views/timeline/timeline-store";
+
+// -- Types ---------------------------------------------------------------------
+
+interface SnapMarkersOverlayProps {
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+// -- Constants -----------------------------------------------------------------
+
+const MARKER_FADE_EXTENT = 220;
+
+// -- Component -----------------------------------------------------------------
+
+const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainerRef }) => {
+  const zoom = useTimelineStore((s) => s.zoom);
+  const vocalOnsetSnapPoints = useTimelineStore((s) => s.vocalOnsetSnapPoints);
+  const showOnsets = useSettingsStore((s) => s.vocalOnsetSnap);
+
+  const layerRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const applyTransform = () => {
+      const layer = layerRef.current;
+      if (layer) {
+        const scrollLeft = scrollContainerRef.current?.scrollLeft ?? useTimelineStore.getState().scrollLeft;
+        layer.style.transform = `translate3d(${GUTTER_WIDTH - scrollLeft}px, 0, 0)`;
+      }
+      rafRef.current = requestAnimationFrame(applyTransform);
+    };
+
+    applyTransform();
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [scrollContainerRef]);
+
+  return (
+    <div
+      data-snap-markers-overlay
+      className="absolute inset-0 pointer-events-none overflow-hidden select-none z-40"
+      style={{ clipPath: `inset(0 0 0 ${GUTTER_WIDTH}px)` }}
+    >
+      <div
+        ref={layerRef}
+        data-snap-markers-layer
+        className="absolute inset-0 pointer-events-none"
+        style={{ transform: `translate3d(${GUTTER_WIDTH}px, 0, 0)` }}
+      >
+        {showOnsets && (
+          <div className="absolute inset-0 pointer-events-none z-10">
+            {vocalOnsetSnapPoints.map((time, index) => (
+              <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: index tiebreaks identical onset times
+                key={`${time}-${index}`}
+                data-snap-marker="onset"
+                className="snap-onset-line absolute top-0 pointer-events-none"
+                style={{ left: time * zoom, height: MARKER_FADE_EXTENT }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// -- Exports -------------------------------------------------------------------
+
+export { SnapMarkersOverlay, MARKER_FADE_EXTENT };

--- a/src/views/timeline/snap-markers-overlay.tsx
+++ b/src/views/timeline/snap-markers-overlay.tsx
@@ -76,7 +76,7 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
                 key={`${time}-${index}`}
                 data-snap-marker="onset"
                 data-covered={coveredOnsets.has(index) ? "" : undefined}
-                className={`snap-onset-line absolute top-0 pointer-events-none ${
+                className={`snap-onset-line absolute top-0 -translate-x-1/2 pointer-events-none ${
                   coveredOnsets.has(index) ? "snap-onset-covered" : ""
                 }`}
                 style={{ left: time * zoom, height: WAVEFORM_HEIGHT }}

--- a/src/views/timeline/snap.test.ts
+++ b/src/views/timeline/snap.test.ts
@@ -118,6 +118,54 @@ describe("collectSnapAnchors", () => {
     expect(anchors.map((a) => a.t)).toEqual([0.12, 0.72]);
   });
 
+  it("emits one custom anchor per finite, non-negative custom time", () => {
+    const anchors = collectSnapAnchors([wordTimedLine()], new Set(), null, [], true, [0.25, 0.85]);
+    const customs = anchors.filter((a) => a.kind === "custom");
+    expect(customs.map((a) => a.t)).toEqual([0.25, 0.85]);
+    expect(customs.every((a) => a.label === "custom")).toBe(true);
+  });
+
+  it("filters out non-finite and negative custom times", () => {
+    const anchors = collectSnapAnchors(
+      [wordTimedLine()],
+      new Set(),
+      null,
+      [],
+      true,
+      [-1, 0, Number.NaN, Number.POSITIVE_INFINITY, 0.5],
+    );
+    const customTimes = anchors.filter((a) => a.kind === "custom").map((a) => a.t);
+    expect(customTimes).toEqual([0, 0.5]);
+  });
+
+  it("emits no custom anchors for an empty custom-times array", () => {
+    const anchors = collectSnapAnchors([wordTimedLine()], new Set(), null, [0.1], true, []);
+    expect(anchors.some((a) => a.kind === "custom")).toBe(false);
+  });
+
+  it("coexists with vocal-onset anchors when both arrays are provided", () => {
+    const anchors = collectSnapAnchors([wordTimedLine()], new Set(), null, [0.12], true, [0.9]);
+    const onsets = anchors.filter((a) => a.kind === "vocal-onset");
+    const customs = anchors.filter((a) => a.kind === "custom");
+    expect(onsets.map((a) => a.t)).toEqual([0.12]);
+    expect(customs.map((a) => a.t)).toEqual([0.9]);
+  });
+
+  it("can collect custom snap points without timeline anchors", () => {
+    const anchors = collectSnapAnchors([wordTimedLine()], new Set(), 0.42, [], false, [0.3, 0.7]);
+    expect(anchors.map((a) => a.kind)).toEqual(["custom", "custom"]);
+    expect(anchors.map((a) => a.t)).toEqual([0.3, 0.7]);
+  });
+
+  it("backward-compat: calling without the custom-times arg is unchanged", () => {
+    const lines = [wordTimedLine(), lineSyncedLine()];
+    const onsets = [0.12, 0.72];
+    const withoutArg = collectSnapAnchors(lines, new Set(), 1.5, onsets, true);
+    const withEmptyArg = collectSnapAnchors(lines, new Set(), 1.5, onsets, true, []);
+    expect(withoutArg).toEqual(withEmptyArg);
+    expect(withoutArg.some((a) => a.kind === "custom")).toBe(false);
+  });
+
   it("omits playhead when playheadTime is null", () => {
     const anchors = collectSnapAnchors([wordTimedLine()], new Set(), null);
     expect(anchors.some((a) => a.kind === "playhead")).toBe(false);

--- a/src/views/timeline/snap.test.ts
+++ b/src/views/timeline/snap.test.ts
@@ -126,14 +126,13 @@ describe("collectSnapAnchors", () => {
   });
 
   it("filters out non-finite and negative custom times", () => {
-    const anchors = collectSnapAnchors(
-      [wordTimedLine()],
-      new Set(),
-      null,
-      [],
-      true,
-      [-1, 0, Number.NaN, Number.POSITIVE_INFINITY, 0.5],
-    );
+    const anchors = collectSnapAnchors([wordTimedLine()], new Set(), null, [], true, [
+      -1,
+      0,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      0.5,
+    ]);
     const customTimes = anchors.filter((a) => a.kind === "custom").map((a) => a.t);
     expect(customTimes).toEqual([0, 0.5]);
   });

--- a/src/views/timeline/snap.ts
+++ b/src/views/timeline/snap.ts
@@ -3,7 +3,14 @@ import type { LyricLine } from "@/domain/line/model";
 
 // -- Types ---------------------------------------------------------------------
 
-type AnchorKind = "word-begin" | "word-end" | "line-begin" | "line-end" | "playhead" | "vocal-onset";
+type AnchorKind =
+  | "word-begin"
+  | "word-end"
+  | "line-begin"
+  | "line-end"
+  | "playhead"
+  | "vocal-onset"
+  | "custom";
 
 interface SnapAnchor {
   t: number;
@@ -50,6 +57,7 @@ function collectSnapAnchors(
   playheadTime: number | null,
   vocalOnsetTimes: number[] = [],
   includeTimelineAnchors = true,
+  customSnapTimes: number[] = [],
 ): SnapAnchor[] {
   const anchors: SnapAnchor[] = [];
 
@@ -122,6 +130,10 @@ function collectSnapAnchors(
 
   for (const t of vocalOnsetTimes) {
     if (Number.isFinite(t) && t >= 0) anchors.push({ t, kind: "vocal-onset", label: "vocal onset" });
+  }
+
+  for (const t of customSnapTimes) {
+    if (Number.isFinite(t) && t >= 0) anchors.push({ t, kind: "custom", label: "custom" });
   }
 
   anchors.sort((a, b) => a.t - b.t);

--- a/src/views/timeline/snap.ts
+++ b/src/views/timeline/snap.ts
@@ -3,14 +3,7 @@ import type { LyricLine } from "@/domain/line/model";
 
 // -- Types ---------------------------------------------------------------------
 
-type AnchorKind =
-  | "word-begin"
-  | "word-end"
-  | "line-begin"
-  | "line-end"
-  | "playhead"
-  | "vocal-onset"
-  | "custom";
+type AnchorKind = "word-begin" | "word-end" | "line-begin" | "line-end" | "playhead" | "vocal-onset" | "custom";
 
 interface SnapAnchor {
   t: number;

--- a/src/views/timeline/timeline-header.browser.test.tsx
+++ b/src/views/timeline/timeline-header.browser.test.tsx
@@ -2,6 +2,7 @@ import { createRef } from "react";
 import { describe, expect, it } from "vitest";
 import { useAudioStore } from "@/stores/audio";
 import { useSettingsStore } from "@/stores/settings";
+import { getEffectiveKeysArray } from "@/stores/shortcut-bindings";
 import { TimelineHeader } from "@/views/timeline/timeline-header";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { render } from "@/test/render";
@@ -80,6 +81,46 @@ describe("TimelineHeader", () => {
     const screen = await render(<TimelineHeader />);
     const snapButton = screen.container.querySelector("button[title*='Snap']") as HTMLElement;
     expect(snapButton.className).toContain("opacity-50");
+  });
+
+  it("renders the Marker button", async () => {
+    const screen = await render(<TimelineHeader />);
+    await expect.element(screen.getByRole("button", { name: /Marker/ })).toBeInTheDocument();
+  });
+
+  it("toggles markerMode in the timeline store when the Marker button is clicked", async () => {
+    useTimelineStore.setState({ markerMode: false });
+    const screen = await render(<TimelineHeader />);
+    await screen.getByRole("button", { name: /Marker/ }).click();
+    expect(useTimelineStore.getState().markerMode).toBe(true);
+    await screen.getByRole("button", { name: /Marker/ }).click();
+    expect(useTimelineStore.getState().markerMode).toBe(false);
+  });
+
+  it("renders the Marker button with the ghost variant when markerMode is off", async () => {
+    useTimelineStore.setState({ markerMode: false });
+    const screen = await render(<TimelineHeader />);
+    const markerButton = screen.container.querySelector("button[title*='Marker']") as HTMLElement;
+    expect(markerButton.className).toContain("opacity-60");
+    expect(markerButton.className).toContain("text-composer-text-muted");
+  });
+
+  it("renders the Marker button with the primary variant when markerMode is on", async () => {
+    useTimelineStore.setState({ markerMode: true });
+    const screen = await render(<TimelineHeader />);
+    const markerButton = screen.container.querySelector("button[title*='Marker']") as HTMLElement;
+    expect(markerButton.className).not.toContain("opacity-60");
+    expect(markerButton.className).toContain("bg-composer-accent-dark");
+  });
+
+  it("shows the marker-mode shortcut badge when hints are enabled", async () => {
+    useSettingsStore.setState({ showShortcutHints: true });
+    const screen = await render(<TimelineHeader />);
+    const markerButton = screen.container.querySelector("button[title*='Marker']") as HTMLElement;
+    const keys = getEffectiveKeysArray("timeline.toggleMarkerMode");
+    for (const key of keys) {
+      expect(markerButton.textContent ?? "").toContain(key);
+    }
   });
 
   describe("zoom without a scroll ref", () => {

--- a/src/views/timeline/timeline-header.tsx
+++ b/src/views/timeline/timeline-header.tsx
@@ -19,6 +19,7 @@ import {
   IconFocusCentered,
   IconLayoutDistributeHorizontal,
   IconMagnet,
+  IconMapPin,
   IconMinus,
   IconPlus,
   IconTextPlus,
@@ -49,11 +50,14 @@ const TimelineHeader: React.FC<TimelineHeaderProps> = ({ onImportLyrics, scrollC
   const togglePreviewSidebar = useTimelineStore((s) => s.togglePreviewSidebar);
   const rollingEditMode = useTimelineStore((s) => s.rollingEditMode);
   const toggleRollingEditMode = useTimelineStore((s) => s.toggleRollingEditMode);
+  const markerMode = useTimelineStore((s) => s.markerMode);
+  const toggleMarkerMode = useTimelineStore((s) => s.toggleMarkerMode);
   const showHints = useSettingsStore((s) => s.showShortcutHints);
   const snapEnabled = useSettingsStore((s) => s.timelineSnap);
   const setSetting = useSettingsStore((s) => s.set);
   const isBypassing = useTimelineStore((s) => s.isBypassing);
   const toggleSnapKeys = getEffectiveKeysArray("timeline.toggleSnap");
+  const toggleMarkerKeys = getEffectiveKeysArray("timeline.toggleMarkerMode");
   const lines = useProjectStore((s) => s.lines);
   const collapsedInstances = useTimelineStore((s) => s.collapsedInstances);
   const setInstanceCollapsed = useTimelineStore((s) => s.setInstanceCollapsed);
@@ -191,6 +195,20 @@ const TimelineHeader: React.FC<TimelineHeaderProps> = ({ onImportLyrics, scrollC
           <IconMagnet size={16} />
           <span>Snap</span>
           {showHints && <InlineKeyBadge keys={toggleSnapKeys} />}
+        </Button>
+
+        {/* Marker mode toggle */}
+        <Button
+          variant={markerMode ? "primary" : "ghost"}
+          size="sm"
+          onClick={toggleMarkerMode}
+          hasIcon
+          className={cn(!markerMode && "opacity-60")}
+          title={`Marker mode${toggleMarkerKeys.length ? ` (${toggleMarkerKeys.join(" ")})` : ""}`}
+        >
+          <IconMapPin size={16} />
+          <span>Marker</span>
+          {showHints && <InlineKeyBadge keys={toggleMarkerKeys} />}
         </Button>
 
         {/* Import lyrics */}

--- a/src/views/timeline/timeline-panel.tsx
+++ b/src/views/timeline/timeline-panel.tsx
@@ -21,6 +21,7 @@ import { WordEditOverlay } from "@/views/timeline/word-edit-overlay";
 import { TimelineHeader } from "@/views/timeline/timeline-header";
 import { TimelineInfoPanel } from "@/views/timeline/timeline-info-panel";
 import { SnapGuideline } from "@/views/timeline/snap-guideline";
+import { SnapMarkersOverlay } from "@/views/timeline/snap-markers-overlay";
 import { TimelinePlayhead } from "@/views/timeline/timeline-playhead";
 import { TimelinePreviewSidebar } from "@/views/timeline/timeline-preview-sidebar";
 import { TimelineRows } from "@/views/timeline/timeline-rows";
@@ -474,6 +475,8 @@ const TimelinePanel: React.FC = () => {
               <TimelinePlayhead containerHeight={contentHeight} scrollContainerRef={scrollContainerRef} />
 
               <SnapGuideline />
+
+              <SnapMarkersOverlay scrollContainerRef={scrollContainerRef} />
 
               {marqueeRect && <MarqueeSelection rect={marqueeRect} scrollContainerRef={scrollContainerRef} />}
 

--- a/src/views/timeline/timeline-playhead.tsx
+++ b/src/views/timeline/timeline-playhead.tsx
@@ -4,7 +4,8 @@ import { getBannerNodes } from "@/views/timeline/banner-progress-registry";
 import { GROUP_HEADER_HEIGHT } from "@/views/timeline/group-header-row";
 import { buildPlayheadMask } from "@/views/timeline/timeline-playhead-mask";
 import { createPlayheadDrag } from "@/views/timeline/playhead-drag";
-import { GUTTER_WIDTH, useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
+import { GUTTER_WIDTH, timeToX } from "@/views/timeline/coords";
+import { useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
 import { isLinked } from "@/domain/instance/predicates";
 import { effectiveBounds } from "@/domain/line/bounds";
 import { computeRowLayout } from "@/views/timeline/utils";
@@ -125,7 +126,7 @@ const TimelinePlayhead: React.FC<TimelinePlayheadProps> = ({ containerHeight, sc
 
       const displayTime = isDraggingPlayhead ? dragTime : currentTime;
       const actualScrollLeft = container?.scrollLeft ?? scrollLeft;
-      const position = displayTime * zoom - actualScrollLeft + GUTTER_WIDTH - 1; // -1 to center the 2px wide playhead
+      const position = timeToX(displayTime, zoom, actualScrollLeft) - 1; // -1 to center the 2px wide playhead
       playheadRef.current.style.transform = `translate3d(${position}px, 0, 0)`;
 
       // Update height to match full scrollable content
@@ -135,7 +136,7 @@ const TimelinePlayhead: React.FC<TimelinePlayheadProps> = ({ containerHeight, sc
 
       const containerRect = containerRef.current?.getBoundingClientRect();
       if (containerRect) {
-        const playheadCenterXLocal = displayTime * zoom - actualScrollLeft + GUTTER_WIDTH;
+        const playheadCenterXLocal = timeToX(displayTime, zoom, actualScrollLeft);
         const playheadCenterXViewport = playheadCenterXLocal + containerRect.left;
         playheadCenterXLocalRef.current = playheadCenterXLocal;
         containerLeftRef.current = containerRect.left;

--- a/src/views/timeline/timeline-store.test.ts
+++ b/src/views/timeline/timeline-store.test.ts
@@ -71,7 +71,7 @@ describe("customSnapPoints", () => {
     s.addCustomSnapPoint(3);
     s.addCustomSnapPoint(1);
     s.addCustomSnapPoint(-2);
-    s.addCustomSnapPoint(NaN);
+    s.addCustomSnapPoint(Number.NaN);
     expect(useTimelineStore.getState().customSnapPoints).toEqual([1, 3]);
   });
 
@@ -125,7 +125,7 @@ describe("customSnapPoints", () => {
       const s = useTimelineStore.getState();
       s.addCustomSnapPoint(1);
       s.addCustomSnapPoint(3);
-      s.moveCustomSnapPoint(0, NaN);
+      s.moveCustomSnapPoint(0, Number.NaN);
       expect(useTimelineStore.getState().customSnapPoints).toEqual([3]);
     });
 

--- a/src/views/timeline/timeline-store.test.ts
+++ b/src/views/timeline/timeline-store.test.ts
@@ -10,6 +10,57 @@ describe("rollingEditMode", () => {
   });
 });
 
+describe("markerMode", () => {
+  beforeEach(() => {
+    useTimelineStore.setState({ markerMode: false });
+  });
+
+  it("defaults to false", () => {
+    expect(useTimelineStore.getState().markerMode).toBe(false);
+  });
+
+  it("toggleMarkerMode flips it", () => {
+    useTimelineStore.getState().toggleMarkerMode();
+    expect(useTimelineStore.getState().markerMode).toBe(true);
+  });
+
+  it("setMarkerMode sets the given boolean", () => {
+    useTimelineStore.getState().setMarkerMode(true);
+    expect(useTimelineStore.getState().markerMode).toBe(true);
+    useTimelineStore.getState().setMarkerMode(false);
+    expect(useTimelineStore.getState().markerMode).toBe(false);
+  });
+
+  describe("invariants", () => {
+    it("toggling twice returns to false", () => {
+      const s = useTimelineStore.getState();
+      s.toggleMarkerMode();
+      s.toggleMarkerMode();
+      expect(useTimelineStore.getState().markerMode).toBe(false);
+    });
+
+    it("setMarkerMode(false) when already false is idempotent", () => {
+      useTimelineStore.getState().setMarkerMode(false);
+      expect(useTimelineStore.getState().markerMode).toBe(false);
+      useTimelineStore.getState().setMarkerMode(false);
+      expect(useTimelineStore.getState().markerMode).toBe(false);
+    });
+
+    it("is independent of customSnapPoints", () => {
+      const s = useTimelineStore.getState();
+      useTimelineStore.setState({ customSnapPoints: [] });
+      s.setMarkerMode(true);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([]);
+
+      s.addCustomSnapPoint(2);
+      expect(useTimelineStore.getState().markerMode).toBe(true);
+
+      s.setMarkerMode(false);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([2]);
+    });
+  });
+});
+
 describe("customSnapPoints", () => {
   beforeEach(() => {
     useTimelineStore.setState({ customSnapPoints: [] });

--- a/src/views/timeline/timeline-store.test.ts
+++ b/src/views/timeline/timeline-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 
 describe("rollingEditMode", () => {
@@ -7,5 +7,150 @@ describe("rollingEditMode", () => {
     expect(useTimelineStore.getState().rollingEditMode).toBe(false);
     useTimelineStore.getState().toggleRollingEditMode();
     expect(useTimelineStore.getState().rollingEditMode).toBe(true);
+  });
+});
+
+describe("customSnapPoints", () => {
+  beforeEach(() => {
+    useTimelineStore.setState({ customSnapPoints: [] });
+  });
+
+  it("addCustomSnapPoint inserts, filters non-finite/negative, sorts asc", () => {
+    const s = useTimelineStore.getState();
+    s.addCustomSnapPoint(3);
+    s.addCustomSnapPoint(1);
+    s.addCustomSnapPoint(-2);
+    s.addCustomSnapPoint(NaN);
+    expect(useTimelineStore.getState().customSnapPoints).toEqual([1, 3]);
+  });
+
+  it("removeCustomSnapPoint removes by index", () => {
+    const s = useTimelineStore.getState();
+    s.addCustomSnapPoint(1);
+    s.addCustomSnapPoint(2);
+    s.addCustomSnapPoint(3);
+    s.removeCustomSnapPoint(1);
+    expect(useTimelineStore.getState().customSnapPoints).toEqual([1, 3]);
+  });
+
+  it("moveCustomSnapPoint repositions and re-sorts", () => {
+    const s = useTimelineStore.getState();
+    s.addCustomSnapPoint(1);
+    s.addCustomSnapPoint(3);
+    s.moveCustomSnapPoint(0, 5);
+    expect(useTimelineStore.getState().customSnapPoints).toEqual([3, 5]);
+  });
+
+  it("clearCustomSnapPoints empties", () => {
+    const s = useTimelineStore.getState();
+    s.addCustomSnapPoint(1);
+    s.addCustomSnapPoint(2);
+    s.clearCustomSnapPoints();
+    expect(useTimelineStore.getState().customSnapPoints).toEqual([]);
+  });
+
+  describe("edge cases", () => {
+    it("keeps duplicate times (no dedupe, mirrors setVocalOnsetSnapPoints)", () => {
+      const s = useTimelineStore.getState();
+      s.addCustomSnapPoint(2);
+      s.addCustomSnapPoint(2);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([2, 2]);
+    });
+
+    it("accepts zero as a valid snap point", () => {
+      const s = useTimelineStore.getState();
+      s.addCustomSnapPoint(0);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([0]);
+    });
+
+    it("rejects Infinity and -Infinity", () => {
+      const s = useTimelineStore.getState();
+      s.addCustomSnapPoint(Number.POSITIVE_INFINITY);
+      s.addCustomSnapPoint(Number.NEGATIVE_INFINITY);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([]);
+    });
+
+    it("moveCustomSnapPoint to a non-finite value drops the moved entry", () => {
+      const s = useTimelineStore.getState();
+      s.addCustomSnapPoint(1);
+      s.addCustomSnapPoint(3);
+      s.moveCustomSnapPoint(0, NaN);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([3]);
+    });
+
+    it("moveCustomSnapPoint to a negative value drops the moved entry", () => {
+      const s = useTimelineStore.getState();
+      s.addCustomSnapPoint(1);
+      s.addCustomSnapPoint(3);
+      s.moveCustomSnapPoint(1, -5);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([1]);
+    });
+
+    it("moveCustomSnapPoint with out-of-range index is a no-op", () => {
+      const s = useTimelineStore.getState();
+      s.addCustomSnapPoint(1);
+      s.addCustomSnapPoint(3);
+      s.moveCustomSnapPoint(5, 99);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([1, 3]);
+      s.moveCustomSnapPoint(-1, 99);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([1, 3]);
+    });
+
+    it("removeCustomSnapPoint with out-of-range index is a no-op", () => {
+      const s = useTimelineStore.getState();
+      s.addCustomSnapPoint(1);
+      s.addCustomSnapPoint(3);
+      s.removeCustomSnapPoint(5);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([1, 3]);
+      s.removeCustomSnapPoint(-1);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([1, 3]);
+    });
+
+    it("clearCustomSnapPoints on an already-empty array stays empty", () => {
+      const s = useTimelineStore.getState();
+      s.clearCustomSnapPoints();
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([]);
+    });
+  });
+
+  describe("invariants", () => {
+    it("stays sorted ascending after every operation", () => {
+      const s = useTimelineStore.getState();
+      s.addCustomSnapPoint(9);
+      s.addCustomSnapPoint(2);
+      s.addCustomSnapPoint(5);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([2, 5, 9]);
+      s.moveCustomSnapPoint(0, 7);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([5, 7, 9]);
+      s.removeCustomSnapPoint(1);
+      expect(useTimelineStore.getState().customSnapPoints).toEqual([5, 9]);
+    });
+
+    it("writes a new array reference each mutation (no in-place mutation)", () => {
+      const s = useTimelineStore.getState();
+      s.addCustomSnapPoint(1);
+      const afterAdd = useTimelineStore.getState().customSnapPoints;
+      s.addCustomSnapPoint(2);
+      const afterSecondAdd = useTimelineStore.getState().customSnapPoints;
+      expect(afterSecondAdd).not.toBe(afterAdd);
+
+      s.moveCustomSnapPoint(0, 4);
+      const afterMove = useTimelineStore.getState().customSnapPoints;
+      expect(afterMove).not.toBe(afterSecondAdd);
+
+      s.removeCustomSnapPoint(0);
+      const afterRemove = useTimelineStore.getState().customSnapPoints;
+      expect(afterRemove).not.toBe(afterMove);
+    });
+
+    it("out-of-range move is a true no-op and preserves the array reference", () => {
+      const s = useTimelineStore.getState();
+      s.addCustomSnapPoint(1);
+      const before = useTimelineStore.getState().customSnapPoints;
+      s.moveCustomSnapPoint(99, 5);
+      const after = useTimelineStore.getState().customSnapPoints;
+      expect(after).toEqual([1]);
+      expect(after).toBe(before);
+    });
   });
 });

--- a/src/views/timeline/timeline-store.test.ts
+++ b/src/views/timeline/timeline-store.test.ts
@@ -24,13 +24,6 @@ describe("markerMode", () => {
     expect(useTimelineStore.getState().markerMode).toBe(true);
   });
 
-  it("setMarkerMode sets the given boolean", () => {
-    useTimelineStore.getState().setMarkerMode(true);
-    expect(useTimelineStore.getState().markerMode).toBe(true);
-    useTimelineStore.getState().setMarkerMode(false);
-    expect(useTimelineStore.getState().markerMode).toBe(false);
-  });
-
   describe("invariants", () => {
     it("toggling twice returns to false", () => {
       const s = useTimelineStore.getState();
@@ -39,23 +32,16 @@ describe("markerMode", () => {
       expect(useTimelineStore.getState().markerMode).toBe(false);
     });
 
-    it("setMarkerMode(false) when already false is idempotent", () => {
-      useTimelineStore.getState().setMarkerMode(false);
-      expect(useTimelineStore.getState().markerMode).toBe(false);
-      useTimelineStore.getState().setMarkerMode(false);
-      expect(useTimelineStore.getState().markerMode).toBe(false);
-    });
-
     it("is independent of customSnapPoints", () => {
       const s = useTimelineStore.getState();
       useTimelineStore.setState({ customSnapPoints: [] });
-      s.setMarkerMode(true);
+      s.toggleMarkerMode();
       expect(useTimelineStore.getState().customSnapPoints).toEqual([]);
 
       s.addCustomSnapPoint(2);
       expect(useTimelineStore.getState().markerMode).toBe(true);
 
-      s.setMarkerMode(false);
+      s.toggleMarkerMode();
       expect(useTimelineStore.getState().customSnapPoints).toEqual([2]);
     });
   });

--- a/src/views/timeline/timeline-store.ts
+++ b/src/views/timeline/timeline-store.ts
@@ -51,6 +51,7 @@ interface TimelineState {
   vocalOnsetSnapPoints: number[];
   vocalOnsetDetectionStatus: "idle" | "processing" | "error";
   vocalOnsetDetectionError: string | null;
+  customSnapPoints: number[];
 }
 
 interface TimelineActions {
@@ -84,6 +85,11 @@ interface TimelineActions {
   setSnappedAnchorTime: (t: number | null) => void;
   setVocalOnsetSnapPoints: (points: number[]) => void;
   setVocalOnsetDetectionStatus: (status: "idle" | "processing" | "error", error?: string | null) => void;
+  setCustomSnapPoints: (points: number[]) => void;
+  addCustomSnapPoint: (time: number) => void;
+  removeCustomSnapPoint: (index: number) => void;
+  moveCustomSnapPoint: (index: number, time: number) => void;
+  clearCustomSnapPoints: () => void;
 }
 
 // -- Constants -----------------------------------------------------------------
@@ -128,6 +134,7 @@ const useTimelineStore = create<TimelineState & TimelineActions>((set, get) => {
     vocalOnsetSnapPoints: [],
     vocalOnsetDetectionStatus: "idle",
     vocalOnsetDetectionError: null,
+    customSnapPoints: [],
 
     setZoom: (zoom) => set({ zoom: Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom)) }),
     zoomIn: () => set((s) => ({ zoom: Math.min(MAX_ZOOM, s.zoom + ZOOM_STEP) })),
@@ -172,6 +179,19 @@ const useTimelineStore = create<TimelineState & TimelineActions>((set, get) => {
       }),
     setVocalOnsetDetectionStatus: (vocalOnsetDetectionStatus, error = null) =>
       set({ vocalOnsetDetectionStatus, vocalOnsetDetectionError: error }),
+    setCustomSnapPoints: (points) =>
+      set({
+        customSnapPoints: points.filter((point) => Number.isFinite(point) && point >= 0).toSorted((a, b) => a - b),
+      }),
+    addCustomSnapPoint: (time) => get().setCustomSnapPoints([...get().customSnapPoints, time]),
+    removeCustomSnapPoint: (index) =>
+      get().setCustomSnapPoints(get().customSnapPoints.filter((_, idx) => idx !== index)),
+    moveCustomSnapPoint: (index, time) => {
+      const points = get().customSnapPoints;
+      if (index < 0 || index >= points.length) return;
+      get().setCustomSnapPoints(points.map((point, idx) => (idx === index ? time : point)));
+    },
+    clearCustomSnapPoints: () => get().setCustomSnapPoints([]),
   };
 });
 

--- a/src/views/timeline/timeline-store.ts
+++ b/src/views/timeline/timeline-store.ts
@@ -77,7 +77,6 @@ interface TimelineActions {
   clearEditingWord: () => void;
   toggleRollingEditMode: () => void;
   toggleMarkerMode: () => void;
-  setMarkerMode: (v: boolean) => void;
   setInstanceCollapsed: (key: string, isCollapsed: boolean) => void;
   toggleInstanceCollapsed: (key: string) => void;
   setPingingGroupId: (groupId: string | null) => void;
@@ -167,7 +166,6 @@ const useTimelineStore = create<TimelineState & TimelineActions>((set, get) => {
     clearEditingWord: () => set({ editingWord: null }),
     toggleRollingEditMode: () => set((s) => ({ rollingEditMode: !s.rollingEditMode })),
     toggleMarkerMode: () => set((s) => ({ markerMode: !s.markerMode })),
-    setMarkerMode: (v) => set({ markerMode: v }),
     setInstanceCollapsed: (key, isCollapsed) =>
       set((s) => ({ collapsedInstances: { ...s.collapsedInstances, [key]: isCollapsed } })),
     toggleInstanceCollapsed: (key) =>

--- a/src/views/timeline/timeline-store.ts
+++ b/src/views/timeline/timeline-store.ts
@@ -40,6 +40,7 @@ interface TimelineState {
   contextMenu: ContextMenuState | null;
   editingWord: EditingWord | null;
   rollingEditMode: boolean;
+  markerMode: boolean;
   collapsedInstances: Record<string, boolean>;
   pingingGroupId: string | null;
   renamingGroupId: string | null;
@@ -75,6 +76,8 @@ interface TimelineActions {
   setEditingWord: (editing: EditingWord | null) => void;
   clearEditingWord: () => void;
   toggleRollingEditMode: () => void;
+  toggleMarkerMode: () => void;
+  setMarkerMode: (v: boolean) => void;
   setInstanceCollapsed: (key: string, isCollapsed: boolean) => void;
   toggleInstanceCollapsed: (key: string) => void;
   setPingingGroupId: (groupId: string | null) => void;
@@ -123,6 +126,7 @@ const useTimelineStore = create<TimelineState & TimelineActions>((set, get) => {
     contextMenu: null,
     editingWord: null,
     rollingEditMode: settings.defaultRollingEdit,
+    markerMode: false,
     collapsedInstances: {},
     pingingGroupId: null,
     renamingGroupId: null,
@@ -162,6 +166,8 @@ const useTimelineStore = create<TimelineState & TimelineActions>((set, get) => {
     setEditingWord: (editingWord) => set({ editingWord }),
     clearEditingWord: () => set({ editingWord: null }),
     toggleRollingEditMode: () => set((s) => ({ rollingEditMode: !s.rollingEditMode })),
+    toggleMarkerMode: () => set((s) => ({ markerMode: !s.markerMode })),
+    setMarkerMode: (v) => set({ markerMode: v }),
     setInstanceCollapsed: (key, isCollapsed) =>
       set((s) => ({ collapsedInstances: { ...s.collapsedInstances, [key]: isCollapsed } })),
     toggleInstanceCollapsed: (key) =>

--- a/src/views/timeline/timeline-waveform.browser.test.tsx
+++ b/src/views/timeline/timeline-waveform.browser.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { TimelineWaveform } from "@/views/timeline/timeline-waveform";
 import { useAudioStore } from "@/stores/audio";
-import { useSettingsStore } from "@/stores/settings";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { createAudioFile } from "@/test/audio-fixtures";
 import { render } from "@/test/render";
@@ -11,22 +10,6 @@ function setupWaveformAudio(duration = 30) {
     source: { type: "file", file: createAudioFile() },
     duration,
   });
-}
-
-function stubRect(element: HTMLElement, width: number): void {
-  Object.defineProperty(element, "getBoundingClientRect", {
-    value: () => ({ left: 0, top: 0, right: width, bottom: 80, width, height: 80, x: 0, y: 0, toJSON: () => "" }),
-  });
-}
-
-function trackSeek(): { get: () => number } {
-  let seeked = -1;
-  useAudioStore.setState({
-    seekTo: (time: number) => {
-      seeked = time;
-    },
-  } as Parameters<typeof useAudioStore.setState>[0]);
-  return { get: () => seeked };
 }
 
 describe("TimelineWaveform", () => {
@@ -110,116 +93,6 @@ describe("TimelineWaveform", () => {
     });
     clickLayer.dispatchEvent(new MouseEvent("click", { clientX: width, clientY: 40, bubbles: true }));
     expect(seeked).toBeCloseTo(20, 3);
-  });
-});
-
-describe("TimelineWaveform marker placement", () => {
-  function getClickLayer(container: HTMLElement, width: number): HTMLElement {
-    const layer = container.querySelector(".cursor-pointer") as HTMLElement;
-    stubRect(layer, width);
-    return layer;
-  }
-
-  it("marker mode ON: single click adds a custom point at the clicked time and does not seek", async () => {
-    setupWaveformAudio(30);
-    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [] });
-    const seek = trackSeek();
-    const screen = await render(<TimelineWaveform />);
-    const layer = getClickLayer(screen.container, 1500);
-
-    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
-
-    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
-    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15, 3);
-    expect(seek.get()).toBe(-1);
-  });
-
-  it("marker mode ON: clicking near an onset within threshold snaps the added point onto the onset", async () => {
-    setupWaveformAudio(30);
-    useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
-    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [15.1] });
-    const screen = await render(<TimelineWaveform />);
-    const layer = getClickLayer(screen.container, 1500);
-
-    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
-
-    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
-    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15.1, 6);
-  });
-
-  it("marker mode ON: clicking with no onsets nearby adds the raw clicked time", async () => {
-    setupWaveformAudio(30);
-    useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
-    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [2, 27] });
-    const screen = await render(<TimelineWaveform />);
-    const layer = getClickLayer(screen.container, 1500);
-
-    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
-
-    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
-    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15, 3);
-  });
-
-  it("marker mode ON: a double-click does not add a second point on top of the single-click adds", async () => {
-    setupWaveformAudio(30);
-    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [] });
-    const screen = await render(<TimelineWaveform />);
-    const layer = getClickLayer(screen.container, 1500);
-
-    layer.dispatchEvent(new MouseEvent("dblclick", { clientX: 750, clientY: 40, bubbles: true }));
-
-    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(0);
-  });
-
-  it("marker mode OFF: single click seeks and adds no point", async () => {
-    setupWaveformAudio(30);
-    useTimelineStore.setState({ zoom: 50, markerMode: false, customSnapPoints: [], vocalOnsetSnapPoints: [] });
-    const seek = trackSeek();
-    const screen = await render(<TimelineWaveform />);
-    const layer = getClickLayer(screen.container, 1500);
-
-    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
-
-    expect(seek.get()).toBeCloseTo(15, 3);
-    expect(useTimelineStore.getState().customSnapPoints.length).toBe(0);
-  });
-
-  it("marker mode OFF: a double-click adds exactly one custom point", async () => {
-    setupWaveformAudio(30);
-    useTimelineStore.setState({ zoom: 50, markerMode: false, customSnapPoints: [], vocalOnsetSnapPoints: [] });
-    const screen = await render(<TimelineWaveform />);
-    const layer = getClickLayer(screen.container, 1500);
-
-    layer.dispatchEvent(new MouseEvent("dblclick", { clientX: 750, clientY: 40, bubbles: true }));
-
-    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
-    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15, 3);
-  });
-
-  it("marker mode OFF: a double-click near an onset within threshold snaps onto the onset", async () => {
-    setupWaveformAudio(30);
-    useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
-    useTimelineStore.setState({ zoom: 50, markerMode: false, customSnapPoints: [], vocalOnsetSnapPoints: [15.1] });
-    const screen = await render(<TimelineWaveform />);
-    const layer = getClickLayer(screen.container, 1500);
-
-    layer.dispatchEvent(new MouseEvent("dblclick", { clientX: 750, clientY: 40, bubbles: true }));
-
-    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
-    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15.1, 6);
-  });
-
-  it("onset snapping is suppressed when the vocalOnsetSnap setting is off, mirroring the drag", async () => {
-    setupWaveformAudio(30);
-    useSettingsStore.setState({ vocalOnsetSnap: false, timelineSnapThreshold: 12 });
-    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [15.1] });
-    const screen = await render(<TimelineWaveform />);
-    const layer = getClickLayer(screen.container, 1500);
-
-    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
-
-    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
-    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15, 3);
   });
 });
 

--- a/src/views/timeline/timeline-waveform.browser.test.tsx
+++ b/src/views/timeline/timeline-waveform.browser.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { TimelineWaveform } from "@/views/timeline/timeline-waveform";
 import { useAudioStore } from "@/stores/audio";
+import { useSettingsStore } from "@/stores/settings";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { createAudioFile } from "@/test/audio-fixtures";
 import { render } from "@/test/render";
@@ -10,6 +11,22 @@ function setupWaveformAudio(duration = 30) {
     source: { type: "file", file: createAudioFile() },
     duration,
   });
+}
+
+function stubRect(element: HTMLElement, width: number): void {
+  Object.defineProperty(element, "getBoundingClientRect", {
+    value: () => ({ left: 0, top: 0, right: width, bottom: 80, width, height: 80, x: 0, y: 0, toJSON: () => "" }),
+  });
+}
+
+function trackSeek(): { get: () => number } {
+  let seeked = -1;
+  useAudioStore.setState({
+    seekTo: (time: number) => {
+      seeked = time;
+    },
+  } as Parameters<typeof useAudioStore.setState>[0]);
+  return { get: () => seeked };
 }
 
 describe("TimelineWaveform", () => {
@@ -93,6 +110,116 @@ describe("TimelineWaveform", () => {
     });
     clickLayer.dispatchEvent(new MouseEvent("click", { clientX: width, clientY: 40, bubbles: true }));
     expect(seeked).toBeCloseTo(20, 3);
+  });
+});
+
+describe("TimelineWaveform marker placement", () => {
+  function getClickLayer(container: HTMLElement, width: number): HTMLElement {
+    const layer = container.querySelector(".cursor-pointer") as HTMLElement;
+    stubRect(layer, width);
+    return layer;
+  }
+
+  it("marker mode ON: single click adds a custom point at the clicked time and does not seek", async () => {
+    setupWaveformAudio(30);
+    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [] });
+    const seek = trackSeek();
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
+    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15, 3);
+    expect(seek.get()).toBe(-1);
+  });
+
+  it("marker mode ON: clicking near an onset within threshold snaps the added point onto the onset", async () => {
+    setupWaveformAudio(30);
+    useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [15.1] });
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
+    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15.1, 6);
+  });
+
+  it("marker mode ON: clicking with no onsets nearby adds the raw clicked time", async () => {
+    setupWaveformAudio(30);
+    useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [2, 27] });
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
+    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15, 3);
+  });
+
+  it("marker mode ON: a double-click does not add a second point on top of the single-click adds", async () => {
+    setupWaveformAudio(30);
+    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [] });
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("dblclick", { clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(0);
+  });
+
+  it("marker mode OFF: single click seeks and adds no point", async () => {
+    setupWaveformAudio(30);
+    useTimelineStore.setState({ zoom: 50, markerMode: false, customSnapPoints: [], vocalOnsetSnapPoints: [] });
+    const seek = trackSeek();
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
+
+    expect(seek.get()).toBeCloseTo(15, 3);
+    expect(useTimelineStore.getState().customSnapPoints.length).toBe(0);
+  });
+
+  it("marker mode OFF: a double-click adds exactly one custom point", async () => {
+    setupWaveformAudio(30);
+    useTimelineStore.setState({ zoom: 50, markerMode: false, customSnapPoints: [], vocalOnsetSnapPoints: [] });
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("dblclick", { clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
+    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15, 3);
+  });
+
+  it("marker mode OFF: a double-click near an onset within threshold snaps onto the onset", async () => {
+    setupWaveformAudio(30);
+    useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({ zoom: 50, markerMode: false, customSnapPoints: [], vocalOnsetSnapPoints: [15.1] });
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("dblclick", { clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
+    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15.1, 6);
+  });
+
+  it("onset snapping is suppressed when the vocalOnsetSnap setting is off, mirroring the drag", async () => {
+    setupWaveformAudio(30);
+    useSettingsStore.setState({ vocalOnsetSnap: false, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [15.1] });
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
+    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15, 3);
   });
 });
 

--- a/src/views/timeline/timeline-waveform.marker.browser.test.tsx
+++ b/src/views/timeline/timeline-waveform.marker.browser.test.tsx
@@ -87,6 +87,34 @@ describe("TimelineWaveform marker placement", () => {
     await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(0);
   });
 
+  it("marker mode ON: a real physical double-click sequence adds exactly one point", async () => {
+    setupWaveformAudio(30);
+    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [] });
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("click", { detail: 1, clientX: 750, clientY: 40, bubbles: true }));
+    layer.dispatchEvent(new MouseEvent("click", { detail: 2, clientX: 750, clientY: 40, bubbles: true }));
+    layer.dispatchEvent(new MouseEvent("dblclick", { detail: 2, clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
+    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15, 3);
+  });
+
+  it("marker mode ON: a triple-click sequence still adds exactly one point", async () => {
+    setupWaveformAudio(30);
+    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [] });
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("click", { detail: 1, clientX: 750, clientY: 40, bubbles: true }));
+    layer.dispatchEvent(new MouseEvent("click", { detail: 2, clientX: 750, clientY: 40, bubbles: true }));
+    layer.dispatchEvent(new MouseEvent("click", { detail: 3, clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
+    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15, 3);
+  });
+
   it("marker mode OFF: single click seeks and adds no point", async () => {
     setupWaveformAudio(30);
     useTimelineStore.setState({ zoom: 50, markerMode: false, customSnapPoints: [], vocalOnsetSnapPoints: [] });

--- a/src/views/timeline/timeline-waveform.marker.browser.test.tsx
+++ b/src/views/timeline/timeline-waveform.marker.browser.test.tsx
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import { TimelineWaveform } from "@/views/timeline/timeline-waveform";
+import { useAudioStore } from "@/stores/audio";
+import { useSettingsStore } from "@/stores/settings";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+import { createAudioFile } from "@/test/audio-fixtures";
+import { render } from "@/test/render";
+
+function setupWaveformAudio(duration = 30) {
+  useAudioStore.setState({
+    source: { type: "file", file: createAudioFile() },
+    duration,
+  });
+}
+
+function stubRect(element: HTMLElement, width: number): void {
+  Object.defineProperty(element, "getBoundingClientRect", {
+    value: () => ({ left: 0, top: 0, right: width, bottom: 80, width, height: 80, x: 0, y: 0, toJSON: () => "" }),
+  });
+}
+
+function trackSeek(): { get: () => number } {
+  let seeked = -1;
+  useAudioStore.setState({
+    seekTo: (time: number) => {
+      seeked = time;
+    },
+  } as Parameters<typeof useAudioStore.setState>[0]);
+  return { get: () => seeked };
+}
+
+describe("TimelineWaveform marker placement", () => {
+  function getClickLayer(container: HTMLElement, width: number): HTMLElement {
+    const layer = container.querySelector('[role="button"]') as HTMLElement;
+    stubRect(layer, width);
+    return layer;
+  }
+
+  it("marker mode ON: single click adds a custom point at the clicked time and does not seek", async () => {
+    setupWaveformAudio(30);
+    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [] });
+    const seek = trackSeek();
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
+    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15, 3);
+    expect(seek.get()).toBe(-1);
+  });
+
+  it("marker mode ON: clicking near an onset within threshold snaps the added point onto the onset", async () => {
+    setupWaveformAudio(30);
+    useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [15.1] });
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
+    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15.1, 6);
+  });
+
+  it("marker mode ON: clicking with no onsets nearby adds the raw clicked time", async () => {
+    setupWaveformAudio(30);
+    useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [2, 27] });
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
+    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15, 3);
+  });
+
+  it("marker mode ON: a double-click does not add a second point on top of the single-click adds", async () => {
+    setupWaveformAudio(30);
+    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [] });
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("dblclick", { clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(0);
+  });
+
+  it("marker mode OFF: single click seeks and adds no point", async () => {
+    setupWaveformAudio(30);
+    useTimelineStore.setState({ zoom: 50, markerMode: false, customSnapPoints: [], vocalOnsetSnapPoints: [] });
+    const seek = trackSeek();
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
+
+    expect(seek.get()).toBeCloseTo(15, 3);
+    expect(useTimelineStore.getState().customSnapPoints.length).toBe(0);
+  });
+
+  it("marker mode OFF: a double-click adds exactly one custom point", async () => {
+    setupWaveformAudio(30);
+    useTimelineStore.setState({ zoom: 50, markerMode: false, customSnapPoints: [], vocalOnsetSnapPoints: [] });
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("dblclick", { clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
+    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15, 3);
+  });
+
+  it("marker mode OFF: a double-click near an onset within threshold snaps onto the onset", async () => {
+    setupWaveformAudio(30);
+    useSettingsStore.setState({ vocalOnsetSnap: true, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({ zoom: 50, markerMode: false, customSnapPoints: [], vocalOnsetSnapPoints: [15.1] });
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("dblclick", { clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
+    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15.1, 6);
+  });
+
+  it("onset snapping is suppressed when the vocalOnsetSnap setting is off, mirroring the drag", async () => {
+    setupWaveformAudio(30);
+    useSettingsStore.setState({ vocalOnsetSnap: false, timelineSnapThreshold: 12 });
+    useTimelineStore.setState({ zoom: 50, markerMode: true, customSnapPoints: [], vocalOnsetSnapPoints: [15.1] });
+    const screen = await render(<TimelineWaveform />);
+    const layer = getClickLayer(screen.container, 1500);
+
+    layer.dispatchEvent(new MouseEvent("click", { clientX: 750, clientY: 40, bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().customSnapPoints.length).toBe(1);
+    expect(useTimelineStore.getState().customSnapPoints[0]).toBeCloseTo(15, 3);
+  });
+});
+
+describe("TimelineWaveform marker-mode armed state", () => {
+  function getClickLayer(): HTMLElement | null {
+    return document.querySelector<HTMLElement>('[role="button"][aria-label]');
+  }
+
+  it("does not carry the armed class and reads as a seek affordance when marker mode is off", async () => {
+    setupWaveformAudio(30);
+    useTimelineStore.setState({ markerMode: false });
+    await render(<TimelineWaveform />);
+    const layer = getClickLayer();
+    expect(layer?.className).not.toContain("waveform-armed");
+    expect(layer?.className).toContain("cursor-pointer");
+    expect(layer?.getAttribute("aria-label")).toBe("Seek to position");
+  });
+
+  it("carries the armed class and reads as a placement affordance when marker mode is on", async () => {
+    setupWaveformAudio(30);
+    useTimelineStore.setState({ markerMode: true });
+    await render(<TimelineWaveform />);
+    const layer = getClickLayer();
+    expect(layer?.className).toContain("waveform-armed");
+    expect(layer?.className).not.toContain("cursor-pointer");
+    expect(layer?.getAttribute("aria-label")).toBe("Place snap point");
+  });
+
+  it("flips the armed class reactively when marker mode toggles in the store", async () => {
+    setupWaveformAudio(30);
+    useTimelineStore.setState({ markerMode: false });
+    const screen = await render(<TimelineWaveform />);
+    const layer = () => screen.container.querySelector<HTMLElement>('[role="button"][aria-label]');
+    expect(layer()?.className).not.toContain("waveform-armed");
+
+    useTimelineStore.setState({ markerMode: true });
+    await expect.poll(() => layer()?.className).toContain("waveform-armed");
+    expect(layer()?.getAttribute("aria-label")).toBe("Place snap point");
+    expect(layer()?.className).not.toContain("cursor-pointer");
+
+    useTimelineStore.setState({ markerMode: false });
+    await expect.poll(() => layer()?.className).not.toContain("waveform-armed");
+    expect(layer()?.getAttribute("aria-label")).toBe("Seek to position");
+    expect(layer()?.className).toContain("cursor-pointer");
+  });
+});

--- a/src/views/timeline/timeline-waveform.tsx
+++ b/src/views/timeline/timeline-waveform.tsx
@@ -128,7 +128,10 @@ const TimelineWaveform: React.FC = () => {
         role="button"
         tabIndex={-1}
         aria-label={markerMode ? "Place snap point" : "Seek to position"}
-        className={cn("absolute top-0 left-0 z-10", markerMode ? "waveform-armed" : "cursor-pointer")}
+        className={cn(
+          "absolute top-0 left-0 z-10 transition-shadow duration-200 ease-out",
+          markerMode ? "waveform-armed" : "cursor-pointer",
+        )}
         key="waveform-click-layer"
         style={{
           width: totalWidth,

--- a/src/views/timeline/timeline-waveform.tsx
+++ b/src/views/timeline/timeline-waveform.tsx
@@ -1,5 +1,6 @@
 import { useAudioStore } from "@/stores/audio";
 import { useSettingsStore } from "@/stores/settings";
+import { cn } from "@/utils/cn";
 import { snapTimeToOnset } from "@/views/timeline/snap-marker-math";
 import { useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
 import WavesurferPlayer from "@wavesurfer/react";
@@ -15,6 +16,7 @@ const TimelineWaveform: React.FC = () => {
   const seekTo = useAudioStore((s) => s.seekTo);
 
   const zoom = useTimelineStore((s) => s.zoom);
+  const markerMode = useTimelineStore((s) => s.markerMode);
 
   const [ws, setWs] = useState<WaveSurfer | null>(null);
 
@@ -124,8 +126,8 @@ const TimelineWaveform: React.FC = () => {
       <div
         role="button"
         tabIndex={-1}
-        aria-label="Seek to position"
-        className="absolute top-0 left-0 z-10 cursor-pointer"
+        aria-label={markerMode ? "Place snap point" : "Seek to position"}
+        className={cn("absolute top-0 left-0 z-10", markerMode ? "waveform-armed" : "cursor-pointer")}
         key="waveform-click-layer"
         style={{
           width: totalWidth,

--- a/src/views/timeline/timeline-waveform.tsx
+++ b/src/views/timeline/timeline-waveform.tsx
@@ -59,6 +59,7 @@ const TimelineWaveform: React.FC = () => {
       if (!duration || totalWidth <= 0) return;
       const time = timeFromClick(e);
       if (useTimelineStore.getState().markerMode) {
+        if (e.detail > 1) return;
         addSnappedPoint(time);
         return;
       }

--- a/src/views/timeline/timeline-waveform.tsx
+++ b/src/views/timeline/timeline-waveform.tsx
@@ -1,4 +1,6 @@
 import { useAudioStore } from "@/stores/audio";
+import { useSettingsStore } from "@/stores/settings";
+import { snapTimeToOnset } from "@/views/timeline/snap-marker-math";
 import { useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
 import WavesurferPlayer from "@wavesurfer/react";
 import { useCallback, useEffect, useState } from "react";
@@ -33,17 +35,44 @@ const TimelineWaveform: React.FC = () => {
     ws.zoom(zoom);
   }, [ws, zoom]);
 
-  // Handle click to seek
-  const seekToClickedPosition = useCallback(
+  const timeFromClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      return (x / totalWidth) * duration;
+    },
+    [duration, totalWidth],
+  );
+
+  const addSnappedPoint = useCallback((time: number) => {
+    const { zoom: currentZoom, vocalOnsetSnapPoints, addCustomSnapPoint } = useTimelineStore.getState();
+    const { vocalOnsetSnap, timelineSnapThreshold } = useSettingsStore.getState();
+    const onsets = vocalOnsetSnap ? vocalOnsetSnapPoints : [];
+    addCustomSnapPoint(snapTimeToOnset(time, onsets, currentZoom, timelineSnapThreshold));
+  }, []);
+
+  const handleClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       e.stopPropagation();
       if (!duration || totalWidth <= 0) return;
-      const rect = e.currentTarget.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const time = (x / totalWidth) * duration;
+      const time = timeFromClick(e);
+      if (useTimelineStore.getState().markerMode) {
+        addSnappedPoint(time);
+        return;
+      }
       seekTo(time);
     },
-    [duration, totalWidth, seekTo],
+    [duration, totalWidth, seekTo, timeFromClick, addSnappedPoint],
+  );
+
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      if (!duration || totalWidth <= 0) return;
+      if (useTimelineStore.getState().markerMode) return;
+      addSnappedPoint(timeFromClick(e));
+    },
+    [duration, totalWidth, timeFromClick, addSnappedPoint],
   );
 
   const onDestroy = useCallback(() => setWs(null), []);
@@ -102,7 +131,8 @@ const TimelineWaveform: React.FC = () => {
           width: totalWidth,
           height: WAVEFORM_HEIGHT,
         }}
-        onClick={seekToClickedPosition}
+        onClick={handleClick}
+        onDoubleClick={handleDoubleClick}
         onKeyDown={() => {}}
       />
     </div>

--- a/src/views/timeline/use-snap-marker-drag.ts
+++ b/src/views/timeline/use-snap-marker-drag.ts
@@ -1,0 +1,97 @@
+import { useCallback, useRef, useState } from "react";
+import { useSettingsStore } from "@/stores/settings";
+import { snapTimeToOnset } from "@/views/timeline/snap-marker-math";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+import { xToTime } from "@/views/timeline/coords";
+
+// -- Types ---------------------------------------------------------------------
+
+interface SnapMarkerDragConfig {
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+interface SnapMarkerDrag {
+  draggingTime: number | null;
+  onHeadPointerDown: (index: number, event: React.PointerEvent<HTMLElement>) => void;
+}
+
+// -- Helpers -------------------------------------------------------------------
+
+function resolveIndexByTime(points: number[], target: number): number {
+  let bestIndex = -1;
+  let bestDelta = Number.POSITIVE_INFINITY;
+  for (let index = 0; index < points.length; index++) {
+    const delta = Math.abs(points[index] - target);
+    if (delta < bestDelta) {
+      bestDelta = delta;
+      bestIndex = index;
+    }
+  }
+  return bestIndex;
+}
+
+// -- Hook ----------------------------------------------------------------------
+
+function useSnapMarkerDrag({ scrollContainerRef }: SnapMarkerDragConfig): SnapMarkerDrag {
+  const [draggingTime, setDraggingTime] = useState<number | null>(null);
+  const lastWrittenRef = useRef<number>(0);
+
+  const onHeadPointerDown = useCallback(
+    (index: number, event: React.PointerEvent<HTMLElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.stopPropagation();
+
+      const head = event.currentTarget;
+      head.setPointerCapture(event.pointerId);
+
+      const startPoints = useTimelineStore.getState().customSnapPoints;
+      lastWrittenRef.current = startPoints[index] ?? 0;
+      setDraggingTime(lastWrittenRef.current);
+
+      const computeTime = (clientX: number): number => {
+        const container = scrollContainerRef.current;
+        if (!container) return lastWrittenRef.current;
+        const { zoom, scrollLeft: storeScrollLeft } = useTimelineStore.getState();
+        const scrollLeft = container.scrollLeft ?? storeScrollLeft;
+        const rect = container.getBoundingClientRect();
+        const raw = xToTime(clientX, rect, zoom, scrollLeft);
+        const onsets = useSettingsStore.getState().vocalOnsetSnap
+          ? useTimelineStore.getState().vocalOnsetSnapPoints
+          : [];
+        const thresholdPx = useSettingsStore.getState().timelineSnapThreshold;
+        return snapTimeToOnset(raw, onsets, zoom, thresholdPx);
+      };
+
+      const handlePointerMove = (moveEvent: PointerEvent): void => {
+        const store = useTimelineStore.getState();
+        const currentIndex = resolveIndexByTime(store.customSnapPoints, lastWrittenRef.current);
+        if (currentIndex === -1) return;
+        const time = computeTime(moveEvent.clientX);
+        lastWrittenRef.current = time;
+        store.moveCustomSnapPoint(currentIndex, time);
+        setDraggingTime(time);
+      };
+
+      const handlePointerUp = (): void => {
+        head.removeEventListener("pointermove", handlePointerMove);
+        head.removeEventListener("pointerup", handlePointerUp);
+        head.removeEventListener("pointercancel", handlePointerUp);
+        if (head.hasPointerCapture(event.pointerId)) head.releasePointerCapture(event.pointerId);
+        setDraggingTime(null);
+      };
+
+      head.addEventListener("pointermove", handlePointerMove);
+      head.addEventListener("pointerup", handlePointerUp);
+      head.addEventListener("pointercancel", handlePointerUp);
+    },
+    [scrollContainerRef],
+  );
+
+  return { draggingTime, onHeadPointerDown };
+}
+
+// -- Exports -------------------------------------------------------------------
+
+export { useSnapMarkerDrag };
+export type { SnapMarkerDrag };

--- a/src/views/timeline/use-timeline-keyboard.browser.test.tsx
+++ b/src/views/timeline/use-timeline-keyboard.browser.test.tsx
@@ -27,6 +27,36 @@ describe("useTimelineKeyboard", () => {
     expect(useTimelineStore.getState().rollingEditMode).toBe(true);
   });
 
+  it("toggles marker mode on and off when the marker mode shortcut is pressed", async () => {
+    useProjectStore.setState({ activeTab: "timeline" });
+    expect(useTimelineStore.getState().markerMode).toBe(false);
+    const scrollContainerRef = createRef<HTMLDivElement | null>();
+    await renderHook(() => useTimelineKeyboard(scrollContainerRef, [], 0));
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "i", bubbles: true }));
+    expect(useTimelineStore.getState().markerMode).toBe(true);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "i", bubbles: true }));
+    expect(useTimelineStore.getState().markerMode).toBe(false);
+  });
+
+  it("does not toggle marker mode while a text input is focused", async () => {
+    useProjectStore.setState({ activeTab: "timeline" });
+    expect(useTimelineStore.getState().markerMode).toBe(false);
+    const scrollContainerRef = createRef<HTMLDivElement | null>();
+    await renderHook(() => useTimelineKeyboard(scrollContainerRef, [], 0));
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    await expect.poll(() => document.activeElement).toBe(input);
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "i", bubbles: true }));
+    expect(useTimelineStore.getState().markerMode).toBe(false);
+
+    input.remove();
+  });
+
   it("merges two space-separated words into one when the merge shortcut is pressed", async () => {
     const line = createLine({
       text: "every day",

--- a/src/views/timeline/use-timeline-keyboard.ts
+++ b/src/views/timeline/use-timeline-keyboard.ts
@@ -344,6 +344,10 @@ function useTimelineKeyboard(
         case "timeline.toggleRollingEdit":
           useTimelineStore.getState().toggleRollingEditMode();
           break;
+        case "timeline.toggleMarkerMode":
+          e.preventDefault();
+          useTimelineStore.getState().toggleMarkerMode();
+          break;
         case "timeline.setWordBegin":
           e.preventDefault();
           handleSetWordTiming("begin");

--- a/src/views/timeline/use-timeline-snap.custom-points.browser.test.tsx
+++ b/src/views/timeline/use-timeline-snap.custom-points.browser.test.tsx
@@ -1,0 +1,113 @@
+import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+import { useTimelineSnap } from "@/views/timeline/use-timeline-snap";
+import { beforeEach, describe, expect, it } from "vitest";
+import { renderHook } from "vitest-browser-react";
+
+// -- Helpers ------------------------------------------------------------------
+
+const ZOOM = 100;
+const THRESHOLD = 12;
+const SELF_IDS = new Set<string>();
+const ALLOW_SHIFT = () => true;
+
+function beginAt(result: { current: ReturnType<typeof useTimelineSnap> }): void {
+  result.current.beginGesture({ selfIds: SELF_IDS, leaderKey: "leader", overlapCheck: ALLOW_SHIFT });
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("useTimelineSnap · custom snap points", () => {
+  beforeEach(() => {
+    useAudioStore.setState({ audioElement: null, currentTime: 0, duration: 30 });
+    useProjectStore.setState({ lines: [] });
+    useTimelineStore.setState({
+      zoom: ZOOM,
+      isBypassing: false,
+      vocalOnsetSnapPoints: [],
+      customSnapPoints: [],
+      snappedBlockId: null,
+      snappedAnchorTime: null,
+    });
+    useSettingsStore.setState({
+      timelineSnap: false,
+      vocalOnsetSnap: false,
+      timelineSnapThreshold: THRESHOLD,
+    });
+  });
+
+  it("snaps a block to a custom point when both timelineSnap and vocalOnsetSnap are OFF", async () => {
+    useTimelineStore.setState({ customSnapPoints: [1] });
+    const { result } = await renderHook(() => useTimelineSnap());
+
+    beginAt(result);
+
+    const edge = 0.95;
+    const proposedDeltaPx = 0;
+    const shiftPx = result.current.computeShiftPx(proposedDeltaPx, [edge]);
+
+    expect(shiftPx).toBeCloseTo((1 - edge) * ZOOM, 4);
+    expect(useTimelineStore.getState().snappedAnchorTime).toBeCloseTo(1, 4);
+  });
+
+  it("does not snap when there are no custom points and both snaps are OFF", async () => {
+    useTimelineStore.setState({ customSnapPoints: [] });
+    const { result } = await renderHook(() => useTimelineSnap());
+
+    beginAt(result);
+
+    const shiftPx = result.current.computeShiftPx(0, [0.95]);
+
+    expect(shiftPx).toBe(0);
+    expect(useTimelineStore.getState().snappedAnchorTime).toBeNull();
+  });
+
+  it("snaps to the nearest of a custom point and a vocal onset when both are active (additive)", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: true });
+    useTimelineStore.setState({ customSnapPoints: [1], vocalOnsetSnapPoints: [2] });
+    const { result } = await renderHook(() => useTimelineSnap());
+
+    beginAt(result);
+
+    const nearOnsetShift = result.current.computeShiftPx(0, [2.05]);
+    expect(nearOnsetShift).toBeCloseTo((2 - 2.05) * ZOOM, 4);
+    expect(useTimelineStore.getState().snappedAnchorTime).toBeCloseTo(2, 4);
+
+    const nearCustomShift = result.current.computeShiftPx(0, [0.95]);
+    expect(nearCustomShift).toBeCloseTo((1 - 0.95) * ZOOM, 4);
+    expect(useTimelineStore.getState().snappedAnchorTime).toBeCloseTo(1, 4);
+  });
+
+  it("keeps vocal onsets gated by vocalOnsetSnap even when a custom point enables snapping", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: false });
+    useTimelineStore.setState({ customSnapPoints: [1], vocalOnsetSnapPoints: [2] });
+    const { result } = await renderHook(() => useTimelineSnap());
+
+    beginAt(result);
+
+    const shiftPx = result.current.computeShiftPx(0, [2.05]);
+
+    expect(shiftPx).toBe(0);
+    expect(useTimelineStore.getState().snappedAnchorTime).toBeNull();
+  });
+
+  it("does not emit timeline grid anchors when timelineSnap is OFF but a custom point exists", async () => {
+    useProjectStore.setState({
+      lines: [{ id: "g1", text: "grid", agentId: "v1", begin: 2, end: 3 }],
+    });
+    useTimelineStore.setState({ customSnapPoints: [1] });
+    const { result } = await renderHook(() => useTimelineSnap());
+
+    beginAt(result);
+
+    const nearGrid = result.current.computeShiftPx(0, [1.98]);
+    expect(nearGrid).toBe(0);
+    expect(useTimelineStore.getState().snappedAnchorTime).toBeNull();
+
+    const nearCustom = result.current.computeShiftPx(0, [0.95]);
+    expect(nearCustom).toBeCloseTo((1 - 0.95) * ZOOM, 4);
+    expect(useTimelineStore.getState().snappedAnchorTime).toBeCloseTo(1, 4);
+  });
+});

--- a/src/views/timeline/use-timeline-snap.ts
+++ b/src/views/timeline/use-timeline-snap.ts
@@ -49,6 +49,7 @@ function useTimelineSnap(): UseTimelineSnap {
   useTimelineStore((s) => s.zoom);
   useTimelineStore((s) => s.isBypassing);
   useTimelineStore((s) => s.vocalOnsetSnapPoints);
+  useTimelineStore((s) => s.customSnapPoints);
 
   const ctxRef = useRef<SnapCtx>({
     anchors: [],
@@ -64,7 +65,14 @@ function useTimelineSnap(): UseTimelineSnap {
     const timeline = useTimelineStore.getState();
     const playhead = audio.audioElement?.currentTime ?? audio.currentTime ?? null;
     const vocalOnsets = settings.vocalOnsetSnap ? timeline.vocalOnsetSnapPoints : [];
-    ctxRef.current.anchors = collectSnapAnchors(lines, args.selfIds, playhead, vocalOnsets, settings.timelineSnap);
+    ctxRef.current.anchors = collectSnapAnchors(
+      lines,
+      args.selfIds,
+      playhead,
+      vocalOnsets,
+      settings.timelineSnap,
+      timeline.customSnapPoints,
+    );
     ctxRef.current.selfIds = args.selfIds;
     ctxRef.current.leaderKey = args.leaderKey;
     ctxRef.current.overlapCheck = args.overlapCheck;
@@ -82,7 +90,10 @@ function useTimelineSnap(): UseTimelineSnap {
     const ctx = ctxRef.current;
     const settings = useSettingsStore.getState();
     const timeline = useTimelineStore.getState();
-    const enabled = settings.timelineSnap || (settings.vocalOnsetSnap && timeline.vocalOnsetSnapPoints.length > 0);
+    const enabled =
+      settings.timelineSnap ||
+      (settings.vocalOnsetSnap && timeline.vocalOnsetSnapPoints.length > 0) ||
+      timeline.customSnapPoints.length > 0;
     const threshold = useSettingsStore.getState().timelineSnapThreshold;
     const bypassing = useTimelineStore.getState().isBypassing;
     const zoom = timeline.zoom;


### PR DESCRIPTION
Vocal-onset and custom snap points now render as marker lines over the timeline waveform.

- Marker mode (`I` or the toolbar pin): click the waveform to drop a custom point; double-click to drop one when it's off.
- Drag a pin to move it (snaps onto a nearby onset); hover for the time and a delete.
- Custom points always snap; onset guides show and snap when "Snap to vocal onsets" is on.
- Session-only: points clear on reload and when the song changes.
