### PR TITLE
Line-synced background vocals (#122)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.32.0",
+  "version": "1.33.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/domain/group/linking.ts
+++ b/src/domain/group/linking.ts
@@ -1,4 +1,4 @@
-import type { LyricLine } from "@/domain/line/model";
+import type { LooseLine, LyricLine } from "@/domain/line/model";
 
 // -- Types --------------------------------------------------------------------
 
@@ -26,8 +26,8 @@ function isLinkedSibling(line: LyricLine, scope: LinkScope | null): boolean {
 // The subset of a line update that mirrors onto linked siblings: shared content
 // fields, plus explicit clears of timing arrays (a defined timing value is
 // instance-specific and never propagates).
-function extractLinkedFields(updates: Partial<LyricLine>): Partial<LyricLine> {
-  const linked: Partial<LyricLine> = {};
+function extractLinkedFields(updates: Partial<LooseLine>): Partial<LooseLine> {
+  const linked: Partial<LooseLine> = {};
   if ("text" in updates) linked.text = updates.text;
   if ("agentId" in updates) linked.agentId = updates.agentId;
   if ("backgroundText" in updates) linked.backgroundText = updates.backgroundText;

--- a/src/domain/instance/bounds.test.ts
+++ b/src/domain/instance/bounds.test.ts
@@ -87,7 +87,12 @@ describe("instanceBounds", () => {
     expect(instanceBounds(lines)).toEqual({ begin: 2, end: 5 });
   });
 
-  it("ignores stale line.begin/end when bg words present (no main timing)", () => {
+  // A line with begin/end and no main words is line-synced main, not stale
+  // timing. Under the voice model a line-synced main is first-class, so its
+  // bounds count alongside the background, exactly as a word-synced main does
+  // (see "includes background words in the bounds" above). Previously the
+  // line-synced main was dropped whenever a background was present.
+  it("counts line-synced main bounds alongside background words", () => {
     const lines: LyricLine[] = [
       line({
         id: "a",
@@ -96,7 +101,19 @@ describe("instanceBounds", () => {
         backgroundWords: [{ text: "b", begin: 4, end: 5 }],
       }),
     ];
-    expect(instanceBounds(lines)).toEqual({ begin: 4, end: 5 });
+    expect(instanceBounds(lines)).toEqual({ begin: 0, end: 999 });
+  });
+
+  it("takes the union of line-synced main and a background that extends past it", () => {
+    const lines: LyricLine[] = [
+      line({
+        id: "a",
+        begin: 2,
+        end: 5,
+        backgroundWords: [{ text: "b", begin: 1, end: 8 }],
+      }),
+    ];
+    expect(instanceBounds(lines)).toEqual({ begin: 1, end: 8 });
   });
 
   it("skips untimed lines when others are timed", () => {

--- a/src/domain/instance/bounds.ts
+++ b/src/domain/instance/bounds.ts
@@ -4,29 +4,18 @@ import type { LyricLine } from "@/domain/line/model";
 
 // -- Functions ----------------------------------------------------------------
 
+// The union of all timed content across a slice: per line, the main voice and
+// the background voice each contribute their own bounds. effectiveBounds is not
+// used here because it is a layout envelope gated on the main voice (it returns
+// null for a background-only line); instanceBounds must count that background.
 function instanceBounds(lines: LyricLine[]): Bounds | null {
   let begin = Number.POSITIVE_INFINITY;
   let end = Number.NEGATIVE_INFINITY;
   for (const line of lines) {
-    const hasWords = !!line.words?.length;
-    const hasBg = !!line.backgroundWords?.length;
-    if (hasWords) {
-      const m = mainBounds(line);
-      if (m) {
-        if (m.begin < begin) begin = m.begin;
-        if (m.end > end) end = m.end;
-      }
-    }
-    if (hasBg) {
-      const b = bgBounds(line);
-      if (b) {
-        if (b.begin < begin) begin = b.begin;
-        if (b.end > end) end = b.end;
-      }
-    }
-    if (!hasWords && !hasBg) {
-      if (line.begin !== undefined && line.begin < begin) begin = line.begin;
-      if (line.end !== undefined && line.end > end) end = line.end;
+    for (const b of [mainBounds(line), bgBounds(line)]) {
+      if (!b) continue;
+      if (b.begin < begin) begin = b.begin;
+      if (b.end > end) end = b.end;
     }
   }
   if (!Number.isFinite(begin) || !Number.isFinite(end)) return null;

--- a/src/domain/instance/cross-instance.test.ts
+++ b/src/domain/instance/cross-instance.test.ts
@@ -1,19 +1,21 @@
 /**
  * @vitest-environment node
  */
+import { reconcileLine } from "@/domain/line/model";
 import type { LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
 import { wouldDropCrossInstance } from "./cross-instance";
 
-const grouped = (id: string, gid: string, inst: number): LyricLine => ({
-  id,
-  text: "x",
-  agentId: "v1",
-  groupId: gid,
-  instanceIdx: inst,
-  templateLineIdx: 0,
-});
-const plain = (id: string): LyricLine => ({ id, text: "x", agentId: "v1" });
+const grouped = (id: string, gid: string, inst: number): LyricLine =>
+  reconcileLine({
+    id,
+    text: "x",
+    agentId: "v1",
+    groupId: gid,
+    instanceIdx: inst,
+    templateLineIdx: 0,
+  });
+const plain = (id: string): LyricLine => reconcileLine({ id, text: "x", agentId: "v1" });
 
 describe("wouldDropCrossInstance", () => {
   it("refuses move between two instances of the same group", () => {
@@ -42,7 +44,7 @@ describe("wouldDropCrossInstance", () => {
 
   it("treats a line with groupId but no instanceIdx as different from one with both", () => {
     // Edge case: a line that lost instanceIdx mid-edit shouldn't merge with a properly-grouped one
-    const partial: LyricLine = { id: "a", text: "x", agentId: "v1", groupId: "g1" };
+    const partial: LyricLine = reconcileLine({ id: "a", text: "x", agentId: "v1", groupId: "g1" });
     expect(wouldDropCrossInstance(partial, grouped("b", "g1", 0))).toBe(true);
   });
 });

--- a/src/domain/line/background.test.ts
+++ b/src/domain/line/background.test.ts
@@ -5,10 +5,14 @@ import {
   CLEARED_BACKGROUND,
   manualBackgroundWordEdit,
 } from "@/domain/line/background";
+import { mainBounds } from "@/domain/line/bounds";
+import { reconcileLine } from "@/domain/line/model";
 import type { LyricLine } from "@/domain/line/model";
+import { isLineSynced } from "@/domain/line/predicates";
+import { bgSource, bgText, bgWords, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 
-const line: LyricLine = { id: "a", text: "hello", agentId: "v1" };
+const line: LyricLine = reconcileLine({ id: "a", text: "hello", agentId: "v1" });
 
 const bgWord: WordTiming = { text: "ooh", begin: 1.2, end: 1.8 };
 
@@ -89,13 +93,13 @@ describe("CLEARED_BACKGROUND", () => {
 describe("applyBackground", () => {
   it("sets then clears a line's background coherently", () => {
     const withBg = applyBackground(line, { text: "ooh", source: "manual" });
-    expect(withBg.backgroundText).toBe("ooh");
-    expect(withBg.backgroundTextSource).toBe("manual");
+    expect(bgText(withBg)).toBe("ooh");
+    expect(bgSource(withBg)).toBe("manual");
 
     const cleared = applyBackground(withBg, { text: "", source: "manual" });
-    expect(cleared.backgroundText).toBeUndefined();
-    expect(cleared.backgroundWords).toBeUndefined();
-    expect(cleared.backgroundTextSource).toBeUndefined();
+    expect(bgText(cleared)).toBeUndefined();
+    expect(bgWords(cleared)).toBeUndefined();
+    expect(bgSource(cleared)).toBeUndefined();
   });
 });
 
@@ -108,7 +112,7 @@ describe("applyBackground immutability and field preservation", () => {
   });
 
   it("preserves unrelated fields on an untimed line", () => {
-    const source: LyricLine = {
+    const source: LyricLine = reconcileLine({
       id: "u1",
       text: "verse one",
       agentId: "v2",
@@ -116,7 +120,7 @@ describe("applyBackground immutability and field preservation", () => {
       instanceIdx: 0,
       templateLineIdx: 3,
       detached: true,
-    };
+    });
     const result = applyBackground(source, { text: "ooh", source: "extraction" });
     expect(result).toMatchObject({
       id: "u1",
@@ -130,7 +134,7 @@ describe("applyBackground immutability and field preservation", () => {
   });
 
   it("preserves the word-synced timing variant", () => {
-    const wordSynced: LyricLine = {
+    const wordSynced: LyricLine = reconcileLine({
       id: "w1",
       text: "hello world",
       agentId: "v1",
@@ -138,25 +142,24 @@ describe("applyBackground immutability and field preservation", () => {
         { text: "hello ", begin: 0, end: 0.5 },
         { text: "world", begin: 0.5, end: 1 },
       ],
-    };
+    });
     const result = applyBackground(wordSynced, { text: "ooh", source: "manual" });
-    expect(result.words).toEqual(wordSynced.words);
-    expect(result.begin).toBeUndefined();
-    expect(result.end).toBeUndefined();
+    expect(mainWords(result)).toEqual(mainWords(wordSynced));
+    expect(isLineSynced(result)).toBe(false);
   });
 
   it("preserves the line-synced timing variant", () => {
-    const lineSynced: LyricLine = {
+    const lineSynced: LyricLine = reconcileLine({
       id: "l1",
       text: "hello world",
       agentId: "v1",
       begin: 2.5,
       end: 6.75,
-    };
+    });
     const result = applyBackground(lineSynced, { text: "ooh", source: "extraction" });
-    expect(result.begin).toBe(2.5);
-    expect(result.end).toBe(6.75);
-    expect(result.words).toBeUndefined();
+    expect(mainBounds(result)?.begin).toBe(2.5);
+    expect(mainBounds(result)?.end).toBe(6.75);
+    expect(mainWords(result)).toBeUndefined();
   });
 });
 
@@ -164,24 +167,24 @@ describe("applyBackground overwriting", () => {
   it("flips an existing manual provenance to extraction", () => {
     const manual = applyBackground(line, { text: "ooh", source: "manual" });
     const overwritten = applyBackground(manual, { text: "aah", source: "extraction" });
-    expect(overwritten.backgroundText).toBe("aah");
-    expect(overwritten.backgroundTextSource).toBe("extraction");
+    expect(bgText(overwritten)).toBe("aah");
+    expect(bgSource(overwritten)).toBe("extraction");
   });
 
   it("flips an existing extraction provenance to manual", () => {
     const extracted = applyBackground(line, { text: "ooh", source: "extraction" });
     const overwritten = applyBackground(extracted, { text: "aah", source: "manual" });
-    expect(overwritten.backgroundText).toBe("aah");
-    expect(overwritten.backgroundTextSource).toBe("manual");
+    expect(bgText(overwritten)).toBe("aah");
+    expect(bgSource(overwritten)).toBe("manual");
   });
 
   it("clears backgroundWords when clearing a line that had words-based background", () => {
     const withWords = applyBackground(line, { words: [bgWord], source: "extraction" });
-    expect(withWords.backgroundWords).toEqual([bgWord]);
+    expect(bgWords(withWords)).toEqual([bgWord]);
     const cleared = applyBackground(withWords, { text: "", source: "manual" });
-    expect(cleared.backgroundWords).toBeUndefined();
-    expect(cleared.backgroundText).toBeUndefined();
-    expect(cleared.backgroundTextSource).toBeUndefined();
+    expect(bgWords(cleared)).toBeUndefined();
+    expect(bgText(cleared)).toBeUndefined();
+    expect(bgSource(cleared)).toBeUndefined();
   });
 });
 

--- a/src/domain/line/background.test.ts
+++ b/src/domain/line/background.test.ts
@@ -2,14 +2,17 @@ import { describe, expect, it } from "vitest";
 import {
   applyBackground,
   backgroundFields,
+  buildBackgroundVoice,
   CLEARED_BACKGROUND,
   manualBackgroundWordEdit,
+  setBackground,
 } from "@/domain/line/background";
-import { mainBounds } from "@/domain/line/bounds";
+import { bgBounds, mainBounds } from "@/domain/line/bounds";
 import { reconcileLine } from "@/domain/line/model";
 import type { LyricLine } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/line/predicates";
-import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { bgSource, bgText, bgVoice, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { isLineSynced as isVoiceLineSynced } from "@/domain/voice/predicates";
 import type { WordTiming } from "@/domain/word/timing";
 
 const line: LyricLine = reconcileLine({ id: "a", text: "hello", agentId: "v1" });
@@ -213,5 +216,195 @@ describe("manualBackgroundWordEdit", () => {
       { text: "oh", begin: 0.5, end: 1 },
     ]);
     expect(fields.backgroundText).toBe("oh|oh");
+  });
+});
+
+describe("applyBackground granularity resolution", () => {
+  it("makes untimed bg text a line-synced background on a line-synced main", () => {
+    const lineSynced: LyricLine = reconcileLine({ id: "ls", text: "hello world", agentId: "v1", begin: 2, end: 6 });
+    const result = applyBackground(lineSynced, { text: "ooh", source: "extraction" });
+    expect(bgText(result)).toBe("ooh");
+    expect(bgBounds(result)).toEqual({ begin: 4, end: 6 });
+    expect(bgWords(result)).toBeUndefined();
+    const voice = bgVoice(result);
+    expect(voice).not.toBeNull();
+    expect(isVoiceLineSynced(voice as NonNullable<typeof voice>)).toBe(true);
+  });
+
+  it("distributes untimed bg text over a word-synced main's second half", () => {
+    const wordSynced: LyricLine = reconcileLine({
+      id: "ws",
+      text: "hello world",
+      agentId: "v1",
+      words: [
+        { text: "hello ", begin: 0, end: 2 },
+        { text: "world", begin: 2, end: 4 },
+      ],
+    });
+    const result = applyBackground(wordSynced, { text: "ooh aah", source: "manual" });
+    const words = bgWords(result);
+    expect(words).toBeDefined();
+    expect(words).toHaveLength(2);
+    expect((words as WordTiming[])[0].begin).toBeGreaterThanOrEqual(2);
+    expect((words as WordTiming[])[1].end).toBe(4);
+  });
+
+  it("keeps untimed bg text untimed on an untimed main", () => {
+    const result = applyBackground(line, { text: "ooh", source: "extraction" });
+    expect(bgText(result)).toBe("ooh");
+    expect(bgWords(result)).toBeUndefined();
+    expect(bgBounds(result)).toBeNull();
+  });
+
+  it("keeps a word-synced bg verbatim regardless of main state", () => {
+    const wordSynced: LyricLine = reconcileLine({
+      id: "ws",
+      text: "hello world",
+      agentId: "v1",
+      words: [
+        { text: "hello ", begin: 0, end: 2 },
+        { text: "world", begin: 2, end: 4 },
+      ],
+    });
+    const inputWords: WordTiming[] = [
+      { text: "ooh ", begin: 1, end: 1.5 },
+      { text: "aah", begin: 1.5, end: 2 },
+    ];
+    const result = applyBackground(wordSynced, { words: inputWords, source: "manual" });
+    expect(bgWords(result)).toEqual(inputWords);
+  });
+
+  it("preserves an extraction source through line-synced resolution", () => {
+    const lineSynced: LyricLine = reconcileLine({ id: "ls", text: "hello world", agentId: "v1", begin: 2, end: 6 });
+    const result = applyBackground(lineSynced, { text: "ooh", source: "extraction" });
+    expect(bgSource(result)).toBe("extraction");
+  });
+
+  it("preserves a manual source through distribution", () => {
+    const wordSynced: LyricLine = reconcileLine({
+      id: "ws",
+      text: "hello world",
+      agentId: "v1",
+      words: [
+        { text: "hello ", begin: 0, end: 2 },
+        { text: "world", begin: 2, end: 4 },
+      ],
+    });
+    const result = applyBackground(wordSynced, { text: "ooh aah", source: "manual" });
+    expect(bgSource(result)).toBe("manual");
+  });
+
+  it("clears a line-synced background through the funnel on a blank write", () => {
+    const lineSynced: LyricLine = reconcileLine({ id: "ls", text: "hello world", agentId: "v1", begin: 2, end: 6 });
+    const withBg = applyBackground(lineSynced, { text: "ooh", source: "extraction" });
+    expect(bgBounds(withBg)).toEqual({ begin: 4, end: 6 });
+    const cleared = applyBackground(withBg, { text: "   ", source: "manual" });
+    expect(bgVoice(cleared)).toBeNull();
+    expect("background" in cleared).toBe(false);
+  });
+
+  it("clears a word-synced background through the funnel on a blank write", () => {
+    const wordSynced: LyricLine = reconcileLine({
+      id: "ws",
+      text: "hello world",
+      agentId: "v1",
+      words: [
+        { text: "hello ", begin: 0, end: 2 },
+        { text: "world", begin: 2, end: 4 },
+      ],
+    });
+    const withBg = applyBackground(wordSynced, { words: [bgWord], source: "manual" });
+    expect(bgWords(withBg)).toEqual([bgWord]);
+    const cleared = applyBackground(withBg, { text: "", source: "manual" });
+    expect(bgVoice(cleared)).toBeNull();
+    expect("background" in cleared).toBe(false);
+  });
+});
+
+describe("setBackground", () => {
+  const voice = { text: "ooh", begin: 1, end: 2, source: "manual" } as const;
+
+  it("sets a nested background voice and returns a new reference", () => {
+    const snapshot = structuredClone(line);
+    const result = setBackground(line, { ...voice });
+    expect(result).not.toBe(line);
+    expect(bgVoice(result)).toEqual(voice);
+    expect(line).toEqual(snapshot);
+  });
+
+  it("removes the background key entirely on a null write", () => {
+    const withBg = setBackground(line, { ...voice });
+    const cleared = setBackground(withBg, null);
+    expect("background" in cleared).toBe(false);
+    expect(bgVoice(cleared)).toBeNull();
+  });
+
+  it("is idempotent when clearing an already-absent background", () => {
+    const cleared = setBackground(line, null);
+    expect("background" in cleared).toBe(false);
+    expect(bgVoice(cleared)).toBeNull();
+  });
+
+  it("leaves every background accessor coherent after a clear", () => {
+    const withBg = setBackground(line, { text: "ooh", words: [bgWord], source: "extraction" });
+    const cleared = setBackground(withBg, null);
+    expect(bgText(cleared)).toBeUndefined();
+    expect(bgWords(cleared)).toBeUndefined();
+    expect(bgSource(cleared)).toBeUndefined();
+    expect(bgBounds(cleared)).toBeNull();
+  });
+});
+
+describe("buildBackgroundVoice", () => {
+  it("builds a word-synced voice when words are present, defaulting text to empty", () => {
+    expect(buildBackgroundVoice({ words: [bgWord], source: "extraction" })).toEqual({
+      text: "",
+      words: [bgWord],
+      source: "extraction",
+    });
+  });
+
+  it("builds an untimed voice from text only", () => {
+    expect(buildBackgroundVoice({ text: "ooh", source: "manual" })).toEqual({ text: "ooh", source: "manual" });
+  });
+
+  it("returns null for whitespace-only text with no words", () => {
+    expect(buildBackgroundVoice({ text: "   ", source: "manual" })).toBeNull();
+  });
+
+  it("returns null for empty text with no words", () => {
+    expect(buildBackgroundVoice({ text: "", source: "extraction" })).toBeNull();
+  });
+
+  it("treats an empty words array with text as untimed, not word-synced", () => {
+    expect(buildBackgroundVoice({ words: [], text: "ooh", source: "manual" })).toEqual({
+      text: "ooh",
+      source: "manual",
+    });
+  });
+
+  it("lets words win when both text and words are present", () => {
+    expect(buildBackgroundVoice({ text: "ooh", words: [bgWord], source: "manual" })).toEqual({
+      text: "ooh",
+      words: [bgWord],
+      source: "manual",
+    });
+  });
+});
+
+describe("applyBackground invariants", () => {
+  it("composes to a fixed point on a line-synced main", () => {
+    const lineSynced: LyricLine = reconcileLine({ id: "ls", text: "hello world", agentId: "v1", begin: 2, end: 6 });
+    const params = { text: "ooh", source: "extraction" } as const;
+    const once = applyBackground(lineSynced, params);
+    const twice = applyBackground(once, params);
+    expect(twice).toEqual(once);
+  });
+
+  it("does not mutate the input line during resolution", () => {
+    const lineSynced: LyricLine = reconcileLine({ id: "ls", text: "hello world", agentId: "v1", begin: 2, end: 6 });
+    const snapshot = structuredClone(lineSynced);
+    applyBackground(lineSynced, { text: "ooh", source: "extraction" });
+    expect(lineSynced).toEqual(snapshot);
   });
 });

--- a/src/domain/line/background.test.ts
+++ b/src/domain/line/background.test.ts
@@ -9,7 +9,7 @@ import { mainBounds } from "@/domain/line/bounds";
 import { reconcileLine } from "@/domain/line/model";
 import type { LyricLine } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/line/predicates";
-import { bgSource, bgText, bgWords, mainWords } from "@/domain/line/voices";
+import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 
 const line: LyricLine = reconcileLine({ id: "a", text: "hello", agentId: "v1" });
@@ -124,13 +124,13 @@ describe("applyBackground immutability and field preservation", () => {
     const result = applyBackground(source, { text: "ooh", source: "extraction" });
     expect(result).toMatchObject({
       id: "u1",
-      text: "verse one",
       agentId: "v2",
       groupId: "g1",
       instanceIdx: 0,
       templateLineIdx: 3,
       detached: true,
     });
+    expect(lineText(result)).toBe("verse one");
   });
 
   it("preserves the word-synced timing variant", () => {

--- a/src/domain/line/background.ts
+++ b/src/domain/line/background.ts
@@ -98,3 +98,5 @@ export {
   manualBackgroundWordEdit,
   setBackground,
 };
+
+export type { BackgroundParams };

--- a/src/domain/line/background.ts
+++ b/src/domain/line/background.ts
@@ -1,7 +1,9 @@
+import { mainBounds } from "@/domain/line/bounds";
 import type { LineFields, LyricLine } from "@/domain/line/model";
-import { reconcileLine, toFlat } from "@/domain/line/model";
 import { reconstructLineText } from "@/domain/line/reconstruct-text";
-import type { BackgroundSource } from "@/domain/voice/model";
+import { resolveBgGranularity } from "@/domain/line/resolve-bg-granularity";
+import { mainVoice } from "@/domain/line/voices";
+import type { BackgroundSource, BackgroundVoice } from "@/domain/voice/model";
 import type { WordTiming } from "@/domain/word/timing";
 import { getSplitCharacter } from "@/utils/split-character";
 
@@ -15,13 +17,48 @@ interface BackgroundParams {
 
 type BackgroundFields = Pick<LineFields, "backgroundText" | "backgroundWords" | "backgroundTextSource">;
 
+// -- Nested writes ------------------------------------------------------------
+
+// Pure nested write of a line's background voice. A null voice drops the
+// background key entirely (immutably); otherwise the voice is set verbatim.
+// Never mutates the input line.
+function setBackground(line: LyricLine, voice: BackgroundVoice | null): LyricLine {
+  if (voice === null) {
+    const { background: _background, ...rest } = line;
+    return rest;
+  }
+  return { ...line, background: voice };
+}
+
+// Builds a BackgroundVoice from write params. Words win over text; empty or
+// whitespace-only text with no words yields null so the background is cleared.
+function buildBackgroundVoice(params: BackgroundParams): BackgroundVoice | null {
+  const words = params.words && params.words.length > 0 ? params.words : undefined;
+  const text = params.text && params.text.trim().length > 0 ? params.text : undefined;
+  if (words) return { text: text ?? "", words, source: params.source };
+  if (text) return { text, source: params.source };
+  return null;
+}
+
 // -- Funnel -------------------------------------------------------------------
 
-// The single chokepoint for writing a line's background-vocal fields. Keeps
-// backgroundText, backgroundWords, and the backgroundTextSource provenance flag
-// coherent so the flag can never drift: an empty write clears all three.
-// Callers must pass coherent text and words (the extraction code derives text
-// from words via reconstructLineText before calling here).
+// The single chokepoint for writing a line's background voice. Builds the voice
+// from params, resolves its granularity against the line's main voice (so an
+// untimed bg text becomes line-synced over a line-synced main, distributed over
+// a word-synced main, or stays untimed over an untimed main), then writes it
+// nested and directly. This bypasses the flat round-trip, which cannot express
+// a line-synced background (LooseLine has no backgroundBegin/backgroundEnd).
+function applyBackground(line: LyricLine, params: BackgroundParams): LyricLine {
+  const bg = buildBackgroundVoice(params);
+  if (bg === null) return setBackground(line, null);
+  const resolved = resolveBgGranularity(mainVoice(line), bg, { fallbackBounds: mainBounds(line) });
+  return setBackground(line, resolved);
+}
+
+// Keeps backgroundText, backgroundWords, and the backgroundTextSource
+// provenance flag coherent for the flat write paths (word-synced and untimed
+// background edits that round-trip through reconcileLine): an empty write clears
+// all three.
 function backgroundFields(params: BackgroundParams): BackgroundFields {
   const text = params.text && params.text.trim().length > 0 ? params.text : undefined;
   const words = params.words && params.words.length > 0 ? params.words : undefined;
@@ -29,10 +66,6 @@ function backgroundFields(params: BackgroundParams): BackgroundFields {
     return { backgroundText: undefined, backgroundWords: undefined, backgroundTextSource: undefined };
   }
   return { backgroundText: text, backgroundWords: words, backgroundTextSource: params.source };
-}
-
-function applyBackground(line: LyricLine, params: BackgroundParams): LyricLine {
-  return reconcileLine({ ...toFlat(line), ...backgroundFields(params) });
 }
 
 // The coherent all-undefined triple, for clear sites where there is no
@@ -57,4 +90,11 @@ function manualBackgroundWordEdit(words: WordTiming[]): BackgroundFields {
 
 // -- Exports ------------------------------------------------------------------
 
-export { applyBackground, backgroundFields, CLEARED_BACKGROUND, manualBackgroundWordEdit };
+export {
+  applyBackground,
+  backgroundFields,
+  buildBackgroundVoice,
+  CLEARED_BACKGROUND,
+  manualBackgroundWordEdit,
+  setBackground,
+};

--- a/src/domain/line/background.ts
+++ b/src/domain/line/background.ts
@@ -1,12 +1,11 @@
 import type { LineFields, LyricLine } from "@/domain/line/model";
-import { reconcileLine } from "@/domain/line/model";
+import { reconcileLine, toFlat } from "@/domain/line/model";
 import { reconstructLineText } from "@/domain/line/reconstruct-text";
+import type { BackgroundSource } from "@/domain/voice/model";
 import type { WordTiming } from "@/domain/word/timing";
 import { getSplitCharacter } from "@/utils/split-character";
 
 // -- Types --------------------------------------------------------------------
-
-type BackgroundSource = "extraction" | "manual";
 
 interface BackgroundParams {
   text?: string;
@@ -33,7 +32,7 @@ function backgroundFields(params: BackgroundParams): BackgroundFields {
 }
 
 function applyBackground(line: LyricLine, params: BackgroundParams): LyricLine {
-  return reconcileLine({ ...line, ...backgroundFields(params) });
+  return reconcileLine({ ...toFlat(line), ...backgroundFields(params) });
 }
 
 // The coherent all-undefined triple, for clear sites where there is no
@@ -59,4 +58,3 @@ function manualBackgroundWordEdit(words: WordTiming[]): BackgroundFields {
 // -- Exports ------------------------------------------------------------------
 
 export { applyBackground, backgroundFields, CLEARED_BACKGROUND, manualBackgroundWordEdit };
-export type { BackgroundSource };

--- a/src/domain/line/bounds.ts
+++ b/src/domain/line/bounds.ts
@@ -1,24 +1,17 @@
-import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
-import { type Bounds, firstBegin, lastEnd } from "@/domain/word/bounds";
+import { bgVoice, mainVoice } from "@/domain/line/voices";
+import type { Bounds } from "@/domain/word/bounds";
 import type { LyricLine } from "@/domain/line/model";
+import { voiceBounds } from "@/domain/voice/bounds";
 
 // -- Functions ----------------------------------------------------------------
 
 function mainBounds(line: LyricLine): Bounds | null {
-  if (isWordSynced(line)) {
-    const words = line.words!;
-    return { begin: firstBegin(words), end: lastEnd(words) };
-  }
-  if (isLineSynced(line)) {
-    return { begin: line.begin, end: line.end };
-  }
-  return null;
+  return voiceBounds(mainVoice(line));
 }
 
 function bgBounds(line: LyricLine): Bounds | null {
-  if (!line.backgroundWords?.length) return null;
-  const bg = line.backgroundWords;
-  return { begin: firstBegin(bg), end: lastEnd(bg) };
+  const bg = bgVoice(line);
+  return bg ? voiceBounds(bg) : null;
 }
 
 function effectiveBounds(line: LyricLine): Bounds | null {

--- a/src/domain/line/bounds.ts
+++ b/src/domain/line/bounds.ts
@@ -11,7 +11,7 @@ function mainBounds(line: LyricLine): Bounds | null {
 
 function bgBounds(line: LyricLine): Bounds | null {
   const bg = bgVoice(line);
-  return bg ? voiceBounds(bg) : null;
+  return bg !== null ? voiceBounds(bg) : null;
 }
 
 function effectiveBounds(line: LyricLine): Bounds | null {

--- a/src/domain/line/effective-words.test.ts
+++ b/src/domain/line/effective-words.test.ts
@@ -1,6 +1,6 @@
 import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
-import { effectiveWords, getEffectiveLines } from "@/domain/line/effective-words";
+import { getEffectiveLines } from "@/domain/line/effective-words";
 import { bgText, bgVoice, bgWords, mainVoice, mainWords } from "@/domain/line/voices";
 import { bgBounds, mainBounds } from "@/domain/line/bounds";
 import { setBackground } from "@/domain/line/background";
@@ -11,38 +11,6 @@ import { isLineSynced, isWordSynced } from "@/domain/voice/predicates";
 function line(extras: Partial<LooseLine> = {}): LyricLine {
   return reconcileLine({ id: "l1", text: "Hello", agentId: "v1", ...extras });
 }
-
-// -- effectiveWords -----------------------------------------------------------
-
-describe("effectiveWords", () => {
-  it("returns the words array when word-synced", () => {
-    const words = [
-      { text: "Hello ", begin: 0, end: 1 },
-      { text: "world", begin: 1, end: 2 },
-    ];
-    expect(effectiveWords(line({ words }))).toEqual(words);
-  });
-
-  it("returns a single synthetic word covering line-synced begin/end", () => {
-    expect(effectiveWords(line({ text: "Hello world", begin: 3, end: 7 }))).toEqual([
-      { text: "Hello world", begin: 3, end: 7 },
-    ]);
-  });
-
-  it("strips split characters from synthetic word text", () => {
-    expect(effectiveWords(line({ text: "Hel|lo wo|rld", begin: 3, end: 7 }))).toEqual([
-      { text: "Hello world", begin: 3, end: 7 },
-    ]);
-  });
-
-  it("returns empty array when no timing at all", () => {
-    expect(effectiveWords(line())).toEqual([]);
-  });
-
-  it("returns empty array for a word-synced line with an empty words array", () => {
-    expect(effectiveWords(line({ words: [] }))).toEqual([]);
-  });
-});
 
 // -- getEffectiveLines --------------------------------------------------------
 

--- a/src/domain/line/effective-words.test.ts
+++ b/src/domain/line/effective-words.test.ts
@@ -73,29 +73,44 @@ describe("getEffectiveLines", () => {
   });
 });
 
-// -- background preservation through the line-synced-main conversion ----------
+// -- background conversion through getEffectiveLines --------------------------
 
-describe("getEffectiveLines: background preservation", () => {
-  it("keeps a line-synced background line-synced while converting a line-synced main", () => {
+// behavior changed: line-synced bg now renders as a single effective word,
+// symmetric with main (it no longer stays line-synced for a bespoke bar). The
+// raw store line is untouched; only the rendered/effective view converts.
+describe("getEffectiveLines: background conversion", () => {
+  it("converts a line-synced background into a single effective bg word, mirroring main", () => {
     const input = setBackground(line({ id: "a", text: "Main", begin: 1, end: 4 }), {
       text: "Oooh",
       begin: 1.5,
       end: 3.5,
       source: "manual",
     });
-    const originalBgBounds = bgBounds(input);
 
     const out = getEffectiveLines([input])[0];
 
-    expect(mainWords(out)?.length ?? 0).toBeGreaterThanOrEqual(1);
     expect(isWordSynced(mainVoice(out))).toBe(true);
+    expect(mainWords(out)).toEqual([{ text: "Main", begin: 1, end: 4 }]);
 
-    expect(bgWords(out)).toBeUndefined();
-    expect(bgBounds(out)).toEqual(originalBgBounds);
+    expect(bgWords(out)).toEqual([{ text: "Oooh", begin: 1.5, end: 3.5 }]);
+    expect(bgBounds(out)).toEqual({ begin: 1.5, end: 3.5 });
     expect(bgText(out)).toBe("Oooh");
     const bg = bgVoice(out);
     expect(bg).not.toBeNull();
-    if (bg !== null) expect(isLineSynced(bg)).toBe(true);
+    if (bg !== null) expect(isWordSynced(bg)).toBe(true);
+  });
+
+  it("strips split characters from the synthesized bg word text", () => {
+    const input = setBackground(line({ id: "a", text: "Main", begin: 1, end: 4 }), {
+      text: "Oo|oh",
+      begin: 1.5,
+      end: 3.5,
+      source: "manual",
+    });
+
+    const out = getEffectiveLines([input])[0];
+
+    expect(bgWords(out)).toEqual([{ text: "Oooh", begin: 1.5, end: 3.5 }]);
   });
 
   it("keeps a word-synced background word-synced verbatim", () => {
@@ -132,7 +147,7 @@ describe("getEffectiveLines: background preservation", () => {
     expect(bgText(out)).toBe("Oooh");
   });
 
-  it("returns a word-synced-main line with a line-synced background verbatim", () => {
+  it("converts a line-synced background even when the main is already word-synced", () => {
     const words = [{ text: "Main", begin: 1, end: 4 }];
     const input = setBackground(line({ id: "a", text: "Main", words }), {
       text: "Oooh",
@@ -143,9 +158,27 @@ describe("getEffectiveLines: background preservation", () => {
 
     const out = getEffectiveLines([input])[0];
 
-    expect(out).toBe(input);
-    expect(bgWords(out)).toBeUndefined();
+    expect(isWordSynced(mainVoice(out))).toBe(true);
+    expect(mainWords(out)).toEqual(words);
+    expect(bgWords(out)).toEqual([{ text: "Oooh", begin: 1.5, end: 3.5 }]);
     expect(bgBounds(out)).toEqual({ begin: 1.5, end: 3.5 });
+    const bg = bgVoice(out);
+    expect(bg).not.toBeNull();
+    if (bg !== null) expect(isWordSynced(bg)).toBe(true);
+  });
+
+  it("leaves a fully word-synced line (both voices word-synced) untouched by reference", () => {
+    const words = [{ text: "Main", begin: 1, end: 4 }];
+    const bgWordsArr = [{ text: "Oooh", begin: 1.5, end: 3.5 }];
+    const input = setBackground(line({ id: "a", text: "Main", words }), {
+      text: "Oooh",
+      words: bgWordsArr,
+      source: "manual",
+    });
+
+    const out = getEffectiveLines([input])[0];
+
+    expect(out).toBe(input);
   });
 
   it("produces no background key when the line has no background", () => {

--- a/src/domain/line/effective-words.test.ts
+++ b/src/domain/line/effective-words.test.ts
@@ -1,6 +1,7 @@
 import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
 import { effectiveWords, getEffectiveLines } from "@/domain/line/effective-words";
+import { mainWords } from "@/domain/line/voices";
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -45,18 +46,18 @@ describe("effectiveWords", () => {
 describe("getEffectiveLines", () => {
   it("injects synthetic single-word array for line-synced lines", () => {
     const lines: LyricLine[] = [line({ id: "a", text: "Hi", begin: 1, end: 2 })];
-    expect(getEffectiveLines(lines)[0].words).toEqual([{ text: "Hi", begin: 1, end: 2 }]);
+    expect(mainWords(getEffectiveLines(lines)[0])).toEqual([{ text: "Hi", begin: 1, end: 2 }]);
   });
 
   it("leaves word-synced lines untouched", () => {
     const words = [{ text: "Hi ", begin: 0, end: 1 }];
     const lines: LyricLine[] = [line({ words })];
-    expect(getEffectiveLines(lines)[0].words).toBe(words);
+    expect(mainWords(getEffectiveLines(lines)[0])).toBe(words);
   });
 
   it("leaves untimed lines untouched (no synthetic words)", () => {
     const lines: LyricLine[] = [line({ id: "a", text: "Hi" })];
-    expect(getEffectiveLines(lines)[0].words).toBeUndefined();
+    expect(mainWords(getEffectiveLines(lines)[0])).toBeUndefined();
   });
 
   it("preserves other line properties", () => {

--- a/src/domain/line/effective-words.test.ts
+++ b/src/domain/line/effective-words.test.ts
@@ -1,7 +1,10 @@
 import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
 import { effectiveWords, getEffectiveLines } from "@/domain/line/effective-words";
-import { mainWords } from "@/domain/line/voices";
+import { bgText, bgVoice, bgWords, mainVoice, mainWords } from "@/domain/line/voices";
+import { bgBounds, mainBounds } from "@/domain/line/bounds";
+import { setBackground } from "@/domain/line/background";
+import { isLineSynced, isWordSynced } from "@/domain/voice/predicates";
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -67,5 +70,112 @@ describe("getEffectiveLines", () => {
     expect(out.agentId).toBe("v9");
     expect(out.groupId).toBe("g1");
     expect(out.instanceIdx).toBe(3);
+  });
+});
+
+// -- background preservation through the line-synced-main conversion ----------
+
+describe("getEffectiveLines: background preservation", () => {
+  it("keeps a line-synced background line-synced while converting a line-synced main", () => {
+    const input = setBackground(line({ id: "a", text: "Main", begin: 1, end: 4 }), {
+      text: "Oooh",
+      begin: 1.5,
+      end: 3.5,
+      source: "manual",
+    });
+    const originalBgBounds = bgBounds(input);
+
+    const out = getEffectiveLines([input])[0];
+
+    expect(mainWords(out)?.length ?? 0).toBeGreaterThanOrEqual(1);
+    expect(isWordSynced(mainVoice(out))).toBe(true);
+
+    expect(bgWords(out)).toBeUndefined();
+    expect(bgBounds(out)).toEqual(originalBgBounds);
+    expect(bgText(out)).toBe("Oooh");
+    const bg = bgVoice(out);
+    expect(bg).not.toBeNull();
+    if (bg !== null) expect(isLineSynced(bg)).toBe(true);
+  });
+
+  it("keeps a word-synced background word-synced verbatim", () => {
+    const bgWordsArr = [
+      { text: "Oo ", begin: 1.5, end: 2 },
+      { text: "ooh", begin: 2, end: 3 },
+    ];
+    const input = setBackground(line({ id: "a", text: "Main", begin: 1, end: 4 }), {
+      text: "Oo ooh",
+      words: bgWordsArr,
+      source: "manual",
+    });
+
+    const out = getEffectiveLines([input])[0];
+
+    expect(isWordSynced(mainVoice(out))).toBe(true);
+    expect(bgWords(out)).toEqual(bgWordsArr);
+    const bg = bgVoice(out);
+    expect(bg).not.toBeNull();
+    if (bg !== null) expect(isWordSynced(bg)).toBe(true);
+  });
+
+  it("keeps an untimed background untimed", () => {
+    const input = setBackground(line({ id: "a", text: "Main", begin: 1, end: 4 }), {
+      text: "Oooh",
+      source: "manual",
+    });
+
+    const out = getEffectiveLines([input])[0];
+
+    expect(isWordSynced(mainVoice(out))).toBe(true);
+    expect(bgWords(out)).toBeUndefined();
+    expect(bgBounds(out)).toBeNull();
+    expect(bgText(out)).toBe("Oooh");
+  });
+
+  it("returns a word-synced-main line with a line-synced background verbatim", () => {
+    const words = [{ text: "Main", begin: 1, end: 4 }];
+    const input = setBackground(line({ id: "a", text: "Main", words }), {
+      text: "Oooh",
+      begin: 1.5,
+      end: 3.5,
+      source: "manual",
+    });
+
+    const out = getEffectiveLines([input])[0];
+
+    expect(out).toBe(input);
+    expect(bgWords(out)).toBeUndefined();
+    expect(bgBounds(out)).toEqual({ begin: 1.5, end: 3.5 });
+  });
+
+  it("produces no background key when the line has no background", () => {
+    const input = line({ id: "a", text: "Main", begin: 1, end: 4 });
+
+    const out = getEffectiveLines([input])[0];
+
+    expect(isWordSynced(mainVoice(out))).toBe(true);
+    expect("background" in out).toBe(false);
+  });
+
+  describe("invariants", () => {
+    it("does not mutate the input line", () => {
+      const input = setBackground(line({ id: "a", text: "Main", begin: 1, end: 4 }), {
+        text: "Oooh",
+        begin: 1.5,
+        end: 3.5,
+        source: "manual",
+      });
+      const snapshotMainBounds = mainBounds(input);
+      const snapshotBgBounds = bgBounds(input);
+
+      getEffectiveLines([input]);
+
+      expect(isLineSynced(mainVoice(input))).toBe(true);
+      expect(mainBounds(input)).toEqual(snapshotMainBounds);
+      expect(bgBounds(input)).toEqual(snapshotBgBounds);
+      const bg = bgVoice(input);
+      expect(bg).not.toBeNull();
+      if (bg !== null) expect(isLineSynced(bg)).toBe(true);
+    });
   });
 });

--- a/src/domain/line/effective-words.ts
+++ b/src/domain/line/effective-words.ts
@@ -3,13 +3,8 @@ import { reconcileLine, toFlat } from "@/domain/line/model";
 import { bgVoice, mainVoice } from "@/domain/line/voices";
 import { effectiveVoiceWords } from "@/domain/voice/effective-words";
 import { isLineSynced as isLineSyncedVoice } from "@/domain/voice/predicates";
-import type { WordTiming } from "@/domain/word/timing";
 
 // -- Functions ----------------------------------------------------------------
-
-function effectiveWords(line: LyricLine): WordTiming[] {
-  return effectiveVoiceWords(mainVoice(line));
-}
 
 // Render-only transform: converts each voice's line-synced timing into a single
 // effective word so the timeline renders both the main and the background as a
@@ -33,4 +28,4 @@ function getEffectiveLines(lines: LyricLine[]): LyricLine[] {
 
 // -- Exports ------------------------------------------------------------------
 
-export { effectiveWords, getEffectiveLines };
+export { getEffectiveLines };

--- a/src/domain/line/effective-words.ts
+++ b/src/domain/line/effective-words.ts
@@ -1,16 +1,13 @@
 import type { LyricLine } from "@/domain/line/model";
 import type { WordTiming } from "@/domain/word/timing";
 import { isLineSynced } from "@/domain/line/predicates";
-import { stripSplitCharacter } from "@/utils/split-character";
+import { mainVoice } from "@/domain/line/voices";
+import { effectiveVoiceWords } from "@/domain/voice/effective-words";
 
 // -- Functions ----------------------------------------------------------------
 
 function effectiveWords(line: LyricLine): WordTiming[] {
-  if (line.words?.length) return line.words;
-  if (isLineSynced(line)) {
-    return [{ text: stripSplitCharacter(line.text), begin: line.begin, end: line.end }];
-  }
-  return [];
+  return effectiveVoiceWords(mainVoice(line));
 }
 
 function getEffectiveLines(lines: LyricLine[]): LyricLine[] {

--- a/src/domain/line/effective-words.ts
+++ b/src/domain/line/effective-words.ts
@@ -1,7 +1,5 @@
-import { setBackground } from "@/domain/line/background";
 import type { LyricLine } from "@/domain/line/model";
 import { reconcileLine, toFlat } from "@/domain/line/model";
-import { isLineSynced } from "@/domain/line/predicates";
 import { bgVoice, mainVoice } from "@/domain/line/voices";
 import { effectiveVoiceWords } from "@/domain/voice/effective-words";
 import { isLineSynced as isLineSyncedVoice } from "@/domain/voice/predicates";
@@ -13,14 +11,23 @@ function effectiveWords(line: LyricLine): WordTiming[] {
   return effectiveVoiceWords(mainVoice(line));
 }
 
+// Render-only transform: converts each voice's line-synced timing into a single
+// effective word so the timeline renders both the main and the background as a
+// WordTrack block (symmetric, no bespoke bar). The raw store lines keep their
+// true line-synced timing; only the rendered view changes. The two voices
+// convert independently, so a word-synced-main + line-synced-bg line still gets
+// its background converted.
 function getEffectiveLines(lines: LyricLine[]): LyricLine[] {
   return lines.map((line) => {
-    if (!isLineSynced(line)) return line;
-    const converted = reconcileLine({ ...toFlat(line), words: effectiveWords(line) });
-    // toFlat cannot express a line-synced background (LooseLine has no
-    // backgroundBegin/end), so the round-trip rebuilds it untimed. Restore it.
+    const main = mainVoice(line);
     const bg = bgVoice(line);
-    return bg !== null && isLineSyncedVoice(bg) ? setBackground(converted, bg) : converted;
+    const convertMain = isLineSyncedVoice(main);
+    const convertBg = bg !== null && isLineSyncedVoice(bg);
+    if (!convertMain && !convertBg) return line;
+    const flat = { ...toFlat(line) };
+    if (convertMain) flat.words = effectiveVoiceWords(main);
+    if (convertBg) flat.backgroundWords = effectiveVoiceWords(bg);
+    return reconcileLine(flat);
   });
 }
 

--- a/src/domain/line/effective-words.ts
+++ b/src/domain/line/effective-words.ts
@@ -1,4 +1,5 @@
 import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, toFlat } from "@/domain/line/model";
 import type { WordTiming } from "@/domain/word/timing";
 import { isLineSynced } from "@/domain/line/predicates";
 import { mainVoice } from "@/domain/line/voices";
@@ -13,8 +14,7 @@ function effectiveWords(line: LyricLine): WordTiming[] {
 function getEffectiveLines(lines: LyricLine[]): LyricLine[] {
   return lines.map((line) => {
     if (!isLineSynced(line)) return line;
-    const { begin, end, ...rest } = line;
-    return { ...rest, words: effectiveWords(line) };
+    return reconcileLine({ ...toFlat(line), words: effectiveWords(line) });
   });
 }
 

--- a/src/domain/line/effective-words.ts
+++ b/src/domain/line/effective-words.ts
@@ -1,9 +1,11 @@
+import { setBackground } from "@/domain/line/background";
 import type { LyricLine } from "@/domain/line/model";
 import { reconcileLine, toFlat } from "@/domain/line/model";
-import type { WordTiming } from "@/domain/word/timing";
 import { isLineSynced } from "@/domain/line/predicates";
-import { mainVoice } from "@/domain/line/voices";
+import { bgVoice, mainVoice } from "@/domain/line/voices";
 import { effectiveVoiceWords } from "@/domain/voice/effective-words";
+import { isLineSynced as isLineSyncedVoice } from "@/domain/voice/predicates";
+import type { WordTiming } from "@/domain/word/timing";
 
 // -- Functions ----------------------------------------------------------------
 
@@ -14,7 +16,11 @@ function effectiveWords(line: LyricLine): WordTiming[] {
 function getEffectiveLines(lines: LyricLine[]): LyricLine[] {
   return lines.map((line) => {
     if (!isLineSynced(line)) return line;
-    return reconcileLine({ ...toFlat(line), words: effectiveWords(line) });
+    const converted = reconcileLine({ ...toFlat(line), words: effectiveWords(line) });
+    // toFlat cannot express a line-synced background (LooseLine has no
+    // backgroundBegin/end), so the round-trip rebuilds it untimed. Restore it.
+    const bg = bgVoice(line);
+    return bg !== null && isLineSyncedVoice(bg) ? setBackground(converted, bg) : converted;
   });
 }
 

--- a/src/domain/line/follow-main-granularity.test.ts
+++ b/src/domain/line/follow-main-granularity.test.ts
@@ -1,0 +1,199 @@
+import { bgBounds } from "@/domain/line/bounds";
+import { followMainGranularity } from "@/domain/line/follow-main-granularity";
+import { type LooseLine, reconcileLine } from "@/domain/line/model";
+import { bgVoice, bgWords } from "@/domain/line/voices";
+import { isWordSynced } from "@/domain/voice/predicates";
+import { describe, expect, it } from "vitest";
+
+// Pure unit tests for followMainGranularity: the once-only main-to-word
+// transition that lets an existing background follow main into word-synced
+// granularity. No store, no mocks - real reconcileLine-built lines.
+
+function line(fields: LooseLine) {
+  return reconcileLine(fields);
+}
+
+function lineSyncedMainWithLineSyncedBg(begin: number, end: number) {
+  // Build a line-synced bg the way the funnel does: reconcileLine cannot carry a
+  // line-synced background, so place one nested directly over a line-synced main.
+  const base = line({ id: "L1", text: "Real line", agentId: "v1", begin, end });
+  const half = { begin: (begin + end) / 2, end };
+  return { ...base, background: { text: "ooh ahh", begin: half.begin, end: half.end, source: "manual" as const } };
+}
+
+const wordMain = [
+  { text: "Real ", begin: 2, end: 5 },
+  { text: "line", begin: 5, end: 10 },
+];
+
+describe("followMainGranularity · transition resolution", () => {
+  it("line-synced bg distributes over its OWN bounds when main becomes word-synced", () => {
+    const before = lineSyncedMainWithLineSyncedBg(2, 10);
+    const ownBounds = bgBounds(before);
+    if (!ownBounds) throw new Error("expected line-synced bg bounds");
+    const after = line({ id: "L1", text: "Real line", agentId: "v1", words: wordMain });
+    const afterWithBg = { ...after, background: before.background };
+
+    const result = followMainGranularity(before, afterWithBg);
+
+    const words = bgWords(result);
+    expect(words).toBeDefined();
+    if (!words) throw new Error("expected bg words");
+    expect(words.length).toBe(2);
+    expect(words[0].begin).toBe(ownBounds.begin);
+    expect(words[words.length - 1].end).toBe(ownBounds.end);
+  });
+
+  it("untimed bg distributes over the new main's second half when main becomes word-synced", () => {
+    const before = line({ id: "L1", text: "Real line", agentId: "v1", backgroundText: "ooh ahh" });
+    const after = line({ id: "L1", text: "Real line", agentId: "v1", words: wordMain, backgroundText: "ooh ahh" });
+
+    const result = followMainGranularity(before, after);
+
+    const words = bgWords(result);
+    expect(words).toBeDefined();
+    if (!words) throw new Error("expected bg words");
+    expect(words[0].begin).toBe((2 + 10) / 2);
+    expect(words[words.length - 1].end).toBe(10);
+  });
+
+  it("word-synced bg is returned on the same `after` reference (no re-distribution)", () => {
+    const before = line({ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 10 });
+    const after = line({
+      id: "L1",
+      text: "Real line",
+      agentId: "v1",
+      words: wordMain,
+      backgroundText: "ooh ahh",
+      backgroundWords: [
+        { text: "ooh ", begin: 3, end: 4 },
+        { text: "ahh", begin: 4, end: 5 },
+      ],
+      backgroundTextSource: "manual",
+    });
+
+    const result = followMainGranularity(before, after);
+
+    expect(result).toBe(after);
+    expect(bgVoice(result)).toBe(bgVoice(after));
+  });
+});
+
+describe("followMainGranularity · guards", () => {
+  it("returns `after` unchanged and reference-equal when main was ALREADY word-synced", () => {
+    const before = line({
+      id: "L1",
+      text: "Real line",
+      agentId: "v1",
+      words: [
+        { text: "Real ", begin: 0, end: 1 },
+        { text: "line", begin: 1, end: 2 },
+      ],
+      backgroundText: "ooh ahh",
+      backgroundWords: [{ text: "ooh ahh", begin: 0, end: 2 }],
+      backgroundTextSource: "manual",
+    });
+    const after = line({ id: "L1", text: "Real line", agentId: "v1", words: wordMain, backgroundText: "ooh ahh" });
+
+    const result = followMainGranularity(before, after);
+
+    expect(result).toBe(after);
+  });
+
+  it("returns `after` reference-equal when after's main is NOT word-synced", () => {
+    const before = line({ id: "L1", text: "Real line", agentId: "v1", backgroundText: "ooh ahh" });
+    const after = line({ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 10, backgroundText: "ooh ahh" });
+
+    const result = followMainGranularity(before, after);
+
+    expect(result).toBe(after);
+  });
+
+  it("returns `after` reference-equal when there is no background to follow", () => {
+    const before = line({ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 10 });
+    const after = line({ id: "L1", text: "Real line", agentId: "v1", words: wordMain });
+
+    const result = followMainGranularity(before, after);
+
+    expect(result).toBe(after);
+  });
+});
+
+describe("followMainGranularity · invariants", () => {
+  it("does not mutate the input `before` line", () => {
+    const before = lineSyncedMainWithLineSyncedBg(2, 10);
+    const snapshot = structuredClone(before);
+    const after = {
+      ...line({ id: "L1", text: "Real line", agentId: "v1", words: wordMain }),
+      background: before.background,
+    };
+
+    followMainGranularity(before, after);
+
+    expect(before).toEqual(snapshot);
+  });
+
+  it("does not mutate the input `after` line", () => {
+    const before = lineSyncedMainWithLineSyncedBg(2, 10);
+    const after = {
+      ...line({ id: "L1", text: "Real line", agentId: "v1", words: wordMain }),
+      background: { ...before.background },
+    };
+    const snapshot = structuredClone(after);
+
+    followMainGranularity(before, after);
+
+    expect(after).toEqual(snapshot);
+  });
+
+  it("is idempotent: running twice equals running once", () => {
+    const before = lineSyncedMainWithLineSyncedBg(2, 10);
+    const after = {
+      ...line({ id: "L1", text: "Real line", agentId: "v1", words: wordMain }),
+      background: before.background,
+    };
+
+    const once = followMainGranularity(before, after);
+    const twice = followMainGranularity(once, once);
+
+    expect(twice).toEqual(once);
+    expect(twice).toBe(once);
+  });
+});
+
+describe("followMainGranularity · edge cases", () => {
+  it("returns `after` unchanged when after's main has empty words (not word-synced)", () => {
+    const before = line({ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 10, backgroundText: "ooh ahh" });
+    const after = { ...before, main: { text: "Real line", words: [] } };
+
+    const result = followMainGranularity(before, after);
+
+    expect(result).toBe(after);
+    expect(isWordSynced(after.main)).toBe(false);
+  });
+
+  it("keeps a line-synced bg untimed-distributed when its own bounds are present", () => {
+    const before = lineSyncedMainWithLineSyncedBg(0, 20);
+    const ownBounds = bgBounds(before);
+    if (!ownBounds) throw new Error("expected line-synced bg bounds");
+    const after = {
+      ...line({
+        id: "L1",
+        text: "Real line",
+        agentId: "v1",
+        words: [
+          { text: "Real ", begin: 0, end: 10 },
+          { text: "line", begin: 10, end: 20 },
+        ],
+      }),
+      background: before.background,
+    };
+
+    const result = followMainGranularity(before, after);
+
+    const words = bgWords(result);
+    if (!words) throw new Error("expected bg words");
+    expect(words[0].begin).toBe(ownBounds.begin);
+    expect(words[words.length - 1].end).toBe(ownBounds.end);
+  });
+});

--- a/src/domain/line/follow-main-granularity.ts
+++ b/src/domain/line/follow-main-granularity.ts
@@ -1,0 +1,31 @@
+import { setBackground } from "@/domain/line/background";
+import { mainBounds } from "@/domain/line/bounds";
+import type { LyricLine } from "@/domain/line/model";
+import { resolveBgGranularity } from "@/domain/line/resolve-bg-granularity";
+import { bgVoice, mainVoice } from "@/domain/line/voices";
+import { isWordSynced } from "@/domain/voice/predicates";
+
+// -- Granularity follow -------------------------------------------------------
+
+// When a line's MAIN voice transitions INTO word-synced (it was untimed or
+// line-synced before, and the write gave it words), re-resolve its existing
+// background ONCE so the background follows main into word-synced granularity.
+// A background that was already word-synced is returned verbatim (resolver
+// reference check); a line-synced background distributes over its own bounds;
+// an untimed background distributes over the new main's bounds.
+//
+// The `isWordSynced(before)` guard makes this fire only on the transition, never
+// on a subsequent word edit of an already-word-synced line, so later word edits
+// to the background are never clobbered.
+function followMainGranularity(before: LyricLine, after: LyricLine): LyricLine {
+  if (isWordSynced(mainVoice(before))) return after;
+  if (!isWordSynced(mainVoice(after))) return after;
+  const bg = bgVoice(after);
+  if (bg === null) return after;
+  const resolved = resolveBgGranularity(mainVoice(after), bg, { fallbackBounds: mainBounds(after) });
+  return resolved === bg ? after : setBackground(after, resolved);
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { followMainGranularity };

--- a/src/domain/line/main-words.test.ts
+++ b/src/domain/line/main-words.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { applyMainWordEdit, mainWordEditFields } from "@/domain/line/main-words";
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { lineText, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 
-const baseLine = (overrides: Partial<LyricLine> = {}): LyricLine =>
-  ({
+const baseLine = (overrides: Partial<LooseLine> = {}): LyricLine =>
+  reconcileLine({
     id: "l1",
     agentId: "a1",
     text: "hello world",
@@ -14,7 +14,7 @@ const baseLine = (overrides: Partial<LyricLine> = {}): LyricLine =>
       { text: "world", begin: 0.5, end: 1 },
     ],
     ...overrides,
-  }) as LyricLine;
+  });
 
 describe("applyMainWordEdit", () => {
   describe("happy paths", () => {

--- a/src/domain/line/main-words.test.ts
+++ b/src/domain/line/main-words.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { applyMainWordEdit, mainWordEditFields } from "@/domain/line/main-words";
 import type { LyricLine } from "@/domain/line/model";
+import { lineText, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 
 const baseLine = (overrides: Partial<LyricLine> = {}): LyricLine =>
@@ -20,7 +21,7 @@ describe("applyMainWordEdit", () => {
     it("sets the new words", () => {
       const words: WordTiming[] = [{ text: "hey", begin: 0, end: 0.5 }];
       const result = applyMainWordEdit(baseLine(), words);
-      expect(result.words).toEqual(words);
+      expect(mainWords(result)).toEqual(words);
     });
     it("re-derives text from the new words", () => {
       const words: WordTiming[] = [
@@ -28,7 +29,7 @@ describe("applyMainWordEdit", () => {
         { text: "hello", begin: 0.5, end: 1 },
       ];
       const result = applyMainWordEdit(baseLine(), words);
-      expect(result.text).toBe("world hello");
+      expect(lineText(result)).toBe("world hello");
     });
   });
 
@@ -36,7 +37,7 @@ describe("applyMainWordEdit", () => {
     it("clears words and begin/end when given an empty array (reconcileLine semantics)", () => {
       const line = baseLine();
       const result = applyMainWordEdit(line, []);
-      expect(result.words).toEqual([]);
+      expect(mainWords(result)).toEqual([]);
     });
     it("preserves agentId, groupId, instanceIdx, and other non-timing fields", () => {
       const line = baseLine({ groupId: "g1", instanceIdx: 2, templateLineIdx: 0 });
@@ -61,7 +62,7 @@ describe("applyMainWordEdit", () => {
         { text: "b", begin: 0.5, end: 1 },
       ];
       const result = applyMainWordEdit(baseLine(), words);
-      expect(result.text).toBe(reconstructLineText(words, getSplitCharacter()));
+      expect(lineText(result)).toBe(reconstructLineText(words, getSplitCharacter()));
     });
   });
 });
@@ -97,8 +98,8 @@ describe("mainWordEditFields", () => {
       ];
       const direct = applyMainWordEdit(baseLine(), words);
       const fields = mainWordEditFields(words);
-      expect(direct.text).toBe(fields.text);
-      expect(direct.words).toEqual(fields.words);
+      expect(lineText(direct)).toBe(fields.text);
+      expect(mainWords(direct)).toEqual(fields.words);
     });
 
     it("does not mutate the input words array", () => {

--- a/src/domain/line/main-words.ts
+++ b/src/domain/line/main-words.ts
@@ -1,4 +1,4 @@
-import { type LineFields, type LyricLine, reconcileLine } from "@/domain/line/model";
+import { type LineFields, type LyricLine, reconcileLine, toFlat } from "@/domain/line/model";
 import { reconstructLineText } from "@/domain/line/reconstruct-text";
 import type { WordTiming } from "@/domain/word/timing";
 import { getSplitCharacter } from "@/utils/split-character";
@@ -10,7 +10,7 @@ type MainWordFields = Pick<LineFields, "text"> & { words: WordTiming[] };
 // -- Functions ----------------------------------------------------------------
 
 // Spread-friendly partial for the main-word funnel: returns the reconciled
-// `{ words, text }` pair so callers building Partial<LyricLine> updates can
+// `{ words, text }` pair so callers building Partial<LooseLine> updates can
 // Object.assign without first constructing a full line.
 function mainWordEditFields(words: WordTiming[]): MainWordFields {
   return { words, text: reconstructLineText(words, getSplitCharacter()) };
@@ -21,7 +21,7 @@ function mainWordEditFields(words: WordTiming[]): MainWordFields {
 // with the new word order. Edit-view text writes funnel through
 // reconcileMatchedTiming in the opposite direction and do not call this.
 function applyMainWordEdit(line: LyricLine, words: WordTiming[]): LyricLine {
-  return reconcileLine({ ...line, ...mainWordEditFields(words) });
+  return reconcileLine({ ...toFlat(line), ...mainWordEditFields(words) });
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/src/domain/line/migrate.test.ts
+++ b/src/domain/line/migrate.test.ts
@@ -1,0 +1,320 @@
+import type { NestedLyricLine } from "@/domain/line/model";
+import { describe, expect, it } from "vitest";
+import type { WordTiming } from "@/domain/word/timing";
+import { migrateLine } from "@/domain/line/migrate";
+
+// -- Fixtures -----------------------------------------------------------------
+
+const helloWords: WordTiming[] = [
+  { text: "Hel", begin: 1.2, end: 1.6 },
+  { text: "lo ", begin: 1.6, end: 2.1 },
+  { text: "world", begin: 2.1, end: 2.9 },
+];
+
+const ahWords: WordTiming[] = [
+  { text: "ah ", begin: 6.0, end: 7.2 },
+  { text: "oh", begin: 7.2, end: 8.5 },
+];
+
+const wordSyncedFlat = {
+  id: "l1",
+  agentId: "v1",
+  text: "Hello world",
+  words: helloWords,
+  groupId: "g1",
+  instanceIdx: 0,
+  templateLineIdx: 2,
+  detached: true,
+};
+
+const lineSyncedFlat = {
+  id: "l2",
+  agentId: "v2",
+  text: "Hello world",
+  begin: 3.0,
+  end: 7.5,
+};
+
+const untimedFlat = {
+  id: "l3",
+  agentId: "v1",
+  text: "Hello world",
+};
+
+const bgWithWordsFlat = {
+  id: "l4",
+  agentId: "v1",
+  text: "Hello world",
+  begin: 3.0,
+  end: 7.5,
+  backgroundText: "ah oh",
+  backgroundWords: ahWords,
+  backgroundTextSource: "extraction" as const,
+};
+
+const bgWithoutWordsFlat = {
+  id: "l5",
+  agentId: "v1",
+  text: "Hello world",
+  backgroundText: "ah oh",
+  backgroundTextSource: "manual" as const,
+};
+
+const noBgFlat = {
+  id: "l6",
+  agentId: "v1",
+  text: "Hello world",
+  begin: 3.0,
+  end: 7.5,
+};
+
+// -- migrateLine: happy paths -------------------------------------------------
+
+describe("migrateLine", () => {
+  describe("happy paths", () => {
+    it("migrates a word-synced flat line to a nested word voice", () => {
+      const result = migrateLine(wordSyncedFlat);
+      expect(result).toEqual({
+        id: "l1",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 0,
+        templateLineIdx: 2,
+        detached: true,
+        main: { text: "Hello world", words: helloWords },
+      });
+    });
+
+    it("preserves the words array by reference", () => {
+      const result = migrateLine(wordSyncedFlat);
+      if (!("words" in result.main)) throw new Error("expected a word voice");
+      expect(result.main.words).toBe(helloWords);
+    });
+
+    it("migrates a line-synced flat line to a nested line voice", () => {
+      const result = migrateLine(lineSyncedFlat);
+      expect(result).toEqual({
+        id: "l2",
+        agentId: "v2",
+        main: { text: "Hello world", begin: 3.0, end: 7.5 },
+      });
+    });
+
+    it("migrates an untimed flat line to a nested untimed voice", () => {
+      const result = migrateLine(untimedFlat);
+      expect(result).toEqual({
+        id: "l3",
+        agentId: "v1",
+        main: { text: "Hello world" },
+      });
+    });
+
+    it("migrates an empty-text untimed flat line", () => {
+      const result = migrateLine({ id: "l7", agentId: "v1", text: "" });
+      expect(result).toEqual({ id: "l7", agentId: "v1", main: { text: "" } });
+    });
+
+    it("migrates a flat line with word-synced background", () => {
+      const result = migrateLine(bgWithWordsFlat);
+      expect(result).toEqual({
+        id: "l4",
+        agentId: "v1",
+        main: { text: "Hello world", begin: 3.0, end: 7.5 },
+        background: { text: "ah oh", words: ahWords, source: "extraction" },
+      });
+    });
+
+    it("migrates a flat line with untimed background", () => {
+      const result = migrateLine(bgWithoutWordsFlat);
+      expect(result).toEqual({
+        id: "l5",
+        agentId: "v1",
+        main: { text: "Hello world" },
+        background: { text: "ah oh", source: "manual" },
+      });
+    });
+
+    it("omits the background key entirely for a line with no background", () => {
+      const result = migrateLine(noBgFlat);
+      expect(result).toEqual({
+        id: "l6",
+        agentId: "v1",
+        main: { text: "Hello world", begin: 3.0, end: 7.5 },
+      });
+      expect("background" in result).toBe(false);
+    });
+  });
+
+  // -- migrateLine: edge cases ------------------------------------------------
+
+  describe("edge cases", () => {
+    it("treats begin: 0 as line-synced (guards against falsy-begin bug)", () => {
+      const result = migrateLine({ id: "l8", agentId: "v1", text: "zero", begin: 0, end: 1.5 });
+      expect(result.main).toEqual({ text: "zero", begin: 0, end: 1.5 });
+    });
+
+    it("builds an empty-text word-synced background when only backgroundWords are set", () => {
+      const result = migrateLine({
+        id: "l9",
+        agentId: "v1",
+        text: "Hello world",
+        backgroundWords: ahWords,
+      });
+      expect(result.background).toEqual({ text: "", words: ahWords, source: undefined });
+      if (result.background === undefined || !("words" in result.background)) {
+        throw new Error("expected a word-synced background voice");
+      }
+      expect(result.background.words).toBe(ahWords);
+    });
+
+    it("treats an empty backgroundWords array as no background", () => {
+      const result = migrateLine({
+        id: "l10",
+        agentId: "v1",
+        text: "Hello world",
+        backgroundWords: [],
+      });
+      expect("background" in result).toBe(false);
+    });
+
+    it("prefers words over stale begin/end on the main voice", () => {
+      const result = migrateLine({
+        id: "l11",
+        agentId: "v1",
+        text: "Hello world",
+        begin: 0,
+        end: 999,
+        words: helloWords,
+      });
+      expect(result.main).toEqual({ text: "Hello world", words: helloWords });
+      if (!("words" in result.main)) throw new Error("expected a word voice");
+      expect(result.main.words).toBe(helloWords);
+    });
+
+    it("preserves unicode text verbatim", () => {
+      const result = migrateLine({ id: "l12", agentId: "v1", text: "안녕 🎵", begin: 2, end: 4 });
+      expect(result.main).toEqual({ text: "안녕 🎵", begin: 2, end: 4 });
+    });
+  });
+
+  // -- migrateLine: invariants ------------------------------------------------
+
+  describe("invariants", () => {
+    it("preserves all defined identity fields", () => {
+      const result = migrateLine(wordSyncedFlat);
+      expect(result.id).toBe("l1");
+      expect(result.agentId).toBe("v1");
+      expect(result.groupId).toBe("g1");
+      expect(result.instanceIdx).toBe(0);
+      expect(result.templateLineIdx).toBe(2);
+      expect(result.detached).toBe(true);
+    });
+
+    it("does not emit absent identity fields as undefined keys", () => {
+      const result = migrateLine(untimedFlat);
+      expect("groupId" in result).toBe(false);
+      expect("instanceIdx" in result).toBe(false);
+      expect("templateLineIdx" in result).toBe(false);
+      expect("detached" in result).toBe(false);
+    });
+
+    it("preserves instanceIdx: 0 (guards against falsy-index drop)", () => {
+      const result = migrateLine({ id: "l13", agentId: "v1", text: "x", instanceIdx: 0, groupId: "g9" });
+      expect(result.instanceIdx).toBe(0);
+      expect(result.groupId).toBe("g9");
+    });
+
+    it("preserves detached: false explicitly", () => {
+      const result = migrateLine({ id: "l14", agentId: "v1", text: "x", detached: false });
+      expect(result.detached).toBe(false);
+    });
+
+    it.each([
+      ["word-synced", wordSyncedFlat],
+      ["line-synced", lineSyncedFlat],
+      ["untimed", untimedFlat],
+      ["bg-with-words", bgWithWordsFlat],
+      ["bg-without-words", bgWithoutWordsFlat],
+      ["no-bg", noBgFlat],
+    ])("is idempotent for a %s flat line", (_label, flat) => {
+      const once = migrateLine(flat);
+      const twice = migrateLine(once);
+      expect(twice).toEqual(once);
+    });
+  });
+
+  // -- migrateLine: error paths -----------------------------------------------
+
+  describe("error paths", () => {
+    it("throws for null input", () => {
+      expect(() => migrateLine(null)).toThrow();
+    });
+
+    it("throws for a number input", () => {
+      expect(() => migrateLine(42)).toThrow();
+    });
+
+    it("throws for a string input", () => {
+      expect(() => migrateLine("not a line")).toThrow();
+    });
+
+    it("throws for an empty object (missing id and agentId)", () => {
+      expect(() => migrateLine({})).toThrow();
+    });
+
+    it("throws for a flat object missing text", () => {
+      expect(() => migrateLine({ id: "l1", agentId: "v1" })).toThrow();
+    });
+
+    it("throws for a flat object with a non-string id", () => {
+      expect(() => migrateLine({ id: 1, agentId: "v1", text: "x" })).toThrow();
+    });
+
+    it("throws for a flat object missing agentId", () => {
+      expect(() => migrateLine({ id: "l1", text: "x" })).toThrow();
+    });
+
+    it("throws for a nested object whose main has no text", () => {
+      expect(() => migrateLine({ id: "l1", agentId: "v1", main: { begin: 1, end: 2 } })).toThrow();
+    });
+
+    it("throws for a nested object whose main is not an object", () => {
+      expect(() => migrateLine({ id: "l1", agentId: "v1", main: "x" })).toThrow();
+    });
+  });
+
+  // -- migrateLine: nested passthrough ----------------------------------------
+
+  describe("nested passthrough", () => {
+    it("preserves a nested word voice verbatim", () => {
+      const nested: NestedLyricLine = {
+        id: "n1",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 3,
+        main: { text: "Hello world", words: helloWords },
+        background: { text: "ah oh", words: ahWords, source: "extraction" },
+      };
+      const result = migrateLine(nested);
+      expect(result).toEqual(nested);
+      if (!("words" in result.main)) throw new Error("expected a word voice");
+      expect(result.main.words).toBe(helloWords);
+    });
+
+    it("preserves a nested untimed voice with no background", () => {
+      const nested: NestedLyricLine = { id: "n2", agentId: "v2", main: { text: "Hello" } };
+      const result = migrateLine(nested);
+      expect(result).toEqual(nested);
+      expect("background" in result).toBe(false);
+    });
+
+    it("does not emit absent identity fields as undefined keys on the nested branch", () => {
+      const nested: NestedLyricLine = { id: "n3", agentId: "v1", main: { text: "x", begin: 1, end: 2 } };
+      const result = migrateLine(nested);
+      expect("groupId" in result).toBe(false);
+      expect("instanceIdx" in result).toBe(false);
+      expect("templateLineIdx" in result).toBe(false);
+      expect("detached" in result).toBe(false);
+    });
+  });
+});

--- a/src/domain/line/migrate.test.ts
+++ b/src/domain/line/migrate.test.ts
@@ -317,4 +317,75 @@ describe("migrateLine", () => {
       expect("detached" in result).toBe(false);
     });
   });
+
+  // -- migrateLine: nested validation -----------------------------------------
+
+  describe("nested validation", () => {
+    it("treats background: null as no background (omits the key)", () => {
+      const result = migrateLine({ id: "n4", agentId: "v1", main: { text: "x" }, background: null });
+      expect("background" in result).toBe(false);
+    });
+
+    it("is idempotent for an already-nested line with a valid background", () => {
+      const nested: NestedLyricLine = {
+        id: "n5",
+        agentId: "v1",
+        main: { text: "Hello world", words: helloWords },
+        background: { text: "ah oh", words: ahWords, source: "extraction" },
+      };
+      const result = migrateLine(nested);
+      expect(result).toEqual(nested);
+    });
+
+    it("throws when a nested main is invalid (no text)", () => {
+      expect(() => migrateLine({ id: "n6", agentId: "v1", main: { begin: 1, end: 2 } })).toThrow();
+    });
+
+    it("throws when a nested main has a begin but no end", () => {
+      expect(() => migrateLine({ id: "n7", agentId: "v1", main: { text: "x", begin: 1 } })).toThrow();
+    });
+
+    it("throws when a nested background has an invalid shape (non-string text)", () => {
+      expect(() => migrateLine({ id: "n8", agentId: "v1", main: { text: "x" }, background: { text: 5 } })).toThrow();
+    });
+
+    it("throws when a nested background has an unknown source", () => {
+      expect(() =>
+        migrateLine({ id: "n9", agentId: "v1", main: { text: "x" }, background: { text: "ah", source: "auto" } }),
+      ).toThrow();
+    });
+
+    it("prefers words over stale begin/end on a nested main (matches the flat path)", () => {
+      const result = migrateLine({
+        id: "n10",
+        agentId: "v1",
+        main: { text: "hello", words: helloWords, begin: 1, end: 2 },
+      });
+      expect(result.main).toEqual({ text: "hello", words: helloWords });
+      expect("begin" in result.main).toBe(false);
+      expect("end" in result.main).toBe(false);
+      if (!("words" in result.main)) throw new Error("expected a word voice");
+      expect(result.main.words).toBe(helloWords);
+    });
+
+    it("keeps a valid line-synced nested main unchanged (begin/end survive)", () => {
+      const result = migrateLine({
+        id: "n11",
+        agentId: "v1",
+        main: { text: "hello", begin: 3, end: 7.5 },
+      });
+      expect(result.main).toEqual({ text: "hello", begin: 3, end: 7.5 });
+    });
+
+    it("keeps a valid word-synced nested main unchanged", () => {
+      const result = migrateLine({
+        id: "n12",
+        agentId: "v1",
+        main: { text: "hello", words: helloWords },
+      });
+      expect(result.main).toEqual({ text: "hello", words: helloWords });
+      if (!("words" in result.main)) throw new Error("expected a word voice");
+      expect(result.main.words).toBe(helloWords);
+    });
+  });
 });

--- a/src/domain/line/migrate.ts
+++ b/src/domain/line/migrate.ts
@@ -1,9 +1,18 @@
 import { reconcileLine, type LineIdentity, type LooseLine, type NestedLyricLine } from "@/domain/line/model";
-import type { BackgroundVoice, Voice } from "@/domain/voice/model";
-import { bgVoice, mainVoice } from "@/domain/line/voices";
+import { isBackgroundVoice, isVoice } from "@/domain/voice/predicates";
+import type { Voice } from "@/domain/voice/model";
 import type { WordTiming } from "@/domain/word/timing";
+import { bgVoice, mainVoice } from "@/domain/line/voices";
 
 // -- Helpers ------------------------------------------------------------------
+
+// Collapse a validated voice to exactly one timing arm, mirroring reconcileLine:
+// words wins over a stale begin/end pair so the flat and nested paths agree.
+function normalizeVoiceArm(v: Voice): Voice {
+  if ("words" in v) return { text: v.text, words: v.words };
+  if ("begin" in v) return { text: v.text, begin: v.begin, end: v.end };
+  return { text: v.text };
+}
 
 function pickIdentity(source: Record<string, unknown>): LineIdentity {
   const identity: LineIdentity = { id: source.id as string, agentId: source.agentId as string };
@@ -37,9 +46,14 @@ function migrateFlat(source: Record<string, unknown>): NestedLyricLine {
 }
 
 function migrateNested(source: Record<string, unknown>, main: Record<string, unknown>): NestedLyricLine {
-  if (typeof main.text !== "string") throw new Error("migrateLine: nested line `main` is missing a string `text`");
-  const result: NestedLyricLine = { ...pickIdentity(source), main: main as Voice };
-  if (source.background !== undefined) result.background = source.background as BackgroundVoice;
+  if (!isVoice(main)) throw new Error("migrateLine: nested line `main` is not a valid voice");
+  const result: NestedLyricLine = { ...pickIdentity(source), main: normalizeVoiceArm(main) };
+  if (source.background != null) {
+    if (!isBackgroundVoice(source.background)) {
+      throw new Error("migrateLine: nested line `background` is not a valid background voice");
+    }
+    result.background = source.background;
+  }
   return result;
 }
 

--- a/src/domain/line/migrate.ts
+++ b/src/domain/line/migrate.ts
@@ -1,0 +1,64 @@
+import { reconcileLine, type LineIdentity, type LooseLine, type NestedLyricLine } from "@/domain/line/model";
+import type { BackgroundVoice, Voice } from "@/domain/voice/model";
+import { bgVoice, mainVoice } from "@/domain/line/voices";
+import type { WordTiming } from "@/domain/word/timing";
+
+// -- Helpers ------------------------------------------------------------------
+
+function pickIdentity(source: Record<string, unknown>): LineIdentity {
+  const identity: LineIdentity = { id: source.id as string, agentId: source.agentId as string };
+  if (typeof source.groupId === "string") identity.groupId = source.groupId;
+  if (typeof source.instanceIdx === "number") identity.instanceIdx = source.instanceIdx;
+  if (typeof source.templateLineIdx === "number") identity.templateLineIdx = source.templateLineIdx;
+  if (typeof source.detached === "boolean") identity.detached = source.detached;
+  return identity;
+}
+
+function migrateFlat(source: Record<string, unknown>): NestedLyricLine {
+  if (typeof source.text !== "string") throw new Error("migrateLine: flat line is missing a string `text`");
+  const loose: LooseLine = {
+    id: source.id as string,
+    agentId: source.agentId as string,
+    text: source.text,
+  };
+  if (typeof source.begin === "number") loose.begin = source.begin;
+  if (typeof source.end === "number") loose.end = source.end;
+  if (Array.isArray(source.words)) loose.words = source.words as WordTiming[];
+  if (typeof source.backgroundText === "string") loose.backgroundText = source.backgroundText;
+  if (Array.isArray(source.backgroundWords)) loose.backgroundWords = source.backgroundWords as WordTiming[];
+  if (source.backgroundTextSource === "extraction" || source.backgroundTextSource === "manual") {
+    loose.backgroundTextSource = source.backgroundTextSource;
+  }
+  const reconciled = reconcileLine(loose);
+  const background = bgVoice(reconciled);
+  const result: NestedLyricLine = { ...pickIdentity(source), main: mainVoice(reconciled) };
+  if (background !== null) result.background = background;
+  return result;
+}
+
+function migrateNested(source: Record<string, unknown>, main: Record<string, unknown>): NestedLyricLine {
+  if (typeof main.text !== "string") throw new Error("migrateLine: nested line `main` is missing a string `text`");
+  const result: NestedLyricLine = { ...pickIdentity(source), main: main as Voice };
+  if (source.background !== undefined) result.background = source.background as BackgroundVoice;
+  return result;
+}
+
+// -- Functions ----------------------------------------------------------------
+
+function migrateLine(input: unknown): NestedLyricLine {
+  if (typeof input !== "object" || input === null) {
+    throw new Error("migrateLine: input must be a non-null object");
+  }
+  const source = input as Record<string, unknown>;
+  if (typeof source.id !== "string") throw new Error("migrateLine: line is missing a string `id`");
+  if (typeof source.agentId !== "string") throw new Error("migrateLine: line is missing a string `agentId`");
+  if (typeof source.main === "object" && source.main !== null) {
+    return migrateNested(source, source.main as Record<string, unknown>);
+  }
+  if (source.main !== undefined) throw new Error("migrateLine: nested line `main` must be an object");
+  return migrateFlat(source);
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { migrateLine };

--- a/src/domain/line/model.test.ts
+++ b/src/domain/line/model.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import { type LooseLine, reconcileLine, toFlat } from "@/domain/line/model";
+import { isUntimed, isWordSynced } from "@/domain/voice/predicates";
+import type { WordTiming } from "@/domain/word/timing";
+
+// -- Fixtures -----------------------------------------------------------------
+
+const mainWords: WordTiming[] = [
+  { text: "Hel", begin: 1.25, end: 1.8 },
+  { text: "lo", begin: 1.8, end: 2.4 },
+];
+
+const bgWords: WordTiming[] = [
+  { text: "ah", begin: 6.1, end: 6.9 },
+  { text: "oh", begin: 6.9, end: 7.5 },
+];
+
+const IDENTITY = { id: "line-7", text: "Hello world", agentId: "v2" } as const;
+
+type MainCase = { name: string; fields: Partial<LooseLine> };
+type BgCase = { name: string; fields: Partial<LooseLine> };
+
+const MAIN_CASES: MainCase[] = [
+  { name: "untimed", fields: {} },
+  { name: "line-synced", fields: { begin: 3.5, end: 8.25 } },
+  { name: "word-synced", fields: { words: mainWords } },
+];
+
+const BG_CASES: BgCase[] = [
+  { name: "none", fields: {} },
+  { name: "text-only", fields: { backgroundText: "ooh ah" } },
+  { name: "word-synced", fields: { backgroundText: "ah oh", backgroundWords: bgWords } },
+];
+
+function loose(extras: Partial<LooseLine> = {}): LooseLine {
+  return { ...IDENTITY, ...extras };
+}
+
+// -- reconcileLine -> toFlat round-trip ---------------------------------------
+
+describe("reconcileLine -> toFlat round-trip", () => {
+  for (const main of MAIN_CASES) {
+    for (const bg of BG_CASES) {
+      it(`is an identity for main=${main.name} bg=${bg.name}`, () => {
+        const input = loose({ ...main.fields, ...bg.fields });
+        expect(toFlat(reconcileLine(input))).toEqual(input);
+      });
+    }
+  }
+});
+
+// -- idempotence --------------------------------------------------------------
+
+describe("idempotence", () => {
+  for (const main of MAIN_CASES) {
+    for (const bg of BG_CASES) {
+      it(`one extra trip changes nothing for main=${main.name} bg=${bg.name}`, () => {
+        const input = loose({ ...main.fields, ...bg.fields });
+        const once = reconcileLine(input);
+        const twice = reconcileLine(toFlat(once));
+        expect(twice).toEqual(once);
+      });
+    }
+  }
+});
+
+// -- normalization asymmetry --------------------------------------------------
+
+describe("normalization asymmetry", () => {
+  it("word-only background normalizes authored text from undefined to empty string", () => {
+    const input = loose({ backgroundWords: bgWords });
+    expect(input.backgroundText).toBeUndefined();
+
+    const reconciled = reconcileLine(input);
+    expect(reconciled.background).toEqual({ text: "", words: bgWords, source: undefined });
+    expect(reconciled.background?.text).toBe("");
+
+    const flat = toFlat(reconciled);
+    expect(flat.backgroundText).toBe("");
+    expect(flat.backgroundText).not.toBeUndefined();
+  });
+
+  it("is idempotent after the first normalization", () => {
+    const input = loose({ backgroundWords: bgWords });
+    const once = reconcileLine(input);
+    const twice = reconcileLine(toFlat(once));
+    expect(twice).toEqual(once);
+    expect(twice.background).toEqual({ text: "", words: bgWords, source: undefined });
+  });
+});
+
+// -- invariants ---------------------------------------------------------------
+
+describe("invariants", () => {
+  describe("words wins over begin/end", () => {
+    it("reconciles a main with both words and begin/end to word-synced with no begin/end", () => {
+      const input = loose({ words: mainWords, begin: 0, end: 999 });
+      const reconciled = reconcileLine(input);
+
+      expect(isWordSynced(reconciled.main)).toBe(true);
+      expect("words" in reconciled.main).toBe(true);
+      expect("begin" in reconciled.main).toBe(false);
+      expect("end" in reconciled.main).toBe(false);
+    });
+
+    it("toFlat emits no begin/end when words won", () => {
+      const flat = toFlat(reconcileLine(loose({ words: mainWords, begin: 0, end: 999 })));
+      expect(flat.words).toEqual(mainWords);
+      expect("begin" in flat).toBe(false);
+      expect("end" in flat).toBe(false);
+    });
+  });
+
+  describe("identity preserved", () => {
+    it("survives a round-trip with every identity field set", () => {
+      const input: LooseLine = {
+        id: "line-99",
+        text: "Identity line",
+        agentId: "v3",
+        groupId: "group-2",
+        instanceIdx: 4,
+        templateLineIdx: 1,
+        detached: true,
+        words: mainWords,
+      };
+      const flat = toFlat(reconcileLine(input));
+      expect(flat).toEqual(input);
+      expect(flat.groupId).toBe("group-2");
+      expect(flat.instanceIdx).toBe(4);
+      expect(flat.templateLineIdx).toBe(1);
+      expect(flat.detached).toBe(true);
+      expect(flat.agentId).toBe("v3");
+      expect(flat.id).toBe("line-99");
+    });
+
+    it("survives a round-trip with no optional identity fields set", () => {
+      const input: LooseLine = { id: "bare", text: "Bare line", agentId: "v1" };
+      const reconciled = reconcileLine(input);
+      expect("groupId" in reconciled).toBe(false);
+      expect("instanceIdx" in reconciled).toBe(false);
+      expect("templateLineIdx" in reconciled).toBe(false);
+      expect("detached" in reconciled).toBe(false);
+
+      const flat = toFlat(reconciled);
+      expect(flat).toEqual(input);
+      expect("groupId" in flat).toBe(false);
+      expect("instanceIdx" in flat).toBe(false);
+      expect("templateLineIdx" in flat).toBe(false);
+      expect("detached" in flat).toBe(false);
+    });
+  });
+
+  describe("provenance preserved", () => {
+    it("survives the round-trip for a text-only extraction background", () => {
+      const input = loose({ backgroundText: "ooh", backgroundTextSource: "extraction" });
+      const flat = toFlat(reconcileLine(input));
+      expect(flat.backgroundTextSource).toBe("extraction");
+      expect(flat).toEqual(input);
+    });
+
+    it("survives the round-trip for a text-only manual background", () => {
+      const input = loose({ backgroundText: "ooh", backgroundTextSource: "manual" });
+      const flat = toFlat(reconcileLine(input));
+      expect(flat.backgroundTextSource).toBe("manual");
+      expect(flat).toEqual(input);
+    });
+
+    it("survives the round-trip for a word-synced extraction background", () => {
+      const input = loose({ backgroundText: "ah oh", backgroundWords: bgWords, backgroundTextSource: "extraction" });
+      const flat = toFlat(reconcileLine(input));
+      expect(flat.backgroundTextSource).toBe("extraction");
+      expect(flat).toEqual(input);
+    });
+
+    it("survives the round-trip for a word-synced manual background", () => {
+      const input = loose({ backgroundText: "ah oh", backgroundWords: bgWords, backgroundTextSource: "manual" });
+      const flat = toFlat(reconcileLine(input));
+      expect(flat.backgroundTextSource).toBe("manual");
+      expect(flat).toEqual(input);
+    });
+  });
+});
+
+// -- edge cases ---------------------------------------------------------------
+
+describe("edge cases", () => {
+  describe("empty words array", () => {
+    it("stores main = { text, words: [] } verbatim and classifies the line untimed", () => {
+      const reconciled = reconcileLine(loose({ words: [] }));
+      expect(reconciled.main).toEqual({ text: "Hello world", words: [] });
+      expect("words" in reconciled.main).toBe(true);
+      expect(isUntimed(reconciled.main)).toBe(true);
+      expect(isWordSynced(reconciled.main)).toBe(false);
+    });
+
+    it("toFlat emits words: [] (not dropped) and round-trips", () => {
+      const input = loose({ words: [] });
+      const flat = toFlat(reconcileLine(input));
+      expect(flat.words).toEqual([]);
+      expect("words" in flat).toBe(true);
+      expect("begin" in flat).toBe(false);
+      expect("end" in flat).toBe(false);
+      expect(flat).toEqual(input);
+    });
+  });
+
+  describe("empty background words array", () => {
+    it("does not create a word-synced background and emits no background when text is absent", () => {
+      const reconciled = reconcileLine(loose({ backgroundWords: [] }));
+      expect(reconciled.background).toBeUndefined();
+    });
+
+    it("keeps a text-only background when backgroundWords is empty but backgroundText is set", () => {
+      const reconciled = reconcileLine(loose({ backgroundText: "ooh", backgroundWords: [] }));
+      expect(reconciled.background).toEqual({ text: "ooh", source: undefined });
+      expect("words" in (reconciled.background ?? {})).toBe(false);
+    });
+  });
+
+  describe("whitespace and unicode text", () => {
+    it("preserves padded text verbatim through a round-trip", () => {
+      const input = loose({ text: "  héllo  ", begin: 2, end: 4 });
+      expect(toFlat(reconcileLine(input))).toEqual(input);
+    });
+
+    it("preserves a trailing space verbatim through a round-trip", () => {
+      const input = loose({ text: "Hello " });
+      const flat = toFlat(reconcileLine(input));
+      expect(flat.text).toBe("Hello ");
+      expect(flat).toEqual(input);
+    });
+
+    it("preserves unicode main and background text verbatim", () => {
+      const input = loose({ text: "안녕 🎵", begin: 1, end: 2, backgroundText: "コーラス 🎶" });
+      const flat = toFlat(reconcileLine(input));
+      expect(flat.text).toBe("안녕 🎵");
+      expect(flat.backgroundText).toBe("コーラス 🎶");
+      expect(flat).toEqual(input);
+    });
+  });
+});

--- a/src/domain/line/model.ts
+++ b/src/domain/line/model.ts
@@ -1,3 +1,4 @@
+import type { BackgroundVoice, Voice } from "@/domain/voice/model";
 import type { WordTiming } from "@/domain/word/timing";
 
 // -- Types --------------------------------------------------------------------
@@ -43,6 +44,20 @@ type LyricLine = WordSyncedLine | LineSyncedLine | UntimedLine;
 // combination of timing fields may be present. Used for merge scratch objects.
 type LooseLine = LineFields & { words?: WordTiming[]; begin?: number; end?: number };
 
+// The nested target shape the storage flip migrates toward. Identity stays flat;
+// timing lives inside Voice (main) and BackgroundVoice (background) rather than
+// being spread across sibling fields. A later phase makes this the stored model.
+type LineIdentity = {
+  id: string;
+  agentId: string;
+  groupId?: string;
+  instanceIdx?: number;
+  templateLineIdx?: number;
+  detached?: boolean;
+};
+
+type NestedLyricLine = LineIdentity & { main: Voice; background?: BackgroundVoice };
+
 // -- Functions ----------------------------------------------------------------
 
 // The store builds lines by spreading `...line` (a union member) together with
@@ -62,4 +77,4 @@ function reconcileLine(line: LooseLine): LyricLine {
 
 export { reconcileLine };
 
-export type { LineFields, LineSyncedLine, LyricLine, LooseLine };
+export type { LineFields, LineIdentity, LineSyncedLine, LyricLine, LooseLine, NestedLyricLine };

--- a/src/domain/line/model.ts
+++ b/src/domain/line/model.ts
@@ -1,4 +1,4 @@
-import type { BackgroundVoice, Voice } from "@/domain/voice/model";
+import type { BackgroundSource, BackgroundVoice, Voice } from "@/domain/voice/model";
 import type { WordTiming } from "@/domain/word/timing";
 
 // -- Types --------------------------------------------------------------------
@@ -9,44 +9,20 @@ interface LineFields {
   agentId: string;
   backgroundText?: string;
   backgroundWords?: WordTiming[];
-  backgroundTextSource?: "extraction" | "manual";
+  backgroundTextSource?: BackgroundSource;
   groupId?: string;
   instanceIdx?: number;
   templateLineIdx?: number;
   detached?: boolean;
 }
 
-// LyricLine is a discriminated union over its timing shape. The discriminant is
-// structural (presence of `words` vs `begin`/`end`), not a literal `kind` tag,
-// so saved projects need no migration. The `never` constraints make a both-state
-// line (`words` + `begin`) a compile error at every constructor and write.
-interface WordSyncedLine extends LineFields {
-  words: WordTiming[];
-  begin?: never;
-  end?: never;
-}
-
-interface LineSyncedLine extends LineFields {
-  begin: number;
-  end: number;
-  words?: never;
-}
-
-interface UntimedLine extends LineFields {
-  words?: never;
-  begin?: never;
-  end?: never;
-}
-
-type LyricLine = WordSyncedLine | LineSyncedLine | UntimedLine;
-
-// A line shape before reconcileLine narrows it to a concrete variant: any
-// combination of timing fields may be present. Used for merge scratch objects.
+// A line shape before reconcileLine lifts it to the nested model: any
+// combination of flat timing fields may be present. This is the input type for
+// reconcileLine and for every store update payload (callers stay flat).
 type LooseLine = LineFields & { words?: WordTiming[]; begin?: number; end?: number };
 
-// The nested target shape the storage flip migrates toward. Identity stays flat;
-// timing lives inside Voice (main) and BackgroundVoice (background) rather than
-// being spread across sibling fields. A later phase makes this the stored model.
+// Identity fields stay flat on the stored line; timing lives nested inside the
+// main Voice and optional background BackgroundVoice.
 type LineIdentity = {
   id: string;
   agentId: string;
@@ -58,23 +34,58 @@ type LineIdentity = {
 
 type NestedLyricLine = LineIdentity & { main: Voice; background?: BackgroundVoice };
 
+// The stored line shape: nested timing, flat identity. Reads go through the
+// voice seam (`@/domain/line/voices`); writes go through reconcileLine (which
+// takes flat input and lifts to nested) or toFlat + reconcileLine for merges.
+type LyricLine = NestedLyricLine;
+
 // -- Functions ----------------------------------------------------------------
 
-// The store builds lines by spreading `...line` (a union member) together with
-// Partial<LyricLine> updates or fresh timing fields. A generic spread widens
-// past the LyricLine union, so reconcileLine re-narrows a freshly merged line
-// into exactly one variant by its runtime shape. It enforces the core
-// invariant: a line is never both word-synced and line-synced. A `words` array
-// (even empty) wins and drops begin/end.
+// Lifts a flat LooseLine to the nested stored model. A `words` array (even
+// empty) makes the main voice word-synced and drops begin/end; otherwise a
+// begin/end pair makes it line-synced; otherwise it is untimed. A background
+// voice is present when there is background text or a non-empty background word
+// array, carrying the provenance source. This is the single write chokepoint:
+// every store update merges flat fields then calls reconcileLine.
 function reconcileLine(line: LooseLine): LyricLine {
-  const { words, begin, end, ...rest } = line;
-  if (words !== undefined) return { ...rest, words };
-  if (begin !== undefined && end !== undefined) return { ...rest, begin, end };
-  return rest;
+  const { words, begin, end, backgroundText, backgroundWords, backgroundTextSource, text, ...identity } = line;
+  const main: Voice =
+    words !== undefined ? { text, words } : begin !== undefined && end !== undefined ? { text, begin, end } : { text };
+  let background: BackgroundVoice | undefined;
+  if (backgroundWords !== undefined && backgroundWords.length > 0) {
+    background = { text: backgroundText ?? "", words: backgroundWords, source: backgroundTextSource };
+  } else if (backgroundText !== undefined) {
+    background = { text: backgroundText, source: backgroundTextSource };
+  }
+  return background !== undefined ? { ...identity, main, background } : { ...identity, main };
+}
+
+// Flattens a stored nested line back to a LooseLine. The inverse of
+// reconcileLine: spreads identity, derives the flat timing fields from the main
+// voice variant, and the flat background fields from the background voice. Used
+// to merge a flat update payload onto an existing stored line:
+// reconcileLine({ ...toFlat(line), ...updates }).
+function toFlat(line: LyricLine): LooseLine {
+  const { main, background, ...identity } = line;
+  const flat: LooseLine = { ...identity, text: main.text };
+  if ("words" in main) flat.words = main.words;
+  else if ("begin" in main) {
+    flat.begin = main.begin;
+    flat.end = main.end;
+  }
+  // No line-synced-background branch: LooseLine has no backgroundBegin/end field
+  // to emit one, and reconcileLine never builds one. A later phase that adds
+  // line-synced backgrounds must extend both LooseLine and this block.
+  if (background !== undefined) {
+    flat.backgroundText = background.text;
+    if ("words" in background) flat.backgroundWords = background.words;
+    flat.backgroundTextSource = background.source;
+  }
+  return flat;
 }
 
 // -- Exports ------------------------------------------------------------------
 
-export { reconcileLine };
+export { reconcileLine, toFlat };
 
-export type { LineFields, LineIdentity, LineSyncedLine, LyricLine, LooseLine, NestedLyricLine };
+export type { LineFields, LineIdentity, LyricLine, LooseLine, NestedLyricLine };

--- a/src/domain/line/place-voice.test.ts
+++ b/src/domain/line/place-voice.test.ts
@@ -1,0 +1,123 @@
+import { setBackground } from "@/domain/line/background";
+import { mainBounds } from "@/domain/line/bounds";
+import { reconcileLine } from "@/domain/line/model";
+import { placeVoice } from "@/domain/line/place-voice";
+import { bgVoice, mainVoice } from "@/domain/line/voices";
+import { isLineSynced, isUntimed } from "@/domain/voice/predicates";
+import { describe, expect, it } from "vitest";
+
+// -- Constants -----------------------------------------------------------------
+
+const DUR = 0.3;
+
+// -- Helpers -------------------------------------------------------------------
+
+function untimedLine(text: string): ReturnType<typeof reconcileLine> {
+  return reconcileLine({ id: "l1", text, agentId: "v1" });
+}
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("placeVoice", () => {
+  describe("main", () => {
+    it("places a multi-word line as main line-synced over max(wordCount,1)*dur", () => {
+      const line = untimedLine("hello there world");
+      const placed = placeVoice(line, "main", 5, DUR);
+      const bounds = mainBounds(placed);
+      expect(bounds?.begin).toBeCloseTo(5, 9);
+      expect(bounds?.end).toBeCloseTo(5 + 3 * DUR, 9);
+      expect(isLineSynced(mainVoice(placed))).toBe(true);
+    });
+
+    it("treats an empty-text line as one word (max(0,1)=1)", () => {
+      const line = untimedLine("");
+      const placed = placeVoice(line, "main", 2, DUR);
+      const bounds = mainBounds(placed);
+      expect(bounds?.begin).toBeCloseTo(2, 9);
+      expect(bounds?.end).toBeCloseTo(2 + DUR, 9);
+      expect(isLineSynced(mainVoice(placed))).toBe(true);
+    });
+
+    it("does not create a background when none exists", () => {
+      const placed = placeVoice(untimedLine("a b"), "main", 0, DUR);
+      expect(bgVoice(placed)).toBeNull();
+    });
+
+    it("preserves an existing line-synced background (durability parity)", () => {
+      const base = reconcileLine({ id: "l1", text: "lead vocals", agentId: "v1" });
+      const withBg = setBackground(base, { text: "echo echo", begin: 10, end: 12, source: "manual" });
+      const placed = placeVoice(withBg, "main", 3, DUR);
+
+      const bg = bgVoice(placed);
+      expect(bg).not.toBeNull();
+      expect(bg && isLineSynced(bg)).toBe(true);
+      const bounds = bg && isLineSynced(bg) ? { begin: bg.begin, end: bg.end } : null;
+      expect(bounds?.begin).toBeCloseTo(10, 9);
+      expect(bounds?.end).toBeCloseTo(12, 9);
+    });
+  });
+
+  describe("background", () => {
+    it("places an untimed bg text as a line-synced background over max(wordCount,1)*dur", () => {
+      const base = reconcileLine({ id: "l1", text: "lead", agentId: "v1", backgroundText: "oh oh oh" });
+      const placed = placeVoice(base, "background", 7, DUR);
+
+      const bg = bgVoice(placed);
+      expect(bg).not.toBeNull();
+      expect(bg && isLineSynced(bg)).toBe(true);
+      const bounds = bg && isLineSynced(bg) ? { begin: bg.begin, end: bg.end } : null;
+      expect(bounds?.begin).toBeCloseTo(7, 9);
+      expect(bounds?.end).toBeCloseTo(7 + 3 * DUR, 9);
+      expect(bg?.source).toBe("manual");
+    });
+
+    it("leaves the main voice untouched when placing the background", () => {
+      const base = reconcileLine({ id: "l1", text: "lead", agentId: "v1", backgroundText: "oh oh" });
+      const placed = placeVoice(base, "background", 7, DUR);
+      expect(isUntimed(mainVoice(placed))).toBe(true);
+      expect(mainBounds(placed)).toBeNull();
+    });
+
+    it("is a no-op when there is no background text", () => {
+      const line = untimedLine("lead vocals");
+      const placed = placeVoice(line, "background", 4, DUR);
+      expect(placed).toEqual(line);
+      expect(bgVoice(placed)).toBeNull();
+    });
+
+    it("treats an empty bg text as no background (no-op)", () => {
+      const base = reconcileLine({ id: "l1", text: "lead", agentId: "v1", backgroundText: "" });
+      const placed = placeVoice(base, "background", 4, DUR);
+      expect(placed).toEqual(base);
+    });
+  });
+
+  describe("invariants", () => {
+    it("main and background placements produce identical begin/end math for equal word counts", () => {
+      const mainLine = untimedLine("one two three");
+      const bgLine = reconcileLine({ id: "l2", text: "lead", agentId: "v1", backgroundText: "a b c" });
+
+      const placedMain = placeVoice(mainLine, "main", 9, DUR);
+      const placedBg = placeVoice(bgLine, "background", 9, DUR);
+
+      const mainEnd = mainBounds(placedMain)?.end;
+      const bg = bgVoice(placedBg);
+      const bgEnd = bg && isLineSynced(bg) ? bg.end : undefined;
+      expect(bgEnd).toBeCloseTo(mainEnd ?? Number.NaN, 9);
+    });
+
+    it("does not mutate the input line (main)", () => {
+      const line = untimedLine("hello world");
+      const snapshot = structuredClone(line);
+      placeVoice(line, "main", 5, DUR);
+      expect(line).toEqual(snapshot);
+    });
+
+    it("does not mutate the input line (background)", () => {
+      const line = reconcileLine({ id: "l1", text: "lead", agentId: "v1", backgroundText: "echo" });
+      const snapshot = structuredClone(line);
+      placeVoice(line, "background", 5, DUR);
+      expect(line).toEqual(snapshot);
+    });
+  });
+});

--- a/src/domain/line/place-voice.ts
+++ b/src/domain/line/place-voice.ts
@@ -1,0 +1,35 @@
+import { setBackground } from "@/domain/line/background";
+import type { LyricLine } from "@/domain/line/model";
+import { reconcileUpdate } from "@/domain/line/reconcile-update";
+import { bgText, lineText } from "@/domain/line/voices";
+import { splitIntoWordsWithMeta } from "@/utils/sync-helpers";
+
+// -- Constants -----------------------------------------------------------------
+
+type PlacedVoice = "main" | "background";
+
+// -- Functions ----------------------------------------------------------------
+
+function placedBounds(text: string, atTime: number, defaultWordDuration: number): { begin: number; end: number } {
+  const wordCount = splitIntoWordsWithMeta(text).parts.length;
+  return { begin: atTime, end: atTime + Math.max(wordCount, 1) * defaultWordDuration };
+}
+
+// Places a voice as line-synced at atTime, spanning max(wordCount,1) default
+// word durations. The MAIN arm routes through reconcileUpdate so an existing
+// line-synced background survives the flat round-trip; the BACKGROUND arm writes
+// the nested voice directly (the bg funnel params cannot carry begin/end), and
+// is a no-op when there is no untimed bg text to place.
+function placeVoice(line: LyricLine, voice: PlacedVoice, atTime: number, defaultWordDuration: number): LyricLine {
+  if (voice === "main") {
+    return reconcileUpdate(line, placedBounds(lineText(line), atTime, defaultWordDuration));
+  }
+  const text = bgText(line);
+  if (text === undefined || text.length === 0) return line;
+  const { begin, end } = placedBounds(text, atTime, defaultWordDuration);
+  return setBackground(line, { text, begin, end, source: "manual" });
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { placeVoice };

--- a/src/domain/line/predicates.test.ts
+++ b/src/domain/line/predicates.test.ts
@@ -85,6 +85,10 @@ describe("hasAnyTiming", () => {
     expect(hasAnyTiming(line({ backgroundWords: [{ text: "ah", begin: 1, end: 2 }] }))).toBe(true);
   });
 
+  it("returns false when background is text only with no words", () => {
+    expect(hasAnyTiming(line({ backgroundText: "ah" }))).toBe(false);
+  });
+
   it("returns false when only begin is set (incomplete line-sync)", () => {
     expect(hasAnyTiming(line({ begin: 1 }))).toBe(false);
   });

--- a/src/domain/line/predicates.test.ts
+++ b/src/domain/line/predicates.test.ts
@@ -1,3 +1,4 @@
+import { mainBounds } from "@/domain/line/bounds";
 import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
 import { hasAnyTiming, isLineSynced, isWordSynced } from "@/domain/line/predicates";
@@ -35,14 +36,12 @@ describe("isLineSynced", () => {
     expect(isLineSynced(line({ end: 2 }))).toBe(false);
   });
 
-  it("narrows type so begin and end are non-optional inside the guard", () => {
+  it("a line it reports true for carries readable begin and end bounds", () => {
     const l = line({ begin: 1, end: 2 });
-    if (isLineSynced(l)) {
-      const begin: number = l.begin;
-      const end: number = l.end;
-      expect(begin).toBe(1);
-      expect(end).toBe(2);
-    }
+    expect(isLineSynced(l)).toBe(true);
+    const bounds = mainBounds(l);
+    expect(bounds?.begin).toBe(1);
+    expect(bounds?.end).toBe(2);
   });
 });
 

--- a/src/domain/line/predicates.ts
+++ b/src/domain/line/predicates.ts
@@ -1,17 +1,22 @@
 import type { LineSyncedLine, LyricLine } from "@/domain/line/model";
+import { bgVoice, mainVoice } from "@/domain/line/voices";
+import { voiceBounds } from "@/domain/voice/bounds";
+import { isLineSynced as isLineSyncedVoice, isWordSynced as isWordSyncedVoice } from "@/domain/voice/predicates";
 
 // -- Predicates ---------------------------------------------------------------
 
 function isLineSynced(line: LyricLine): line is LineSyncedLine {
-  return !line.words?.length && line.begin !== undefined && line.end !== undefined;
+  return isLineSyncedVoice(mainVoice(line));
 }
 
 function isWordSynced(line: LyricLine): boolean {
-  return !!line.words?.length;
+  return isWordSyncedVoice(mainVoice(line));
 }
 
 function hasAnyTiming(line: LyricLine): boolean {
-  return isWordSynced(line) || isLineSynced(line) || !!line.backgroundWords?.length;
+  if (voiceBounds(mainVoice(line)) !== null) return true;
+  const bg = bgVoice(line);
+  return bg !== null && voiceBounds(bg) !== null;
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/src/domain/line/predicates.ts
+++ b/src/domain/line/predicates.ts
@@ -1,11 +1,11 @@
-import type { LineSyncedLine, LyricLine } from "@/domain/line/model";
+import type { LyricLine } from "@/domain/line/model";
 import { bgVoice, mainVoice } from "@/domain/line/voices";
 import { voiceBounds } from "@/domain/voice/bounds";
 import { isLineSynced as isLineSyncedVoice, isWordSynced as isWordSyncedVoice } from "@/domain/voice/predicates";
 
 // -- Predicates ---------------------------------------------------------------
 
-function isLineSynced(line: LyricLine): line is LineSyncedLine {
+function isLineSynced(line: LyricLine): boolean {
   return isLineSyncedVoice(mainVoice(line));
 }
 

--- a/src/domain/line/reconcile-text.test.ts
+++ b/src/domain/line/reconcile-text.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
+import { mainBounds } from "@/domain/line/bounds";
+import { reconcileLine } from "@/domain/line/model";
 import type { LyricLine } from "@/domain/line/model";
+import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { reconcileMatchedTiming } from "@/domain/line/reconcile-text";
 
 describe("reconcileMatchedTiming", () => {
   it("returns the same reference when the typed text is identical", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "L1",
       text: "Dengar|lah rindu yang menyik|sa i|ni",
       agentId: "v1",
@@ -18,25 +21,25 @@ describe("reconcileMatchedTiming", () => {
         { text: "i", begin: 2.2, end: 2.4 },
         { text: "ni", begin: 2.4, end: 2.6 },
       ],
-    };
+    });
     const result = reconcileMatchedTiming(line, "Dengar|lah rindu yang menyik|sa i|ni");
     expect(result).toBe(line);
   });
 
   it("preserves begin/end on an untouched line-synced line that contains split characters", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "L0",
       text: "Dengar|lah rindu",
       agentId: "v1",
       begin: 1,
       end: 2,
-    };
+    });
     const result = reconcileMatchedTiming(line, "Dengar|lah rindu");
     expect(result).toBe(line);
   });
 
   it("remaps words when split positions move but the syllable count is unchanged", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "L0",
       text: "Den|garlah rin|du",
       agentId: "v1",
@@ -46,16 +49,16 @@ describe("reconcileMatchedTiming", () => {
         { text: "rin", begin: 1, end: 1.5 },
         { text: "du", begin: 1.5, end: 2 },
       ],
-    };
+    });
     const result = reconcileMatchedTiming(line, "Dengar|lah rin|du");
-    expect(result.text).toBe("Dengar|lah rin|du");
-    expect(result.words?.map((w) => w.begin)).toEqual([0, 0.5, 1, 1.5]);
-    expect(result.words?.map((w) => w.end)).toEqual([0.5, 1, 1.5, 2]);
-    expect(result.words?.map((w) => w.text)).toEqual(["Dengar", "lah ", "rin", "du"]);
+    expect(lineText(result)).toBe("Dengar|lah rin|du");
+    expect(mainWords(result)?.map((w) => w.begin)).toEqual([0, 0.5, 1, 1.5]);
+    expect(mainWords(result)?.map((w) => w.end)).toEqual([0.5, 1, 1.5, 2]);
+    expect(mainWords(result)?.map((w) => w.text)).toEqual(["Dengar", "lah ", "rin", "du"]);
   });
 
   it("clears word timing when the syllable count actually changes", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "L0",
       text: "Dengar|lah",
       agentId: "v1",
@@ -63,55 +66,55 @@ describe("reconcileMatchedTiming", () => {
         { text: "Dengar", begin: 0, end: 0.5 },
         { text: "lah", begin: 0.5, end: 1 },
       ],
-    };
+    });
     const result = reconcileMatchedTiming(line, "Dengar|lah|extra");
-    expect(result.text).toBe("Dengar|lah|extra");
-    expect(result.words).toBeUndefined();
+    expect(lineText(result)).toBe("Dengar|lah|extra");
+    expect(mainWords(result)).toBeUndefined();
   });
 
   it("clears begin/end on a line-synced line whose text content actually changed", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "L0",
       text: "Dengarlah rindu",
       agentId: "v1",
       begin: 1,
       end: 2,
-    };
+    });
     const result = reconcileMatchedTiming(line, "Dengarlah rindu sayang");
-    expect(result.text).toBe("Dengarlah rindu sayang");
-    expect(result.begin).toBeUndefined();
-    expect(result.end).toBeUndefined();
+    expect(lineText(result)).toBe("Dengarlah rindu sayang");
+    expect(mainBounds(result)?.begin).toBeUndefined();
+    expect(mainBounds(result)?.end).toBeUndefined();
   });
 });
 
 describe("reconcileMatchedTiming · edge cases", () => {
   it("returns the same reference for an untimed line whose text is identical", () => {
-    const line: LyricLine = { id: "L0", text: "no timing here", agentId: "v1" };
+    const line: LyricLine = reconcileLine({ id: "L0", text: "no timing here", agentId: "v1" });
     const result = reconcileMatchedTiming(line, "no timing here");
     expect(result).toBe(line);
   });
 
   it("updates text on an untimed line whose text changed", () => {
-    const line: LyricLine = { id: "L0", text: "old", agentId: "v1" };
+    const line: LyricLine = reconcileLine({ id: "L0", text: "old", agentId: "v1" });
     const result = reconcileMatchedTiming(line, "new");
-    expect(result.text).toBe("new");
-    expect(result.words).toBeUndefined();
-    expect(result.begin).toBeUndefined();
-    expect(result.end).toBeUndefined();
+    expect(lineText(result)).toBe("new");
+    expect(mainWords(result)).toBeUndefined();
+    expect(mainBounds(result)?.begin).toBeUndefined();
+    expect(mainBounds(result)?.end).toBeUndefined();
   });
 
   it("treats an empty words array as no timing and clears on text change", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "L0",
       text: "Dengar|lah",
       agentId: "v1",
       words: [],
-    };
+    });
     const result = reconcileMatchedTiming(line, "Dengar|lah|extra");
-    expect(result.text).toBe("Dengar|lah|extra");
-    expect(result.words).toBeUndefined();
-    expect(result.begin).toBeUndefined();
-    expect(result.end).toBeUndefined();
+    expect(lineText(result)).toBe("Dengar|lah|extra");
+    expect(mainWords(result)).toBeUndefined();
+    expect(mainBounds(result)?.begin).toBeUndefined();
+    expect(mainBounds(result)?.end).toBeUndefined();
   });
 
   it("does not mutate the input line or its words array", () => {
@@ -121,23 +124,23 @@ describe("reconcileMatchedTiming · edge cases", () => {
       { text: "rin", begin: 1, end: 1.5 },
       { text: "du", begin: 1.5, end: 2 },
     ];
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "L0",
       text: "Den|garlah rin|du",
       agentId: "v1",
       words: originalWords,
-    };
-    const beforeText = line.text;
-    const beforeWords = line.words;
-    const beforeWordsSnapshot = JSON.parse(JSON.stringify(line.words));
+    });
+    const beforeText = lineText(line);
+    const beforeWords = mainWords(line);
+    const beforeWordsSnapshot = JSON.parse(JSON.stringify(mainWords(line)));
     reconcileMatchedTiming(line, "Dengar|lah rin|du");
-    expect(line.text).toBe(beforeText);
-    expect(line.words).toBe(beforeWords);
-    expect(line.words).toEqual(beforeWordsSnapshot);
+    expect(lineText(line)).toBe(beforeText);
+    expect(mainWords(line)).toBe(beforeWords);
+    expect(mainWords(line)).toEqual(beforeWordsSnapshot);
   });
 
   it("preserves background-vocal fields on the remap path", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "L0",
       text: "Den|garlah rin|du",
       agentId: "v1",
@@ -150,15 +153,15 @@ describe("reconcileMatchedTiming · edge cases", () => {
       backgroundText: "ooh",
       backgroundWords: [{ text: "ooh", begin: 0.2, end: 0.8 }],
       backgroundTextSource: "manual",
-    };
+    });
     const result = reconcileMatchedTiming(line, "Dengar|lah rin|du");
-    expect(result.backgroundText).toBe("ooh");
-    expect(result.backgroundWords).toEqual([{ text: "ooh", begin: 0.2, end: 0.8 }]);
-    expect(result.backgroundTextSource).toBe("manual");
+    expect(bgText(result)).toBe("ooh");
+    expect(bgWords(result)).toEqual([{ text: "ooh", begin: 0.2, end: 0.8 }]);
+    expect(bgSource(result)).toBe("manual");
   });
 
   it("preserves background-vocal fields on the clear path", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "L0",
       text: "Dengar|lah",
       agentId: "v1",
@@ -169,15 +172,15 @@ describe("reconcileMatchedTiming · edge cases", () => {
       backgroundText: "ooh",
       backgroundWords: [{ text: "ooh", begin: 0.2, end: 0.8 }],
       backgroundTextSource: "extraction",
-    };
+    });
     const result = reconcileMatchedTiming(line, "Dengar|lah|extra");
-    expect(result.backgroundText).toBe("ooh");
-    expect(result.backgroundWords).toEqual([{ text: "ooh", begin: 0.2, end: 0.8 }]);
-    expect(result.backgroundTextSource).toBe("extraction");
+    expect(bgText(result)).toBe("ooh");
+    expect(bgWords(result)).toEqual([{ text: "ooh", begin: 0.2, end: 0.8 }]);
+    expect(bgSource(result)).toBe("extraction");
   });
 
   it("preserves group fields (groupId, instanceIdx, templateLineIdx) on both paths", () => {
-    const wordSynced: LyricLine = {
+    const wordSynced: LyricLine = reconcileLine({
       id: "L0",
       text: "Den|garlah rin|du",
       agentId: "v1",
@@ -190,7 +193,7 @@ describe("reconcileMatchedTiming · edge cases", () => {
       groupId: "g1",
       instanceIdx: 0,
       templateLineIdx: 0,
-    };
+    });
     const remapped = reconcileMatchedTiming(wordSynced, "Dengar|lah rin|du");
     expect(remapped.groupId).toBe("g1");
     expect(remapped.instanceIdx).toBe(0);

--- a/src/domain/line/reconcile-text.ts
+++ b/src/domain/line/reconcile-text.ts
@@ -1,4 +1,5 @@
-import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { reconcileLine, toFlat, type LyricLine } from "@/domain/line/model";
+import { lineText, mainWords } from "@/domain/line/voices";
 import { remapWordTextsPreservingTiming } from "@/domain/word/remap-text";
 
 // The single chokepoint for re-deciding timing-staleness after a text edit:
@@ -6,16 +7,17 @@ import { remapWordTextsPreservingTiming } from "@/domain/word/remap-text";
 // through here so they cannot drift apart and clear timing on lines the user
 // never touched.
 function reconcileMatchedTiming(line: LyricLine, cleanedText: string): LyricLine {
-  if (line.text === cleanedText) return line;
+  if (lineText(line) === cleanedText) return line;
 
-  if (line.words && line.words.length > 0) {
-    const remapped = remapWordTextsPreservingTiming(line.words, cleanedText);
+  const words = mainWords(line);
+  if (words && words.length > 0) {
+    const remapped = remapWordTextsPreservingTiming(words, cleanedText);
     if (remapped) {
-      return reconcileLine({ ...line, text: cleanedText, words: remapped });
+      return reconcileLine({ ...toFlat(line), text: cleanedText, words: remapped });
     }
   }
 
-  return reconcileLine({ ...line, text: cleanedText, words: undefined, begin: undefined, end: undefined });
+  return reconcileLine({ ...toFlat(line), text: cleanedText, words: undefined, begin: undefined, end: undefined });
 }
 
 export { reconcileMatchedTiming };

--- a/src/domain/line/reconcile-update.test.ts
+++ b/src/domain/line/reconcile-update.test.ts
@@ -73,6 +73,18 @@ describe("reconcileUpdate · background-touching and other-granularity updates",
     expect(bgWords(next)).toBeUndefined();
   });
 
+  it("uses the flat result when the update sets backgroundWords (no line-synced restore)", () => {
+    const prev = lineSyncedBgLine();
+    const backgroundWords = [
+      { text: "ooh ", begin: 0, end: 1 },
+      { text: "ahh", begin: 1, end: 2 },
+    ];
+    const next = reconcileUpdate(prev, { backgroundWords });
+    expect(bgWords(next)).toEqual(backgroundWords);
+    expect(bgBounds(next)).not.toEqual({ begin: 3, end: 7 });
+    expect(bgBounds(next)).toEqual({ begin: 0, end: 2 });
+  });
+
   it("clears the background when the update clears backgroundText", () => {
     const prev = lineSyncedBgLine();
     const next = reconcileUpdate(prev, { backgroundText: undefined, backgroundTextSource: undefined });

--- a/src/domain/line/reconcile-update.test.ts
+++ b/src/domain/line/reconcile-update.test.ts
@@ -1,0 +1,138 @@
+import { bgBounds, mainBounds } from "@/domain/line/bounds";
+import { type LyricLine, reconcileLine } from "@/domain/line/model";
+import { reconcileUpdate } from "@/domain/line/reconcile-update";
+import { bgSource, bgText, bgVoice, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { isLineSynced, isWordSynced } from "@/domain/voice/predicates";
+import type { BackgroundVoice } from "@/domain/voice/model";
+import { describe, expect, it } from "vitest";
+
+// A line-synced background cannot be expressed in the flat LooseLine shape, so a
+// flat update routed through reconcileUpdate must preserve it nested rather than
+// let the toFlat round-trip silently downgrade it to untimed.
+
+function lineSyncedBgLine(): LyricLine {
+  const line = reconcileLine({ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 10 });
+  const background: BackgroundVoice = { text: "ooh ahh", begin: 3, end: 7, source: "manual" };
+  return { ...line, background };
+}
+
+describe("reconcileUpdate · line-synced background durability", () => {
+  it("preserves a line-synced background through a non-background update (agentId)", () => {
+    const prev = lineSyncedBgLine();
+    const next = reconcileUpdate(prev, { agentId: "v2" });
+    expect(next.agentId).toBe("v2");
+    expect(bgBounds(next)).toEqual({ begin: 3, end: 7 });
+    expect(bgWords(next)).toBeUndefined();
+    const bg = bgVoice(next);
+    expect(bg).not.toBeNull();
+    if (bg) expect(isLineSynced(bg)).toBe(true);
+  });
+
+  it("preserves a line-synced background through a main-text edit, keeping main line-synced", () => {
+    const prev = lineSyncedBgLine();
+    const next = reconcileUpdate(prev, { text: "New words" });
+    expect(lineText(next)).toBe("New words");
+    expect(mainBounds(next)).toEqual({ begin: 2, end: 10 });
+    expect(bgBounds(next)).toEqual({ begin: 3, end: 7 });
+    expect(bgSource(next)).toBe("manual");
+  });
+
+  it("preserves a line-synced background through a main begin/end edit", () => {
+    const prev = lineSyncedBgLine();
+    const next = reconcileUpdate(prev, { begin: 1, end: 12 });
+    expect(mainBounds(next)).toEqual({ begin: 1, end: 12 });
+    expect(bgBounds(next)).toEqual({ begin: 3, end: 7 });
+  });
+});
+
+describe("reconcileUpdate · transition resolves over the background's own bounds", () => {
+  it("distributes a line-synced bg over its OWN bounds, not the main fallback, when main becomes word-synced", () => {
+    const prev = lineSyncedBgLine();
+    const next = reconcileUpdate(prev, {
+      words: [
+        { text: "Real ", begin: 2, end: 5 },
+        { text: "line", begin: 5, end: 10 },
+      ],
+    });
+    expect(isWordSynced(next.main)).toBe(true);
+    const words = bgWords(next);
+    expect(words).toBeDefined();
+    if (!words) throw new Error("expected bg words");
+    expect(words.length).toBe(2);
+    expect(words[0].begin).toBe(3);
+    expect(words[words.length - 1].end).toBe(7);
+  });
+});
+
+describe("reconcileUpdate · background-touching and other-granularity updates", () => {
+  it("uses the flat result (untimed) when the update explicitly sets backgroundText", () => {
+    const prev = lineSyncedBgLine();
+    const next = reconcileUpdate(prev, { backgroundText: "new bg" });
+    expect(bgText(next)).toBe("new bg");
+    expect(bgBounds(next)).toBeNull();
+    expect(bgWords(next)).toBeUndefined();
+  });
+
+  it("clears the background when the update clears backgroundText", () => {
+    const prev = lineSyncedBgLine();
+    const next = reconcileUpdate(prev, { backgroundText: undefined, backgroundTextSource: undefined });
+    expect(bgVoice(next)).toBeNull();
+  });
+
+  it("leaves a word-synced background intact through a non-background update", () => {
+    const prev = reconcileLine({
+      id: "L1",
+      text: "Real line",
+      agentId: "v1",
+      words: [
+        { text: "Real ", begin: 0, end: 1 },
+        { text: "line", begin: 1, end: 2 },
+      ],
+      backgroundText: "ooh ahh",
+      backgroundWords: [
+        { text: "ooh ", begin: 0, end: 1 },
+        { text: "ahh", begin: 1, end: 2 },
+      ],
+      backgroundTextSource: "extraction",
+    });
+    const next = reconcileUpdate(prev, { agentId: "v2" });
+    expect(bgWords(next)).toEqual([
+      { text: "ooh ", begin: 0, end: 1 },
+      { text: "ahh", begin: 1, end: 2 },
+    ]);
+  });
+
+  it("leaves an untimed background intact through a non-background update", () => {
+    const prev = reconcileLine({ id: "L1", text: "Real line", agentId: "v1", backgroundText: "ooh" });
+    const next = reconcileUpdate(prev, { agentId: "v2" });
+    expect(bgText(next)).toBe("ooh");
+    expect(bgWords(next)).toBeUndefined();
+    expect(bgBounds(next)).toBeNull();
+  });
+
+  it("is a no-op for a line with no background", () => {
+    const prev = reconcileLine({ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 10 });
+    const next = reconcileUpdate(prev, { agentId: "v2" });
+    expect(bgVoice(next)).toBeNull();
+    expect("background" in next).toBe(false);
+  });
+});
+
+describe("reconcileUpdate · invariants", () => {
+  it("does not mutate the input line", () => {
+    const prev = lineSyncedBgLine();
+    const snapshot = structuredClone(prev);
+    reconcileUpdate(prev, { words: [{ text: "Real line", begin: 2, end: 10 }] });
+    expect(prev).toEqual(snapshot);
+  });
+
+  it("keeps main words intact when only the background follows", () => {
+    const prev = lineSyncedBgLine();
+    const words = [
+      { text: "Real ", begin: 2, end: 5 },
+      { text: "line", begin: 5, end: 10 },
+    ];
+    const next = reconcileUpdate(prev, { words });
+    expect(mainWords(next)).toEqual(words);
+  });
+});

--- a/src/domain/line/reconcile-update.ts
+++ b/src/domain/line/reconcile-update.ts
@@ -1,0 +1,33 @@
+import { setBackground } from "@/domain/line/background";
+import { followMainGranularity } from "@/domain/line/follow-main-granularity";
+import { type LooseLine, type LyricLine, reconcileLine, toFlat } from "@/domain/line/model";
+import { bgVoice } from "@/domain/line/voices";
+import { isLineSynced } from "@/domain/voice/predicates";
+
+// -- Functions ----------------------------------------------------------------
+
+function touchesBackground(updates: Partial<LooseLine>): boolean {
+  return "backgroundText" in updates || "backgroundWords" in updates || "backgroundTextSource" in updates;
+}
+
+// The reconcile chokepoint for the generic per-line update mutators. Merges the
+// flat update onto the line's flat projection and lifts back to nested. A
+// line-synced background cannot survive that round-trip (LooseLine has no
+// backgroundBegin/end, so toFlat drops its bounds and reconcileLine rebuilds it
+// untimed), so when the update leaves the background untouched the prior nested
+// background is restored. followMainGranularity then resolves it against the new
+// main, distributing a line-synced background over its OWN bounds on the
+// main-to-word transition. Every other write is a no-op for the background.
+function reconcileUpdate(prev: LyricLine, updates: Partial<LooseLine>): LyricLine {
+  const reconciled = reconcileLine({ ...toFlat(prev), ...updates });
+  const prevBg = bgVoice(prev);
+  const base =
+    !touchesBackground(updates) && prevBg !== null && isLineSynced(prevBg)
+      ? setBackground(reconciled, prevBg)
+      : reconciled;
+  return followMainGranularity(prev, base);
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { reconcileUpdate };

--- a/src/domain/line/reconstruct-text.ts
+++ b/src/domain/line/reconstruct-text.ts
@@ -1,4 +1,6 @@
 import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, toFlat } from "@/domain/line/model";
+import { bgText as bgTextField, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 
 // -- Text reconstruction ------------------------------------------------------
@@ -47,13 +49,15 @@ function wordContentSpans(words: WordTiming[], splitChar: string): WordContentSp
 // words keeps text as its primary, editable field. Returns the same reference
 // when nothing changes, so untouched lines stay reference-stable.
 function withDerivedText(line: LyricLine, splitChar: string): LyricLine {
-  const text = line.words && line.words.length > 0 ? reconstructLineText(line.words, splitChar) : line.text;
+  const mainText = lineText(line);
+  const words = mainWords(line);
+  const text = words && words.length > 0 ? reconstructLineText(words, splitChar) : mainText;
+  const currentBgText = bgTextField(line);
+  const backgroundWords = bgWords(line);
   const backgroundText =
-    line.backgroundWords && line.backgroundWords.length > 0
-      ? reconstructLineText(line.backgroundWords, splitChar)
-      : line.backgroundText;
-  if (text === line.text && backgroundText === line.backgroundText) return line;
-  return { ...line, text, backgroundText };
+    backgroundWords && backgroundWords.length > 0 ? reconstructLineText(backgroundWords, splitChar) : currentBgText;
+  if (text === mainText && backgroundText === currentBgText) return line;
+  return reconcileLine({ ...toFlat(line), text, backgroundText });
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/src/domain/line/resolve-bg-granularity.test.ts
+++ b/src/domain/line/resolve-bg-granularity.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "vitest";
+import { resolveBgGranularity } from "@/domain/line/resolve-bg-granularity";
+import type { BackgroundVoice, Voice } from "@/domain/voice/model";
+import { isLineSynced, isUntimed, isWordSynced } from "@/domain/voice/predicates";
+import type { Bounds } from "@/domain/word/bounds";
+import { voiceBounds } from "@/domain/voice/bounds";
+
+// -- Fixtures -----------------------------------------------------------------
+
+const mainWordSynced: Voice = {
+  text: "hello world now",
+  words: [
+    { text: "hello ", begin: 0.0, end: 1.0 },
+    { text: "world ", begin: 1.0, end: 2.0 },
+    { text: "now", begin: 2.0, end: 3.0 },
+  ],
+};
+
+const mainLineSynced: Voice = { text: "hello world now", begin: 0.0, end: 3.0 };
+
+const mainUntimed: Voice = { text: "hello world now" };
+
+const FALLBACK: Bounds = { begin: 0.0, end: 4.0 };
+
+function secondHalfOf(b: Bounds): Bounds {
+  return { begin: (b.begin + b.end) / 2, end: b.end };
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("resolveBgGranularity", () => {
+  describe("resolution table", () => {
+    it("word-synced bg + main word-synced: unchanged", () => {
+      const bg: BackgroundVoice = {
+        text: "ooh ahh",
+        words: [
+          { text: "ooh ", begin: 1.0, end: 2.0 },
+          { text: "ahh", begin: 2.0, end: 3.0 },
+        ],
+        source: "extraction",
+      };
+      const result = resolveBgGranularity(mainWordSynced, bg, { fallbackBounds: FALLBACK });
+      expect(isWordSynced(result)).toBe(true);
+      expect(result).toEqual(bg);
+      expect(result.source).toBe("extraction");
+    });
+
+    it("word-synced bg + main line-synced: unchanged", () => {
+      const bg: BackgroundVoice = {
+        text: "ooh ahh",
+        words: [
+          { text: "ooh ", begin: 1.0, end: 2.0 },
+          { text: "ahh", begin: 2.0, end: 3.0 },
+        ],
+        source: "manual",
+      };
+      const result = resolveBgGranularity(mainLineSynced, bg, { fallbackBounds: FALLBACK });
+      expect(isWordSynced(result)).toBe(true);
+      expect(result).toEqual(bg);
+      expect(result.source).toBe("manual");
+    });
+
+    it("word-synced bg + main untimed: unchanged", () => {
+      const bg: BackgroundVoice = {
+        text: "ooh ahh",
+        words: [
+          { text: "ooh ", begin: 1.0, end: 2.0 },
+          { text: "ahh", begin: 2.0, end: 3.0 },
+        ],
+        source: "extraction",
+      };
+      const result = resolveBgGranularity(mainUntimed, bg, { fallbackBounds: FALLBACK });
+      expect(isWordSynced(result)).toBe(true);
+      expect(result).toEqual(bg);
+    });
+
+    it("line-synced bg + main word-synced: distributes over the bg's OWN bounds", () => {
+      const bg: BackgroundVoice = { text: "ooh ahh", begin: 1.5, end: 3.5, source: "extraction" };
+      const result = resolveBgGranularity(mainWordSynced, bg, { fallbackBounds: FALLBACK });
+      expect(isWordSynced(result)).toBe(true);
+      const bounds = voiceBounds(result);
+      expect(bounds).not.toBeNull();
+      expect(bounds?.begin).toBe(1.5);
+      expect(bounds?.end).toBe(3.5);
+      expect(result.text).toBe("ooh ahh");
+      expect(result.source).toBe("extraction");
+    });
+
+    it("line-synced bg + main line-synced: unchanged (stays line-synced)", () => {
+      const bg: BackgroundVoice = { text: "ooh ahh", begin: 1.5, end: 3.5, source: "manual" };
+      const result = resolveBgGranularity(mainLineSynced, bg, { fallbackBounds: FALLBACK });
+      expect(isLineSynced(result)).toBe(true);
+      expect(result).toEqual(bg);
+    });
+
+    it("line-synced bg + main untimed: unchanged (stays line-synced)", () => {
+      const bg: BackgroundVoice = { text: "ooh ahh", begin: 1.5, end: 3.5, source: "extraction" };
+      const result = resolveBgGranularity(mainUntimed, bg, { fallbackBounds: FALLBACK });
+      expect(isLineSynced(result)).toBe(true);
+      expect(result).toEqual(bg);
+    });
+
+    it("untimed bg + main word-synced: word-synced over the fallback second half", () => {
+      const bg: BackgroundVoice = { text: "ooh ahh", source: "extraction" };
+      const result = resolveBgGranularity(mainWordSynced, bg, { fallbackBounds: FALLBACK });
+      expect(isWordSynced(result)).toBe(true);
+      const expected = secondHalfOf(FALLBACK);
+      const bounds = voiceBounds(result);
+      expect(bounds?.begin).toBe(expected.begin);
+      expect(bounds?.end).toBe(expected.end);
+      expect(result.text).toBe("ooh ahh");
+      expect(result.source).toBe("extraction");
+    });
+
+    it("untimed bg + main line-synced: line-synced over the fallback second half", () => {
+      const bg: BackgroundVoice = { text: "ooh ahh", source: "manual" };
+      const result = resolveBgGranularity(mainLineSynced, bg, { fallbackBounds: FALLBACK });
+      expect(isLineSynced(result)).toBe(true);
+      const expected = secondHalfOf(FALLBACK);
+      if (!isLineSynced(result)) throw new Error("expected line-synced result");
+      expect(result.begin).toBe(expected.begin);
+      expect(result.end).toBe(expected.end);
+      expect(result.text).toBe("ooh ahh");
+      expect(result.source).toBe("manual");
+    });
+
+    it("untimed bg + main untimed: unchanged (stays untimed)", () => {
+      const bg: BackgroundVoice = { text: "ooh ahh", source: "extraction" };
+      const result = resolveBgGranularity(mainUntimed, bg, { fallbackBounds: FALLBACK });
+      expect(isUntimed(result)).toBe(true);
+      expect(result).toEqual(bg);
+    });
+  });
+
+  describe("guards", () => {
+    it("never re-distributes a word-synced bg, even when main is word-synced (pinned)", () => {
+      const bg: BackgroundVoice = {
+        text: "ooh ahh yeah",
+        words: [
+          { text: "ooh ", begin: 5.0, end: 6.0 },
+          { text: "ahh ", begin: 6.0, end: 7.0 },
+          { text: "yeah", begin: 7.0, end: 8.0 },
+        ],
+        source: "extraction",
+      };
+      const result = resolveBgGranularity(mainWordSynced, bg, { fallbackBounds: FALLBACK });
+      if (!isWordSynced(result)) throw new Error("expected word-synced result");
+      expect(result.words).toEqual(bg.words);
+      expect(voiceBounds(result)).toEqual({ begin: 5.0, end: 8.0 });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("does not fabricate words from empty bg text + main word-synced (stays untimed)", () => {
+      const bg: BackgroundVoice = { text: "", source: "extraction" };
+      const result = resolveBgGranularity(mainWordSynced, bg, { fallbackBounds: FALLBACK });
+      expect(isUntimed(result)).toBe(true);
+      expect(isWordSynced(result)).toBe(false);
+      expect("words" in result ? result.words : []).toEqual([]);
+    });
+
+    it("does not fabricate a line-synced voice from empty bg text + main line-synced (stays untimed)", () => {
+      const bg: BackgroundVoice = { text: "", source: "manual" };
+      const result = resolveBgGranularity(mainLineSynced, bg, { fallbackBounds: FALLBACK });
+      expect(isUntimed(result)).toBe(true);
+      expect(result).toEqual(bg);
+    });
+
+    it("returns the untimed bg unchanged when fallbackBounds is null and main is word-synced", () => {
+      const bg: BackgroundVoice = { text: "ooh ahh", source: "extraction" };
+      const result = resolveBgGranularity(mainWordSynced, bg, { fallbackBounds: null });
+      expect(isUntimed(result)).toBe(true);
+      expect(result).toEqual(bg);
+    });
+
+    it("returns the untimed bg unchanged when fallbackBounds is null and main is line-synced", () => {
+      const bg: BackgroundVoice = { text: "ooh ahh", source: "manual" };
+      const result = resolveBgGranularity(mainLineSynced, bg, { fallbackBounds: null });
+      expect(isUntimed(result)).toBe(true);
+      expect(result).toEqual(bg);
+    });
+
+    it("treats an empty-words bg as untimed and falls back to fallback bounds (not pinned)", () => {
+      const bg: BackgroundVoice = { text: "ooh ahh", words: [], source: "extraction" };
+      expect(voiceBounds(bg)).toBeNull();
+      expect(isUntimed(bg)).toBe(true);
+      const result = resolveBgGranularity(mainWordSynced, bg, { fallbackBounds: FALLBACK });
+      expect(isWordSynced(result)).toBe(true);
+      const bounds = voiceBounds(result);
+      expect(bounds?.begin).toBe(2.0);
+      expect(bounds?.end).toBe(4.0);
+      expect(result.source).toBe("extraction");
+    });
+
+    it("returns an empty-words bg unchanged when no fallback bounds are available (defensive)", () => {
+      const bg: BackgroundVoice = { text: "ooh ahh", words: [], source: "extraction" };
+      const result = resolveBgGranularity(mainWordSynced, bg, { fallbackBounds: null });
+      expect(result).toEqual(bg);
+    });
+
+    it("handles a single-word untimed bg over the fallback second half", () => {
+      const bg: BackgroundVoice = { text: "ooh", source: "manual" };
+      const result = resolveBgGranularity(mainWordSynced, bg, { fallbackBounds: FALLBACK });
+      expect(isWordSynced(result)).toBe(true);
+      const bounds = voiceBounds(result);
+      expect(bounds?.begin).toBe(2.0);
+      expect(bounds?.end).toBe(4.0);
+    });
+
+    it("handles begin: 0 fallback bounds without treating the second half as falsy", () => {
+      const bg: BackgroundVoice = { text: "ooh ahh", source: "manual" };
+      const result = resolveBgGranularity(mainLineSynced, bg, { fallbackBounds: { begin: 0, end: 2 } });
+      if (!isLineSynced(result)) throw new Error("expected line-synced result");
+      expect(result.begin).toBe(1);
+      expect(result.end).toBe(2);
+    });
+  });
+
+  describe("invariants", () => {
+    const cells: Array<{ name: string; main: Voice; bg: BackgroundVoice; fallbackBounds: Bounds | null }> = [
+      {
+        name: "word bg + main word",
+        main: mainWordSynced,
+        bg: { text: "ooh ahh", words: [{ text: "ooh ahh", begin: 1, end: 2 }], source: "extraction" },
+        fallbackBounds: FALLBACK,
+      },
+      {
+        name: "line bg + main word",
+        main: mainWordSynced,
+        bg: { text: "ooh ahh", begin: 1.5, end: 3.5, source: "manual" },
+        fallbackBounds: FALLBACK,
+      },
+      {
+        name: "line bg + main line",
+        main: mainLineSynced,
+        bg: { text: "ooh ahh", begin: 1.5, end: 3.5, source: "extraction" },
+        fallbackBounds: FALLBACK,
+      },
+      {
+        name: "untimed bg + main word",
+        main: mainWordSynced,
+        bg: { text: "ooh ahh", source: "manual" },
+        fallbackBounds: FALLBACK,
+      },
+      {
+        name: "untimed bg + main line",
+        main: mainLineSynced,
+        bg: { text: "ooh ahh", source: "extraction" },
+        fallbackBounds: FALLBACK,
+      },
+      {
+        name: "untimed bg + main untimed",
+        main: mainUntimed,
+        bg: { text: "ooh ahh", source: "manual" },
+        fallbackBounds: FALLBACK,
+      },
+    ];
+
+    it("is idempotent across every cell (running twice equals once)", () => {
+      for (const { main, bg, fallbackBounds } of cells) {
+        const once = resolveBgGranularity(main, bg, { fallbackBounds });
+        const twice = resolveBgGranularity(main, once, { fallbackBounds });
+        expect(twice).toEqual(once);
+      }
+    });
+
+    it("preserves source extraction across every transformation", () => {
+      for (const { main, bg, fallbackBounds } of cells) {
+        const withSource: BackgroundVoice = { ...bg, source: "extraction" };
+        const result = resolveBgGranularity(main, withSource, { fallbackBounds });
+        expect(result.source).toBe("extraction");
+      }
+    });
+
+    it("preserves source manual across every transformation", () => {
+      for (const { main, bg, fallbackBounds } of cells) {
+        const withSource: BackgroundVoice = { ...bg, source: "manual" };
+        const result = resolveBgGranularity(main, withSource, { fallbackBounds });
+        expect(result.source).toBe("manual");
+      }
+    });
+
+    it("preserves a missing source (does not stamp one)", () => {
+      const bg: BackgroundVoice = { text: "ooh ahh", begin: 1.5, end: 3.5 };
+      const result = resolveBgGranularity(mainWordSynced, bg, { fallbackBounds: FALLBACK });
+      expect("source" in result).toBe(false);
+    });
+
+    it("does not mutate the input bg (purity) across every cell", () => {
+      for (const { main, bg, fallbackBounds } of cells) {
+        const snapshot = structuredClone(bg);
+        resolveBgGranularity(main, bg, { fallbackBounds });
+        expect(bg).toEqual(snapshot);
+      }
+    });
+  });
+});

--- a/src/domain/line/resolve-bg-granularity.ts
+++ b/src/domain/line/resolve-bg-granularity.ts
@@ -1,0 +1,59 @@
+import type { BackgroundVoice, Voice } from "@/domain/voice/model";
+import { isLineSynced, isWordSynced } from "@/domain/voice/predicates";
+import { voiceBounds } from "@/domain/voice/bounds";
+import type { Bounds } from "@/domain/word/bounds";
+import { distributeWordsInLine } from "@/utils/sync-helpers";
+
+// -- Types --------------------------------------------------------------------
+
+interface ResolveBgGranularityOptions {
+  fallbackBounds: Bounds | null;
+}
+
+// -- Helpers ------------------------------------------------------------------
+
+function secondHalf(b: Bounds): Bounds {
+  return { begin: (b.begin + b.end) / 2, end: b.end };
+}
+
+function withSource(voice: Voice, source: BackgroundVoice["source"]): BackgroundVoice {
+  return source === undefined ? voice : { ...voice, source };
+}
+
+function distributeOver(text: string, bounds: Bounds, source: BackgroundVoice["source"]): BackgroundVoice | null {
+  const words = distributeWordsInLine(text, bounds.begin, bounds.end);
+  if (words.length === 0) return null;
+  return withSource({ text, words }, source);
+}
+
+// -- Resolver -----------------------------------------------------------------
+
+function resolveBgGranularity(main: Voice, bg: BackgroundVoice, opts: ResolveBgGranularityOptions): BackgroundVoice {
+  if (isWordSynced(bg)) return bg;
+
+  const ownBounds = voiceBounds(bg);
+  if (ownBounds !== null) {
+    if (isWordSynced(main)) {
+      return distributeOver(bg.text, ownBounds, bg.source) ?? bg;
+    }
+    return bg;
+  }
+
+  const fallback = opts.fallbackBounds;
+  if (fallback === null) return bg;
+  const half = secondHalf(fallback);
+
+  if (isWordSynced(main)) {
+    return distributeOver(bg.text, half, bg.source) ?? bg;
+  }
+
+  if (isLineSynced(main) && bg.text.trim().length > 0) {
+    return withSource({ text: bg.text, begin: half.begin, end: half.end }, bg.source);
+  }
+
+  return bg;
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { resolveBgGranularity };

--- a/src/domain/line/voices.test.ts
+++ b/src/domain/line/voices.test.ts
@@ -1,0 +1,177 @@
+import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
+import { describe, expect, it } from "vitest";
+import type { WordTiming } from "@/domain/word/timing";
+import { bgVoice, mainVoice } from "@/domain/line/voices";
+
+// -- Helpers ------------------------------------------------------------------
+
+function line(extras: Partial<LooseLine> = {}): LyricLine {
+  return reconcileLine({ id: "l1", text: "Hello", agentId: "v1", ...extras });
+}
+
+// -- mainVoice ----------------------------------------------------------------
+
+describe("mainVoice", () => {
+  describe("happy paths", () => {
+    it("returns a word-synced voice for a word-synced line", () => {
+      const words: WordTiming[] = [
+        { text: "hel", begin: 1, end: 2 },
+        { text: "lo", begin: 2, end: 3 },
+      ];
+      const voice = mainVoice(line({ words }));
+      expect(voice).toEqual({ text: "Hello", words });
+    });
+
+    it("carries the words array by reference, not a copy", () => {
+      const words: WordTiming[] = [{ text: "hi", begin: 1, end: 2 }];
+      const voice = mainVoice(line({ words }));
+      if (!("words" in voice)) throw new Error("expected word-synced voice");
+      expect(voice.words).toBe(words);
+    });
+
+    it("returns a line-synced voice for a line-synced line", () => {
+      const voice = mainVoice(line({ begin: 3, end: 7 }));
+      expect(voice).toEqual({ text: "Hello", begin: 3, end: 7 });
+    });
+
+    it("returns an untimed voice for a line with no timing", () => {
+      const voice = mainVoice(line());
+      expect(voice).toEqual({ text: "Hello" });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns an untimed voice with no begin or words keys", () => {
+      const voice = mainVoice(line());
+      expect("begin" in voice).toBe(false);
+      expect("end" in voice).toBe(false);
+      expect("words" in voice).toBe(false);
+    });
+
+    it("treats an empty-text line as untimed (text preserved verbatim)", () => {
+      const voice = mainVoice(line({ text: "" }));
+      expect(voice).toEqual({ text: "" });
+    });
+
+    it("treats begin: 0 as line-synced (guards against falsy-begin bug)", () => {
+      const voice = mainVoice(line({ begin: 0, end: 1 }));
+      expect(voice).toEqual({ text: "Hello", begin: 0, end: 1 });
+    });
+
+    it("treats an empty words array as untimed, matching ?.length falsiness", () => {
+      const voice = mainVoice(line({ words: [] }));
+      expect(voice).toEqual({ text: "Hello" });
+      expect("words" in voice).toBe(false);
+    });
+
+    it("prefers words over stale begin/end (regression: TTML import populates both)", () => {
+      const words: WordTiming[] = [{ text: "a", begin: 2, end: 5 }];
+      const voice = mainVoice(line({ begin: 0, end: 999, words }));
+      expect(voice).toEqual({ text: "Hello", words });
+      if (!("words" in voice)) throw new Error("expected word-synced voice");
+      expect(voice.words).toBe(words);
+    });
+
+    it("preserves unicode text verbatim", () => {
+      const voice = mainVoice(line({ text: "안녕 🎵", begin: 2, end: 4 }));
+      expect(voice).toEqual({ text: "안녕 🎵", begin: 2, end: 4 });
+    });
+  });
+});
+
+// -- bgVoice ------------------------------------------------------------------
+
+describe("bgVoice", () => {
+  describe("happy paths", () => {
+    it("returns a word-synced background voice with words and source", () => {
+      const backgroundWords: WordTiming[] = [
+        { text: "ah", begin: 6, end: 9 },
+        { text: "oh", begin: 9, end: 12 },
+      ];
+      const voice = bgVoice(line({ backgroundText: "ah oh", backgroundWords, backgroundTextSource: "extraction" }));
+      expect(voice).toEqual({ text: "ah oh", words: backgroundWords, source: "extraction" });
+    });
+
+    it("carries the background words array by reference, not a copy", () => {
+      const backgroundWords: WordTiming[] = [{ text: "ah", begin: 6, end: 9 }];
+      const voice = bgVoice(line({ backgroundText: "ah", backgroundWords }));
+      if (voice === null || !("words" in voice)) throw new Error("expected word-synced bg voice");
+      expect(voice.words).toBe(backgroundWords);
+    });
+
+    it("returns an untimed background voice when only backgroundText is set", () => {
+      const voice = bgVoice(line({ backgroundText: "ah", backgroundTextSource: "manual" }));
+      expect(voice).toEqual({ text: "ah", source: "manual" });
+    });
+
+    it("returns null when the line has no background content at all", () => {
+      expect(bgVoice(line())).toBeNull();
+    });
+  });
+
+  describe("background words present without backgroundText", () => {
+    it("returns a word-synced bg voice with empty text when only backgroundWords are set", () => {
+      const backgroundWords: WordTiming[] = [
+        { text: "ah", begin: 6, end: 9 },
+        { text: "oh", begin: 9, end: 12 },
+      ];
+      const voice = bgVoice(line({ backgroundWords }));
+      expect(voice).toEqual({ text: "", words: backgroundWords, source: undefined });
+      if (voice === null || !("words" in voice)) throw new Error("expected word-synced bg voice");
+      expect(voice.words).toBe(backgroundWords);
+    });
+
+    it("carries the source verbatim when only backgroundWords are set", () => {
+      const backgroundWords: WordTiming[] = [{ text: "ah", begin: 6, end: 9 }];
+      const voice = bgVoice(line({ backgroundWords, backgroundTextSource: "manual" }));
+      expect(voice).toEqual({ text: "", words: backgroundWords, source: "manual" });
+    });
+
+    it("returns null when backgroundWords is empty and there is no backgroundText", () => {
+      expect(bgVoice(line({ backgroundWords: [] }))).toBeNull();
+    });
+  });
+
+  describe("source passthrough", () => {
+    it("carries the extraction source verbatim", () => {
+      const voice = bgVoice(line({ backgroundText: "ah", backgroundTextSource: "extraction" }));
+      expect(voice).toEqual({ text: "ah", source: "extraction" });
+    });
+
+    it("carries the manual source verbatim", () => {
+      const voice = bgVoice(line({ backgroundText: "ah", backgroundTextSource: "manual" }));
+      expect(voice).toEqual({ text: "ah", source: "manual" });
+    });
+
+    it("carries an undefined source verbatim", () => {
+      const voice = bgVoice(line({ backgroundText: "ah" }));
+      expect(voice).toEqual({ text: "ah", source: undefined });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns a voice (not null) for an empty-string backgroundText", () => {
+      const voice = bgVoice(line({ backgroundText: "" }));
+      expect(voice).not.toBeNull();
+      expect(voice).toEqual({ text: "", source: undefined });
+    });
+
+    it("treats an empty backgroundWords array as untimed (no words key)", () => {
+      const voice = bgVoice(line({ backgroundText: "ah", backgroundWords: [] }));
+      expect(voice).toEqual({ text: "ah", source: undefined });
+      if (voice === null) throw new Error("expected a voice");
+      expect("words" in voice).toBe(false);
+    });
+
+    it("returns a word-synced bg voice even when main line is untimed", () => {
+      const backgroundWords: WordTiming[] = [{ text: "ah", begin: 6, end: 9 }];
+      const voice = bgVoice(line({ backgroundText: "ah", backgroundWords }));
+      expect(voice).toEqual({ text: "ah", words: backgroundWords, source: undefined });
+    });
+
+    it("preserves unicode backgroundText verbatim", () => {
+      const voice = bgVoice(line({ backgroundText: "안녕 🎵" }));
+      expect(voice).toEqual({ text: "안녕 🎵", source: undefined });
+    });
+  });
+});

--- a/src/domain/line/voices.test.ts
+++ b/src/domain/line/voices.test.ts
@@ -1,7 +1,7 @@
 import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
 import type { WordTiming } from "@/domain/word/timing";
-import { bgVoice, mainVoice } from "@/domain/line/voices";
+import { bgVoice, lineText, mainVoice } from "@/domain/line/voices";
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -173,5 +173,41 @@ describe("bgVoice", () => {
       const voice = bgVoice(line({ backgroundText: "안녕 🎵" }));
       expect(voice).toEqual({ text: "안녕 🎵", source: undefined });
     });
+  });
+});
+
+// -- lineText -----------------------------------------------------------------
+
+describe("lineText", () => {
+  it("returns the text of a word-synced line", () => {
+    expect(lineText(line({ words: [{ text: "Hello", begin: 1, end: 2 }] }))).toBe("Hello");
+  });
+
+  it("returns the text of a line-synced line", () => {
+    expect(lineText(line({ begin: 3, end: 7 }))).toBe("Hello");
+  });
+
+  it("returns the text of an untimed line", () => {
+    expect(lineText(line())).toBe("Hello");
+  });
+
+  it("returns empty string for an empty-text line", () => {
+    expect(lineText(line({ text: "" }))).toBe("");
+  });
+
+  it("preserves unicode text verbatim", () => {
+    expect(lineText(line({ text: "안녕 🎵" }))).toBe("안녕 🎵");
+  });
+
+  it("agrees with mainVoice(line).text across variants", () => {
+    const cases: LyricLine[] = [
+      line(),
+      line({ begin: 1, end: 2 }),
+      line({ words: [{ text: "Hello", begin: 1, end: 2 }] }),
+      line({ text: "" }),
+    ];
+    for (const l of cases) {
+      expect(lineText(l)).toBe(mainVoice(l).text);
+    }
   });
 });

--- a/src/domain/line/voices.test.ts
+++ b/src/domain/line/voices.test.ts
@@ -1,5 +1,6 @@
 import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
+import { isUntimed } from "@/domain/voice/predicates";
 import type { WordTiming } from "@/domain/word/timing";
 import { bgSource, bgText, bgVoice, bgWords, lineText, mainVoice, mainWords } from "@/domain/line/voices";
 
@@ -58,10 +59,10 @@ describe("mainVoice", () => {
       expect(voice).toEqual({ text: "Hello", begin: 0, end: 1 });
     });
 
-    it("treats an empty words array as untimed, matching ?.length falsiness", () => {
+    it("stores an empty words array verbatim and classifies it untimed", () => {
       const voice = mainVoice(line({ words: [] }));
-      expect(voice).toEqual({ text: "Hello" });
-      expect("words" in voice).toBe(false);
+      expect(voice).toEqual({ text: "Hello", words: [] });
+      expect(isUntimed(voice)).toBe(true);
     });
 
     it("prefers words over stale begin/end (regression: TTML import populates both)", () => {
@@ -257,9 +258,9 @@ describe("bgText", () => {
     expect(bgText(line())).toBeUndefined();
   });
 
-  it("returns undefined for a word-only background (unlike bgVoice which normalises to empty string)", () => {
+  it("returns the stored empty string for a word-only background with no authored text", () => {
     const backgroundWords: WordTiming[] = [{ text: "ah", begin: 1, end: 2 }];
-    expect(bgText(line({ backgroundWords }))).toBeUndefined();
+    expect(bgText(line({ backgroundWords }))).toBe("");
     expect(bgVoice(line({ backgroundWords }))?.text).toBe("");
   });
 });

--- a/src/domain/line/voices.test.ts
+++ b/src/domain/line/voices.test.ts
@@ -1,7 +1,7 @@
 import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
 import type { WordTiming } from "@/domain/word/timing";
-import { bgVoice, lineText, mainVoice } from "@/domain/line/voices";
+import { bgSource, bgText, bgVoice, bgWords, lineText, mainVoice, mainWords } from "@/domain/line/voices";
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -209,5 +209,70 @@ describe("lineText", () => {
     for (const l of cases) {
       expect(lineText(l)).toBe(mainVoice(l).text);
     }
+  });
+});
+
+// -- mainWords ----------------------------------------------------------------
+
+describe("mainWords", () => {
+  it("returns the word array of a word-synced line by reference", () => {
+    const words: WordTiming[] = [{ text: "Hello", begin: 1, end: 2 }];
+    expect(mainWords(line({ words }))).toBe(words);
+  });
+
+  it("returns undefined for a line-synced line", () => {
+    expect(mainWords(line({ begin: 1, end: 2 }))).toBeUndefined();
+  });
+
+  it("returns undefined for an untimed line", () => {
+    expect(mainWords(line())).toBeUndefined();
+  });
+});
+
+// -- bgWords ------------------------------------------------------------------
+
+describe("bgWords", () => {
+  it("returns the background word array by reference", () => {
+    const backgroundWords: WordTiming[] = [{ text: "ah", begin: 1, end: 2 }];
+    expect(bgWords(line({ backgroundText: "ah", backgroundWords }))).toBe(backgroundWords);
+  });
+
+  it("returns undefined when there is no background", () => {
+    expect(bgWords(line())).toBeUndefined();
+  });
+
+  it("returns undefined for a text-only background", () => {
+    expect(bgWords(line({ backgroundText: "ah" }))).toBeUndefined();
+  });
+});
+
+// -- bgText -------------------------------------------------------------------
+
+describe("bgText", () => {
+  it("returns the authored background text", () => {
+    expect(bgText(line({ backgroundText: "ah" }))).toBe("ah");
+  });
+
+  it("returns undefined when there is no background text", () => {
+    expect(bgText(line())).toBeUndefined();
+  });
+
+  it("returns undefined for a word-only background (unlike bgVoice which normalises to empty string)", () => {
+    const backgroundWords: WordTiming[] = [{ text: "ah", begin: 1, end: 2 }];
+    expect(bgText(line({ backgroundWords }))).toBeUndefined();
+    expect(bgVoice(line({ backgroundWords }))?.text).toBe("");
+  });
+});
+
+// -- bgSource -----------------------------------------------------------------
+
+describe("bgSource", () => {
+  it("returns the provenance flag", () => {
+    expect(bgSource(line({ backgroundText: "ah", backgroundTextSource: "manual" }))).toBe("manual");
+    expect(bgSource(line({ backgroundText: "ah", backgroundTextSource: "extraction" }))).toBe("extraction");
+  });
+
+  it("returns undefined when there is no background", () => {
+    expect(bgSource(line())).toBeUndefined();
   });
 });

--- a/src/domain/line/voices.ts
+++ b/src/domain/line/voices.ts
@@ -1,0 +1,25 @@
+import type { LyricLine } from "@/domain/line/model";
+import type { BackgroundVoice, Voice } from "@/domain/voice/model";
+
+// -- Functions ----------------------------------------------------------------
+
+function mainVoice(line: LyricLine): Voice {
+  if (line.words?.length) return { text: line.text, words: line.words };
+  if (line.begin !== undefined && line.end !== undefined) {
+    return { text: line.text, begin: line.begin, end: line.end };
+  }
+  return { text: line.text };
+}
+
+function bgVoice(line: LyricLine): BackgroundVoice | null {
+  const words = line.backgroundWords?.length ? line.backgroundWords : undefined;
+  if (line.backgroundText === undefined && words === undefined) return null;
+  const source = line.backgroundTextSource;
+  const text = line.backgroundText ?? "";
+  if (words) return { text, words, source };
+  return { text, source };
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { mainVoice, bgVoice };

--- a/src/domain/line/voices.ts
+++ b/src/domain/line/voices.ts
@@ -20,8 +20,8 @@ function lineText(line: LyricLine): string {
 
 // Raw word-synced word array of the main voice, or undefined when the main
 // voice is not word-synced. Use this for call sites that need the actual word
-// array (filter, map, length), not the synthesized single word of
-// `effectiveWords`.
+// array (filter, map, length), not the synthesized single word that
+// `effectiveVoiceWords` / `getEffectiveLines` produce for line-synced voices.
 function mainWords(line: LyricLine): WordTiming[] | undefined {
   return "words" in line.main ? line.main.words : undefined;
 }

--- a/src/domain/line/voices.ts
+++ b/src/domain/line/voices.ts
@@ -20,6 +20,14 @@ function bgVoice(line: LyricLine): BackgroundVoice | null {
   return { text, source };
 }
 
+// The main voice's text. Every voice variant carries text, so this never
+// returns undefined. Prefer this over reading the flat field at call sites: it
+// reads `line.main.text` once storage is nested, and avoids allocating a Voice
+// just to read its text.
+function lineText(line: LyricLine): string {
+  return line.text;
+}
+
 // -- Exports ------------------------------------------------------------------
 
-export { mainVoice, bgVoice };
+export { mainVoice, bgVoice, lineText };

--- a/src/domain/line/voices.ts
+++ b/src/domain/line/voices.ts
@@ -5,55 +5,42 @@ import type { WordTiming } from "@/domain/word/timing";
 // -- Functions ----------------------------------------------------------------
 
 function mainVoice(line: LyricLine): Voice {
-  if (line.words?.length) return { text: line.text, words: line.words };
-  if (line.begin !== undefined && line.end !== undefined) {
-    return { text: line.text, begin: line.begin, end: line.end };
-  }
-  return { text: line.text };
+  return line.main;
 }
 
 function bgVoice(line: LyricLine): BackgroundVoice | null {
-  const words = line.backgroundWords?.length ? line.backgroundWords : undefined;
-  if (line.backgroundText === undefined && words === undefined) return null;
-  const source = line.backgroundTextSource;
-  const text = line.backgroundText ?? "";
-  if (words) return { text, words, source };
-  return { text, source };
+  return line.background ?? null;
 }
 
 // The main voice's text. Every voice variant carries text, so this never
-// returns undefined. Prefer this over reading the flat field at call sites: it
-// reads `line.main.text` once storage is nested, and avoids allocating a Voice
-// just to read its text.
+// returns undefined. Reads `line.main.text` directly.
 function lineText(line: LyricLine): string {
-  return line.text;
+  return line.main.text;
 }
 
 // Raw word-synced word array of the main voice, or undefined when the main
-// voice is not word-synced. Mirrors the old `line.words` read exactly. Use this
-// for call sites that need the actual word array (filter, map, length), not the
-// synthesized single word of `effectiveWords`.
+// voice is not word-synced. Use this for call sites that need the actual word
+// array (filter, map, length), not the synthesized single word of
+// `effectiveWords`.
 function mainWords(line: LyricLine): WordTiming[] | undefined {
-  return line.words;
+  return "words" in line.main ? line.main.words : undefined;
 }
 
-// Raw word-synced word array of the background voice, or undefined. Mirrors the
-// old `line.backgroundWords` read exactly.
+// Raw word-synced word array of the background voice, or undefined when there
+// is no word-synced background.
 function bgWords(line: LyricLine): WordTiming[] | undefined {
-  return line.backgroundWords;
+  return line.background && "words" in line.background ? line.background.words : undefined;
 }
 
-// Raw background text, or undefined when there is no background. Mirrors the old
-// `line.backgroundText` read exactly. This is the authored text and is undefined
-// for a word-only background, unlike `bgVoice(line)?.text` which normalises to "".
+// Background text, or undefined when there is no background. reconcileLine
+// stores "" for a word-only background with no authored text.
 function bgText(line: LyricLine): string | undefined {
-  return line.backgroundText;
+  return line.background?.text;
 }
 
-// Background provenance flag, or undefined. Mirrors the old
-// `line.backgroundTextSource` read exactly.
+// Background provenance flag, or undefined.
 function bgSource(line: LyricLine): BackgroundSource | undefined {
-  return line.backgroundTextSource;
+  return line.background?.source;
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/src/domain/line/voices.ts
+++ b/src/domain/line/voices.ts
@@ -1,5 +1,6 @@
 import type { LyricLine } from "@/domain/line/model";
-import type { BackgroundVoice, Voice } from "@/domain/voice/model";
+import type { BackgroundSource, BackgroundVoice, Voice } from "@/domain/voice/model";
+import type { WordTiming } from "@/domain/word/timing";
 
 // -- Functions ----------------------------------------------------------------
 
@@ -28,6 +29,33 @@ function lineText(line: LyricLine): string {
   return line.text;
 }
 
+// Raw word-synced word array of the main voice, or undefined when the main
+// voice is not word-synced. Mirrors the old `line.words` read exactly. Use this
+// for call sites that need the actual word array (filter, map, length), not the
+// synthesized single word of `effectiveWords`.
+function mainWords(line: LyricLine): WordTiming[] | undefined {
+  return line.words;
+}
+
+// Raw word-synced word array of the background voice, or undefined. Mirrors the
+// old `line.backgroundWords` read exactly.
+function bgWords(line: LyricLine): WordTiming[] | undefined {
+  return line.backgroundWords;
+}
+
+// Raw background text, or undefined when there is no background. Mirrors the old
+// `line.backgroundText` read exactly. This is the authored text and is undefined
+// for a word-only background, unlike `bgVoice(line)?.text` which normalises to "".
+function bgText(line: LyricLine): string | undefined {
+  return line.backgroundText;
+}
+
+// Background provenance flag, or undefined. Mirrors the old
+// `line.backgroundTextSource` read exactly.
+function bgSource(line: LyricLine): BackgroundSource | undefined {
+  return line.backgroundTextSource;
+}
+
 // -- Exports ------------------------------------------------------------------
 
-export { mainVoice, bgVoice, lineText };
+export { mainVoice, bgVoice, lineText, mainWords, bgWords, bgText, bgSource };

--- a/src/domain/voice/bounds.test.ts
+++ b/src/domain/voice/bounds.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { Voice } from "@/domain/voice/model";
+import { voiceBounds } from "@/domain/voice/bounds";
+
+// -- Tests --------------------------------------------------------------------
+
+describe("voiceBounds", () => {
+  describe("happy paths", () => {
+    it("returns first.begin and last.end for a multi-word voice", () => {
+      const voice: Voice = {
+        text: "hello world now",
+        words: [
+          { text: "hello", begin: 0.5, end: 1.0 },
+          { text: "world", begin: 1.0, end: 1.75 },
+          { text: "now", begin: 1.75, end: 2.5 },
+        ],
+      };
+      expect(voiceBounds(voice)).toEqual({ begin: 0.5, end: 2.5 });
+    });
+
+    it("returns the single word's begin/end for a single-word voice", () => {
+      const voice: Voice = {
+        text: "ooh",
+        words: [{ text: "ooh", begin: 1.2, end: 3.4 }],
+      };
+      expect(voiceBounds(voice)).toEqual({ begin: 1.2, end: 3.4 });
+    });
+
+    it("returns its own begin/end for a line-synced voice", () => {
+      const voice: Voice = { text: "ooh", begin: 1.5, end: 3.25 };
+      expect(voiceBounds(voice)).toEqual({ begin: 1.5, end: 3.25 });
+    });
+
+    it("returns null for an untimed voice", () => {
+      const voice: Voice = { text: "ooh" };
+      expect(voiceBounds(voice)).toBeNull();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles begin: 0 on a line-synced voice without treating it as untimed", () => {
+      const voice: Voice = { text: "ooh", begin: 0, end: 1 };
+      expect(voiceBounds(voice)).toEqual({ begin: 0, end: 1 });
+    });
+
+    it("handles begin: 0 on a word-synced voice", () => {
+      const voice: Voice = {
+        text: "ooh",
+        words: [{ text: "ooh", begin: 0, end: 1 }],
+      };
+      expect(voiceBounds(voice)).toEqual({ begin: 0, end: 1 });
+    });
+
+    it("returns null for a voice with an empty words array", () => {
+      const voice: Voice = { text: "", words: [] };
+      expect(voiceBounds(voice)).toBeNull();
+    });
+
+    it("returns null for an empty-string untimed voice", () => {
+      const voice: Voice = { text: "" };
+      expect(voiceBounds(voice)).toBeNull();
+    });
+  });
+});

--- a/src/domain/voice/bounds.ts
+++ b/src/domain/voice/bounds.ts
@@ -1,0 +1,16 @@
+import type { Bounds } from "@/domain/word/bounds";
+import { firstBegin, lastEnd } from "@/domain/word/bounds";
+import type { Voice } from "@/domain/voice/model";
+import { isLineSynced, isWordSynced } from "@/domain/voice/predicates";
+
+// -- Functions ----------------------------------------------------------------
+
+function voiceBounds(v: Voice): Bounds | null {
+  if (isWordSynced(v)) return { begin: firstBegin(v.words), end: lastEnd(v.words) };
+  if (isLineSynced(v)) return { begin: v.begin, end: v.end };
+  return null;
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { voiceBounds };

--- a/src/domain/voice/effective-words.test.ts
+++ b/src/domain/voice/effective-words.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { Voice } from "@/domain/voice/model";
+import { effectiveVoiceWords } from "@/domain/voice/effective-words";
+
+// -- Tests --------------------------------------------------------------------
+
+describe("effectiveVoiceWords", () => {
+  describe("happy paths", () => {
+    it("returns one WordTiming for a line-synced voice with its begin/end", () => {
+      const voice: Voice = { text: "ooh", begin: 1.5, end: 3.25 };
+      expect(effectiveVoiceWords(voice)).toEqual([{ text: "ooh", begin: 1.5, end: 3.25 }]);
+    });
+
+    it("strips the split character from a line-synced voice's text", () => {
+      const voice: Voice = { text: "be|au|ti|ful", begin: 0.5, end: 2.0 };
+      const result = effectiveVoiceWords(voice);
+      expect(result).toEqual([{ text: "beautiful", begin: 0.5, end: 2.0 }]);
+      expect(result[0].text).not.toContain("|");
+    });
+
+    it("returns the words array for a word-synced voice", () => {
+      const words = [
+        { text: "hello", begin: 0.5, end: 1.0 },
+        { text: "world", begin: 1.0, end: 1.75 },
+      ];
+      const voice: Voice = { text: "hello world", words };
+      expect(effectiveVoiceWords(voice)).toEqual(words);
+    });
+
+    it("returns an empty array for an untimed voice", () => {
+      const voice: Voice = { text: "ooh" };
+      expect(effectiveVoiceWords(voice)).toEqual([]);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles begin: 0 on a line-synced voice", () => {
+      const voice: Voice = { text: "ooh", begin: 0, end: 1 };
+      expect(effectiveVoiceWords(voice)).toEqual([{ text: "ooh", begin: 0, end: 1 }]);
+    });
+
+    it("returns an empty array for an empty-string untimed voice", () => {
+      const voice: Voice = { text: "" };
+      expect(effectiveVoiceWords(voice)).toEqual([]);
+    });
+
+    it("returns an empty array for a voice with an empty words array", () => {
+      const voice: Voice = { text: "", words: [] };
+      expect(effectiveVoiceWords(voice)).toEqual([]);
+    });
+  });
+
+  describe("invariants", () => {
+    it("returns the same words array reference for a word-synced voice", () => {
+      const words = [{ text: "ooh", begin: 0, end: 1 }];
+      const voice: Voice = { text: "ooh", words };
+      expect(effectiveVoiceWords(voice)).toBe(words);
+    });
+  });
+});

--- a/src/domain/voice/effective-words.ts
+++ b/src/domain/voice/effective-words.ts
@@ -1,0 +1,16 @@
+import type { WordTiming } from "@/domain/word/timing";
+import { stripSplitCharacter } from "@/utils/split-character";
+import type { Voice } from "@/domain/voice/model";
+import { isLineSynced, isWordSynced } from "@/domain/voice/predicates";
+
+// -- Functions ----------------------------------------------------------------
+
+function effectiveVoiceWords(v: Voice): WordTiming[] {
+  if (isWordSynced(v)) return v.words;
+  if (isLineSynced(v)) return [{ text: stripSplitCharacter(v.text), begin: v.begin, end: v.end }];
+  return [];
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { effectiveVoiceWords };

--- a/src/domain/voice/model.ts
+++ b/src/domain/voice/model.ts
@@ -1,0 +1,16 @@
+import type { WordTiming } from "@/domain/word/timing";
+
+// -- Types --------------------------------------------------------------------
+
+type UntimedVoice = { text: string };
+type LineSyncedVoice = { text: string; begin: number; end: number };
+type WordSyncedVoice = { text: string; words: WordTiming[] };
+
+type Voice = UntimedVoice | LineSyncedVoice | WordSyncedVoice;
+
+type BackgroundSource = "extraction" | "manual";
+type BackgroundVoice = Voice & { source?: BackgroundSource };
+
+// -- Exports ------------------------------------------------------------------
+
+export type { Voice, BackgroundVoice, BackgroundSource, UntimedVoice, LineSyncedVoice, WordSyncedVoice };

--- a/src/domain/voice/predicates.test.ts
+++ b/src/domain/voice/predicates.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Voice } from "@/domain/voice/model";
-import { isLineSynced, isUntimed, isWordSynced } from "@/domain/voice/predicates";
+import { isBackgroundVoice, isLineSynced, isUntimed, isVoice, isWordSynced } from "@/domain/voice/predicates";
 
 // -- Tests --------------------------------------------------------------------
 
@@ -95,6 +95,124 @@ describe("voice predicates", () => {
         const trueCount = [isUntimed(voice), isLineSynced(voice), isWordSynced(voice)].filter(Boolean).length;
         expect(trueCount).toBe(1);
       }
+    });
+  });
+});
+
+// -- isVoice ------------------------------------------------------------------
+
+describe("isVoice", () => {
+  describe("happy paths", () => {
+    it("accepts an untimed voice", () => {
+      expect(isVoice({ text: "a" })).toBe(true);
+    });
+
+    it("accepts a line-synced voice", () => {
+      expect(isVoice({ text: "a", begin: 1, end: 2 })).toBe(true);
+    });
+
+    it("accepts a word-synced voice", () => {
+      expect(isVoice({ text: "a", words: [{ text: "a", begin: 1, end: 2 }] })).toBe(true);
+    });
+
+    it("accepts a voice with an empty words array", () => {
+      expect(isVoice({ text: "a", words: [] })).toBe(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("accepts begin: 0 / end: 0 (guards against falsy-number rejection)", () => {
+      expect(isVoice({ text: "a", begin: 0, end: 0 })).toBe(true);
+    });
+
+    it("accepts an empty-string text", () => {
+      expect(isVoice({ text: "" })).toBe(true);
+    });
+
+    it("accepts a voice carrying an extra source key (structural superset)", () => {
+      expect(isVoice({ text: "a", source: "manual" })).toBe(true);
+    });
+  });
+
+  describe("rejections", () => {
+    it("rejects null", () => {
+      expect(isVoice(null)).toBe(false);
+    });
+
+    it("rejects undefined", () => {
+      expect(isVoice(undefined)).toBe(false);
+    });
+
+    it("rejects a non-object", () => {
+      expect(isVoice("a")).toBe(false);
+      expect(isVoice(5)).toBe(false);
+    });
+
+    it("rejects an object with no text", () => {
+      expect(isVoice({})).toBe(false);
+    });
+
+    it("rejects a non-string text", () => {
+      expect(isVoice({ text: 5 })).toBe(false);
+    });
+
+    it("rejects begin without end", () => {
+      expect(isVoice({ text: "a", begin: 1 })).toBe(false);
+    });
+
+    it("rejects end without begin", () => {
+      expect(isVoice({ text: "a", end: 2 })).toBe(false);
+    });
+
+    it("rejects a non-number begin", () => {
+      expect(isVoice({ text: "a", begin: "1", end: 2 })).toBe(false);
+    });
+
+    it("rejects a non-number end", () => {
+      expect(isVoice({ text: "a", begin: 1, end: "2" })).toBe(false);
+    });
+
+    it("rejects words that are not an array", () => {
+      expect(isVoice({ text: "a", words: "x" })).toBe(false);
+    });
+  });
+});
+
+// -- isBackgroundVoice --------------------------------------------------------
+
+describe("isBackgroundVoice", () => {
+  describe("happy paths", () => {
+    it("accepts a voice with no source", () => {
+      expect(isBackgroundVoice({ text: "a" })).toBe(true);
+    });
+
+    it("accepts a voice with source extraction", () => {
+      expect(isBackgroundVoice({ text: "a", source: "extraction" })).toBe(true);
+    });
+
+    it("accepts a voice with source manual", () => {
+      expect(isBackgroundVoice({ text: "a", source: "manual" })).toBe(true);
+    });
+
+    it("accepts a word-synced voice with source", () => {
+      expect(isBackgroundVoice({ text: "a", words: [{ text: "a", begin: 1, end: 2 }], source: "extraction" })).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("rejections", () => {
+    it("rejects a non-voice", () => {
+      expect(isBackgroundVoice({ text: 5 })).toBe(false);
+      expect(isBackgroundVoice(null)).toBe(false);
+    });
+
+    it("rejects an unknown source string", () => {
+      expect(isBackgroundVoice({ text: "a", source: "auto" })).toBe(false);
+    });
+
+    it("rejects a non-string source", () => {
+      expect(isBackgroundVoice({ text: "a", source: 1 })).toBe(false);
     });
   });
 });

--- a/src/domain/voice/predicates.test.ts
+++ b/src/domain/voice/predicates.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { Voice } from "@/domain/voice/model";
+import { isLineSynced, isUntimed, isWordSynced } from "@/domain/voice/predicates";
+
+// -- Tests --------------------------------------------------------------------
+
+describe("voice predicates", () => {
+  describe("happy paths", () => {
+    it("classifies an untimed voice exclusively as untimed", () => {
+      const voice: Voice = { text: "ooh" };
+      expect(isUntimed(voice)).toBe(true);
+      expect(isLineSynced(voice)).toBe(false);
+      expect(isWordSynced(voice)).toBe(false);
+    });
+
+    it("classifies a line-synced voice exclusively as line-synced", () => {
+      const voice: Voice = { text: "ooh", begin: 1.5, end: 3.25 };
+      expect(isLineSynced(voice)).toBe(true);
+      expect(isUntimed(voice)).toBe(false);
+      expect(isWordSynced(voice)).toBe(false);
+    });
+
+    it("classifies a word-synced voice exclusively as word-synced", () => {
+      const voice: Voice = {
+        text: "hello world",
+        words: [
+          { text: "hello", begin: 0.5, end: 1.0 },
+          { text: "world", begin: 1.0, end: 1.75 },
+        ],
+      };
+      expect(isWordSynced(voice)).toBe(true);
+      expect(isUntimed(voice)).toBe(false);
+      expect(isLineSynced(voice)).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("treats a voice with an empty words array as untimed, not word-synced", () => {
+      const voice: Voice = { text: "", words: [] };
+      expect(isWordSynced(voice)).toBe(false);
+      expect(isLineSynced(voice)).toBe(false);
+      expect(isUntimed(voice)).toBe(true);
+    });
+
+    it("treats begin: 0 as line-synced (guards against falsy-begin bug)", () => {
+      const voice: Voice = { text: "ooh", begin: 0, end: 1 };
+      expect(isLineSynced(voice)).toBe(true);
+      expect(isUntimed(voice)).toBe(false);
+      expect(isWordSynced(voice)).toBe(false);
+    });
+
+    it("treats a single word with begin: 0 as word-synced", () => {
+      const voice: Voice = {
+        text: "ooh",
+        words: [{ text: "ooh", begin: 0, end: 1 }],
+      };
+      expect(isWordSynced(voice)).toBe(true);
+      expect(isLineSynced(voice)).toBe(false);
+      expect(isUntimed(voice)).toBe(false);
+    });
+
+    it("does not let whitespace text affect classification", () => {
+      const untimed: Voice = { text: "   " };
+      expect(isUntimed(untimed)).toBe(true);
+      expect(isLineSynced(untimed)).toBe(false);
+      expect(isWordSynced(untimed)).toBe(false);
+    });
+
+    it("does not let unicode text affect classification", () => {
+      const voice: Voice = { text: "안녕 🎵", begin: 2, end: 4 };
+      expect(isLineSynced(voice)).toBe(true);
+      expect(isUntimed(voice)).toBe(false);
+      expect(isWordSynced(voice)).toBe(false);
+    });
+
+    it("treats an empty-string untimed voice as untimed", () => {
+      const voice: Voice = { text: "" };
+      expect(isUntimed(voice)).toBe(true);
+      expect(isLineSynced(voice)).toBe(false);
+      expect(isWordSynced(voice)).toBe(false);
+    });
+  });
+
+  describe("invariants", () => {
+    it("exactly one predicate is true for every voice shape", () => {
+      const voices: Voice[] = [
+        { text: "ooh" },
+        { text: "" },
+        { text: "ooh", begin: 0, end: 1 },
+        { text: "ooh", begin: 1.5, end: 3.25 },
+        { text: "", words: [] },
+        { text: "hi", words: [{ text: "hi", begin: 0, end: 1 }] },
+      ];
+      for (const voice of voices) {
+        const trueCount = [isUntimed(voice), isLineSynced(voice), isWordSynced(voice)].filter(Boolean).length;
+        expect(trueCount).toBe(1);
+      }
+    });
+  });
+});

--- a/src/domain/voice/predicates.ts
+++ b/src/domain/voice/predicates.ts
@@ -1,4 +1,4 @@
-import type { LineSyncedVoice, Voice, WordSyncedVoice } from "@/domain/voice/model";
+import type { BackgroundVoice, LineSyncedVoice, Voice, WordSyncedVoice } from "@/domain/voice/model";
 
 // -- Functions ----------------------------------------------------------------
 
@@ -14,6 +14,26 @@ function isUntimed(v: Voice): boolean {
   return !isWordSynced(v) && !isLineSynced(v);
 }
 
+// Individual WordTiming entries are not deep-validated, matching the flat
+// migration path which casts `words as WordTiming[]`.
+function isVoice(x: unknown): x is Voice {
+  if (typeof x !== "object" || x === null) return false;
+  const candidate = x as Record<string, unknown>;
+  if (typeof candidate.text !== "string") return false;
+  if ("words" in candidate && !Array.isArray(candidate.words)) return false;
+  if ("begin" in candidate || "end" in candidate) {
+    if (typeof candidate.begin !== "number" || typeof candidate.end !== "number") return false;
+  }
+  return true;
+}
+
+function isBackgroundVoice(x: unknown): x is BackgroundVoice {
+  if (!isVoice(x)) return false;
+  const candidate = x as Record<string, unknown>;
+  if ("source" in candidate && candidate.source !== "extraction" && candidate.source !== "manual") return false;
+  return true;
+}
+
 // -- Exports ------------------------------------------------------------------
 
-export { isUntimed, isLineSynced, isWordSynced };
+export { isUntimed, isLineSynced, isWordSynced, isVoice, isBackgroundVoice };

--- a/src/domain/voice/predicates.ts
+++ b/src/domain/voice/predicates.ts
@@ -1,0 +1,19 @@
+import type { LineSyncedVoice, Voice, WordSyncedVoice } from "@/domain/voice/model";
+
+// -- Functions ----------------------------------------------------------------
+
+function isWordSynced(v: Voice): v is WordSyncedVoice {
+  return "words" in v && v.words.length > 0;
+}
+
+function isLineSynced(v: Voice): v is LineSyncedVoice {
+  return "begin" in v && !isWordSynced(v);
+}
+
+function isUntimed(v: Voice): boolean {
+  return !isWordSynced(v) && !isLineSynced(v);
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { isUntimed, isLineSynced, isWordSynced };

--- a/src/domain/word/explicit-toggle.test.ts
+++ b/src/domain/word/explicit-toggle.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment node
+ */
+import { computeExplicitToggle } from "@/domain/word/explicit-toggle";
+import type { WordTiming } from "@/domain/word/timing";
+import { describe, expect, it } from "vitest";
+
+function words(): WordTiming[] {
+  return [
+    { text: "I ", begin: 0, end: 0.5 },
+    { text: "love ", begin: 0.5, end: 1 },
+    { text: "you", begin: 1, end: 1.5 },
+  ];
+}
+
+describe("computeExplicitToggle · marking", () => {
+  it("marks the selected word explicit when none are marked", () => {
+    const result = computeExplicitToggle(words(), "words", [1]);
+    expect(result?.newWords.map((w) => w.explicit)).toEqual([undefined, true, undefined]);
+  });
+
+  it("marks all selected when several are unmarked", () => {
+    const result = computeExplicitToggle(words(), "words", [0, 2]);
+    expect(result?.newWords.map((w) => w.explicit)).toEqual([true, undefined, true]);
+  });
+});
+
+describe("computeExplicitToggle · unmarking", () => {
+  it("unmarks when every selected word is already explicit", () => {
+    const marked = words().map((w) => ({ ...w, explicit: true as const }));
+    const result = computeExplicitToggle(marked, "words", [0, 1, 2]);
+    expect(result?.newWords.every((w) => w.explicit === undefined)).toBe(true);
+  });
+
+  it("marks the rest when the selection is mixed (not all marked)", () => {
+    const mixed: WordTiming[] = [
+      { text: "I ", begin: 0, end: 0.5, explicit: true },
+      { text: "love ", begin: 0.5, end: 1 },
+      { text: "you", begin: 1, end: 1.5 },
+    ];
+    const result = computeExplicitToggle(mixed, "words", [0, 1]);
+    expect(result?.newWords[0].explicit).toBe(true);
+    expect(result?.newWords[1].explicit).toBe(true);
+  });
+});
+
+describe("computeExplicitToggle · syllable group expansion", () => {
+  it("expands the selection to every word in a syllable group", () => {
+    const grouped: WordTiming[] = [
+      { text: "ev", begin: 0, end: 0.3, syllableGroupId: "g" },
+      { text: "er", begin: 0.3, end: 0.6, syllableGroupId: "g" },
+      { text: "y", begin: 0.6, end: 1, syllableGroupId: "g" },
+    ];
+    const result = computeExplicitToggle(grouped, "words", [1]);
+    expect(result?.newWords.map((w) => w.explicit)).toEqual([true, true, true]);
+  });
+});
+
+describe("computeExplicitToggle · background provenance", () => {
+  it("stamps manual provenance for a backgroundWords edit", () => {
+    const result = computeExplicitToggle(words(), "backgroundWords", [0]);
+    expect(result?.extraUpdates.backgroundTextSource).toBe("manual");
+    expect(result?.extraUpdates.backgroundWords).toBeDefined();
+  });
+
+  it("returns no extra updates for a main-words edit", () => {
+    const result = computeExplicitToggle(words(), "words", [0]);
+    expect(result?.extraUpdates).toEqual({});
+  });
+});
+
+describe("computeExplicitToggle · null paths", () => {
+  it("returns null for an empty word array", () => {
+    expect(computeExplicitToggle([], "words", [0])).toBeNull();
+  });
+
+  it("returns null when no indices fall in range", () => {
+    expect(computeExplicitToggle(words(), "words", [9, -1])).toBeNull();
+  });
+
+  it("returns null for an empty selection", () => {
+    expect(computeExplicitToggle(words(), "words", [])).toBeNull();
+  });
+});
+
+describe("computeExplicitToggle · invariants", () => {
+  it("does not mutate the input word array", () => {
+    const input = words();
+    const snapshot = input.map((w) => ({ ...w }));
+    computeExplicitToggle(input, "words", [0, 1]);
+    expect(input).toEqual(snapshot);
+  });
+
+  it("preserves text and timing on every word", () => {
+    const result = computeExplicitToggle(words(), "words", [1]);
+    expect(result?.newWords.map((w) => [w.text, w.begin, w.end])).toEqual([
+      ["I ", 0, 0.5],
+      ["love ", 0.5, 1],
+      ["you", 1, 1.5],
+    ]);
+  });
+});

--- a/src/domain/word/explicit-toggle.ts
+++ b/src/domain/word/explicit-toggle.ts
@@ -1,0 +1,46 @@
+import { manualBackgroundWordEdit } from "@/domain/line/background";
+import type { LooseLine } from "@/domain/line/model";
+import { expandSelectionToGroupmates } from "@/domain/word/syllable-groups";
+import type { WordTiming } from "@/domain/word/timing";
+
+// -- Types --------------------------------------------------------------------
+
+interface ExplicitToggleResult {
+  newWords: WordTiming[];
+  extraUpdates: Partial<LooseLine>;
+}
+
+// -- Operation ----------------------------------------------------------------
+
+// Pure computation behind toggleWordExplicit: expands the selection to syllable
+// groupmates, flips the explicit flag (set only when not all selected words are
+// already marked), and stamps manual provenance for a background-words edit.
+// Returns null when there is nothing to toggle so the caller can early-return.
+function computeExplicitToggle(
+  currentWords: WordTiming[],
+  field: "words" | "backgroundWords",
+  wordIndices: number[],
+): ExplicitToggleResult | null {
+  if (currentWords.length === 0) return null;
+
+  const filtered = wordIndices.filter((i) => i >= 0 && i < currentWords.length);
+  const expanded = expandSelectionToGroupmates(currentWords, filtered).filter((i) => i < currentWords.length);
+  const indexSet = new Set(expanded);
+  if (indexSet.size === 0) return null;
+
+  const nextExplicit = !Array.from(indexSet).every((i) => currentWords[i].explicit === true);
+  const newWords: WordTiming[] = currentWords.map((word, i) => {
+    if (!indexSet.has(i)) return word;
+    if (nextExplicit) return { ...word, explicit: true };
+    const { explicit: _explicit, ...rest } = word;
+    return rest;
+  });
+
+  const extraUpdates = field === "backgroundWords" ? manualBackgroundWordEdit(newWords) : {};
+  return { newWords, extraUpdates };
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { computeExplicitToggle };
+export type { ExplicitToggleResult };

--- a/src/domain/word/move-across-lines.test.ts
+++ b/src/domain/word/move-across-lines.test.ts
@@ -1,7 +1,9 @@
 /**
  * @vitest-environment node
  */
+import { mainBounds } from "@/domain/line/bounds";
 import type { LyricLine } from "@/domain/line/model";
+import { bgSource, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { createLine } from "@/test/factories";
 import { describe, expect, it } from "vitest";
@@ -55,8 +57,8 @@ describe("applyWordMoveAcrossLines: happy paths", () => {
     if (!result.ok) throw new Error("expected ok");
     const a = findById(result.lines, "A");
     const b = findById(result.lines, "B");
-    expect(a.words?.map((w) => w.text.trimEnd())).toEqual(["hello"]);
-    expect(b.words?.map((w) => w.text.trimEnd())).toEqual(["foo", "bar", "world"]);
+    expect(mainWords(a)?.map((w) => w.text.trimEnd())).toEqual(["hello"]);
+    expect(mainWords(b)?.map((w) => w.text.trimEnd())).toEqual(["foo", "bar", "world"]);
   });
 
   it("moves a main word into the background track (main -> bg)", () => {
@@ -94,9 +96,9 @@ describe("applyWordMoveAcrossLines: happy paths", () => {
     if (!result.ok) throw new Error("expected ok");
     const a = findById(result.lines, "A");
     const b = findById(result.lines, "B");
-    expect(a.words?.map((w) => w.text.trimEnd())).toEqual(["hello"]);
-    expect(b.backgroundWords?.map((w) => w.text.trimEnd())).toEqual(["ooh", "world"]);
-    expect(b.backgroundTextSource).toBe("manual");
+    expect(mainWords(a)?.map((w) => w.text.trimEnd())).toEqual(["hello"]);
+    expect(bgWords(b)?.map((w) => w.text.trimEnd())).toEqual(["ooh", "world"]);
+    expect(bgSource(b)).toBe("manual");
   });
 
   it("moves a background word from line A to line B (bg -> bg)", () => {
@@ -137,8 +139,8 @@ describe("applyWordMoveAcrossLines: happy paths", () => {
     if (!result.ok) throw new Error("expected ok");
     const a = findById(result.lines, "A");
     const b = findById(result.lines, "B");
-    expect(a.backgroundWords?.map((w) => w.text.trimEnd())).toEqual(["ooh"]);
-    expect(b.backgroundWords?.map((w) => w.text.trimEnd())).toEqual(["yeah", "ahh"]);
+    expect(bgWords(a)?.map((w) => w.text.trimEnd())).toEqual(["ooh"]);
+    expect(bgWords(b)?.map((w) => w.text.trimEnd())).toEqual(["yeah", "ahh"]);
   });
 
   it("moves a background word into the main track (bg -> main)", () => {
@@ -176,8 +178,8 @@ describe("applyWordMoveAcrossLines: happy paths", () => {
     if (!result.ok) throw new Error("expected ok");
     const a = findById(result.lines, "A");
     const b = findById(result.lines, "B");
-    expect(a.backgroundWords?.map((w) => w.text.trimEnd())).toEqual(["ooh"]);
-    expect(b.words?.map((w) => w.text.trimEnd())).toEqual(["first", "ahh"]);
+    expect(bgWords(a)?.map((w) => w.text.trimEnd())).toEqual(["ooh"]);
+    expect(mainWords(b)?.map((w) => w.text.trimEnd())).toEqual(["first", "ahh"]);
   });
 
   it("moves two main words from one source into one target", () => {
@@ -222,8 +224,8 @@ describe("applyWordMoveAcrossLines: happy paths", () => {
     if (!result.ok) throw new Error("expected ok");
     const a = findById(result.lines, "A");
     const b = findById(result.lines, "B");
-    expect(a.words?.map((w) => w.text.trimEnd())).toEqual(["three"]);
-    expect(b.words?.map((w) => w.text.trimEnd())).toEqual(["alpha", "one", "two"]);
+    expect(mainWords(a)?.map((w) => w.text.trimEnd())).toEqual(["three"]);
+    expect(mainWords(b)?.map((w) => w.text.trimEnd())).toEqual(["alpha", "one", "two"]);
   });
 
   it("moves words from two different source lines into one target line", () => {
@@ -275,9 +277,9 @@ describe("applyWordMoveAcrossLines: happy paths", () => {
     const a = findById(result.lines, "A");
     const b = findById(result.lines, "B");
     const c = findById(result.lines, "C");
-    expect(a.words?.map((w) => w.text.trimEnd())).toEqual(["a1"]);
-    expect(b.words?.map((w) => w.text.trimEnd())).toEqual(["b2"]);
-    expect(c.words?.map((w) => w.text.trimEnd())).toEqual(["c1", "a2", "b1"]);
+    expect(mainWords(a)?.map((w) => w.text.trimEnd())).toEqual(["a1"]);
+    expect(mainWords(b)?.map((w) => w.text.trimEnd())).toEqual(["b2"]);
+    expect(mainWords(c)?.map((w) => w.text.trimEnd())).toEqual(["c1", "a2", "b1"]);
   });
 });
 
@@ -460,7 +462,7 @@ describe("applyWordMoveAcrossLines: invariants", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("expected ok");
     const a = findById(result.lines, "A");
-    expect(a.text).toBe("alpha gamma");
+    expect(lineText(a)).toBe("alpha gamma");
   });
 
   it("re-derives target-line text after merge", () => {
@@ -493,7 +495,7 @@ describe("applyWordMoveAcrossLines: invariants", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("expected ok");
     const b = findById(result.lines, "B");
-    expect(b.text).toBe("foo world");
+    expect(lineText(b)).toBe("foo world");
   });
 
   it("regenerates syllable group ids on inserted words", () => {
@@ -536,7 +538,7 @@ describe("applyWordMoveAcrossLines: invariants", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("expected ok");
     const b = findById(result.lines, "B");
-    const inserted = b.words?.filter((w) => w.text.trimEnd() === "ti" || w.text.trimEnd() === "tle") ?? [];
+    const inserted = mainWords(b)?.filter((w) => w.text.trimEnd() === "ti" || w.text.trimEnd() === "tle") ?? [];
     expect(inserted).toHaveLength(2);
     for (const w of inserted) expect(w.syllableGroupId).not.toBe("shared");
     expect(inserted[0].syllableGroupId).toBeDefined();
@@ -633,9 +635,9 @@ describe("applyWordMoveAcrossLines: invariants", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("expected ok");
     const a = findById(result.lines, "A");
-    expect(a.words).toEqual([]);
-    expect(a.begin).toBeUndefined();
-    expect(a.end).toBeUndefined();
+    expect(mainWords(a)).toEqual([]);
+    expect(mainBounds(a)?.begin).toBeUndefined();
+    expect(mainBounds(a)?.end).toBeUndefined();
   });
 });
 
@@ -669,7 +671,7 @@ describe("applyWordMoveAcrossLines: edge cases", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("expected ok");
     const b = findById(result.lines, "B");
-    expect(b.words?.map((w) => w.text.trimEnd())).toEqual(["world"]);
+    expect(mainWords(b)?.map((w) => w.text.trimEnd())).toEqual(["world"]);
   });
 
   it("rejects when target line is line-synced and target track is word", () => {

--- a/src/domain/word/move-across-lines.ts
+++ b/src/domain/word/move-across-lines.ts
@@ -3,6 +3,7 @@ import { CLEARED_BACKGROUND, manualBackgroundWordEdit } from "@/domain/line/back
 import { applyMainWordEdit } from "@/domain/line/main-words";
 import { type LyricLine, reconcileLine } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/line/predicates";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
 import { boundsOverlap } from "@/domain/word/overlap";
 import type { WordTiming } from "@/domain/word/timing";
@@ -48,7 +49,7 @@ function validateMoves(moves: WordMove[], linesById: Map<string, LyricLine>): Mo
     if (move.targetTrack === "word" && isLineSynced(target) && target.id !== source.id) {
       return { ok: false, reject: "line-synced-target" };
     }
-    const targetArr = move.targetTrack === "word" ? target.words : target.backgroundWords;
+    const targetArr = move.targetTrack === "word" ? mainWords(target) : bgWords(target);
     if (targetArr) {
       for (const existing of targetArr) {
         if (boundsOverlap(move.word, existing)) return { ok: false, reject: "overlap" };
@@ -102,12 +103,14 @@ function planInserts(moves: WordMove[]): Map<string, TargetInserts> {
 
 function applyRemovals(line: LyricLine, removals: SourceRemovals): LyricLine {
   let updated = line;
-  if (removals.word.size > 0 && updated.words) {
-    const remaining = trimTrailingSpaceFromLast(updated.words.filter((_, i) => !removals.word.has(i)));
+  const main = mainWords(updated);
+  if (removals.word.size > 0 && main) {
+    const remaining = trimTrailingSpaceFromLast(main.filter((_, i) => !removals.word.has(i)));
     updated = applyMainWordEdit(updated, remaining);
   }
-  if (removals.bg.size > 0 && updated.backgroundWords) {
-    const remaining = trimTrailingSpaceFromLast(updated.backgroundWords.filter((_, i) => !removals.bg.has(i)));
+  const bg = bgWords(updated);
+  if (removals.bg.size > 0 && bg) {
+    const remaining = trimTrailingSpaceFromLast(bg.filter((_, i) => !removals.bg.has(i)));
     updated =
       remaining.length > 0
         ? reconcileLine({ ...updated, ...manualBackgroundWordEdit(remaining) })
@@ -119,11 +122,11 @@ function applyRemovals(line: LyricLine, removals: SourceRemovals): LyricLine {
 function applyInserts(line: LyricLine, inserts: TargetInserts, duration: number): LyricLine {
   let updated = line;
   if (inserts.word.length > 0) {
-    const merged = resolveOverlapsForward(mergeWordsIntoTrack(updated.words ?? [], inserts.word), duration);
+    const merged = resolveOverlapsForward(mergeWordsIntoTrack(mainWords(updated) ?? [], inserts.word), duration);
     updated = applyMainWordEdit(updated, merged);
   }
   if (inserts.bg.length > 0) {
-    const merged = resolveOverlapsForward(mergeWordsIntoTrack(updated.backgroundWords ?? [], inserts.bg), duration);
+    const merged = resolveOverlapsForward(mergeWordsIntoTrack(bgWords(updated) ?? [], inserts.bg), duration);
     updated = reconcileLine({ ...updated, ...manualBackgroundWordEdit(merged) });
   }
   return updated;

--- a/src/domain/word/move-across-lines.ts
+++ b/src/domain/word/move-across-lines.ts
@@ -1,7 +1,7 @@
 import { wouldDropCrossInstance } from "@/domain/instance/cross-instance";
 import { CLEARED_BACKGROUND, manualBackgroundWordEdit } from "@/domain/line/background";
 import { applyMainWordEdit } from "@/domain/line/main-words";
-import { type LyricLine, reconcileLine } from "@/domain/line/model";
+import { type LyricLine, reconcileLine, toFlat } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/line/predicates";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
@@ -113,8 +113,8 @@ function applyRemovals(line: LyricLine, removals: SourceRemovals): LyricLine {
     const remaining = trimTrailingSpaceFromLast(bg.filter((_, i) => !removals.bg.has(i)));
     updated =
       remaining.length > 0
-        ? reconcileLine({ ...updated, ...manualBackgroundWordEdit(remaining) })
-        : reconcileLine({ ...updated, ...CLEARED_BACKGROUND });
+        ? reconcileLine({ ...toFlat(updated), ...manualBackgroundWordEdit(remaining) })
+        : reconcileLine({ ...toFlat(updated), ...CLEARED_BACKGROUND });
   }
   return updated;
 }
@@ -127,7 +127,7 @@ function applyInserts(line: LyricLine, inserts: TargetInserts, duration: number)
   }
   if (inserts.bg.length > 0) {
     const merged = resolveOverlapsForward(mergeWordsIntoTrack(bgWords(updated) ?? [], inserts.bg), duration);
-    updated = reconcileLine({ ...updated, ...manualBackgroundWordEdit(merged) });
+    updated = reconcileLine({ ...toFlat(updated), ...manualBackgroundWordEdit(merged) });
   }
   return updated;
 }

--- a/src/hooks/useDualClickImport.browser.test.tsx
+++ b/src/hooks/useDualClickImport.browser.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { lineText } from "@/domain/line/voices";
 import { useDualClickImport } from "@/hooks/useDualClickImport";
 import { useImportModalStore } from "@/stores/import-modal-store";
 import { useProjectStore } from "@/stores/project";
@@ -107,7 +108,7 @@ describe("useDualClickImport · file pick wiring", () => {
 
     await expect.poll(() => useProjectStore.getState().lines.length).toBeGreaterThan(0);
     const lines = useProjectStore.getState().lines;
-    expect(lines.map((l) => l.text)).toEqual(["Hello world", "Second line"]);
+    expect(lines.map((l) => lineText(l))).toEqual(["Hello world", "Second line"]);
 
     const recorded = useImportModalStore.getState().lastImportResult;
     expect(recorded?.source.label).toBe("File");

--- a/src/hooks/useImportFromHash.persistence.browser.test.tsx
+++ b/src/hooks/useImportFromHash.persistence.browser.test.tsx
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { bgVoice, mainWords } from "@/domain/line/voices";
+import { mainBounds } from "@/domain/line/bounds";
 import { useImportFromHash } from "@/hooks/useImportFromHash";
 import { usePersistence } from "@/hooks/usePersistence";
 import { getHashImportSettled, getPersistenceSettled } from "@/lib/persistence-settled";
@@ -7,6 +9,7 @@ import { useSettingsStore } from "@/stores/settings";
 import { allowConsole } from "@/test/console-guard";
 import { seedProject } from "@/test/idb";
 import { render } from "@/test/render";
+import type { WordTiming } from "@/domain/word/timing";
 
 // -- Constants ----------------------------------------------------------------
 
@@ -156,5 +159,81 @@ describe("usePersistence + useImportFromHash — hash overrides persistence", ()
     await waitForBootSettled();
 
     expect(useProjectStore.getState().granularity).toBe("word");
+  });
+});
+
+// -- Legacy flat-line migration on hash import --------------------------------
+
+const FLAT_WORDS: WordTiming[] = [
+  { text: "Hel", begin: 1.2, end: 1.6 },
+  { text: "lo", begin: 1.6, end: 2.1 },
+];
+
+const FLAT_BG_WORDS: WordTiming[] = [
+  { text: "ah ", begin: 6.0, end: 7.2 },
+  { text: "oh", begin: 7.2, end: 8.5 },
+];
+
+function flatLinesPayload() {
+  return {
+    metadata: { title: IMPORTED_TITLE, artist: "", album: "", duration: 0 },
+    agents: [IMPORTED_AGENT],
+    lines: [
+      { id: "fl1", agentId: "v1", text: "Hello", words: FLAT_WORDS },
+      { id: "fl2", agentId: "v1", text: "Line synced", begin: 3.0, end: 7.5 },
+      { id: "fl3", agentId: "v1", text: "Main", begin: 3.0, end: 7.5, backgroundWords: FLAT_BG_WORDS },
+    ],
+    granularity: "word" as const,
+  };
+}
+
+describe("useImportFromHash · converter payloads may be flat", () => {
+  beforeEach(() => {
+    setQuery("");
+    setHash("");
+  });
+
+  afterEach(() => {
+    setQuery("");
+    setHash("");
+  });
+
+  it("migrates old flat converter lines into nested voices with timing intact", async () => {
+    autoAcceptHashConfirm();
+    setHash(encodeHashPayload(flatLinesPayload()));
+
+    await render(<HookHost />);
+    await waitForBootSettled();
+
+    const lines = useProjectStore.getState().lines;
+    expect(lines.map((l) => l.id)).toEqual(["fl1", "fl2", "fl3"]);
+
+    const [wordLine, lineLine, bgWordsLine] = lines;
+    expect(mainWords(wordLine)).toEqual(FLAT_WORDS);
+    expect(mainBounds(lineLine)).toEqual({ begin: 3.0, end: 7.5 });
+    const bg = bgVoice(bgWordsLine);
+    if (bg === null || !("words" in bg)) throw new Error("expected a word-synced background");
+    expect(bg.words).toEqual(FLAT_BG_WORDS);
+  });
+
+  it("aborts the import and keeps the saved project when a line is malformed", async () => {
+    allowConsole(/Failed to import from hash/);
+    await seedProject(savedSnapshot());
+    autoAcceptHashConfirm();
+    setHash(
+      encodeHashPayload({
+        metadata: { title: IMPORTED_TITLE, artist: "", album: "", duration: 0 },
+        agents: [IMPORTED_AGENT],
+        lines: [{ id: "bad", agentId: "v1" }],
+        granularity: "word" as const,
+      }),
+    );
+
+    await render(<HookHost />);
+    await waitForBootSettled();
+
+    const state = useProjectStore.getState();
+    expect(state.metadata.title).toBe(SAVED_TITLE);
+    expect(state.lines.map((l) => l.id)).toEqual([SAVED_LINE.id]);
   });
 });

--- a/src/hooks/useImportFromHash.ts
+++ b/src/hooks/useImportFromHash.ts
@@ -1,9 +1,9 @@
 import { loadCurrentProject } from "@/lib/persistence";
 import { getPersistenceSettled, markHashImportSettled } from "@/lib/persistence-settled";
+import { migrateLine } from "@/domain/line/migrate";
 import { useConfirm } from "@/stores/confirm-store";
 import { useProjectStore } from "@/stores/project";
 import type { Agent } from "@/domain/agent/model";
-import type { LyricLine } from "@/domain/line/model";
 import type { ProjectMetadata } from "@/domain/project/metadata";
 import { useEffect } from "react";
 import { toast } from "sonner";
@@ -13,7 +13,7 @@ const IMPORT_HASH_PREFIX = "#import=";
 interface ImportPayload {
   metadata: ProjectMetadata;
   agents: Agent[];
-  lines: LyricLine[];
+  lines: unknown[];
   granularity: "line" | "word";
 }
 
@@ -84,10 +84,13 @@ function useImportFromHash(): void {
           }
         }
 
+        // Migrate before reset() so a malformed line aborts the import without mutating the store.
+        const migratedLines = payload.lines.map(migrateLine);
+
         const state = useProjectStore.getState();
         state.reset();
         state.setMetadata(payload.metadata);
-        state.setLines(payload.lines);
+        state.setLines(migratedLines);
         state.setGranularity(payload.granularity);
         for (const agent of payload.agents) {
           if (!state.agents.some((existing) => existing.id === agent.id)) {

--- a/src/hooks/usePersistence.priming-migration.browser.test.tsx
+++ b/src/hooks/usePersistence.priming-migration.browser.test.tsx
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { renderHook } from "vitest-browser-react";
 import { parseLamePriming } from "@/audio/lame-priming";
 import { DEFAULT_AGENTS } from "@/domain/agent/colors";
-import type { WordTiming } from "@/domain/word/timing";
+import { reconcileLine } from "@/domain/line/model";
+import { mainWords } from "@/domain/line/voices";
 import { usePersistence } from "@/hooks/usePersistence";
 import { clearCurrentProject, loadCurrentProject, saveAudioFile, saveCurrentProject } from "@/lib/persistence";
 import { loadCurrentProjectWithPrimingMigration } from "@/lib/priming-migration";
@@ -17,7 +18,7 @@ function seedSavedProject(opts: { primingStripped: boolean }): Promise<void> {
     { title: "t", artist: "", album: "", duration: 0 },
     DEFAULT_AGENTS,
     [
-      {
+      reconcileLine({
         id: "L1",
         text: "hello world",
         agentId: DEFAULT_AGENTS[0].id,
@@ -25,7 +26,7 @@ function seedSavedProject(opts: { primingStripped: boolean }): Promise<void> {
           { text: "hello", begin: 1.0, end: 1.5 },
           { text: "world", begin: 1.5, end: 2.0 },
         ],
-      },
+      }),
     ],
     [],
     "word",
@@ -60,7 +61,7 @@ describe("loadCurrentProjectWithPrimingMigration", () => {
     const migrated = await loadCurrentProjectWithPrimingMigration();
     expect(migrated).toBeDefined();
     const shiftSec = samples / sampleRate;
-    const words = (migrated!.lines[0] as { words: WordTiming[] }).words;
+    const words = mainWords(migrated!.lines[0]) ?? [];
     expect(words[0].begin).toBeCloseTo(1.0 - shiftSec);
     expect(words[0].end).toBeCloseTo(1.5 - shiftSec);
     expect(words[1].begin).toBeCloseTo(1.5 - shiftSec);
@@ -74,7 +75,7 @@ describe("loadCurrentProjectWithPrimingMigration", () => {
     await seedSavedProject({ primingStripped: true });
 
     const loaded = await loadCurrentProjectWithPrimingMigration();
-    const words = (loaded!.lines[0] as { words: WordTiming[] }).words;
+    const words = mainWords(loaded!.lines[0]) ?? [];
     expect(words[0].begin).toBeCloseTo(1.0);
     expect(words[1].end).toBeCloseTo(2.0);
     expect(loaded!.primingStripped).toBe(true);
@@ -85,7 +86,7 @@ describe("loadCurrentProjectWithPrimingMigration", () => {
 
     const loaded = await loadCurrentProjectWithPrimingMigration();
     expect(loaded!.primingStripped).toBe(false);
-    const words = (loaded!.lines[0] as { words: WordTiming[] }).words;
+    const words = mainWords(loaded!.lines[0]) ?? [];
     expect(words[0].begin).toBeCloseTo(1.0);
     expect(words[1].end).toBeCloseTo(2.0);
   });
@@ -103,7 +104,7 @@ describe("loadCurrentProjectWithPrimingMigration", () => {
 
     const loaded = await loadCurrentProjectWithPrimingMigration();
     expect(loaded!.primingStripped).toBe(true);
-    const words = (loaded!.lines[0] as { words: WordTiming[] }).words;
+    const words = mainWords(loaded!.lines[0]) ?? [];
     expect(words[0].begin).toBeCloseTo(1.0);
   });
 });
@@ -135,7 +136,7 @@ describe("usePersistence priming-stripped flag survives the post-load debounced 
     await saveCurrentProject(
       { title: "race", artist: "", album: "", duration: 0 },
       DEFAULT_AGENTS,
-      [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
+      [reconcileLine({ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id })],
       [],
       "word",
       { applyToAll: false, caseInsensitive: false },
@@ -161,7 +162,7 @@ describe("usePersistence priming-stripped flag survives the post-load debounced 
     await saveCurrentProject(
       { title: "race-zero", artist: "", album: "", duration: 0 },
       DEFAULT_AGENTS,
-      [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
+      [reconcileLine({ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id })],
       [],
       "word",
       { applyToAll: false, caseInsensitive: false },

--- a/src/hooks/usePersistence.snap-points.browser.test.tsx
+++ b/src/hooks/usePersistence.snap-points.browser.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { renderHook } from "vitest-browser-react";
 import { DEFAULT_AGENTS } from "@/domain/agent/colors";
+import { reconcileLine } from "@/domain/line/model";
 import { usePersistence } from "@/hooks/usePersistence";
 import { useVocalOnsetSnapPoints } from "@/hooks/useVocalOnsetSnapPoints";
 import { clearCurrentProject, type SavedProject, saveAudioFile, saveCurrentProject } from "@/lib/persistence";
@@ -55,7 +56,7 @@ describe("usePersistence · customSnapPoints hydration", () => {
     await saveCurrentProject(
       { title: "with-markers", artist: "", album: "", duration: 0 },
       DEFAULT_AGENTS,
-      [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
+      [reconcileLine({ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id })],
       [],
       "word",
       { applyToAll: false, caseInsensitive: false },
@@ -82,7 +83,7 @@ describe("usePersistence · customSnapPoints hydration", () => {
       savedAt: Date.now(),
       metadata: { title: "legacy", artist: "", album: "", duration: 0 },
       agents: DEFAULT_AGENTS,
-      lines: [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
+      lines: [reconcileLine({ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id })],
       groups: [],
       granularity: "word",
       syllableSplitDefaults: { applyToAll: false, caseInsensitive: false },
@@ -108,7 +109,7 @@ describe("usePersistence · customSnapPoints hydration", () => {
     await saveCurrentProject(
       { title: "survives-load", artist: "", album: "", duration: 0 },
       DEFAULT_AGENTS,
-      [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
+      [reconcileLine({ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id })],
       [],
       "word",
       { applyToAll: false, caseInsensitive: false },

--- a/src/hooks/useSyncHandlers.browser.test.tsx
+++ b/src/hooks/useSyncHandlers.browser.test.tsx
@@ -1,3 +1,5 @@
+import { mainBounds } from "@/domain/line/bounds";
+import { bgText, bgWords as bgWordsOf, lineText, mainWords } from "@/domain/line/voices";
 import { useSyncHandlers } from "@/hooks/useSyncHandlers";
 import { useProjectStore } from "@/stores/project";
 import { createLine, createWord } from "@/test/factories";
@@ -57,12 +59,12 @@ describe("useSyncHandlers.handleTap (word granularity)", () => {
       await act(() => {
         result.current.handleTap();
       });
-      expect(useProjectStore.getState().lines[0].text).toBe(ORIGINAL_TEXT);
+      expect(lineText(useProjectStore.getState().lines[0])).toBe(ORIGINAL_TEXT);
       await rerender({ syncState: getSyncState(), currentTime: currentTime + 0.5 });
     }
 
-    expect(useProjectStore.getState().lines[0].words?.length).toBe(5);
-    expect(useProjectStore.getState().lines[0].text).toBe(ORIGINAL_TEXT);
+    expect(mainWords(useProjectStore.getState().lines[0])?.length).toBe(5);
+    expect(lineText(useProjectStore.getState().lines[0])).toBe(ORIGINAL_TEXT);
   });
 
   it("preserves both lines' text across a cross-line tap transition", async () => {
@@ -77,15 +79,15 @@ describe("useSyncHandlers.handleTap (word granularity)", () => {
       await act(() => {
         result.current.handleTap();
       });
-      expect(useProjectStore.getState().lines[0].text).toBe("Hello world");
-      expect(useProjectStore.getState().lines[1].text).toBe("Foo bar");
+      expect(lineText(useProjectStore.getState().lines[0])).toBe("Hello world");
+      expect(lineText(useProjectStore.getState().lines[1])).toBe("Foo bar");
       await rerender({ syncState: getSyncState(), currentTime: currentTime + 0.5 });
     }
 
-    expect(useProjectStore.getState().lines[0].words?.length).toBe(2);
-    expect(useProjectStore.getState().lines[1].words?.length).toBe(2);
-    expect(useProjectStore.getState().lines[0].text).toBe("Hello world");
-    expect(useProjectStore.getState().lines[1].text).toBe("Foo bar");
+    expect(mainWords(useProjectStore.getState().lines[0])?.length).toBe(2);
+    expect(mainWords(useProjectStore.getState().lines[1])?.length).toBe(2);
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("Hello world");
+    expect(lineText(useProjectStore.getState().lines[1])).toBe("Foo bar");
   });
 
   it("preserves text when re-syncing mid-line over an existing word array", async () => {
@@ -111,8 +113,8 @@ describe("useSyncHandlers.handleTap (word granularity)", () => {
       result.current.handleTap();
     });
 
-    expect(useProjectStore.getState().lines[0].text).toBe(ORIGINAL_TEXT);
-    expect(useProjectStore.getState().lines[0].words?.length).toBe(2);
+    expect(lineText(useProjectStore.getState().lines[0])).toBe(ORIGINAL_TEXT);
+    expect(mainWords(useProjectStore.getState().lines[0])?.length).toBe(2);
   });
 
   it("preserves prev-line text when patching a partially synced previous line on cross-line tap", async () => {
@@ -136,11 +138,11 @@ describe("useSyncHandlers.handleTap (word granularity)", () => {
     });
 
     const lines = useProjectStore.getState().lines;
-    expect(lines[0].text).toBe(ORIGINAL_TEXT);
-    expect(lines[0].words).toHaveLength(1);
-    expect(lines[0].words?.[0].end).toBe(TAP_TIME);
-    expect(lines[1].text).toBe("Next line");
-    expect(lines[1].words).toHaveLength(1);
+    expect(lineText(lines[0])).toBe(ORIGINAL_TEXT);
+    expect(mainWords(lines[0])).toHaveLength(1);
+    expect(mainWords(lines[0])?.[0].end).toBe(TAP_TIME);
+    expect(lineText(lines[1])).toBe("Next line");
+    expect(mainWords(lines[1])).toHaveLength(1);
   });
 });
 
@@ -155,17 +157,17 @@ describe("useSyncHandlers.handleTap (line granularity)", () => {
     await act(() => {
       result.current.handleTap();
     });
-    expect(useProjectStore.getState().lines[0].text).toBe("Verse start");
-    expect(useProjectStore.getState().lines[1].text).toBe("Verse two");
-    expect(useProjectStore.getState().lines[0].begin).toBe(0);
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("Verse start");
+    expect(lineText(useProjectStore.getState().lines[1])).toBe("Verse two");
+    expect(mainBounds(useProjectStore.getState().lines[0])?.begin).toBe(0);
     await rerender({ syncState: getSyncState(), currentTime: 1.0 });
 
     await act(() => {
       result.current.handleTap();
     });
-    expect(useProjectStore.getState().lines[0].text).toBe("Verse start");
-    expect(useProjectStore.getState().lines[1].text).toBe("Verse two");
-    expect(useProjectStore.getState().lines[1].begin).toBe(1.0);
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("Verse start");
+    expect(lineText(useProjectStore.getState().lines[1])).toBe("Verse two");
+    expect(mainBounds(useProjectStore.getState().lines[1])?.begin).toBe(1.0);
   });
 });
 
@@ -179,14 +181,14 @@ describe("useSyncHandlers.handleHold (word granularity)", () => {
     await act(() => {
       result.current.handleHoldStart();
     });
-    expect(useProjectStore.getState().lines[0].text).toBe(HOLD_TEXT);
+    expect(lineText(useProjectStore.getState().lines[0])).toBe(HOLD_TEXT);
     await rerender({ syncState: getSyncState(), currentTime: 0.5 });
 
     await act(() => {
       result.current.handleHoldEnd();
     });
-    expect(useProjectStore.getState().lines[0].text).toBe(HOLD_TEXT);
-    expect(useProjectStore.getState().lines[0].words?.length).toBe(1);
+    expect(lineText(useProjectStore.getState().lines[0])).toBe(HOLD_TEXT);
+    expect(mainWords(useProjectStore.getState().lines[0])?.length).toBe(1);
   });
 
   it("preserves text across a handleHoldTap sequence", async () => {
@@ -198,19 +200,19 @@ describe("useSyncHandlers.handleHold (word granularity)", () => {
     await act(() => {
       result.current.handleHoldStart();
     });
-    expect(useProjectStore.getState().lines[0].text).toBe(HOLD_TAP_TEXT);
+    expect(lineText(useProjectStore.getState().lines[0])).toBe(HOLD_TAP_TEXT);
     await rerender({ syncState: getSyncState(), currentTime: 0.4 });
 
     await act(() => {
       result.current.handleHoldTap();
     });
-    expect(useProjectStore.getState().lines[0].text).toBe(HOLD_TAP_TEXT);
+    expect(lineText(useProjectStore.getState().lines[0])).toBe(HOLD_TAP_TEXT);
     await rerender({ syncState: getSyncState(), currentTime: 0.8 });
 
     await act(() => {
       result.current.handleHoldTap();
     });
-    expect(useProjectStore.getState().lines[0].text).toBe(HOLD_TAP_TEXT);
+    expect(lineText(useProjectStore.getState().lines[0])).toBe(HOLD_TAP_TEXT);
   });
 
   it("preserves text when handleHoldStart re-enters a line that already has words", async () => {
@@ -233,8 +235,8 @@ describe("useSyncHandlers.handleHold (word granularity)", () => {
     });
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.text).toBe(TEXT);
-    expect(line.words).toHaveLength(2);
+    expect(lineText(line)).toBe(TEXT);
+    expect(mainWords(line)).toHaveLength(2);
   });
 
   it("preserves text when handleHoldEnd closes an open trailing word", async () => {
@@ -258,8 +260,8 @@ describe("useSyncHandlers.handleHold (word granularity)", () => {
     });
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.text).toBe(TEXT);
-    expect(line.words?.[1].end).toBe(END_TIME);
+    expect(lineText(line)).toBe(TEXT);
+    expect(mainWords(line)?.[1].end).toBe(END_TIME);
   });
 });
 
@@ -283,8 +285,8 @@ describe("sync-panel bg-init contract", () => {
 
     useProjectStore.getState().updateLine(line.id, { backgroundWords: bgWords }, { deriveText: false });
 
-    expect(useProjectStore.getState().lines[0].backgroundText).toBe(BG_TEXT);
-    expect(useProjectStore.getState().lines[0].text).toBe(ORIGINAL_LINE_TEXT);
-    expect(useProjectStore.getState().lines[0].backgroundWords?.length).toBeGreaterThan(0);
+    expect(bgText(useProjectStore.getState().lines[0])).toBe(BG_TEXT);
+    expect(lineText(useProjectStore.getState().lines[0])).toBe(ORIGINAL_LINE_TEXT);
+    expect(bgWordsOf(useProjectStore.getState().lines[0])?.length).toBeGreaterThan(0);
   });
 });

--- a/src/hooks/useSyncHandlers.browser.test.tsx
+++ b/src/hooks/useSyncHandlers.browser.test.tsx
@@ -1,9 +1,9 @@
 import { mainBounds } from "@/domain/line/bounds";
-import { bgText, bgWords as bgWordsOf, lineText, mainWords } from "@/domain/line/voices";
+import { lineText, mainWords } from "@/domain/line/voices";
 import { useSyncHandlers } from "@/hooks/useSyncHandlers";
 import { useProjectStore } from "@/stores/project";
 import { createLine, createWord } from "@/test/factories";
-import { createBgWordsFromLine, type SyncState } from "@/utils/sync-helpers";
+import type { SyncState } from "@/utils/sync-helpers";
 import { describe, expect, it } from "vitest";
 import { renderHook } from "vitest-browser-react";
 
@@ -262,31 +262,5 @@ describe("useSyncHandlers.handleHold (word granularity)", () => {
     const line = useProjectStore.getState().lines[0];
     expect(lineText(line)).toBe(TEXT);
     expect(mainWords(line)?.[1].end).toBe(END_TIME);
-  });
-});
-
-describe("sync-panel bg-init contract", () => {
-  it("preserves backgroundText and text when seeding backgroundWords on a synced line", async () => {
-    const BG_TEXT = "ooh ahh";
-    const ORIGINAL_LINE_TEXT = "Lead vocal melody line";
-    useProjectStore.getState().setLines([
-      createLine({
-        id: "l0",
-        text: ORIGINAL_LINE_TEXT,
-        backgroundText: BG_TEXT,
-        words: [createWord({ text: "Lead ", begin: 0, end: 0.5 }), createWord({ text: "vocal", begin: 0.5, end: 1.0 })],
-      }),
-    ]);
-
-    const line = useProjectStore.getState().lines[0];
-    const bgWords = createBgWordsFromLine(line);
-    expect(bgWords).not.toBeNull();
-    if (!bgWords) return;
-
-    useProjectStore.getState().updateLine(line.id, { backgroundWords: bgWords }, { deriveText: false });
-
-    expect(bgText(useProjectStore.getState().lines[0])).toBe(BG_TEXT);
-    expect(lineText(useProjectStore.getState().lines[0])).toBe(ORIGINAL_LINE_TEXT);
-    expect(bgWordsOf(useProjectStore.getState().lines[0])?.length).toBeGreaterThan(0);
   });
 });

--- a/src/hooks/useSyncHandlers.helpers.test.ts
+++ b/src/hooks/useSyncHandlers.helpers.test.ts
@@ -4,7 +4,7 @@ import {
   prepareSyncWord,
   withBgSeedIfNeeded,
 } from "@/hooks/useSyncHandlers.helpers";
-import type { LyricLine } from "@/domain/line/model";
+import type { LooseLine } from "@/domain/line/model";
 import { createLine } from "@/test/factories";
 import type { SyncState } from "@/utils/sync-helpers";
 import { describe, expect, it } from "vitest";
@@ -50,7 +50,7 @@ describe("prepareSyncWord", () => {
 describe("withBgSeedIfNeeded", () => {
   it("returns updates unchanged when line has no backgroundText", () => {
     const line = createLine({ text: "Hello" });
-    const updates: Partial<LyricLine> = { begin: 0, end: 1 };
+    const updates: Partial<LooseLine> = { begin: 0, end: 1 };
     const result = withBgSeedIfNeeded(updates, line, 0);
     expect(result.backgroundWords).toBeUndefined();
     expect(result).toBe(updates);
@@ -58,7 +58,7 @@ describe("withBgSeedIfNeeded", () => {
 
   it("seeds backgroundWords when backgroundText exists and backgroundWords empty", () => {
     const line = createLine({ text: "Hello", backgroundText: "ooh ahh" });
-    const result = withBgSeedIfNeeded<Partial<LyricLine>>({ begin: 0, end: 1 }, line, 0.5);
+    const result = withBgSeedIfNeeded<Partial<LooseLine>>({ begin: 0, end: 1 }, line, 0.5);
     expect(result.backgroundWords).toBeDefined();
     expect((result.backgroundWords ?? []).length).toBeGreaterThan(0);
   });
@@ -69,7 +69,7 @@ describe("withBgSeedIfNeeded", () => {
       backgroundText: "ooh ahh",
       backgroundWords: [{ text: "ooh", begin: 0, end: 1 }],
     });
-    const result = withBgSeedIfNeeded<Partial<LyricLine>>({}, line, 0);
+    const result = withBgSeedIfNeeded<Partial<LooseLine>>({}, line, 0);
     expect(result.backgroundWords).toBeUndefined();
   });
 });

--- a/src/hooks/useSyncHandlers.helpers.ts
+++ b/src/hooks/useSyncHandlers.helpers.ts
@@ -1,4 +1,5 @@
 import type { LyricLine } from "@/domain/line/model";
+import { bgText, bgWords, lineText } from "@/domain/line/voices";
 import { createInitialBgWords, splitIntoWordsWithMeta, type SyncState } from "@/utils/sync-helpers";
 
 // -- Types --------------------------------------------------------------------
@@ -23,7 +24,7 @@ function prepareSyncWord(
   if (lines.length === 0 || isComplete) return null;
   const line = lines[lineIndex];
   if (!line) return null;
-  const { parts: lineWords, trailingSpace } = splitIntoWordsWithMeta(line.text);
+  const { parts: lineWords, trailingSpace } = splitIntoWordsWithMeta(lineText(line));
   const wordText = lineWords[wordIndex];
   if (!wordText) return null;
   const textWithSpace = trailingSpace[wordIndex] ? `${wordText} ` : wordText;
@@ -31,8 +32,9 @@ function prepareSyncWord(
 }
 
 function withBgSeedIfNeeded<T extends Partial<LyricLine>>(updates: T, line: LyricLine, bgBegin: number): T {
-  if (line.backgroundText && !line.backgroundWords?.length) {
-    updates.backgroundWords = createInitialBgWords(line.backgroundText, bgBegin);
+  const bgTextValue = bgText(line);
+  if (bgTextValue && !bgWords(line)?.length) {
+    updates.backgroundWords = createInitialBgWords(bgTextValue, bgBegin);
   }
   return updates;
 }

--- a/src/hooks/useSyncHandlers.helpers.ts
+++ b/src/hooks/useSyncHandlers.helpers.ts
@@ -1,4 +1,4 @@
-import type { LyricLine } from "@/domain/line/model";
+import type { LooseLine, LyricLine } from "@/domain/line/model";
 import { bgText, bgWords, lineText } from "@/domain/line/voices";
 import { createInitialBgWords, splitIntoWordsWithMeta, type SyncState } from "@/utils/sync-helpers";
 
@@ -31,7 +31,7 @@ function prepareSyncWord(
   return { line, lineWords, trailingSpace, textWithSpace };
 }
 
-function withBgSeedIfNeeded<T extends Partial<LyricLine>>(updates: T, line: LyricLine, bgBegin: number): T {
+function withBgSeedIfNeeded<T extends Partial<LooseLine>>(updates: T, line: LyricLine, bgBegin: number): T {
   const bgTextValue = bgText(line);
   if (bgTextValue && !bgWords(line)?.length) {
     updates.backgroundWords = createInitialBgWords(bgTextValue, bgBegin);
@@ -44,7 +44,7 @@ function buildInitialWordUpdates(
   textWithSpace: string,
   begin: number,
   end: number,
-): Partial<LyricLine> {
+): Partial<LooseLine> {
   return withBgSeedIfNeeded({ words: [{ text: textWithSpace, begin, end }] }, line, begin);
 }
 

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -2,6 +2,8 @@ import { useAudioStore } from "@/stores/audio";
 import { useConfirm } from "@/stores/confirm-store";
 import { useProjectStore } from "@/stores/project";
 import type { LyricLine } from "@/domain/line/model";
+import { isLineSynced, hasAnyTiming } from "@/domain/line/predicates";
+import { lineText, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { useSettingsStore } from "@/stores/settings";
 import { effectiveBounds } from "@/domain/line/bounds";
@@ -65,7 +67,7 @@ function useSyncHandlers({
     const { line, lineWords, textWithSpace } = prepared;
 
     const fallbackEnd = currentTime + useSettingsStore.getState().defaultWordDuration;
-    const existingWords = line.words ?? [];
+    const existingWords = mainWords(line) ?? [];
 
     if (existingWords.length > 0) {
       const updatedWords = commitTappedWord(existingWords, wordIndex, textWithSpace, currentTime, fallbackEnd);
@@ -75,8 +77,9 @@ function useSyncHandlers({
       updateLineWithHistory(line.id, updates, { deriveText: false, propagateToSiblings: false });
     }
 
-    if (wordIndex === 0 && prevLine?.words?.length) {
-      const prevWords = [...prevLine.words];
+    const prevWordsForTap = prevLine ? mainWords(prevLine) : undefined;
+    if (wordIndex === 0 && prevLine && prevWordsForTap?.length) {
+      const prevWords = [...prevWordsForTap];
       prevWords[prevWords.length - 1] = {
         ...prevWords[prevWords.length - 1],
         end: currentTime,
@@ -105,7 +108,7 @@ function useSyncHandlers({
     const line = lines[lineIndex];
     if (!line) return;
 
-    if (prevLine?.begin !== undefined) {
+    if (prevLine && isLineSynced(prevLine)) {
       updateLine(prevLine.id, { end: currentTime }, { deriveText: false });
     }
 
@@ -134,7 +137,7 @@ function useSyncHandlers({
     if (!prepared) return;
     const { line, textWithSpace } = prepared;
 
-    const existingWords = line.words ?? [];
+    const existingWords = mainWords(line) ?? [];
 
     if (existingWords.length > 0) {
       const updatedWords = commitHeldWord(existingWords, wordIndex, textWithSpace, currentTime);
@@ -144,8 +147,9 @@ function useSyncHandlers({
       updateLineWithHistory(line.id, updates, { deriveText: false, propagateToSiblings: false });
     }
 
-    if (wordIndex === 0 && prevLine?.words?.length) {
-      const prevWords = [...prevLine.words];
+    const prevWordsForHold = prevLine ? mainWords(prevLine) : undefined;
+    if (wordIndex === 0 && prevLine && prevWordsForHold?.length) {
+      const prevWords = [...prevWordsForHold];
       const lastPrevWord = prevWords[prevWords.length - 1];
       if (lastPrevWord.end === lastPrevWord.begin) {
         prevWords[prevWords.length - 1] = { ...lastPrevWord, end: currentTime };
@@ -158,11 +162,12 @@ function useSyncHandlers({
     if (lines.length === 0 || isComplete) return;
 
     const line = lines[lineIndex];
-    if (!line?.words?.length) return;
+    const holdEndWords = line ? mainWords(line) : undefined;
+    if (!line || !holdEndWords?.length) return;
 
-    const { parts: lineWords } = splitIntoWordsWithMeta(line.text);
+    const { parts: lineWords } = splitIntoWordsWithMeta(lineText(line));
 
-    const updatedWords = [...line.words];
+    const updatedWords = [...holdEndWords];
     const currentWordEntry = updatedWords[updatedWords.length - 1];
     updatedWords[updatedWords.length - 1] = { ...currentWordEntry, end: currentTime };
     updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false, propagateToSiblings: false });
@@ -175,11 +180,12 @@ function useSyncHandlers({
     if (lines.length === 0 || isComplete) return;
 
     const line = lines[lineIndex];
-    if (!line?.words?.length) return;
+    const holdTapWords = line ? mainWords(line) : undefined;
+    if (!line || !holdTapWords?.length) return;
 
-    const { parts: lineWords, trailingSpace } = splitIntoWordsWithMeta(line.text);
+    const { parts: lineWords, trailingSpace } = splitIntoWordsWithMeta(lineText(line));
 
-    const updatedWords = [...line.words];
+    const updatedWords = [...holdTapWords];
     const currentWordEntry = updatedWords[updatedWords.length - 1];
     updatedWords[updatedWords.length - 1] = { ...currentWordEntry, end: currentTime };
 
@@ -191,7 +197,7 @@ function useSyncHandlers({
 
       const nextLine = lines[lineIndex + 1];
       if (nextLine) {
-        const { parts: nextLineWords, trailingSpace: nextTrailingSpace } = splitIntoWordsWithMeta(nextLine.text);
+        const { parts: nextLineWords, trailingSpace: nextTrailingSpace } = splitIntoWordsWithMeta(lineText(nextLine));
         const nextWordText = nextLineWords[0];
         if (nextWordText) {
           const textWithSpace = nextTrailingSpace[0] ? `${nextWordText} ` : nextWordText;
@@ -224,11 +230,8 @@ function useSyncHandlers({
   const handleTap = granularity === "word" ? handleTapWord : handleTapLine;
 
   const handleReset = useCallback(async () => {
-    const hasAnyTiming = lines.some(
-      (line) =>
-        line.words?.length || line.begin !== undefined || line.end !== undefined || line.backgroundWords?.length,
-    );
-    if (hasAnyTiming) {
+    const anyLineTimed = lines.some((line) => hasAnyTiming(line));
+    if (anyLineTimed) {
       const ok = await confirm({
         title: "Reset all sync timing?",
         description: "Clear every word and line timing in this project.",
@@ -313,7 +316,7 @@ function useSyncHandlers({
     (delta: number) => {
       if (granularity === "line") {
         for (let i = lines.length - 1; i >= 0; i--) {
-          if (lines[i].begin !== undefined) {
+          if (isLineSynced(lines[i])) {
             handleNudgeLine(i, delta);
             return;
           }
@@ -321,8 +324,9 @@ function useSyncHandlers({
       } else {
         for (let i = lines.length - 1; i >= 0; i--) {
           const line = lines[i];
-          if (line.words?.length) {
-            const lastWordIdx = line.words.length - 1;
+          const lineWords = mainWords(line);
+          if (lineWords?.length) {
+            const lastWordIdx = lineWords.length - 1;
             handleNudgeWord(i, lastWordIdx, delta);
             return;
           }
@@ -335,9 +339,10 @@ function useSyncHandlers({
   const handleSplitWord = useCallback(
     (lineIdx: number, wordIdx: number, newWords: WordTiming[]) => {
       const line = lines[lineIdx];
-      if (!line?.words) return;
+      const splitWords = line ? mainWords(line) : undefined;
+      if (!line || !splitWords) return;
 
-      const updatedWords = [...line.words];
+      const updatedWords = [...splitWords];
       updatedWords.splice(wordIdx, 1, ...newWords);
       const newLineText = updatedWords
         .map((w) => w.text)
@@ -394,7 +399,7 @@ function useSyncHandlers({
     handleSetBgWordEndTime,
     isComplete,
     currentLine,
-    currentWord: currentLine?.text ? splitIntoWords(currentLine.text)[wordIndex] : undefined,
+    currentWord: currentLine && lineText(currentLine) ? splitIntoWords(lineText(currentLine))[wordIndex] : undefined,
   };
 }
 

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -1,7 +1,7 @@
 import { useAudioStore } from "@/stores/audio";
 import { useConfirm } from "@/stores/confirm-store";
 import { useProjectStore } from "@/stores/project";
-import type { LyricLine } from "@/domain/line/model";
+import type { LooseLine, LyricLine } from "@/domain/line/model";
 import { isLineSynced, hasAnyTiming } from "@/domain/line/predicates";
 import { lineText, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
@@ -112,7 +112,7 @@ function useSyncHandlers({
       updateLine(prevLine.id, { end: currentTime }, { deriveText: false });
     }
 
-    const updates = withBgSeedIfNeeded<Partial<LyricLine>>({ begin: currentTime, end: currentTime }, line, currentTime);
+    const updates = withBgSeedIfNeeded<Partial<LooseLine>>({ begin: currentTime, end: currentTime }, line, currentTime);
     updateLineWithHistory(line.id, updates, { deriveText: false, propagateToSiblings: false });
 
     triggerPulse(setShowPulse);

--- a/src/lib/persistence.migrate.browser.test.ts
+++ b/src/lib/persistence.migrate.browser.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { bgVoice, mainWords } from "@/domain/line/voices";
+import { clearCurrentProject, loadCurrentProject } from "@/lib/persistence";
+import { DEFAULT_AGENTS } from "@/domain/agent/colors";
+import { mainBounds } from "@/domain/line/bounds";
+import { PROJECT_STORE_NAME, setInStore } from "@/lib/persistence-idb";
+import type { WordTiming } from "@/domain/word/timing";
+
+// The shared browser setup (src/test/setup-browser.ts) deletes the entire
+// `ttml-composer` database before every test. We also clear the current
+// project record explicitly to mirror the existing IDB test style. These tests
+// run in the browser project because loadCurrentProject hits real IndexedDB.
+
+// -- Fixtures -----------------------------------------------------------------
+
+const wordSyncedWords: WordTiming[] = [
+  { text: "Hel", begin: 1.2, end: 1.6 },
+  { text: "lo", begin: 1.6, end: 2.1 },
+];
+
+const backgroundWords: WordTiming[] = [
+  { text: "ah ", begin: 6.0, end: 7.2 },
+  { text: "oh", begin: 7.2, end: 8.5 },
+];
+
+// A pre-voice-model project blob: lines carry flat sibling timing fields.
+function oldFlatProject() {
+  return {
+    version: 1 as const,
+    savedAt: Date.now(),
+    metadata: { title: "Legacy", artist: "", album: "", duration: 0 },
+    agents: DEFAULT_AGENTS,
+    lines: [
+      { id: "l1", agentId: "v1", text: "Hello", words: wordSyncedWords },
+      { id: "l2", agentId: "v1", text: "Line synced", begin: 3.0, end: 7.5 },
+      { id: "l3", agentId: "v1", text: "Main", backgroundText: "ooh" },
+      { id: "l4", agentId: "v1", text: "Main", begin: 3.0, end: 7.5, backgroundWords },
+    ],
+    groups: [],
+    granularity: "word" as const,
+  };
+}
+
+function nestedProject() {
+  return {
+    version: 1 as const,
+    savedAt: Date.now(),
+    metadata: { title: "Nested", artist: "", album: "", duration: 0 },
+    agents: DEFAULT_AGENTS,
+    lines: [
+      { id: "n1", agentId: "v1", main: { text: "Hello", words: wordSyncedWords } },
+      {
+        id: "n2",
+        agentId: "v1",
+        main: { text: "Main", begin: 3.0, end: 7.5 },
+        background: { text: "ooh oh", words: backgroundWords, source: "extraction" as const },
+      },
+    ],
+    groups: [],
+    granularity: "word" as const,
+  };
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("persistence · loadCurrentProject legacy migration", () => {
+  beforeEach(async () => {
+    await clearCurrentProject();
+  });
+  afterEach(async () => {
+    await clearCurrentProject();
+  });
+
+  it("migrates flat lines from a stored old-format project into nested voices", async () => {
+    await setInStore(PROJECT_STORE_NAME, "current", oldFlatProject());
+
+    const project = await loadCurrentProject();
+    if (!project) throw new Error("expected a stored project");
+
+    const [wordLine, lineLine, bgTextLine, bgWordsLine] = project.lines;
+
+    expect(mainWords(wordLine)).toEqual(wordSyncedWords);
+    expect(mainBounds(lineLine)).toEqual({ begin: 3.0, end: 7.5 });
+    expect(bgVoice(bgTextLine)).toEqual({ text: "ooh", source: undefined });
+
+    const bg = bgVoice(bgWordsLine);
+    if (bg === null || !("words" in bg)) throw new Error("expected a word-synced background");
+    expect(bg.words).toEqual(backgroundWords);
+  });
+
+  it("returns undefined when no project is stored", async () => {
+    const project = await loadCurrentProject();
+    expect(project).toBeUndefined();
+  });
+
+  it("loads an already-nested project unchanged (idempotent)", async () => {
+    const stored = nestedProject();
+    await setInStore(PROJECT_STORE_NAME, "current", stored);
+
+    const project = await loadCurrentProject();
+    if (!project) throw new Error("expected a stored project");
+
+    expect(project.lines).toEqual(stored.lines);
+  });
+});

--- a/src/lib/persistence.snap-points.browser.test.ts
+++ b/src/lib/persistence.snap-points.browser.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DEFAULT_AGENTS } from "@/domain/agent/colors";
+import { reconcileLine } from "@/domain/line/model";
 import type { SnapPoint } from "@/domain/snap-point/model";
 import { clearCurrentProject, loadCurrentProject, type SavedProject, saveCurrentProject } from "@/lib/persistence";
 import { PROJECT_STORE_NAME, setInStore } from "@/lib/persistence-idb";
@@ -15,7 +16,7 @@ function saveWithSnapPoints(customSnapPoints: SnapPoint[]): Promise<void> {
   return saveCurrentProject(
     { title: "snap", artist: "", album: "", duration: 0 },
     DEFAULT_AGENTS,
-    [{ id: "L1", text: "hello", agentId: DEFAULT_AGENTS[0].id }],
+    [reconcileLine({ id: "L1", text: "hello", agentId: DEFAULT_AGENTS[0].id })],
     [],
     "word",
     { applyToAll: false, caseInsensitive: false },
@@ -73,7 +74,7 @@ describe("persistence · customSnapPoints", () => {
       savedAt: Date.now(),
       metadata: { title: "legacy", artist: "", album: "", duration: 0 },
       agents: DEFAULT_AGENTS,
-      lines: [{ id: "L1", text: "hello", agentId: DEFAULT_AGENTS[0].id }],
+      lines: [reconcileLine({ id: "L1", text: "hello", agentId: DEFAULT_AGENTS[0].id })],
       groups: [],
       granularity: "word",
       syllableSplitDefaults: { applyToAll: false, caseInsensitive: false },

--- a/src/lib/persistence.test.ts
+++ b/src/lib/persistence.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_AGENTS } from "@/domain/agent/colors";
+import { bgVoice, mainWords } from "@/domain/line/voices";
 import { importProjectFromFile } from "@/lib/persistence";
+import { mainBounds } from "@/domain/line/bounds";
+import type { WordTiming } from "@/domain/word/timing";
 
 describe("persistence: syllableSplitDefaults", () => {
   it("round-trips syllableSplitDefaults through importProjectFromFile", async () => {
@@ -136,5 +139,85 @@ describe("persistence: customSnapPoints round-trip", () => {
     const parsed = await importProjectFromFile(file);
 
     expect(parsed.customSnapPoints).toBeUndefined();
+  });
+});
+
+// -- Legacy flat-to-nested migration at the load boundary ---------------------
+
+const wordSyncedWords: WordTiming[] = [
+  { text: "Hel", begin: 1.2, end: 1.6 },
+  { text: "lo", begin: 1.6, end: 2.1 },
+];
+
+const bgWords: WordTiming[] = [
+  { text: "ah ", begin: 6.0, end: 7.2 },
+  { text: "oh", begin: 7.2, end: 8.5 },
+];
+
+// A pre-voice-model project blob: lines carry flat sibling timing fields.
+function oldFlatProject() {
+  return {
+    version: 1 as const,
+    savedAt: Date.now(),
+    metadata: { title: "Legacy", artist: "", album: "", duration: 0 },
+    agents: DEFAULT_AGENTS,
+    lines: [
+      { id: "l1", agentId: "v1", text: "Hello", words: wordSyncedWords },
+      { id: "l2", agentId: "v1", text: "Line synced", begin: 3.0, end: 7.5 },
+      { id: "l3", agentId: "v1", text: "Main", backgroundText: "ooh" },
+      { id: "l4", agentId: "v1", text: "Main", begin: 3.0, end: 7.5, backgroundWords: bgWords },
+    ],
+    groups: [],
+    granularity: "word" as const,
+  };
+}
+
+// An already-nested (current-format) project blob.
+function nestedProject() {
+  return {
+    version: 1 as const,
+    savedAt: Date.now(),
+    metadata: { title: "Nested", artist: "", album: "", duration: 0 },
+    agents: DEFAULT_AGENTS,
+    lines: [
+      { id: "n1", agentId: "v1", main: { text: "Hello", words: wordSyncedWords } },
+      {
+        id: "n2",
+        agentId: "v1",
+        main: { text: "Main", begin: 3.0, end: 7.5 },
+        background: { text: "ooh oh", words: bgWords, source: "extraction" as const },
+      },
+    ],
+    groups: [],
+    granularity: "word" as const,
+  };
+}
+
+describe("persistence: legacy flat-to-nested migration on load", () => {
+  describe("importProjectFromFile", () => {
+    it("migrates flat lines from an imported old-format file into nested voices", async () => {
+      const file = new File([JSON.stringify(oldFlatProject())], "legacy.ttml-project.json", {
+        type: "application/json",
+      });
+
+      const project = await importProjectFromFile(file);
+
+      const [wordLine, lineLine, bgTextLine, bgWordsLine] = project.lines;
+      expect(mainWords(wordLine)).toEqual(wordSyncedWords);
+      expect(mainBounds(lineLine)).toEqual({ begin: 3.0, end: 7.5 });
+      expect(bgVoice(bgTextLine)).toEqual({ text: "ooh", source: undefined });
+      const bg = bgVoice(bgWordsLine);
+      if (bg === null || !("words" in bg)) throw new Error("expected a word-synced background");
+      expect(bg.words).toEqual(bgWords);
+    });
+
+    it("imports an already-nested project file unchanged (idempotent)", async () => {
+      const stored = nestedProject();
+      const file = new File([JSON.stringify(stored)], "nested.ttml-project.json", { type: "application/json" });
+
+      const project = await importProjectFromFile(file);
+
+      expect(project.lines).toEqual(stored.lines);
+    });
   });
 });

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -4,6 +4,7 @@ import { DEFAULT_SYLLABLE_SPLIT_DEFAULTS, type SyllableSplitDefaults } from "@/s
 import type { Agent } from "@/domain/agent/model";
 import type { LinkGroup } from "@/domain/group/template";
 import type { LyricLine } from "@/domain/line/model";
+import { migrateLine } from "@/domain/line/migrate";
 import { PROJECT_STORE_NAME, deleteFromStore, getFromStore, setInStore } from "@/lib/persistence-idb";
 import type { ProjectMetadata } from "@/domain/project/metadata";
 import type { SnapPoint } from "@/domain/snap-point/model";
@@ -34,6 +35,17 @@ interface SavedProject {
 
 const CURRENT_PROJECT_KEY = "current";
 const AUDIO_FILE_KEY = "current-audio";
+
+// -- Helpers ------------------------------------------------------------------
+
+// Lifts persisted lines (which may still be the legacy flat shape) to the
+// nested voice model. A record whose `lines` is missing or not an array is
+// passed through untouched: record-level malformed-field handling and its warn
+// live in usePersistence, which falls back to an empty array.
+function migrateLines(lines: SavedProject["lines"]): LyricLine[] {
+  if (!Array.isArray(lines)) return lines;
+  return (lines as unknown[]).map(migrateLine);
+}
 
 // -- Public API ---------------------------------------------------------------
 
@@ -73,7 +85,9 @@ async function saveCurrentProject(
 }
 
 async function loadCurrentProject(): Promise<SavedProject | undefined> {
-  return getFromStore<SavedProject>(PROJECT_STORE_NAME, CURRENT_PROJECT_KEY);
+  const project = await getFromStore<SavedProject>(PROJECT_STORE_NAME, CURRENT_PROJECT_KEY);
+  if (project) project.lines = migrateLines(project.lines);
+  return project;
 }
 
 async function replaceCurrentProject(project: SavedProject): Promise<void> {
@@ -161,6 +175,8 @@ async function importProjectFromFile(file: File): Promise<SavedProject> {
   if (!project.syllableSplitDefaults) {
     project.syllableSplitDefaults = DEFAULT_SYLLABLE_SPLIT_DEFAULTS;
   }
+
+  project.lines = migrateLines(project.lines);
 
   return project;
 }

--- a/src/lib/priming-migration.test.ts
+++ b/src/lib/priming-migration.test.ts
@@ -1,16 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { shiftAllTimings } from "@/lib/priming-migration";
+import { mainBounds } from "@/domain/line/bounds";
+import { reconcileLine } from "@/domain/line/model";
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { shiftAllTimings } from "@/lib/priming-migration";
 import type { WordTiming } from "@/domain/word/timing";
 
 // -- Helpers ------------------------------------------------------------------
 
 function lineSynced(id: string, begin: number, end: number): LyricLine {
-  return { id, text: "x", agentId: "a", begin, end };
+  return reconcileLine({ id, text: "x", agentId: "a", begin, end });
 }
 
 function wordSynced(id: string, words: WordTiming[]): LyricLine {
-  return { id, text: words.map((w) => w.text).join(" "), agentId: "a", words };
+  return reconcileLine({ id, text: words.map((w) => w.text).join(" "), agentId: "a", words });
 }
 
 // -- Tests --------------------------------------------------------------------
@@ -18,9 +21,9 @@ function wordSynced(id: string, words: WordTiming[]): LyricLine {
 describe("shiftAllTimings", () => {
   it("subtracts the shift from line begin and end", () => {
     const out = shiftAllTimings([lineSynced("L", 1.0, 2.0)], 0.5);
-    const line = out[0] as { begin: number; end: number };
-    expect(line.begin).toBeCloseTo(0.5);
-    expect(line.end).toBeCloseTo(1.5);
+    const bounds = mainBounds(out[0]);
+    expect(bounds?.begin).toBeCloseTo(0.5);
+    expect(bounds?.end).toBeCloseTo(1.5);
   });
 
   it("subtracts the shift from every word begin and end", () => {
@@ -33,7 +36,7 @@ describe("shiftAllTimings", () => {
       ],
       0.5,
     );
-    const words = (out[0] as { words: WordTiming[] }).words;
+    const words = mainWords(out[0]) ?? [];
     expect(words[0].begin).toBeCloseTo(0.5);
     expect(words[0].end).toBeCloseTo(1.0);
     expect(words[1].begin).toBeCloseTo(1.0);
@@ -42,23 +45,23 @@ describe("shiftAllTimings", () => {
 
   it("subtracts the shift from background words", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L",
         text: "main",
         agentId: "a",
         words: [{ text: "main", begin: 1.0, end: 2.0 }],
         backgroundText: "bg",
         backgroundWords: [{ text: "bg", begin: 1.2, end: 1.8 }],
-      },
+      }),
     ];
     const out = shiftAllTimings(lines, 0.5);
-    const bg = (out[0] as { backgroundWords: WordTiming[] }).backgroundWords;
+    const bg = bgWords(out[0]) ?? [];
     expect(bg[0].begin).toBeCloseTo(0.7);
     expect(bg[0].end).toBeCloseTo(1.3);
   });
 
   it("leaves untimed lines untouched", () => {
-    const lines: LyricLine[] = [{ id: "L", text: "no timing", agentId: "a" }];
+    const lines: LyricLine[] = [reconcileLine({ id: "L", text: "no timing", agentId: "a" })];
     const out = shiftAllTimings(lines, 0.5);
     expect(out[0]).toEqual(lines[0]);
   });
@@ -71,15 +74,15 @@ describe("shiftAllTimings", () => {
 
   it("preserves WordTiming extras like explicit and syllableGroupId", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L",
         text: "x",
         agentId: "a",
         words: [{ text: "x", begin: 1.0, end: 1.5, explicit: true, syllableGroupId: "g1" }],
-      },
+      }),
     ];
     const shifted = shiftAllTimings(lines, 0.5);
-    const w = (shifted[0] as { words: WordTiming[] }).words[0];
+    const w = (mainWords(shifted[0]) ?? [])[0];
     expect(w.explicit).toBe(true);
     expect(w.syllableGroupId).toBe("g1");
     expect(w.begin).toBeCloseTo(0.5);
@@ -88,16 +91,16 @@ describe("shiftAllTimings", () => {
 
   it("preserves background word extras", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L",
         text: "main",
         agentId: "a",
         backgroundText: "bg",
         backgroundWords: [{ text: "bg", begin: 1.0, end: 1.5, explicit: true, syllableGroupId: "g2" }],
-      },
+      }),
     ];
     const out = shiftAllTimings(lines, 0.5);
-    const bg = (out[0] as { backgroundWords: WordTiming[] }).backgroundWords[0];
+    const bg = (bgWords(out[0]) ?? [])[0];
     expect(bg.explicit).toBe(true);
     expect(bg.syllableGroupId).toBe("g2");
     expect(bg.begin).toBeCloseTo(0.5);
@@ -105,7 +108,7 @@ describe("shiftAllTimings", () => {
 
   it("preserves LineFields like agentId, text, groupId, instanceIdx across all variants", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "wsl",
         text: "hi",
         agentId: "v1",
@@ -113,8 +116,8 @@ describe("shiftAllTimings", () => {
         instanceIdx: 2,
         templateLineIdx: 0,
         words: [{ text: "hi", begin: 1.0, end: 1.5 }],
-      },
-      {
+      }),
+      reconcileLine({
         id: "lsl",
         text: "world",
         agentId: "v2",
@@ -122,14 +125,14 @@ describe("shiftAllTimings", () => {
         instanceIdx: 1,
         begin: 2.0,
         end: 3.0,
-      },
+      }),
     ];
     const out = shiftAllTimings(lines, 0.5);
     expect(out[0].agentId).toBe("v1");
     expect(out[0].groupId).toBe("g1");
     expect(out[0].instanceIdx).toBe(2);
     expect(out[0].templateLineIdx).toBe(0);
-    expect(out[0].text).toBe("hi");
+    expect(lineText(out[0])).toBe("hi");
     expect(out[1].agentId).toBe("v2");
     expect(out[1].groupId).toBe("g2");
     expect(out[1].instanceIdx).toBe(1);
@@ -139,9 +142,9 @@ describe("shiftAllTimings", () => {
 describe("shiftAllTimings: edge cases", () => {
   it("clamps negative line timings to 0", () => {
     const out = shiftAllTimings([lineSynced("L", 0.1, 0.4)], 0.5);
-    const line = out[0] as { begin: number; end: number };
-    expect(line.begin).toBe(0);
-    expect(line.end).toBe(0);
+    const bounds = mainBounds(out[0]);
+    expect(bounds?.begin).toBe(0);
+    expect(bounds?.end).toBe(0);
   });
 
   it("clamps negative word timings to 0", () => {
@@ -154,7 +157,7 @@ describe("shiftAllTimings: edge cases", () => {
       ],
       0.5,
     );
-    const words = (out[0] as { words: WordTiming[] }).words;
+    const words = mainWords(out[0]) ?? [];
     expect(words[0].begin).toBe(0);
     expect(words[0].end).toBe(0);
     expect(words[1].begin).toBeCloseTo(0.1);
@@ -163,16 +166,16 @@ describe("shiftAllTimings: edge cases", () => {
 
   it("clamps negative background word timings to 0", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L",
         text: "main",
         agentId: "a",
         backgroundText: "bg",
         backgroundWords: [{ text: "bg", begin: 0.1, end: 0.3 }],
-      },
+      }),
     ];
     const out = shiftAllTimings(lines, 0.5);
-    const bg = (out[0] as { backgroundWords: WordTiming[] }).backgroundWords[0];
+    const bg = (bgWords(out[0]) ?? [])[0];
     expect(bg.begin).toBe(0);
     expect(bg.end).toBe(0);
   });
@@ -183,9 +186,9 @@ describe("shiftAllTimings: edge cases", () => {
   });
 
   it("handles a word-synced line with no words", () => {
-    const lines: LyricLine[] = [{ id: "L", text: "", agentId: "a", words: [] }];
+    const lines: LyricLine[] = [reconcileLine({ id: "L", text: "", agentId: "a", words: [] })];
     const out = shiftAllTimings(lines, 0.5);
-    expect((out[0] as { words: WordTiming[] }).words).toEqual([]);
+    expect(mainWords(out[0]) ?? []).toEqual([]);
   });
 });
 
@@ -194,13 +197,13 @@ describe("shiftAllTimings: invariants", () => {
     const lines: LyricLine[] = [
       lineSynced("L1", 1.0, 2.0),
       wordSynced("L2", [{ text: "x", begin: 1.0, end: 1.5 }]),
-      {
+      reconcileLine({
         id: "L3",
         text: "main",
         agentId: "a",
         backgroundText: "bg",
         backgroundWords: [{ text: "bg", begin: 1.0, end: 1.5 }],
-      },
+      }),
     ];
     const snapshot = JSON.parse(JSON.stringify(lines));
     shiftAllTimings(lines, 0.5);
@@ -210,7 +213,7 @@ describe("shiftAllTimings: invariants", () => {
   it("returns the same length output", () => {
     const lines: LyricLine[] = [
       lineSynced("L1", 1.0, 2.0),
-      { id: "L2", text: "untimed", agentId: "a" },
+      reconcileLine({ id: "L2", text: "untimed", agentId: "a" }),
       wordSynced("L3", [{ text: "x", begin: 1.0, end: 1.5 }]),
     ];
     const out = shiftAllTimings(lines, 0.5);

--- a/src/lib/priming-migration.ts
+++ b/src/lib/priming-migration.ts
@@ -1,6 +1,7 @@
 import { parseLamePriming } from "@/audio/lame-priming";
 import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { loadAudioFile, loadCurrentProject, replaceCurrentProject, type SavedProject } from "@/lib/persistence";
 
@@ -16,15 +17,17 @@ function shiftWord(word: WordTiming, shiftSec: number): WordTiming {
 
 function shiftLine(line: LyricLine, shiftSec: number): LyricLine {
   const next = { ...line } as LyricLine;
-  if (isWordSynced(next)) {
-    (next as { words: WordTiming[] }).words = next.words!.map((w) => shiftWord(w, shiftSec));
+  const nextWords = mainWords(next);
+  if (isWordSynced(next) && nextWords) {
+    (next as { words: WordTiming[] }).words = nextWords.map((w) => shiftWord(w, shiftSec));
   }
   if (isLineSynced(next)) {
     (next as { begin: number; end: number }).begin = Math.max(0, next.begin - shiftSec);
     (next as { begin: number; end: number }).end = Math.max(0, next.end - shiftSec);
   }
-  if (next.backgroundWords) {
-    next.backgroundWords = next.backgroundWords.map((w) => shiftWord(w, shiftSec));
+  const nextBgWords = bgWords(next);
+  if (nextBgWords) {
+    next.backgroundWords = nextBgWords.map((w) => shiftWord(w, shiftSec));
   }
   return next;
 }

--- a/src/lib/priming-migration.ts
+++ b/src/lib/priming-migration.ts
@@ -1,6 +1,7 @@
 import { parseLamePriming } from "@/audio/lame-priming";
-import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
-import type { LyricLine } from "@/domain/line/model";
+import { mainBounds } from "@/domain/line/bounds";
+import { isLineSynced } from "@/domain/line/predicates";
+import { reconcileLine, toFlat, type LyricLine } from "@/domain/line/model";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { loadAudioFile, loadCurrentProject, replaceCurrentProject, type SavedProject } from "@/lib/persistence";
@@ -16,20 +17,19 @@ function shiftWord(word: WordTiming, shiftSec: number): WordTiming {
 }
 
 function shiftLine(line: LyricLine, shiftSec: number): LyricLine {
-  const next = { ...line } as LyricLine;
-  const nextWords = mainWords(next);
-  if (isWordSynced(next) && nextWords) {
-    (next as { words: WordTiming[] }).words = nextWords.map((w) => shiftWord(w, shiftSec));
+  const flat = toFlat(line);
+  const words = mainWords(line);
+  if (words) flat.words = words.map((w) => shiftWord(w, shiftSec));
+  if (isLineSynced(line)) {
+    const mb = mainBounds(line);
+    if (mb) {
+      flat.begin = Math.max(0, mb.begin - shiftSec);
+      flat.end = Math.max(0, mb.end - shiftSec);
+    }
   }
-  if (isLineSynced(next)) {
-    (next as { begin: number; end: number }).begin = Math.max(0, next.begin - shiftSec);
-    (next as { begin: number; end: number }).end = Math.max(0, next.end - shiftSec);
-  }
-  const nextBgWords = bgWords(next);
-  if (nextBgWords) {
-    next.backgroundWords = nextBgWords.map((w) => shiftWord(w, shiftSec));
-  }
-  return next;
+  const lineBgWords = bgWords(line);
+  if (lineBgWords) flat.backgroundWords = lineBgWords.map((w) => shiftWord(w, shiftSec));
+  return reconcileLine(flat);
 }
 
 // -- Public API ---------------------------------------------------------------

--- a/src/pages/converters/lrc-to-ttml.tsx
+++ b/src/pages/converters/lrc-to-ttml.tsx
@@ -5,6 +5,7 @@ import { ConverterView, type ConvertArgs } from "@/pages/converters/converter-vi
 import { PageHead } from "@/seo/page-head";
 import { breadcrumbListSchema, faqPageSchema, howToSchema, organizationSchema } from "@/seo/schemas";
 import type { Agent } from "@/domain/agent/model";
+import { isWordSynced } from "@/domain/line/predicates";
 import type { ProjectMetadata } from "@/domain/project/metadata";
 import { parseLyricsFile } from "@/utils/lyrics-parsers";
 import { generateTTML } from "@/utils/ttml";
@@ -70,7 +71,7 @@ function convertLrc({ input, filename }: ConvertArgs): { ttml: string; projectPa
       language: result.metadata.language,
     };
     const agents: Agent[] = result.agents ?? [{ id: "v1", type: "person", name: "Voice 1" }];
-    const granularity = result.lines.some((line) => line.words?.length) ? "word" : "line";
+    const granularity = result.lines.some((line) => isWordSynced(line)) ? "word" : "line";
     const ttml = generateTTML({ metadata, agents, lines: result.lines, granularity });
     const projectPayload = JSON.stringify({ metadata, agents, lines: result.lines, granularity });
     return { ttml, projectPayload };

--- a/src/stores/project.agents.test.ts
+++ b/src/stores/project.agents.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { INITIAL_STATE, useProjectStore } from "@/stores/project";
-import type { LyricLine } from "@/domain/line/model";
+import { type LyricLine, reconcileLine } from "@/domain/line/model";
 
 describe("setAgents", () => {
   beforeEach(() => useProjectStore.setState(INITIAL_STATE));
@@ -33,7 +33,7 @@ describe("groupRepeatingSections", () => {
   beforeEach(() => useProjectStore.setState(INITIAL_STATE));
 
   function plain(id: string, text: string): LyricLine {
-    return { id, text, agentId: "v1" };
+    return reconcileLine({ id, text, agentId: "v1" });
   }
 
   it("creates one group with one instance per start", () => {
@@ -88,7 +88,7 @@ describe("groupRepeatingSections", () => {
 
   it("does nothing if any covered line is already grouped", () => {
     const lines: LyricLine[] = [
-      { id: "a", text: "x", agentId: "v1", groupId: "gExisting", instanceIdx: 0, templateLineIdx: 0 },
+      reconcileLine({ id: "a", text: "x", agentId: "v1", groupId: "gExisting", instanceIdx: 0, templateLineIdx: 0 }),
       plain("b", "y"),
       plain("c", "x"),
       plain("d", "y"),

--- a/src/stores/project.background-extraction.test.ts
+++ b/src/stores/project.background-extraction.test.ts
@@ -3,6 +3,7 @@
  */
 import { manualBackgroundWordEdit } from "@/domain/line/background";
 import { type LooseLine, reconcileLine } from "@/domain/line/model";
+import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { useProjectStore } from "@/stores/project";
 import { extractInlineFromLine } from "@/utils/background-vocal-extraction";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -50,12 +51,12 @@ describe("project store · background extraction on linked lines", () => {
     const a0 = lines.find((l) => l.id === "a0");
     const a1 = lines.find((l) => l.id === "a1");
 
-    expect(a0?.text).toBe("Hello");
-    expect(a0?.backgroundText).toBe("ooh");
-    expect(a1?.text).toBe("Hello");
-    expect(a1?.backgroundText).toBe("ooh");
-    expect(a0?.text).not.toContain("(");
-    expect(a1?.text).not.toContain("(");
+    expect(a0 && lineText(a0)).toBe("Hello");
+    expect(a0 && bgText(a0)).toBe("ooh");
+    expect(a1 && lineText(a1)).toBe("Hello");
+    expect(a1 && bgText(a1)).toBe("ooh");
+    expect(a0 && lineText(a0)).not.toContain("(");
+    expect(a1 && lineText(a1)).not.toContain("(");
   });
 
   it("keeps link metadata on both siblings after an untimed extraction", () => {
@@ -110,18 +111,18 @@ describe("project store · background extraction on linked lines", () => {
     const a0 = lines.find((l) => l.id === "a0");
     const a1 = lines.find((l) => l.id === "a1");
 
-    expect(a0?.text).toBe("Hello");
-    expect(a1?.text).toBe("Hello");
-    expect(a0?.backgroundText).toBe("ooh");
-    expect(a1?.backgroundText).toBe("ooh");
+    expect(a0 && lineText(a0)).toBe("Hello");
+    expect(a1 && lineText(a1)).toBe("Hello");
+    expect(a0 && bgText(a0)).toBe("ooh");
+    expect(a1 && bgText(a1)).toBe("ooh");
 
-    expect(a0?.words?.map((w) => w.text)).toEqual(["Hello"]);
-    expect(a1?.words?.map((w) => w.text)).toEqual(["Hello"]);
+    expect(a0 && mainWords(a0)?.map((w) => w.text)).toEqual(["Hello"]);
+    expect(a1 && mainWords(a1)?.map((w) => w.text)).toEqual(["Hello"]);
 
-    expect(a0?.words?.[0].begin).toBe(0);
-    expect(a0?.words?.[0].end).toBe(1);
-    expect(a1?.words?.[0].begin).toBe(30);
-    expect(a1?.words?.[0].end).toBe(31.5);
+    expect(a0 && mainWords(a0)?.[0].begin).toBe(0);
+    expect(a0 && mainWords(a0)?.[0].end).toBe(1);
+    expect(a1 && mainWords(a1)?.[0].begin).toBe(30);
+    expect(a1 && mainWords(a1)?.[0].end).toBe(31.5);
   });
 
   it("leaves a detached sibling untouched when extracting on the source", () => {
@@ -141,8 +142,10 @@ describe("project store · background extraction on linked lines", () => {
     applyPullFromParens("a0");
 
     const lines = useProjectStore.getState().lines;
-    expect(lines.find((l) => l.id === "a0")?.text).toBe("Hello");
-    expect(lines.find((l) => l.id === "a1")?.text).toBe("Hello (ooh)");
+    const a0 = lines.find((l) => l.id === "a0");
+    const a1 = lines.find((l) => l.id === "a1");
+    expect(a0 && lineText(a0)).toBe("Hello");
+    expect(a1 && lineText(a1)).toBe("Hello (ooh)");
   });
 
   it("propagates the background provenance flag to the linked sibling", () => {
@@ -161,10 +164,10 @@ describe("project store · background extraction on linked lines", () => {
     const a0 = lines.find((l) => l.id === "a0");
     const a1 = lines.find((l) => l.id === "a1");
 
-    expect(a0?.backgroundText).toBe("ooh");
-    expect(a0?.backgroundTextSource).toBe("extraction");
-    expect(a1?.backgroundText).toBe("ooh");
-    expect(a1?.backgroundTextSource).toBe("extraction");
+    expect(a0 && bgText(a0)).toBe("ooh");
+    expect(a0 && bgSource(a0)).toBe("extraction");
+    expect(a1 && bgText(a1)).toBe("ooh");
+    expect(a1 && bgSource(a1)).toBe("extraction");
   });
 
   it("propagates a cleared background provenance flag to the linked sibling", () => {
@@ -200,10 +203,10 @@ describe("project store · background extraction on linked lines", () => {
     const a0 = lines.find((l) => l.id === "a0");
     const a1 = lines.find((l) => l.id === "a1");
 
-    expect(a0?.backgroundText).toBeUndefined();
-    expect(a0?.backgroundTextSource).toBeUndefined();
-    expect(a1?.backgroundText).toBeUndefined();
-    expect(a1?.backgroundTextSource).toBeUndefined();
+    expect(a0 && bgText(a0)).toBeUndefined();
+    expect(a0 && bgSource(a0)).toBeUndefined();
+    expect(a1 && bgText(a1)).toBeUndefined();
+    expect(a1 && bgSource(a1)).toBeUndefined();
   });
 
   it("flips the linked sibling's provenance to manual when bg words are edited in the timeline", () => {
@@ -250,12 +253,12 @@ describe("project store · background extraction on linked lines", () => {
     const a0 = lines.find((l) => l.id === "a0");
     const a1 = lines.find((l) => l.id === "a1");
 
-    expect(a0?.backgroundTextSource).toBe("manual");
-    expect(a1?.backgroundTextSource).toBe("manual");
-    expect(a0?.backgroundWords?.[1].end).toBe(1.8);
+    expect(a0 && bgSource(a0)).toBe("manual");
+    expect(a1 && bgSource(a1)).toBe("manual");
+    expect(a0 && bgWords(a0)?.[1].end).toBe(1.8);
     // Sibling keeps its own instance-local timing, only the word structure mirrors.
-    expect(a1?.backgroundWords?.[0].begin).toBe(31);
-    expect(a1?.backgroundWords?.map((w) => w.text)).toEqual(["ooh ", "aah"]);
+    expect(a1 && bgWords(a1)?.[0].begin).toBe(31);
+    expect(a1 && bgWords(a1)?.map((w) => w.text)).toEqual(["ooh ", "aah"]);
   });
 
   it("produces a single undoable history entry covering source + sibling", () => {
@@ -269,7 +272,9 @@ describe("project store · background extraction on linked lines", () => {
 
     useProjectStore.getState().undo();
     const lines = useProjectStore.getState().lines;
-    expect(lines.find((l) => l.id === "a0")?.text).toBe("Hello (ooh)");
-    expect(lines.find((l) => l.id === "a1")?.text).toBe("Hello (ooh)");
+    const a0 = lines.find((l) => l.id === "a0");
+    const a1 = lines.find((l) => l.id === "a1");
+    expect(a0 && lineText(a0)).toBe("Hello (ooh)");
+    expect(a1 && lineText(a1)).toBe("Hello (ooh)");
   });
 });

--- a/src/stores/project.background-extraction.test.ts
+++ b/src/stores/project.background-extraction.test.ts
@@ -33,9 +33,9 @@ describe("project store · background extraction on linked lines", () => {
     if (!target) throw new Error(`line ${lineId} not found`);
     const extracted = extractInlineFromLine(target, { mergeStandaloneLines: false, preserveBrackets: false });
     useProjectStore.getState().updateLineWithHistory(target.id, {
-      text: extracted.text,
-      words: extracted.words,
-      backgroundText: extracted.backgroundText,
+      text: lineText(extracted),
+      words: mainWords(extracted),
+      backgroundText: bgText(extracted),
     });
   }
 

--- a/src/stores/project.background-write.test.ts
+++ b/src/stores/project.background-write.test.ts
@@ -5,9 +5,11 @@ import type { LinkGroup } from "@/domain/group/template";
 import { bgBounds, mainBounds } from "@/domain/line/bounds";
 import { type LooseLine, reconcileLine } from "@/domain/line/model";
 import { applyBackground } from "@/domain/line/background";
+import { placeVoice } from "@/domain/line/place-voice";
 import { bgVoice, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { isLineSynced, isWordSynced } from "@/domain/voice/predicates";
 import { useProjectStore } from "@/stores/project";
+import { splitIntoWordsWithMeta } from "@/utils/sync-helpers";
 import { beforeEach, describe, expect, it } from "vitest";
 
 // Store half of the #122 fix: a nested-aware background write path that persists
@@ -855,5 +857,101 @@ describe("project store · applyLineBackground · invariants", () => {
 
     expect(bgBounds(replacement)).toEqual(beforeBounds);
     expect(mainBounds(replacement)).toEqual({ begin: 2, end: 6 });
+  });
+});
+
+// Regression lock for the Task 8.1 placeVoice funnel: placing one instance's
+// MAIN voice ("place line here" in the timeline) is a pure per-instance timing
+// write. It must NOT propagate to linked siblings, otherwise every sibling
+// instance's background gets cleared or re-resolved. Both UI call sites place
+// through setLineWithHistory with { propagateToSiblings: false }; these tests
+// reproduce that exact production call convention with real store actions.
+describe("project store · placeVoice main · leaves linked siblings untouched", () => {
+  const PLACE_TIME = 5;
+  const PLACE_DUR = 0.4;
+
+  // Background text is consistent with its words (join of the word texts) so
+  // commitHistory's derive-text pass is a no-op: the only thing that can mutate
+  // the sibling here is sibling propagation, which is exactly what we lock out.
+  function seedLinkedPair() {
+    seed(
+      [
+        {
+          id: "a0",
+          text: "I love you",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          backgroundText: "ooh ooh",
+          backgroundWords: [
+            { text: "ooh ", begin: 0, end: 0.5 },
+            { text: "ooh", begin: 0.5, end: 1 },
+          ],
+          backgroundTextSource: "manual",
+        },
+        {
+          id: "a1",
+          text: "I love you",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          backgroundText: "ooh ooh",
+          backgroundWords: [
+            { text: "ooh ", begin: 20, end: 20.5 },
+            { text: "ooh", begin: 20.5, end: 21 },
+          ],
+          backgroundTextSource: "manual",
+        },
+      ],
+      [seedGroup("g1")],
+    );
+  }
+
+  it("regression: placing one instance's main voice does not clobber a linked sibling's background", () => {
+    seedLinkedPair();
+    const siblingBgBefore = bgVoice(getLine("a1"));
+    expect(siblingBgBefore).not.toBeNull();
+
+    const target = getLine("a0");
+    useProjectStore
+      .getState()
+      .setLineWithHistory("a0", placeVoice(target, "main", PLACE_TIME, PLACE_DUR), { propagateToSiblings: false });
+
+    expect(bgVoice(getLine("a1"))).toEqual(siblingBgBefore);
+    expect(bgWords(getLine("a1"))).toEqual([
+      { text: "ooh ", begin: 20, end: 20.5 },
+      { text: "ooh", begin: 20.5, end: 21 },
+    ]);
+  });
+
+  it("places the target line-synced at [time, time + max(wordCount,1)*dur]", () => {
+    seedLinkedPair();
+    const target = getLine("a0");
+    const wordCount = splitIntoWordsWithMeta(lineText(target)).parts.length;
+
+    useProjectStore
+      .getState()
+      .setLineWithHistory("a0", placeVoice(target, "main", PLACE_TIME, PLACE_DUR), { propagateToSiblings: false });
+
+    const placed = getLine("a0");
+    expect(isLineSynced(placed.main)).toBe(true);
+    expect(mainBounds(placed)).toEqual({
+      begin: PLACE_TIME,
+      end: PLACE_TIME + Math.max(wordCount, 1) * PLACE_DUR,
+    });
+  });
+
+  it("leaves the sibling reference-equal (no rewrite at all)", () => {
+    seedLinkedPair();
+    const a1Before = getLine("a1");
+
+    const target = getLine("a0");
+    useProjectStore
+      .getState()
+      .setLineWithHistory("a0", placeVoice(target, "main", PLACE_TIME, PLACE_DUR), { propagateToSiblings: false });
+
+    expect(getLine("a1")).toBe(a1Before);
   });
 });

--- a/src/stores/project.background-write.test.ts
+++ b/src/stores/project.background-write.test.ts
@@ -1,0 +1,395 @@
+/**
+ * @vitest-environment node
+ */
+import type { LinkGroup } from "@/domain/group/template";
+import { bgBounds, mainBounds } from "@/domain/line/bounds";
+import { type LooseLine, reconcileLine } from "@/domain/line/model";
+import { applyBackground } from "@/domain/line/background";
+import { bgVoice, bgWords } from "@/domain/line/voices";
+import { isLineSynced, isWordSynced } from "@/domain/voice/predicates";
+import { useProjectStore } from "@/stores/project";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// Store half of the #122 fix: a nested-aware background write path that persists
+// a resolver-resolved (possibly line-synced) background. The flat update API
+// cannot carry a line-synced background, so an untimed bg text over a
+// line-synced main used to be word-split. These tests exercise the real store
+// actions with real data, no mocks.
+
+beforeEach(() => {
+  useProjectStore.getState().reset();
+  useProjectStore.getState().clearHistory();
+});
+
+function seedGroup(id: string): LinkGroup {
+  return { id, label: "Chorus", color: "#f472b6", templateVersion: 1 };
+}
+
+// Seeds lines in a single setState and marks the store dirty-since-history so
+// the first *WithHistory mutation snapshots this state as the undo baseline.
+function seed(lines: LooseLine[], groups: LinkGroup[] = []) {
+  useProjectStore.setState({
+    groups,
+    lines: lines.map(reconcileLine),
+    isDirtySinceHistory: true,
+  });
+}
+
+function getLine(id: string) {
+  const line = useProjectStore.getState().lines.find((l) => l.id === id);
+  if (!line) throw new Error(`line ${id} not found`);
+  return line;
+}
+
+describe("project store · applyLineBackground", () => {
+  it("regression: line-synced line keeps line-synced background (#122)", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 6 }]);
+
+    useProjectStore.getState().applyLineBackground("L1", { text: "ooh", source: "manual" });
+
+    const stored = getLine("L1");
+    expect(bgBounds(stored)).toEqual({ begin: 4, end: 6 });
+    expect(bgWords(stored)).toBeUndefined();
+    const bg = bgVoice(stored);
+    expect(bg).not.toBeNull();
+    if (bg) expect(isLineSynced(bg)).toBe(true);
+  });
+
+  it("distributes bg to word-synced over a word-synced main", () => {
+    seed([
+      {
+        id: "L1",
+        text: "Real line",
+        agentId: "v1",
+        words: [
+          { text: "Real ", begin: 0, end: 1 },
+          { text: "line", begin: 1, end: 2 },
+        ],
+      },
+    ]);
+
+    useProjectStore.getState().applyLineBackground("L1", { text: "ooh", source: "manual" });
+
+    const stored = getLine("L1");
+    const words = bgWords(stored);
+    expect(words).toBeDefined();
+    const bg = bgVoice(stored);
+    expect(bg).not.toBeNull();
+    if (bg) expect(isWordSynced(bg)).toBe(true);
+  });
+
+  it("keeps bg untimed over an untimed main", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1" }]);
+
+    useProjectStore.getState().applyLineBackground("L1", { text: "ooh", source: "manual" });
+
+    const stored = getLine("L1");
+    expect(bgWords(stored)).toBeUndefined();
+    expect(bgBounds(stored)).toBeNull();
+    const bg = bgVoice(stored);
+    expect(bg).not.toBeNull();
+  });
+
+  it("keeps a word-synced params verbatim regardless of main granularity", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 6 }]);
+
+    const words = [
+      { text: "ooh ", begin: 3, end: 4 },
+      { text: "aah", begin: 4, end: 5 },
+    ];
+    useProjectStore.getState().applyLineBackground("L1", { words, source: "extraction" });
+
+    const stored = getLine("L1");
+    expect(bgWords(stored)).toEqual(words);
+    const bg = bgVoice(stored);
+    if (bg) expect(isWordSynced(bg)).toBe(true);
+  });
+
+  it("no-ops when the target line is absent", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 6 }]);
+    const before = useProjectStore.getState().lines;
+
+    useProjectStore.getState().applyLineBackground("missing", { text: "ooh", source: "manual" });
+
+    expect(useProjectStore.getState().lines).toBe(before);
+  });
+});
+
+describe("project store · applyLineBackground · clearing", () => {
+  it("removes a line-synced background entirely on empty text", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 6 }]);
+    useProjectStore.getState().applyLineBackground("L1", { text: "ooh", source: "manual" });
+    expect(bgVoice(getLine("L1"))).not.toBeNull();
+
+    useProjectStore.getState().applyLineBackground("L1", { text: "", source: "manual" });
+
+    expect(bgVoice(getLine("L1"))).toBeNull();
+  });
+
+  it("removes a word-synced background entirely on empty text", () => {
+    seed([
+      {
+        id: "L1",
+        text: "Real line",
+        agentId: "v1",
+        words: [{ text: "Real line", begin: 0, end: 2 }],
+        backgroundText: "ooh",
+        backgroundWords: [{ text: "ooh", begin: 1, end: 2 }],
+        backgroundTextSource: "extraction",
+      },
+    ]);
+    expect(bgVoice(getLine("L1"))).not.toBeNull();
+
+    useProjectStore.getState().applyLineBackground("L1", { text: "", source: "manual" });
+
+    expect(bgVoice(getLine("L1"))).toBeNull();
+  });
+});
+
+describe("project store · applyLineBackground · history", () => {
+  it("undo restores the prior line and redo re-applies", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 6 }]);
+
+    useProjectStore.getState().applyLineBackground("L1", { text: "ooh", source: "manual" });
+    expect(bgVoice(getLine("L1"))).not.toBeNull();
+    expect(useProjectStore.getState().canUndo()).toBe(true);
+
+    useProjectStore.getState().undo();
+    expect(bgVoice(getLine("L1"))).toBeNull();
+
+    useProjectStore.getState().redo();
+    const restored = getLine("L1");
+    expect(bgBounds(restored)).toEqual({ begin: 4, end: 6 });
+    const bg = bgVoice(restored);
+    if (bg) expect(isLineSynced(bg)).toBe(true);
+  });
+});
+
+describe("project store · applyLineBackground · sibling propagation", () => {
+  it("re-resolves each linked sibling's bg over its own bounds", () => {
+    seed(
+      [
+        {
+          id: "a0",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          begin: 0,
+          end: 4,
+        },
+        {
+          id: "a1",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          begin: 10,
+          end: 20,
+        },
+      ],
+      [seedGroup("g1")],
+    );
+
+    useProjectStore.getState().applyLineBackground("a0", { text: "ooh", source: "manual" });
+
+    const a0 = getLine("a0");
+    const a1 = getLine("a1");
+    expect(bgBounds(a0)).toEqual({ begin: 2, end: 4 });
+    expect(bgBounds(a1)).toEqual({ begin: 15, end: 20 });
+    const bg0 = bgVoice(a0);
+    const bg1 = bgVoice(a1);
+    expect(bg0).not.toBeNull();
+    expect(bg1).not.toBeNull();
+    expect(isLineSynced(bg0 as NonNullable<typeof bg0>)).toBe(true);
+    expect(isLineSynced(bg1 as NonNullable<typeof bg1>)).toBe(true);
+  });
+
+  it("re-resolves per sibling main granularity, not by copying timing", () => {
+    seed(
+      [
+        {
+          id: "a0",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          begin: 0,
+          end: 4,
+        },
+        {
+          id: "a1",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          words: [
+            { text: "Real ", begin: 10, end: 11 },
+            { text: "line", begin: 11, end: 12 },
+          ],
+        },
+      ],
+      [seedGroup("g1")],
+    );
+
+    useProjectStore.getState().applyLineBackground("a0", { text: "ooh", source: "manual" });
+
+    const bg0 = bgVoice(getLine("a0"));
+    const bg1 = bgVoice(getLine("a1"));
+    expect(bg0).not.toBeNull();
+    expect(bg1).not.toBeNull();
+    expect(isLineSynced(bg0 as NonNullable<typeof bg0>)).toBe(true);
+    expect(isWordSynced(bg1 as NonNullable<typeof bg1>)).toBe(true);
+  });
+
+  it("leaves a detached sibling untouched", () => {
+    seed(
+      [
+        {
+          id: "a0",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          begin: 0,
+          end: 4,
+        },
+        {
+          id: "a1",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          begin: 10,
+          end: 20,
+          detached: true,
+        },
+      ],
+      [seedGroup("g1")],
+    );
+
+    useProjectStore.getState().applyLineBackground("a0", { text: "ooh", source: "manual" });
+
+    expect(bgVoice(getLine("a0"))).not.toBeNull();
+    expect(bgVoice(getLine("a1"))).toBeNull();
+  });
+
+  it("propagateToSiblings: false leaves the sibling untouched", () => {
+    seed(
+      [
+        {
+          id: "a0",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          begin: 0,
+          end: 4,
+        },
+        {
+          id: "a1",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          begin: 10,
+          end: 20,
+        },
+      ],
+      [seedGroup("g1")],
+    );
+    const a1Before = getLine("a1");
+
+    useProjectStore
+      .getState()
+      .applyLineBackground("a0", { text: "ooh", source: "manual" }, { propagateToSiblings: false });
+
+    expect(bgVoice(getLine("a0"))).not.toBeNull();
+    expect(getLine("a1")).toBe(a1Before);
+    expect(bgVoice(getLine("a1"))).toBeNull();
+  });
+});
+
+describe("project store · setLineWithHistory", () => {
+  it("persists a line-synced background carried on the replacement line", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 6 }]);
+
+    const target = getLine("L1");
+    const replacement = applyBackground(target, { text: "ooh", source: "manual" });
+    expect(bgBounds(replacement)).toEqual({ begin: 4, end: 6 });
+
+    useProjectStore.getState().setLineWithHistory("L1", replacement);
+
+    const stored = getLine("L1");
+    expect(bgBounds(stored)).toEqual({ begin: 4, end: 6 });
+    expect(bgWords(stored)).toBeUndefined();
+    const bg = bgVoice(stored);
+    if (bg) expect(isLineSynced(bg)).toBe(true);
+  });
+
+  it("drops the background when the replacement line has none", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 6 }]);
+    useProjectStore.getState().applyLineBackground("L1", { text: "ooh", source: "manual" });
+    expect(bgVoice(getLine("L1"))).not.toBeNull();
+
+    const cleared = reconcileLine({ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 6 });
+    useProjectStore.getState().setLineWithHistory("L1", cleared);
+
+    expect(bgVoice(getLine("L1"))).toBeNull();
+  });
+
+  it("is a no-op for a missing target and commits no history entry", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 6 }]);
+    const linesBefore = useProjectStore.getState().lines;
+    const canUndoBefore = useProjectStore.getState().canUndo();
+
+    const replacement = reconcileLine({ id: "ghost", text: "ghost", agentId: "v1" });
+    useProjectStore.getState().setLineWithHistory("ghost", replacement);
+
+    expect(useProjectStore.getState().lines).toBe(linesBefore);
+    expect(useProjectStore.getState().canUndo()).toBe(canUndoBefore);
+  });
+});
+
+describe("project store · applyLineBackground · invariants", () => {
+  it("does not mutate the input params", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 6 }]);
+    const params = { text: "ooh", source: "manual" as const };
+    const snapshot = { ...params };
+
+    useProjectStore.getState().applyLineBackground("L1", params);
+
+    expect(params).toEqual(snapshot);
+  });
+
+  it("keeps unrelated lines reference-equal", () => {
+    seed([
+      { id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 6 },
+      { id: "L2", text: "Other line", agentId: "v1", begin: 8, end: 12 },
+    ]);
+    const l2Before = getLine("L2");
+
+    useProjectStore.getState().applyLineBackground("L1", { text: "ooh", source: "manual" });
+
+    expect(getLine("L2")).toBe(l2Before);
+  });
+
+  it("does not mutate the input nextLine in setLineWithHistory", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 6 }]);
+    const replacement = applyBackground(getLine("L1"), { text: "ooh", source: "manual" });
+    const beforeBounds = bgBounds(replacement);
+
+    useProjectStore.getState().setLineWithHistory("L1", replacement);
+
+    expect(bgBounds(replacement)).toEqual(beforeBounds);
+    expect(mainBounds(replacement)).toEqual({ begin: 2, end: 6 });
+  });
+});

--- a/src/stores/project.background-write.test.ts
+++ b/src/stores/project.background-write.test.ts
@@ -5,7 +5,7 @@ import type { LinkGroup } from "@/domain/group/template";
 import { bgBounds, mainBounds } from "@/domain/line/bounds";
 import { type LooseLine, reconcileLine } from "@/domain/line/model";
 import { applyBackground } from "@/domain/line/background";
-import { bgVoice, bgWords } from "@/domain/line/voices";
+import { bgVoice, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { isLineSynced, isWordSynced } from "@/domain/voice/predicates";
 import { useProjectStore } from "@/stores/project";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -344,6 +344,61 @@ describe("project store · setLineWithHistory", () => {
     useProjectStore.getState().setLineWithHistory("L1", cleared);
 
     expect(bgVoice(getLine("L1"))).toBeNull();
+  });
+
+  it("propagates a main-word structural change to a linked word-synced sibling, keeping its own timing", () => {
+    seed(
+      [
+        {
+          id: "a0",
+          text: "Hi (ooh) there",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          words: [
+            { text: "Hi ", begin: 0, end: 1 },
+            { text: "(ooh) ", begin: 1, end: 2 },
+            { text: "there", begin: 2, end: 3 },
+          ],
+        },
+        {
+          id: "a1",
+          text: "Hi (ooh) there",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          words: [
+            { text: "Hi ", begin: 10, end: 11 },
+            { text: "(ooh) ", begin: 11, end: 12 },
+            { text: "there", begin: 12, end: 13 },
+          ],
+        },
+      ],
+      [seedGroup("g1")],
+    );
+
+    const extracted = reconcileLine({
+      id: "a0",
+      text: "Hi there",
+      agentId: "v1",
+      groupId: "g1",
+      instanceIdx: 0,
+      templateLineIdx: 0,
+      words: [
+        { text: "Hi ", begin: 0, end: 1 },
+        { text: "there", begin: 2, end: 3 },
+      ],
+    });
+    useProjectStore.getState().setLineWithHistory("a0", extracted);
+
+    const sibling = getLine("a1");
+    expect(mainWords(sibling)).toEqual([
+      { text: "Hi ", begin: 10, end: 11 },
+      { text: "there", begin: 12, end: 13 },
+    ]);
+    expect(lineText(sibling)).toBe("Hi there");
   });
 
   it("is a no-op for a missing target and commits no history entry", () => {

--- a/src/stores/project.background-write.test.ts
+++ b/src/stores/project.background-write.test.ts
@@ -6,7 +6,7 @@ import { bgBounds, mainBounds } from "@/domain/line/bounds";
 import { type LooseLine, reconcileLine } from "@/domain/line/model";
 import { applyBackground } from "@/domain/line/background";
 import { placeVoice } from "@/domain/line/place-voice";
-import { bgVoice, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { bgText, bgVoice, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { isLineSynced, isWordSynced } from "@/domain/voice/predicates";
 import { useProjectStore } from "@/stores/project";
 import { splitIntoWordsWithMeta } from "@/utils/sync-helpers";
@@ -951,6 +951,95 @@ describe("project store · placeVoice main · leaves linked siblings untouched",
     useProjectStore
       .getState()
       .setLineWithHistory("a0", placeVoice(target, "main", PLACE_TIME, PLACE_DUR), { propagateToSiblings: false });
+
+    expect(getLine("a1")).toBe(a1Before);
+  });
+});
+
+// Mirror of the main-place lock, for the "place background here" timeline item.
+// Placing one instance's BACKGROUND voice is a per-instance timing write that
+// must NOT propagate: a linked sibling that has its own untimed bg must keep it
+// untimed. Both arms place through setLineWithHistory with
+// { propagateToSiblings: false }, reproducing the production call convention.
+describe("project store · placeVoice background · leaves linked siblings untouched", () => {
+  const PLACE_TIME = 5;
+  const PLACE_DUR = 0.4;
+
+  // Two linked instances of the same line, each with an UNTIMED background
+  // (text only, no words). The main is untimed too so both sit in the
+  // placeable state the bg-track menu item gates on.
+  function seedLinkedPair() {
+    seed(
+      [
+        {
+          id: "a0",
+          text: "I love you",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          backgroundText: "ooh ooh",
+          backgroundTextSource: "manual",
+        },
+        {
+          id: "a1",
+          text: "I love you",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          backgroundText: "ooh ooh",
+          backgroundTextSource: "manual",
+        },
+      ],
+      [seedGroup("g1")],
+    );
+  }
+
+  it("regression: placing one instance's bg does not clobber a linked sibling's background", () => {
+    seedLinkedPair();
+    const siblingBgBefore = bgVoice(getLine("a1"));
+    expect(siblingBgBefore).not.toBeNull();
+    expect(bgBounds(getLine("a1"))).toBeNull();
+
+    const target = getLine("a0");
+    useProjectStore.getState().setLineWithHistory("a0", placeVoice(target, "background", PLACE_TIME, PLACE_DUR), {
+      propagateToSiblings: false,
+    });
+
+    expect(bgVoice(getLine("a1"))).toEqual(siblingBgBefore);
+    expect(bgBounds(getLine("a1"))).toBeNull();
+    expect(bgWords(getLine("a1"))).toBeUndefined();
+  });
+
+  it("places the target's bg line-synced at [time, time + max(bgWordCount,1)*dur]", () => {
+    seedLinkedPair();
+    const target = getLine("a0");
+    const text = bgText(target);
+    if (text === undefined) throw new Error("expected bg text");
+    const bgWordCount = splitIntoWordsWithMeta(text).parts.length;
+
+    useProjectStore.getState().setLineWithHistory("a0", placeVoice(target, "background", PLACE_TIME, PLACE_DUR), {
+      propagateToSiblings: false,
+    });
+
+    const placed = getLine("a0");
+    expect(bgWords(placed)).toBeUndefined();
+    expect(bgBounds(placed)).toEqual({
+      begin: PLACE_TIME,
+      end: PLACE_TIME + Math.max(bgWordCount, 1) * PLACE_DUR,
+    });
+    expect(mainBounds(placed)).toBeNull();
+  });
+
+  it("leaves the sibling reference-equal (no rewrite at all)", () => {
+    seedLinkedPair();
+    const a1Before = getLine("a1");
+
+    const target = getLine("a0");
+    useProjectStore.getState().setLineWithHistory("a0", placeVoice(target, "background", PLACE_TIME, PLACE_DUR), {
+      propagateToSiblings: false,
+    });
 
     expect(getLine("a1")).toBe(a1Before);
   });

--- a/src/stores/project.background-write.test.ts
+++ b/src/stores/project.background-write.test.ts
@@ -414,6 +414,313 @@ describe("project store · setLineWithHistory", () => {
   });
 });
 
+describe("project store · main-to-word transition follows background", () => {
+  it("transition: line-synced main + line-synced bg becomes word-synced bg over its own bounds", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 10 }]);
+    useProjectStore.getState().applyLineBackground("L1", { text: "ooh ahh", source: "manual" });
+
+    const before = getLine("L1");
+    expect(bgBounds(before)).toEqual({ begin: 6, end: 10 });
+    expect(bgWords(before)).toBeUndefined();
+
+    useProjectStore.getState().updateLineWithHistory(
+      "L1",
+      {
+        words: [
+          { text: "Real ", begin: 2, end: 5 },
+          { text: "line", begin: 5, end: 10 },
+        ],
+      },
+      { deriveText: false },
+    );
+
+    const after = getLine("L1");
+    expect(isWordSynced(after.main)).toBe(true);
+    const words = bgWords(after);
+    expect(words).toBeDefined();
+    if (!words) throw new Error("expected bg words");
+    expect(words.length).toBe(2);
+    expect(words[0].begin).toBe(6);
+    expect(words[words.length - 1].end).toBe(10);
+  });
+
+  it("leaves a word-synced background's words unchanged when main becomes word-synced", () => {
+    const bgWordsInput = [
+      { text: "ooh ", begin: 3, end: 4 },
+      { text: "ahh", begin: 4, end: 5 },
+    ];
+    seed([
+      {
+        id: "L1",
+        text: "Real line",
+        agentId: "v1",
+        begin: 2,
+        end: 10,
+        backgroundText: "ooh ahh",
+        backgroundWords: bgWordsInput,
+        backgroundTextSource: "extraction",
+      },
+    ]);
+    const bgBefore = bgVoice(getLine("L1"));
+
+    useProjectStore.getState().updateLineWithHistory(
+      "L1",
+      {
+        words: [
+          { text: "Real ", begin: 2, end: 5 },
+          { text: "line", begin: 5, end: 10 },
+        ],
+      },
+      { deriveText: false },
+    );
+
+    const after = getLine("L1");
+    expect(isWordSynced(after.main)).toBe(true);
+    expect(bgVoice(after)).toEqual(bgBefore);
+    expect(bgWords(after)).toEqual(bgWordsInput);
+  });
+
+  it("transition: untimed bg distributes over the new main's second half", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1" }]);
+    useProjectStore.getState().applyLineBackground("L1", { text: "ooh ahh", source: "manual" });
+
+    const before = getLine("L1");
+    expect(bgWords(before)).toBeUndefined();
+    expect(bgBounds(before)).toBeNull();
+
+    useProjectStore.getState().updateLineWithHistory(
+      "L1",
+      {
+        words: [
+          { text: "Real ", begin: 4, end: 8 },
+          { text: "line", begin: 8, end: 12 },
+        ],
+      },
+      { deriveText: false },
+    );
+
+    const after = getLine("L1");
+    expect(isWordSynced(after.main)).toBe(true);
+    const words = bgWords(after);
+    expect(words).toBeDefined();
+    if (!words) throw new Error("expected bg words");
+    expect(words[0].begin).toBe(8);
+    expect(words[words.length - 1].end).toBe(12);
+  });
+
+  it("does not re-resolve a bg when main was ALREADY word-synced before the write", () => {
+    const bgWordsInput = [
+      { text: "ooh ", begin: 0, end: 1 },
+      { text: "ahh", begin: 1, end: 2 },
+    ];
+    seed([
+      {
+        id: "L1",
+        text: "Real line",
+        agentId: "v1",
+        words: [
+          { text: "Real ", begin: 0, end: 1 },
+          { text: "line", begin: 1, end: 2 },
+        ],
+        backgroundText: "ooh ahh",
+        backgroundWords: bgWordsInput,
+        backgroundTextSource: "manual",
+      },
+    ]);
+
+    useProjectStore.getState().updateLineWithHistory(
+      "L1",
+      {
+        words: [
+          { text: "Real ", begin: 0, end: 5 },
+          { text: "line", begin: 5, end: 10 },
+        ],
+      },
+      { deriveText: false },
+    );
+
+    const after = bgWords(getLine("L1"));
+    expect(after).toEqual(bgWordsInput);
+  });
+
+  it("is a no-op for the background when the line has none", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 10 }]);
+
+    useProjectStore.getState().updateLineWithHistory(
+      "L1",
+      {
+        words: [
+          { text: "Real ", begin: 2, end: 5 },
+          { text: "line", begin: 5, end: 10 },
+        ],
+      },
+      { deriveText: false },
+    );
+
+    const after = getLine("L1");
+    expect(isWordSynced(after.main)).toBe(true);
+    expect(bgVoice(after)).toBeNull();
+    expect("background" in after).toBe(false);
+  });
+
+  it("updateLine (no-history) also follows the background into word-synced", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 10 }]);
+    useProjectStore.getState().applyLineBackground("L1", { text: "ooh ahh", source: "manual" });
+
+    useProjectStore.getState().updateLine(
+      "L1",
+      {
+        words: [
+          { text: "Real ", begin: 2, end: 5 },
+          { text: "line", begin: 5, end: 10 },
+        ],
+      },
+      { deriveText: false },
+    );
+
+    const after = getLine("L1");
+    expect(isWordSynced(after.main)).toBe(true);
+    const words = bgWords(after);
+    expect(words).toBeDefined();
+    if (!words) throw new Error("expected bg words");
+    expect(words[0].begin).toBe(6);
+    expect(words[words.length - 1].end).toBe(10);
+  });
+
+  // No generic-mutator path propagates a FRESH `words` array to a line-synced
+  // sibling: propagateWordChanges returns undefined when the sibling has no
+  // main words (`!siblingWords`), so a line-synced sibling never transitions to
+  // word-synced via propagation. The propagated-transition scenario is therefore
+  // unreachable in practice. updateLinesWithHistory does treat each entry as its
+  // own target, so a batch that transitions two linked line-synced lines follows
+  // each of their backgrounds (each via the target reconcile, not propagation).
+  it("updateLinesWithHistory transitions and follows the background of every targeted line", () => {
+    seed(
+      [
+        {
+          id: "a0",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          begin: 0,
+          end: 4,
+        },
+        {
+          id: "a1",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          begin: 10,
+          end: 20,
+        },
+      ],
+      [seedGroup("g1")],
+    );
+    useProjectStore.getState().applyLineBackground("a0", { text: "ooh ahh", source: "manual" });
+    useProjectStore.getState().applyLineBackground("a1", { text: "ooh ahh", source: "manual" });
+
+    const a0BgBefore = bgBounds(getLine("a0"));
+    const a1BgBefore = bgBounds(getLine("a1"));
+    if (!a0BgBefore || !a1BgBefore) throw new Error("expected line-synced backgrounds");
+
+    useProjectStore.getState().updateLinesWithHistory(
+      [
+        {
+          id: "a0",
+          updates: {
+            words: [
+              { text: "Real ", begin: 0, end: 2 },
+              { text: "line", begin: 2, end: 4 },
+            ],
+          },
+        },
+        {
+          id: "a1",
+          updates: {
+            words: [
+              { text: "Real ", begin: 10, end: 15 },
+              { text: "line", begin: 15, end: 20 },
+            ],
+          },
+        },
+      ],
+      { propagateToSiblings: false },
+    );
+
+    const a0 = getLine("a0");
+    const a1 = getLine("a1");
+    expect(isWordSynced(a0.main)).toBe(true);
+    expect(isWordSynced(a1.main)).toBe(true);
+    const a0Bg = bgWords(a0);
+    const a1Bg = bgWords(a1);
+    expect(a0Bg).toBeDefined();
+    expect(a1Bg).toBeDefined();
+    if (!a0Bg || !a1Bg) throw new Error("expected bg words on both");
+    expect(a0Bg[0].begin).toBe(a0BgBefore.begin);
+    expect(a0Bg[a0Bg.length - 1].end).toBe(a0BgBefore.end);
+    expect(a1Bg[0].begin).toBe(a1BgBefore.begin);
+    expect(a1Bg[a1Bg.length - 1].end).toBe(a1BgBefore.end);
+  });
+
+  it("leaves a linked word-synced sibling's word-synced bg untouched on a propagated rename", () => {
+    seed(
+      [
+        {
+          id: "a0",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          words: [
+            { text: "Real ", begin: 0, end: 1 },
+            { text: "line", begin: 1, end: 2 },
+          ],
+          backgroundText: "ooh ahh",
+          backgroundWords: [
+            { text: "ooh ", begin: 0, end: 1 },
+            { text: "ahh", begin: 1, end: 2 },
+          ],
+          backgroundTextSource: "manual",
+        },
+        {
+          id: "a1",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          words: [
+            { text: "Real ", begin: 10, end: 11 },
+            { text: "line", begin: 11, end: 12 },
+          ],
+          backgroundText: "ooh ahh",
+          backgroundWords: [
+            { text: "ooh ", begin: 10, end: 11 },
+            { text: "ahh", begin: 11, end: 12 },
+          ],
+          backgroundTextSource: "manual",
+        },
+      ],
+      [seedGroup("g1")],
+    );
+    const a1BgBefore = bgWords(getLine("a1"));
+
+    useProjectStore.getState().updateLineWithHistory("a0", {
+      words: [
+        { text: "Real ", begin: 0, end: 1 },
+        { text: "song", begin: 1, end: 2 },
+      ],
+    });
+
+    expect(bgWords(getLine("a1"))).toEqual(a1BgBefore);
+  });
+});
+
 describe("project store · applyLineBackground · invariants", () => {
   it("does not mutate the input params", () => {
     seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 6 }]);

--- a/src/stores/project.background-write.test.ts
+++ b/src/stores/project.background-write.test.ts
@@ -719,6 +719,108 @@ describe("project store · main-to-word transition follows background", () => {
 
     expect(bgWords(getLine("a1"))).toEqual(a1BgBefore);
   });
+
+  it("undo restores the line-synced bg and redo restores the followed word-synced bg", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 10 }]);
+    useProjectStore.getState().applyLineBackground("L1", { text: "ooh ahh", source: "manual" });
+    useProjectStore.getState().clearHistory();
+    useProjectStore.setState({ isDirtySinceHistory: true });
+
+    useProjectStore.getState().updateLineWithHistory(
+      "L1",
+      {
+        words: [
+          { text: "Real ", begin: 2, end: 5 },
+          { text: "line", begin: 5, end: 10 },
+        ],
+      },
+      { deriveText: false },
+    );
+    const followed = bgWords(getLine("L1"));
+    expect(followed).toBeDefined();
+
+    useProjectStore.getState().undo();
+    const undone = getLine("L1");
+    expect(bgWords(undone)).toBeUndefined();
+    expect(bgBounds(undone)).toEqual({ begin: 6, end: 10 });
+
+    useProjectStore.getState().redo();
+    expect(bgWords(getLine("L1"))).toEqual(followed);
+  });
+
+  it("distributes a line-synced bg over its OWN bounds, not the main fallback, on transition", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 10 }]);
+    useProjectStore.setState((state) => ({
+      lines: state.lines.map((l) =>
+        l.id === "L1" ? { ...l, background: { text: "ooh ahh", begin: 3, end: 7, source: "manual" as const } } : l,
+      ),
+    }));
+    expect(bgBounds(getLine("L1"))).toEqual({ begin: 3, end: 7 });
+
+    useProjectStore.getState().updateLineWithHistory(
+      "L1",
+      {
+        words: [
+          { text: "Real ", begin: 2, end: 5 },
+          { text: "line", begin: 5, end: 10 },
+        ],
+      },
+      { deriveText: false },
+    );
+
+    const words = bgWords(getLine("L1"));
+    expect(words).toBeDefined();
+    if (!words) throw new Error("expected bg words");
+    expect(words[0].begin).toBe(3);
+    expect(words[words.length - 1].end).toBe(7);
+  });
+
+  it("keeps a line-synced background line-synced through a non-background update", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 10 }]);
+    useProjectStore.getState().applyLineBackground("L1", { text: "ooh", source: "manual" });
+    const bgBefore = bgBounds(getLine("L1"));
+    expect(bgBefore).not.toBeNull();
+
+    useProjectStore.getState().updateLineWithHistory("L1", { agentId: "v2" }, { deriveText: false });
+
+    const after = getLine("L1");
+    expect(after.agentId).toBe("v2");
+    expect(bgBounds(after)).toEqual(bgBefore);
+    expect(bgWords(after)).toBeUndefined();
+    const bg = bgVoice(after);
+    expect(bg).not.toBeNull();
+    if (bg) expect(isLineSynced(bg)).toBe(true);
+  });
+
+  it("distributes a degenerate zero-duration line-synced bg into zero-width words", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", begin: 2, end: 10 }]);
+    useProjectStore.setState((state) => ({
+      lines: state.lines.map((l) =>
+        l.id === "L1" ? { ...l, background: { text: "ooh ahh", begin: 5, end: 5, source: "manual" as const } } : l,
+      ),
+    }));
+    expect(bgBounds(getLine("L1"))).toEqual({ begin: 5, end: 5 });
+
+    useProjectStore.getState().updateLineWithHistory(
+      "L1",
+      {
+        words: [
+          { text: "Real ", begin: 2, end: 5 },
+          { text: "line", begin: 5, end: 10 },
+        ],
+      },
+      { deriveText: false },
+    );
+
+    const words = bgWords(getLine("L1"));
+    expect(words).toBeDefined();
+    if (!words) throw new Error("expected bg words");
+    expect(words.length).toBe(2);
+    for (const word of words) {
+      expect(word.begin).toBe(5);
+      expect(word.end).toBe(5);
+    }
+  });
 });
 
 describe("project store · applyLineBackground · invariants", () => {

--- a/src/stores/project.derive-text.test.ts
+++ b/src/stores/project.derive-text.test.ts
@@ -3,6 +3,7 @@
  */
 import { useProjectStore } from "@/stores/project";
 import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
+import { bgText, lineText } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -39,7 +40,7 @@ describe("updateLineWithHistory derives text from words", () => {
       words: [w("hello ", 0, 1), w("wor", 1, 1.5), w("ld", 1.5, 2)],
     });
 
-    expect(useProjectStore.getState().lines[0].text).toBe("hello wor|ld");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("hello wor|ld");
   });
 
   it("re-derives text on a plain word-text rename", () => {
@@ -49,38 +50,38 @@ describe("updateLineWithHistory derives text from words", () => {
       words: [w("hi ", 0, 1), w("world", 1, 2)],
     });
 
-    expect(useProjectStore.getState().lines[0].text).toBe("hi world");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("hi world");
   });
 
   it("re-derives backgroundText from backgroundWords", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "l1",
         text: "main",
         agentId: "v1",
         backgroundText: "oh yeah",
         backgroundWords: [w("oh ", 0, 1), w("yeah", 1, 2)],
-      },
+      }),
     ]);
 
     useProjectStore.getState().updateLineWithHistory("l1", {
       backgroundWords: [w("oh ", 0, 1), w("ye", 1, 1.5), w("ah", 1.5, 2)],
     });
 
-    expect(useProjectStore.getState().lines[0].backgroundText).toBe("oh ye|ah");
+    expect(bgText(useProjectStore.getState().lines[0])).toBe("oh ye|ah");
   });
 
   it("leaves text untouched for a line with no words", () => {
-    useProjectStore.getState().setLines([{ id: "l1", text: "chorus line", agentId: "v1", begin: 0, end: 5 }]);
+    useProjectStore.getState().setLines([reconcileLine({ id: "l1", text: "chorus line", agentId: "v1", begin: 0, end: 5 })]);
 
     useProjectStore.getState().updateLineWithHistory("l1", { begin: 1 });
 
-    expect(useProjectStore.getState().lines[0].text).toBe("chorus line");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("chorus line");
   });
 
   it("propagates derived text to linked siblings", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "a",
         text: "hello world",
         agentId: "v1",
@@ -88,8 +89,8 @@ describe("updateLineWithHistory derives text from words", () => {
         instanceIdx: 0,
         templateLineIdx: 0,
         words: [w("hello ", 0, 1), w("world", 1, 2)],
-      },
-      {
+      }),
+      reconcileLine({
         id: "b",
         text: "hello world",
         agentId: "v1",
@@ -97,7 +98,7 @@ describe("updateLineWithHistory derives text from words", () => {
         instanceIdx: 1,
         templateLineIdx: 0,
         words: [w("hello ", 10, 11), w("world", 11, 12)],
-      },
+      }),
     ]);
 
     useProjectStore.getState().updateLineWithHistory("a", {
@@ -105,7 +106,7 @@ describe("updateLineWithHistory derives text from words", () => {
     });
 
     const sibling = useProjectStore.getState().lines.find((l) => l.id === "b");
-    expect(sibling?.text).toBe("hi world");
+    expect(sibling && lineText(sibling)).toBe("hi world");
   });
 });
 
@@ -119,7 +120,7 @@ describe("updateLine derives text from words", () => {
       words: [w("hello ", 0, 1), w("wor", 1, 1.5), w("ld", 1.5, 2)],
     });
 
-    expect(useProjectStore.getState().lines[0].text).toBe("hello wor|ld");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("hello wor|ld");
   });
 });
 
@@ -133,7 +134,7 @@ describe("applyWordCountChange derives text from words", () => {
       .getState()
       .applyWordCountChange("l1", [w("hello ", 0, 1), w("wor", 1, 1.5), w("ld", 1.5, 2)], "words", "apply");
 
-    expect(useProjectStore.getState().lines[0].text).toBe("hello wor|ld");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("hello wor|ld");
   });
 });
 
@@ -142,18 +143,18 @@ describe("applyWordCountChange derives text from words", () => {
 describe("moveWordToBg derives text from both tracks", () => {
   it("re-derives main text and backgroundText after a move", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "l1",
         text: "hello world goodbye",
         agentId: "v1",
         words: [w("hello ", 0, 1), w("world ", 1, 2), w("goodbye", 2, 3)],
-      },
+      }),
     ]);
 
     useProjectStore.getState().moveWordToBg("l1", [2], 5, 30);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.text).toBe("hello world");
-    expect(line.backgroundText).toBe("goodbye");
+    expect(lineText(line)).toBe("hello world");
+    expect(bgText(line)).toBe("goodbye");
   });
 });

--- a/src/stores/project.derive-text.test.ts
+++ b/src/stores/project.derive-text.test.ts
@@ -72,7 +72,9 @@ describe("updateLineWithHistory derives text from words", () => {
   });
 
   it("leaves text untouched for a line with no words", () => {
-    useProjectStore.getState().setLines([reconcileLine({ id: "l1", text: "chorus line", agentId: "v1", begin: 0, end: 5 })]);
+    useProjectStore
+      .getState()
+      .setLines([reconcileLine({ id: "l1", text: "chorus line", agentId: "v1", begin: 0, end: 5 })]);
 
     useProjectStore.getState().updateLineWithHistory("l1", { begin: 1 });
 

--- a/src/stores/project.explicit.test.ts
+++ b/src/stores/project.explicit.test.ts
@@ -3,7 +3,8 @@
  */
 import { useProjectStore } from "@/stores/project";
 import type { LineTemplate, LinkGroup } from "@/domain/group/template";
-import type { LyricLine } from "@/domain/line/model";
+import { type LooseLine, reconcileLine } from "@/domain/line/model";
+import { bgSource, bgText, bgWords, mainWords } from "@/domain/line/voices";
 import { beforeEach, describe, expect, it } from "vitest";
 
 beforeEach(() => {
@@ -11,8 +12,8 @@ beforeEach(() => {
   useProjectStore.getState().clearHistory();
 });
 
-function seedSingleLine(line: LyricLine) {
-  useProjectStore.getState().setLines([line]);
+function seedSingleLine(line: LooseLine) {
+  useProjectStore.getState().setLines([reconcileLine(line)]);
 }
 
 describe("toggleWordExplicit · single line", () => {
@@ -29,9 +30,9 @@ describe("toggleWordExplicit · single line", () => {
     });
     useProjectStore.getState().toggleWordExplicit("L1", "words", [1]);
     const updated = useProjectStore.getState().lines[0];
-    expect(updated.words![0].explicit).toBeUndefined();
-    expect(updated.words![1].explicit).toBe(true);
-    expect(updated.words![2].explicit).toBeUndefined();
+    expect(mainWords(updated)![0].explicit).toBeUndefined();
+    expect(mainWords(updated)![1].explicit).toBe(true);
+    expect(mainWords(updated)![2].explicit).toBeUndefined();
   });
 
   it("removes the explicit key (does not store false) when toggling a marked word", () => {
@@ -42,7 +43,7 @@ describe("toggleWordExplicit · single line", () => {
       words: [{ text: "fuck", begin: 0, end: 1, explicit: true }],
     });
     useProjectStore.getState().toggleWordExplicit("L1", "words", [0]);
-    const word = useProjectStore.getState().lines[0].words![0];
+    const word = mainWords(useProjectStore.getState().lines[0])![0];
     expect("explicit" in word).toBe(false);
   });
 
@@ -58,7 +59,7 @@ describe("toggleWordExplicit · single line", () => {
       ],
     });
     useProjectStore.getState().toggleWordExplicit("L1", "words", [0, 1, 2]);
-    const words = useProjectStore.getState().lines[0].words!;
+    const words = mainWords(useProjectStore.getState().lines[0])!;
     expect(words[0].explicit).toBe(true);
     expect(words[1].explicit).toBe(true);
     expect(words[2].explicit).toBe(true);
@@ -76,7 +77,7 @@ describe("toggleWordExplicit · single line", () => {
       ],
     });
     useProjectStore.getState().toggleWordExplicit("L1", "words", [0, 1]);
-    const words = useProjectStore.getState().lines[0].words!;
+    const words = mainWords(useProjectStore.getState().lines[0])!;
     expect(words[0].explicit).toBeUndefined();
     expect(words[1].explicit).toBeUndefined();
   });
@@ -95,9 +96,9 @@ describe("toggleWordExplicit · single line", () => {
     });
     useProjectStore.getState().toggleWordExplicit("L1", "backgroundWords", [1]);
     const line = useProjectStore.getState().lines[0];
-    expect(line.words![0].explicit).toBeUndefined();
-    expect(line.backgroundWords![0].explicit).toBeUndefined();
-    expect(line.backgroundWords![1].explicit).toBe(true);
+    expect(mainWords(line)![0].explicit).toBeUndefined();
+    expect(bgWords(line)![0].explicit).toBeUndefined();
+    expect(bgWords(line)![1].explicit).toBe(true);
   });
 });
 
@@ -106,7 +107,7 @@ describe("toggleWordExplicit · linked-line propagation", () => {
     const group: LinkGroup = { id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 };
     useProjectStore.getState().setGroups([group]);
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "A",
         text: "I fuck you",
         agentId: "v1",
@@ -118,8 +119,8 @@ describe("toggleWordExplicit · linked-line propagation", () => {
           { text: "fuck ", begin: 0.3, end: 0.6 },
           { text: "you", begin: 0.6, end: 1 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "B",
         text: "I fuck you",
         agentId: "v1",
@@ -131,7 +132,7 @@ describe("toggleWordExplicit · linked-line propagation", () => {
           { text: "fuck ", begin: 30.4, end: 30.7 },
           { text: "you", begin: 30.7, end: 31.2 },
         ],
-      },
+      }),
     ]);
   }
 
@@ -139,10 +140,10 @@ describe("toggleWordExplicit · linked-line propagation", () => {
     seedLinkedGroup();
     useProjectStore.getState().toggleWordExplicit("A", "words", [1]);
     const lines = useProjectStore.getState().lines;
-    expect(lines[0].words![1].explicit).toBe(true);
-    expect(lines[1].words![1].explicit).toBe(true);
-    expect(lines[1].words![1].begin).toBeCloseTo(30.4);
-    expect(lines[1].words![1].end).toBeCloseTo(30.7);
+    expect(mainWords(lines[0])![1].explicit).toBe(true);
+    expect(mainWords(lines[1])![1].explicit).toBe(true);
+    expect(mainWords(lines[1])![1].begin).toBeCloseTo(30.4);
+    expect(mainWords(lines[1])![1].end).toBeCloseTo(30.7);
   });
 
   it("does not propagate to detached siblings", () => {
@@ -152,15 +153,15 @@ describe("toggleWordExplicit · linked-line propagation", () => {
       .setLines(useProjectStore.getState().lines.map((l) => (l.id === "B" ? { ...l, detached: true } : l)));
     useProjectStore.getState().toggleWordExplicit("A", "words", [1]);
     const lines = useProjectStore.getState().lines;
-    expect(lines[0].words![1].explicit).toBe(true);
-    expect(lines[1].words![1].explicit).toBeUndefined();
+    expect(mainWords(lines[0])![1].explicit).toBe(true);
+    expect(mainWords(lines[1])![1].explicit).toBeUndefined();
   });
 
   it("clears the flag on siblings when source unmarks", () => {
     const group: LinkGroup = { id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 };
     useProjectStore.getState().setGroups([group]);
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "A",
         text: "I fuck you",
         agentId: "v1",
@@ -172,8 +173,8 @@ describe("toggleWordExplicit · linked-line propagation", () => {
           { text: "fuck ", begin: 0.3, end: 0.6, explicit: true },
           { text: "you", begin: 0.6, end: 1 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "B",
         text: "I fuck you",
         agentId: "v1",
@@ -185,12 +186,12 @@ describe("toggleWordExplicit · linked-line propagation", () => {
           { text: "fuck ", begin: 30.4, end: 30.7, explicit: true },
           { text: "you", begin: 30.7, end: 31.2 },
         ],
-      },
+      }),
     ]);
     useProjectStore.getState().toggleWordExplicit("A", "words", [1]);
     const lines = useProjectStore.getState().lines;
-    expect(lines[0].words![1].explicit).toBeUndefined();
-    expect(lines[1].words![1].explicit).toBeUndefined();
+    expect(mainWords(lines[0])![1].explicit).toBeUndefined();
+    expect(mainWords(lines[1])![1].explicit).toBeUndefined();
   });
 });
 
@@ -214,10 +215,10 @@ describe("addInstance · template materialization carries explicit", () => {
     useProjectStore.getState().addInstance("g1", structure, 30);
     const line = useProjectStore.getState().lines.find((l) => l.groupId === "g1");
     expect(line).toBeDefined();
-    expect(line!.words![0].explicit).toBeUndefined();
-    expect(line!.words![1].explicit).toBe(true);
-    expect(line!.words![1].begin).toBeCloseTo(30.3);
-    expect(line!.words![2].explicit).toBeUndefined();
+    expect(mainWords(line!)![0].explicit).toBeUndefined();
+    expect(mainWords(line!)![1].explicit).toBe(true);
+    expect(mainWords(line!)![1].begin).toBeCloseTo(30.3);
+    expect(mainWords(line!)![2].explicit).toBeUndefined();
   });
 
   it("carries explicit from WordTemplate onto backgroundWords", () => {
@@ -239,9 +240,9 @@ describe("addInstance · template materialization carries explicit", () => {
     ];
     useProjectStore.getState().addInstance("g1", structure, 10);
     const line = useProjectStore.getState().lines.find((l) => l.groupId === "g1");
-    expect(line!.backgroundWords![0].explicit).toBeUndefined();
-    expect(line!.backgroundWords![1].explicit).toBe(true);
-    expect(line!.backgroundWords![1].begin).toBeCloseTo(10.5);
+    expect(bgWords(line!)![0].explicit).toBeUndefined();
+    expect(bgWords(line!)![1].explicit).toBe(true);
+    expect(bgWords(line!)![1].begin).toBeCloseTo(10.5);
   });
 });
 
@@ -254,9 +255,9 @@ describe("toggleWordExplicit · history", () => {
       words: [{ text: "fuck", begin: 0, end: 1 }],
     });
     useProjectStore.getState().toggleWordExplicit("L1", "words", [0]);
-    expect(useProjectStore.getState().lines[0].words![0].explicit).toBe(true);
+    expect(mainWords(useProjectStore.getState().lines[0])![0].explicit).toBe(true);
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].words![0].explicit).toBeUndefined();
+    expect(mainWords(useProjectStore.getState().lines[0])![0].explicit).toBeUndefined();
   });
 });
 
@@ -275,7 +276,7 @@ describe("toggleWordExplicit · syllable expansion (issue #62)", () => {
       ],
     });
     useProjectStore.getState().toggleWordExplicit("L1", "words", [1]);
-    const words = useProjectStore.getState().lines[0].words!;
+    const words = mainWords(useProjectStore.getState().lines[0])!;
     expect(words[1].explicit).toBe(true);
     expect(words[2].explicit).toBe(true);
     expect(words[0].explicit).toBeUndefined();
@@ -293,7 +294,7 @@ describe("toggleWordExplicit · syllable expansion (issue #62)", () => {
       ],
     });
     useProjectStore.getState().toggleWordExplicit("L1", "words", [1]);
-    const words = useProjectStore.getState().lines[0].words!;
+    const words = mainWords(useProjectStore.getState().lines[0])!;
     expect(words[0].explicit).toBeUndefined();
     expect(words[1].explicit).toBeUndefined();
   });
@@ -302,7 +303,7 @@ describe("toggleWordExplicit · syllable expansion (issue #62)", () => {
     const group: LinkGroup = { id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 };
     useProjectStore.getState().setGroups([group]);
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "A",
         text: "fu|cking yeah",
         agentId: "v1",
@@ -314,8 +315,8 @@ describe("toggleWordExplicit · syllable expansion (issue #62)", () => {
           { text: "cking ", begin: 0.2, end: 0.5 },
           { text: "yeah", begin: 0.5, end: 1 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "B",
         text: "fu|cking yeah",
         agentId: "v1",
@@ -327,14 +328,14 @@ describe("toggleWordExplicit · syllable expansion (issue #62)", () => {
           { text: "cking ", begin: 30.2, end: 30.5 },
           { text: "yeah", begin: 30.5, end: 31 },
         ],
-      },
+      }),
     ]);
     useProjectStore.getState().toggleWordExplicit("A", "words", [0]);
     const lines = useProjectStore.getState().lines;
-    expect(lines[0].words![0].explicit).toBe(true);
-    expect(lines[0].words![1].explicit).toBe(true);
-    expect(lines[1].words![0].explicit).toBe(true);
-    expect(lines[1].words![1].explicit).toBe(true);
+    expect(mainWords(lines[0])![0].explicit).toBe(true);
+    expect(mainWords(lines[0])![1].explicit).toBe(true);
+    expect(mainWords(lines[1])![0].explicit).toBe(true);
+    expect(mainWords(lines[1])![1].explicit).toBe(true);
   });
 });
 
@@ -351,7 +352,7 @@ describe("markWordsExplicit · syllable + batch (issue #62)", () => {
       ],
     });
     useProjectStore.getState().markWordsExplicit([{ lineId: "L1", field: "words", wordIndex: 0 }], true);
-    const words = useProjectStore.getState().lines[0].words!;
+    const words = mainWords(useProjectStore.getState().lines[0])!;
     expect(words[0].explicit).toBe(true);
     expect(words[1].explicit).toBe(true);
     expect(words[2].explicit).toBeUndefined();
@@ -361,7 +362,7 @@ describe("markWordsExplicit · syllable + batch (issue #62)", () => {
     const group: LinkGroup = { id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 };
     useProjectStore.getState().setGroups([group]);
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "A",
         text: "fuck this shit",
         agentId: "v1",
@@ -373,8 +374,8 @@ describe("markWordsExplicit · syllable + batch (issue #62)", () => {
           { text: "this ", begin: 0.3, end: 0.6 },
           { text: "shit", begin: 0.6, end: 1, explicit: true },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "B",
         text: "fuck this shit",
         agentId: "v1",
@@ -386,7 +387,7 @@ describe("markWordsExplicit · syllable + batch (issue #62)", () => {
           { text: "this ", begin: 30.3, end: 30.6 },
           { text: "shit", begin: 30.6, end: 31, explicit: true },
         ],
-      },
+      }),
     ]);
     useProjectStore.getState().markWordsExplicit(
       [
@@ -396,10 +397,10 @@ describe("markWordsExplicit · syllable + batch (issue #62)", () => {
       true,
     );
     const lines = useProjectStore.getState().lines;
-    expect(lines[0].words![0].explicit).toBe(true);
-    expect(lines[0].words![2].explicit).toBe(true);
-    expect(lines[1].words![0].explicit).toBe(true);
-    expect(lines[1].words![2].explicit).toBe(true);
+    expect(mainWords(lines[0])![0].explicit).toBe(true);
+    expect(mainWords(lines[0])![2].explicit).toBe(true);
+    expect(mainWords(lines[1])![0].explicit).toBe(true);
+    expect(mainWords(lines[1])![2].explicit).toBe(true);
   });
 });
 
@@ -423,25 +424,25 @@ describe("toggleWordExplicit · background provenance", () => {
     seedExtractionBgLine();
     useProjectStore.getState().toggleWordExplicit("L1", "backgroundWords", [1]);
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundTextSource).toBe("manual");
-    expect(line.backgroundWords![1].explicit).toBe(true);
-    expect(line.backgroundWords![0].explicit).toBeUndefined();
-    expect(line.backgroundText).toBe("oh shit");
+    expect(bgSource(line)).toBe("manual");
+    expect(bgWords(line)![1].explicit).toBe(true);
+    expect(bgWords(line)![0].explicit).toBeUndefined();
+    expect(bgText(line)).toBe("oh shit");
   });
 
   it("leaves backgroundTextSource untouched when editing the main words field", () => {
     seedExtractionBgLine();
     useProjectStore.getState().toggleWordExplicit("L1", "words", [0]);
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundTextSource).toBe("extraction");
-    expect(line.words![0].explicit).toBe(true);
+    expect(bgSource(line)).toBe("extraction");
+    expect(mainWords(line)![0].explicit).toBe(true);
   });
 
   it("flips linked siblings to manual when a background-word edit propagates", () => {
     const group: LinkGroup = { id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 };
     useProjectStore.getState().setGroups([group]);
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "A",
         text: "main",
         agentId: "v1",
@@ -455,8 +456,8 @@ describe("toggleWordExplicit · background provenance", () => {
           { text: "oh ", begin: 1, end: 1.25 },
           { text: "shit", begin: 1.25, end: 1.5 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "B",
         text: "main",
         agentId: "v1",
@@ -470,23 +471,23 @@ describe("toggleWordExplicit · background provenance", () => {
           { text: "oh ", begin: 31, end: 31.25 },
           { text: "shit", begin: 31.25, end: 31.5 },
         ],
-      },
+      }),
     ]);
     useProjectStore.getState().toggleWordExplicit("A", "backgroundWords", [1]);
     const lines = useProjectStore.getState().lines;
-    expect(lines[0].backgroundTextSource).toBe("manual");
-    expect(lines[1].backgroundTextSource).toBe("manual");
-    expect(lines[0].backgroundWords![1].explicit).toBe(true);
-    expect(lines[1].backgroundWords![1].explicit).toBe(true);
-    expect(lines[1].backgroundWords![1].begin).toBeCloseTo(31.25);
+    expect(bgSource(lines[0])).toBe("manual");
+    expect(bgSource(lines[1])).toBe("manual");
+    expect(bgWords(lines[0])![1].explicit).toBe(true);
+    expect(bgWords(lines[1])![1].explicit).toBe(true);
+    expect(bgWords(lines[1])![1].begin).toBeCloseTo(31.25);
   });
 
   it("undo restores the prior extraction provenance", () => {
     seedExtractionBgLine();
     useProjectStore.getState().toggleWordExplicit("L1", "backgroundWords", [1]);
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("extraction");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("extraction");
   });
 });
 
@@ -506,9 +507,9 @@ describe("markWordsExplicit · background provenance", () => {
     });
     useProjectStore.getState().markWordsExplicit([{ lineId: "L1", field: "backgroundWords", wordIndex: 0 }], true);
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundTextSource).toBe("manual");
-    expect(line.backgroundWords![0].explicit).toBe(true);
-    expect(line.backgroundText).toBe("oh shit");
+    expect(bgSource(line)).toBe("manual");
+    expect(bgWords(line)![0].explicit).toBe(true);
+    expect(bgText(line)).toBe("oh shit");
   });
 
   it("leaves backgroundTextSource untouched when marking the main words field", () => {
@@ -526,15 +527,15 @@ describe("markWordsExplicit · background provenance", () => {
     });
     useProjectStore.getState().markWordsExplicit([{ lineId: "L1", field: "words", wordIndex: 0 }], true);
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundTextSource).toBe("extraction");
-    expect(line.words![0].explicit).toBe(true);
+    expect(bgSource(line)).toBe("extraction");
+    expect(mainWords(line)![0].explicit).toBe(true);
   });
 
   it("flips linked siblings to manual when a background-word edit propagates", () => {
     const group: LinkGroup = { id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 };
     useProjectStore.getState().setGroups([group]);
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "A",
         text: "main",
         agentId: "v1",
@@ -548,8 +549,8 @@ describe("markWordsExplicit · background provenance", () => {
           { text: "oh ", begin: 1, end: 1.25 },
           { text: "shit", begin: 1.25, end: 1.5 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "B",
         text: "main",
         agentId: "v1",
@@ -563,21 +564,21 @@ describe("markWordsExplicit · background provenance", () => {
           { text: "oh ", begin: 31, end: 31.25 },
           { text: "shit", begin: 31.25, end: 31.5 },
         ],
-      },
+      }),
     ]);
     useProjectStore.getState().markWordsExplicit([{ lineId: "A", field: "backgroundWords", wordIndex: 0 }], true);
     const lines = useProjectStore.getState().lines;
-    expect(lines[0].backgroundTextSource).toBe("manual");
-    expect(lines[1].backgroundTextSource).toBe("manual");
-    expect(lines[0].backgroundWords![0].explicit).toBe(true);
-    expect(lines[1].backgroundWords![0].explicit).toBe(true);
+    expect(bgSource(lines[0])).toBe("manual");
+    expect(bgSource(lines[1])).toBe("manual");
+    expect(bgWords(lines[0])![0].explicit).toBe(true);
+    expect(bgWords(lines[1])![0].explicit).toBe(true);
   });
 });
 
 describe("markWordsExplicit · batch action", () => {
   it("applies multiple targets in a single history entry so one undo reverts them all", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "L1",
         text: "fuck this",
         agentId: "v1",
@@ -585,8 +586,8 @@ describe("markWordsExplicit · batch action", () => {
           { text: "fuck ", begin: 0, end: 0.5 },
           { text: "this", begin: 0.5, end: 1 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "L2",
         text: "shit happens",
         agentId: "v1",
@@ -594,8 +595,8 @@ describe("markWordsExplicit · batch action", () => {
           { text: "shit ", begin: 1, end: 1.5 },
           { text: "happens", begin: 1.5, end: 2 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "L3",
         text: "damn cool",
         agentId: "v1",
@@ -603,7 +604,7 @@ describe("markWordsExplicit · batch action", () => {
           { text: "damn ", begin: 2, end: 2.5 },
           { text: "cool", begin: 2.5, end: 3 },
         ],
-      },
+      }),
     ]);
 
     useProjectStore.getState().markWordsExplicit(
@@ -616,22 +617,22 @@ describe("markWordsExplicit · batch action", () => {
     );
 
     const after = useProjectStore.getState().lines;
-    expect(after[0].words![0].explicit).toBe(true);
-    expect(after[1].words![0].explicit).toBe(true);
-    expect(after[2].words![0].explicit).toBe(true);
+    expect(mainWords(after[0])![0].explicit).toBe(true);
+    expect(mainWords(after[1])![0].explicit).toBe(true);
+    expect(mainWords(after[2])![0].explicit).toBe(true);
 
     useProjectStore.getState().undo();
     const undone = useProjectStore.getState().lines;
-    expect(undone[0].words![0].explicit).toBeUndefined();
-    expect(undone[1].words![0].explicit).toBeUndefined();
-    expect(undone[2].words![0].explicit).toBeUndefined();
+    expect(mainWords(undone[0])![0].explicit).toBeUndefined();
+    expect(mainWords(undone[1])![0].explicit).toBeUndefined();
+    expect(mainWords(undone[2])![0].explicit).toBeUndefined();
   });
 
   it("propagates to linked siblings for each target", () => {
     const group: LinkGroup = { id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 };
     useProjectStore.getState().setGroups([group]);
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "A",
         text: "I fuck you",
         agentId: "v1",
@@ -643,8 +644,8 @@ describe("markWordsExplicit · batch action", () => {
           { text: "fuck ", begin: 0.3, end: 0.6 },
           { text: "you", begin: 0.6, end: 1 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "B",
         text: "I fuck you",
         agentId: "v1",
@@ -656,13 +657,13 @@ describe("markWordsExplicit · batch action", () => {
           { text: "fuck ", begin: 30.4, end: 30.7 },
           { text: "you", begin: 30.7, end: 31.2 },
         ],
-      },
+      }),
     ]);
 
     useProjectStore.getState().markWordsExplicit([{ lineId: "A", field: "words", wordIndex: 1 }], true);
     const lines = useProjectStore.getState().lines;
-    expect(lines[0].words![1].explicit).toBe(true);
-    expect(lines[1].words![1].explicit).toBe(true);
+    expect(mainWords(lines[0])![1].explicit).toBe(true);
+    expect(mainWords(lines[1])![1].explicit).toBe(true);
   });
 
   it("is a no-op when targets is empty", () => {
@@ -694,7 +695,7 @@ describe("markWordsExplicit · batch action", () => {
       ],
       false,
     );
-    const words = useProjectStore.getState().lines[0].words!;
+    const words = mainWords(useProjectStore.getState().lines[0])!;
     expect(words[0].explicit).toBeUndefined();
     expect(words[1].explicit).toBeUndefined();
   });

--- a/src/stores/project.groups.test.ts
+++ b/src/stores/project.groups.test.ts
@@ -3,7 +3,10 @@
  */
 import { useProjectStore } from "@/stores/project";
 import type { LineTemplate, LinkGroup } from "@/domain/group/template";
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { mainBounds } from "@/domain/line/bounds";
+import { isLineSynced } from "@/domain/line/predicates";
 import { beforeEach, describe, expect, it } from "vitest";
 
 beforeEach(() => {
@@ -21,7 +24,7 @@ describe("project store · group types", () => {
   });
 
   it("LyricLine accepts optional group fields", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "l1",
       text: "I love you",
       agentId: "v1",
@@ -29,7 +32,7 @@ describe("project store · group types", () => {
       instanceIdx: 0,
       templateLineIdx: 0,
       detached: false,
-    };
+    });
     expect(line.groupId).toBe("g1");
     expect(line.instanceIdx).toBe(0);
     expect(line.templateLineIdx).toBe(0);
@@ -50,11 +53,13 @@ describe("project store · history captures groups", () => {
     const initialGroups = [seedGroup("g1")];
     useProjectStore.setState({ groups: initialGroups, lines: [] });
 
-    useProjectStore.getState().setLinesWithHistory([{ id: "l1", text: "test", agentId: "v1", groupId: "g1" }]);
+    useProjectStore
+      .getState()
+      .setLinesWithHistory([reconcileLine({ id: "l1", text: "test", agentId: "v1", groupId: "g1" })]);
 
     useProjectStore.setState({ groups: [] });
 
-    useProjectStore.getState().setLinesWithHistory([{ id: "l2", text: "test2", agentId: "v1" }]);
+    useProjectStore.getState().setLinesWithHistory([reconcileLine({ id: "l2", text: "test2", agentId: "v1" })]);
 
     useProjectStore.getState().undo();
 
@@ -64,11 +69,11 @@ describe("project store · history captures groups", () => {
   it("redo restores the post-edit groups", () => {
     useProjectStore.setState({ groups: [seedGroup("g1")], lines: [] });
 
-    useProjectStore.getState().setLinesWithHistory([{ id: "l1", text: "a", agentId: "v1" }]);
+    useProjectStore.getState().setLinesWithHistory([reconcileLine({ id: "l1", text: "a", agentId: "v1" })]);
 
     useProjectStore.setState({ groups: [seedGroup("g1"), seedGroup("g2", { label: "Verse" })] });
 
-    useProjectStore.getState().setLinesWithHistory([{ id: "l2", text: "b", agentId: "v1" }]);
+    useProjectStore.getState().setLinesWithHistory([reconcileLine({ id: "l2", text: "b", agentId: "v1" })]);
 
     useProjectStore.getState().undo();
     expect(useProjectStore.getState().groups.map((g) => g.id)).toEqual(["g1"]);
@@ -83,7 +88,7 @@ describe("project store · history captures groups", () => {
 
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "l1",
           text: "hi there",
           agentId: "v1",
@@ -91,7 +96,7 @@ describe("project store · history captures groups", () => {
             { text: "hi ", begin: 0, end: 1 },
             { text: "there", begin: 1, end: 2 },
           ],
-        },
+        }),
       ],
     });
 
@@ -119,15 +124,17 @@ describe("project store · group registry mutators", () => {
   it("addGroupWithLines undoes group + lines in a single step (no residue)", () => {
     useProjectStore.setState({
       lines: [
-        { id: "l1", text: "a", agentId: "v1" },
-        { id: "l2", text: "b", agentId: "v1" },
+        reconcileLine({ id: "l1", text: "a", agentId: "v1" }),
+        reconcileLine({ id: "l2", text: "b", agentId: "v1" }),
       ],
     });
 
-    useProjectStore.getState().addGroupWithLines(seedGroup("g1"), [
-      { id: "l1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "l2", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 },
-    ]);
+    useProjectStore
+      .getState()
+      .addGroupWithLines(seedGroup("g1"), [
+        reconcileLine({ id: "l1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+        reconcileLine({ id: "l2", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 }),
+      ]);
 
     expect(useProjectStore.getState().groups).toHaveLength(1);
     expect(useProjectStore.getState().lines[0].groupId).toBe("g1");
@@ -164,19 +171,19 @@ describe("project store · group registry mutators", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "l1",
           text: "test",
           agentId: "v1",
           groupId: "g1",
           instanceIdx: 0,
           templateLineIdx: 0,
-        },
-        {
+        }),
+        reconcileLine({
           id: "l2",
           text: "untouched",
           agentId: "v1",
-        },
+        }),
       ],
     });
 
@@ -186,7 +193,7 @@ describe("project store · group registry mutators", () => {
     expect(useProjectStore.getState().lines[0].groupId).toBeUndefined();
     expect(useProjectStore.getState().lines[0].instanceIdx).toBeUndefined();
     expect(useProjectStore.getState().lines[0].templateLineIdx).toBeUndefined();
-    expect(useProjectStore.getState().lines[1].text).toBe("untouched");
+    expect(lineText(useProjectStore.getState().lines[1])).toBe("untouched");
   });
 
   it("removeGroup is undoable (group + line fields restored together)", () => {
@@ -194,7 +201,7 @@ describe("project store · group registry mutators", () => {
     useProjectStore
       .getState()
       .setLinesWithHistory([
-        { id: "l1", text: "test", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
+        reconcileLine({ id: "l1", text: "test", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
       ]);
 
     useProjectStore.getState().removeGroup("g1");
@@ -235,10 +242,10 @@ describe("project store · instance mutators", () => {
     expect(created).toHaveLength(1);
     expect(created[0].instanceIdx).toBe(0);
     expect(created[0].templateLineIdx).toBe(0);
-    expect(created[0].begin).toBeUndefined();
-    expect(created[0].words?.[0].begin).toBeCloseTo(30);
-    expect(created[0].words?.[1].begin).toBeCloseTo(30.4);
-    expect(created[0].words?.[2].end).toBeCloseTo(31.2);
+    expect(isLineSynced(created[0])).toBe(false);
+    expect(mainWords(created[0])?.[0].begin).toBeCloseTo(30);
+    expect(mainWords(created[0])?.[1].begin).toBeCloseTo(30.4);
+    expect(mainWords(created[0])?.[2].end).toBeCloseTo(31.2);
   });
 
   it("addInstance carries backgroundText/backgroundWords/backgroundTextSource from the template", () => {
@@ -258,9 +265,9 @@ describe("project store · instance mutators", () => {
 
     const created = useProjectStore.getState().lines.filter((l) => l.groupId === "g1");
     expect(created).toHaveLength(1);
-    expect(created[0].backgroundText).toBe("ooh");
-    expect(created[0].backgroundWords?.[0].begin).toBeCloseTo(30);
-    expect(created[0].backgroundTextSource).toBe("extraction");
+    expect(bgText(created[0])).toBe("ooh");
+    expect(bgWords(created[0])?.[0].begin).toBeCloseTo(30);
+    expect(bgSource(created[0])).toBe("extraction");
   });
 
   it("addInstance carries a manual-sourced background flag", () => {
@@ -278,7 +285,7 @@ describe("project store · instance mutators", () => {
     useProjectStore.getState().addInstance("g1", structure, 0);
 
     const created = useProjectStore.getState().lines.filter((l) => l.groupId === "g1");
-    expect(created[0].backgroundTextSource).toBe("manual");
+    expect(bgSource(created[0])).toBe("manual");
   });
 
   it("addInstance leaves backgroundTextSource undefined for a template with no background", () => {
@@ -288,7 +295,7 @@ describe("project store · instance mutators", () => {
     useProjectStore.getState().addInstance("g1", structure, 0);
 
     const created = useProjectStore.getState().lines.filter((l) => l.groupId === "g1");
-    expect(created[0].backgroundTextSource).toBeUndefined();
+    expect(bgSource(created[0])).toBeUndefined();
   });
 
   it("addInstance picks the next unused instanceIdx", () => {
@@ -310,9 +317,9 @@ describe("project store · instance mutators", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        { id: "a0", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-        { id: "a1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
-        { id: "b0", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 },
+        reconcileLine({ id: "a0", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+        reconcileLine({ id: "a1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 }),
+        reconcileLine({ id: "b0", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 }),
       ],
     });
 
@@ -329,7 +336,7 @@ describe("project store · instance mutators", () => {
   it("removeInstance dissolves the group when removing the last instance", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
-      lines: [{ id: "a", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }],
+      lines: [reconcileLine({ id: "a", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 })],
     });
 
     useProjectStore.getState().removeInstance("g1", 0);
@@ -342,7 +349,7 @@ describe("project store · instance mutators", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a",
           text: "I love you",
           agentId: "v1",
@@ -354,7 +361,7 @@ describe("project store · instance mutators", () => {
             { text: "love ", begin: 30.4, end: 30.8 },
             { text: "you", begin: 30.8, end: 31.2 },
           ],
-        },
+        }),
       ],
     });
 
@@ -364,8 +371,8 @@ describe("project store · instance mutators", () => {
     expect(line.groupId).toBeUndefined();
     expect(line.instanceIdx).toBeUndefined();
     expect(line.templateLineIdx).toBeUndefined();
-    expect(line.text).toBe("I love you");
-    expect(line.words?.[0].begin).toBeCloseTo(30);
+    expect(lineText(line)).toBe("I love you");
+    expect(mainWords(line)?.[0].begin).toBeCloseTo(30);
   });
 
   it("instance mutators are undoable", () => {
@@ -385,7 +392,7 @@ describe("project store · shiftInstance", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a0",
           text: "hi",
           agentId: "v1",
@@ -396,8 +403,8 @@ describe("project store · shiftInstance", () => {
             { text: "hi ", begin: 30, end: 31 },
             { text: "there", begin: 31, end: 32 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "a1",
           text: "hi",
           agentId: "v1",
@@ -408,7 +415,7 @@ describe("project store · shiftInstance", () => {
             { text: "hi ", begin: 60, end: 61 },
             { text: "there", begin: 61, end: 62 },
           ],
-        },
+        }),
       ],
     });
 
@@ -418,18 +425,18 @@ describe("project store · shiftInstance", () => {
     const i0 = lines.find((l) => l.id === "a0");
     const i1 = lines.find((l) => l.id === "a1");
 
-    expect(i0?.words?.[0].begin).toBeCloseTo(30);
-    expect(i0?.words?.[1].end).toBeCloseTo(32);
+    expect(i0 && mainWords(i0)?.[0].begin).toBeCloseTo(30);
+    expect(i0 && mainWords(i0)?.[1].end).toBeCloseTo(32);
 
-    expect(i1?.words?.[0].begin).toBeCloseTo(65);
-    expect(i1?.words?.[1].end).toBeCloseTo(67);
+    expect(i1 && mainWords(i1)?.[0].begin).toBeCloseTo(65);
+    expect(i1 && mainWords(i1)?.[1].end).toBeCloseTo(67);
   });
 
   it("shifts background words too", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a",
           text: "hi",
           agentId: "v1",
@@ -438,13 +445,13 @@ describe("project store · shiftInstance", () => {
           templateLineIdx: 0,
           backgroundText: "yeah",
           backgroundWords: [{ text: "yeah", begin: 30, end: 31 }],
-        },
+        }),
       ],
     });
 
     useProjectStore.getState().shiftInstance("g1", 0, 2);
 
-    const bg = useProjectStore.getState().lines[0].backgroundWords?.[0];
+    const bg = bgWords(useProjectStore.getState().lines[0])?.[0];
     expect(bg?.begin).toBeCloseTo(32);
     expect(bg?.end).toBeCloseTo(33);
   });
@@ -453,7 +460,7 @@ describe("project store · shiftInstance", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a",
           text: "hi",
           agentId: "v1",
@@ -462,23 +469,23 @@ describe("project store · shiftInstance", () => {
           templateLineIdx: 0,
           begin: 10,
           end: 11,
-        },
+        }),
       ],
     });
     useProjectStore.getState().clearHistory();
 
     useProjectStore.getState().shiftInstance("g1", 0, 5);
-    expect(useProjectStore.getState().lines[0].begin).toBeCloseTo(15);
+    expect(mainBounds(useProjectStore.getState().lines[0])?.begin).toBeCloseTo(15);
 
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].begin).toBeCloseTo(10);
+    expect(mainBounds(useProjectStore.getState().lines[0])?.begin).toBeCloseTo(10);
   });
 
   it("does not shift a line whose link metadata still matches but detached=true (defense-in-depth)", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "live",
           text: "x",
           agentId: "v1",
@@ -486,8 +493,8 @@ describe("project store · shiftInstance", () => {
           instanceIdx: 0,
           templateLineIdx: 0,
           words: [{ text: "x", begin: 10, end: 11 }],
-        },
-        {
+        }),
+        reconcileLine({
           id: "stale-detached",
           text: "y",
           agentId: "v1",
@@ -496,15 +503,17 @@ describe("project store · shiftInstance", () => {
           templateLineIdx: 1,
           detached: true,
           words: [{ text: "y", begin: 10, end: 11 }],
-        },
+        }),
       ],
     });
     useProjectStore.getState().clearHistory();
 
     useProjectStore.getState().shiftInstance("g1", 0, 0.5);
     const after = useProjectStore.getState().lines;
-    expect(after.find((l) => l.id === "live")?.words?.[0].begin).toBeCloseTo(10.5);
-    expect(after.find((l) => l.id === "stale-detached")?.words?.[0].begin).toBeCloseTo(10);
+    const live = after.find((l) => l.id === "live");
+    const staleDetached = after.find((l) => l.id === "stale-detached");
+    expect(live && mainWords(live)?.[0].begin).toBeCloseTo(10.5);
+    expect(staleDetached && mainWords(staleDetached)?.[0].begin).toBeCloseTo(10);
   });
 });
 
@@ -513,7 +522,7 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a0",
           text: "I love you",
           agentId: "v1",
@@ -522,8 +531,8 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
           templateLineIdx: 0,
           begin: 30,
           end: 32,
-        },
-        {
+        }),
+        reconcileLine({
           id: "a1",
           text: "I love you",
           agentId: "v1",
@@ -532,7 +541,7 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
           templateLineIdx: 0,
           begin: 60,
           end: 62,
-        },
+        }),
       ],
     });
   }
@@ -542,8 +551,10 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
     useProjectStore.getState().updateLineWithHistory("a0", { text: "I really love you" });
 
     const lines = useProjectStore.getState().lines;
-    expect(lines.find((l) => l.id === "a0")?.text).toBe("I really love you");
-    expect(lines.find((l) => l.id === "a1")?.text).toBe("I really love you");
+    const a0 = lines.find((l) => l.id === "a0");
+    const a1 = lines.find((l) => l.id === "a1");
+    expect(a0 && lineText(a0)).toBe("I really love you");
+    expect(a1 && lineText(a1)).toBe("I really love you");
   });
 
   it("propagates agentId edits", () => {
@@ -560,10 +571,12 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
     useProjectStore.getState().updateLineWithHistory("a0", { begin: 25, end: 27 });
 
     const lines = useProjectStore.getState().lines;
-    expect(lines.find((l) => l.id === "a0")?.begin).toBe(25);
-    expect(lines.find((l) => l.id === "a0")?.end).toBe(27);
-    expect(lines.find((l) => l.id === "a1")?.begin).toBe(60);
-    expect(lines.find((l) => l.id === "a1")?.end).toBe(62);
+    const a0 = lines.find((l) => l.id === "a0");
+    const a1 = lines.find((l) => l.id === "a1");
+    expect(a0 && mainBounds(a0)?.begin).toBe(25);
+    expect(a0 && mainBounds(a0)?.end).toBe(27);
+    expect(a1 && mainBounds(a1)?.begin).toBe(60);
+    expect(a1 && mainBounds(a1)?.end).toBe(62);
   });
 
   it("skips detached siblings", () => {
@@ -575,8 +588,10 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
     useProjectStore.getState().updateLineWithHistory("a0", { text: "new text" });
 
     const lines = useProjectStore.getState().lines;
-    expect(lines.find((l) => l.id === "a0")?.text).toBe("new text");
-    expect(lines.find((l) => l.id === "a1")?.text).toBe("I love you");
+    const a0 = lines.find((l) => l.id === "a0");
+    const a1 = lines.find((l) => l.id === "a1");
+    expect(a0 && lineText(a0)).toBe("new text");
+    expect(a1 && lineText(a1)).toBe("I love you");
   });
 
   it("does not affect lines from other groups", () => {
@@ -584,30 +599,38 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
     useProjectStore.setState((state) => ({
       lines: [
         ...state.lines,
-        { id: "x", text: "other group", agentId: "v1", groupId: "g2", instanceIdx: 0, templateLineIdx: 0 },
+        reconcileLine({
+          id: "x",
+          text: "other group",
+          agentId: "v1",
+          groupId: "g2",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+        }),
       ],
     }));
 
     useProjectStore.getState().updateLineWithHistory("a0", { text: "changed" });
 
-    expect(useProjectStore.getState().lines.find((l) => l.id === "x")?.text).toBe("other group");
+    const x = useProjectStore.getState().lines.find((l) => l.id === "x");
+    expect(x && lineText(x)).toBe("other group");
   });
 
   it("standalone (non-grouped) edits work as before (regression)", () => {
     useProjectStore.setState({
-      lines: [{ id: "s", text: "standalone", agentId: "v1" }],
+      lines: [reconcileLine({ id: "s", text: "standalone", agentId: "v1" })],
     });
 
     useProjectStore.getState().updateLineWithHistory("s", { text: "edited" });
 
-    expect(useProjectStore.getState().lines[0].text).toBe("edited");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("edited");
   });
 
   it("propagates word text edits to siblings while preserving sibling timing", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a0",
           text: "I love you",
           agentId: "v1",
@@ -619,8 +642,8 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
             { text: "love ", begin: 30.4, end: 30.8 },
             { text: "you", begin: 30.8, end: 31.2 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "a1",
           text: "I love you",
           agentId: "v1",
@@ -632,7 +655,7 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
             { text: "love ", begin: 60.5, end: 61.0 },
             { text: "you", begin: 61.0, end: 61.5 },
           ],
-        },
+        }),
       ],
     });
 
@@ -646,18 +669,18 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
 
     const lines = useProjectStore.getState().lines;
     const a1 = lines.find((l) => l.id === "a1");
-    expect(a1?.words?.[1].text).toBe("really ");
-    expect(a1?.words?.[1].begin).toBe(60.5);
-    expect(a1?.words?.[1].end).toBe(61.0);
-    expect(a1?.words?.[0].begin).toBe(60);
-    expect(a1?.words?.[2].end).toBe(61.5);
+    expect(a1 && mainWords(a1)?.[1].text).toBe("really ");
+    expect(a1 && mainWords(a1)?.[1].begin).toBe(60.5);
+    expect(a1 && mainWords(a1)?.[1].end).toBe(61.0);
+    expect(a1 && mainWords(a1)?.[0].begin).toBe(60);
+    expect(a1 && mainWords(a1)?.[2].end).toBe(61.5);
   });
 
   it("propagates background word text edits to siblings", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a0",
           text: "main",
           agentId: "v1",
@@ -669,8 +692,8 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
             { text: "ohh ", begin: 30, end: 30.5 },
             { text: "ahh", begin: 30.5, end: 31 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "a1",
           text: "main",
           agentId: "v1",
@@ -682,7 +705,7 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
             { text: "ohh ", begin: 60, end: 60.7 },
             { text: "ahh", begin: 60.7, end: 61.4 },
           ],
-        },
+        }),
       ],
     });
 
@@ -694,17 +717,17 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
     });
 
     const a1 = useProjectStore.getState().lines.find((l) => l.id === "a1");
-    expect(a1?.backgroundWords?.[0].text).toBe("ooh ");
-    expect(a1?.backgroundWords?.[1].text).toBe("yeah");
-    expect(a1?.backgroundWords?.[0].begin).toBe(60);
-    expect(a1?.backgroundWords?.[1].end).toBe(61.4);
+    expect((a1 && bgWords(a1))?.[0].text).toBe("ooh ");
+    expect((a1 && bgWords(a1))?.[1].text).toBe("yeah");
+    expect((a1 && bgWords(a1))?.[0].begin).toBe(60);
+    expect((a1 && bgWords(a1))?.[1].end).toBe(61.4);
   });
 
   it("propagates word splits to siblings, scaling timing to sibling span", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a0",
           text: "loving you",
           agentId: "v1",
@@ -715,8 +738,8 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
             { text: "loving ", begin: 0, end: 1 },
             { text: "you", begin: 1, end: 2 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "a1",
           text: "loving you",
           agentId: "v1",
@@ -727,7 +750,7 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
             { text: "loving ", begin: 10, end: 12 },
             { text: "you", begin: 12, end: 14 },
           ],
-        },
+        }),
       ],
     });
 
@@ -740,21 +763,21 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
     });
 
     const a1 = useProjectStore.getState().lines.find((l) => l.id === "a1");
-    expect(a1?.words?.length).toBe(3);
-    expect(a1?.words?.map((w) => w.text)).toEqual(["lov", "ing ", "you"]);
-    expect(a1?.words?.[0].begin).toBe(10);
-    expect(a1?.words?.[0].end).toBe(11);
-    expect(a1?.words?.[1].begin).toBe(11);
-    expect(a1?.words?.[1].end).toBe(12);
-    expect(a1?.words?.[2].begin).toBe(12);
-    expect(a1?.words?.[2].end).toBe(14);
+    expect((a1 && mainWords(a1))?.length).toBe(3);
+    expect((a1 && mainWords(a1))?.map((w) => w.text)).toEqual(["lov", "ing ", "you"]);
+    expect((a1 && mainWords(a1))?.[0].begin).toBe(10);
+    expect((a1 && mainWords(a1))?.[0].end).toBe(11);
+    expect((a1 && mainWords(a1))?.[1].begin).toBe(11);
+    expect((a1 && mainWords(a1))?.[1].end).toBe(12);
+    expect((a1 && mainWords(a1))?.[2].begin).toBe(12);
+    expect((a1 && mainWords(a1))?.[2].end).toBe(14);
   });
 
   it("propagates word merges (count decreases) to siblings", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a0",
           text: "lov ing you",
           agentId: "v1",
@@ -766,8 +789,8 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
             { text: "ing ", begin: 0.5, end: 1 },
             { text: "you", begin: 1, end: 2 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "a1",
           text: "lov ing you",
           agentId: "v1",
@@ -779,7 +802,7 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
             { text: "ing ", begin: 11, end: 12 },
             { text: "you", begin: 12, end: 14 },
           ],
-        },
+        }),
       ],
     });
 
@@ -791,19 +814,19 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
     });
 
     const a1 = useProjectStore.getState().lines.find((l) => l.id === "a1");
-    expect(a1?.words?.length).toBe(2);
-    expect(a1?.words?.map((w) => w.text)).toEqual(["loving ", "you"]);
-    expect(a1?.words?.[0].begin).toBe(10);
-    expect(a1?.words?.[0].end).toBe(12);
-    expect(a1?.words?.[1].begin).toBe(12);
-    expect(a1?.words?.[1].end).toBe(14);
+    expect((a1 && mainWords(a1))?.length).toBe(2);
+    expect((a1 && mainWords(a1))?.map((w) => w.text)).toEqual(["loving ", "you"]);
+    expect((a1 && mainWords(a1))?.[0].begin).toBe(10);
+    expect((a1 && mainWords(a1))?.[0].end).toBe(12);
+    expect((a1 && mainWords(a1))?.[1].begin).toBe(12);
+    expect((a1 && mainWords(a1))?.[1].end).toBe(14);
   });
 
   it("does not propagate structural changes to detached siblings", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a0",
           text: "hi",
           agentId: "v1",
@@ -811,8 +834,8 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
           instanceIdx: 0,
           templateLineIdx: 0,
           words: [{ text: "hi", begin: 0, end: 1 }],
-        },
-        {
+        }),
+        reconcileLine({
           id: "a1",
           text: "hi",
           agentId: "v1",
@@ -821,7 +844,7 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
           templateLineIdx: 0,
           detached: true,
           words: [{ text: "hi", begin: 10, end: 11 }],
-        },
+        }),
       ],
     });
 
@@ -833,15 +856,15 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
     });
 
     const a1 = useProjectStore.getState().lines.find((l) => l.id === "a1");
-    expect(a1?.words?.length).toBe(1);
-    expect(a1?.words?.[0].text).toBe("hi");
+    expect((a1 && mainWords(a1))?.length).toBe(1);
+    expect((a1 && mainWords(a1))?.[0].text).toBe("hi");
   });
 
   it("clears sibling words/begin/end when source explicitly clears them with a text edit", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a0",
           text: "I love you",
           agentId: "v1",
@@ -853,8 +876,8 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
             { text: "love ", begin: 30.4, end: 30.8 },
             { text: "you", begin: 30.8, end: 31.2 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "a1",
           text: "I love you",
           agentId: "v1",
@@ -866,7 +889,7 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
             { text: "love ", begin: 60.5, end: 61.0 },
             { text: "you", begin: 61.0, end: 61.5 },
           ],
-        },
+        }),
       ],
     });
 
@@ -880,21 +903,21 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
     const lines = useProjectStore.getState().lines;
     const a0 = lines.find((l) => l.id === "a0");
     const a1 = lines.find((l) => l.id === "a1");
-    expect(a0?.text).toBe("I luv you");
-    expect(a0?.words).toBeUndefined();
-    expect(a0?.begin).toBeUndefined();
-    expect(a0?.end).toBeUndefined();
-    expect(a1?.text).toBe("I luv you");
-    expect(a1?.words).toBeUndefined();
-    expect(a1?.begin).toBeUndefined();
-    expect(a1?.end).toBeUndefined();
+    expect(a0 && lineText(a0)).toBe("I luv you");
+    expect(a0 && mainWords(a0)).toBeUndefined();
+    expect(a0 && mainBounds(a0)?.begin).toBeUndefined();
+    expect(a0 && mainBounds(a0)?.end).toBeUndefined();
+    expect(a1 && lineText(a1)).toBe("I luv you");
+    expect(a1 && mainWords(a1)).toBeUndefined();
+    expect(a1 && mainBounds(a1)?.begin).toBeUndefined();
+    expect(a1 && mainBounds(a1)?.end).toBeUndefined();
   });
 
   it("clears sibling backgroundWords when source clears them with a text edit", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a0",
           text: "main",
           agentId: "v1",
@@ -906,8 +929,8 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
             { text: "ohh ", begin: 30, end: 30.5 },
             { text: "ahh", begin: 30.5, end: 31 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "a1",
           text: "main",
           agentId: "v1",
@@ -919,7 +942,7 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
             { text: "ohh ", begin: 60, end: 60.5 },
             { text: "ahh", begin: 60.5, end: 61 },
           ],
-        },
+        }),
       ],
     });
 
@@ -929,8 +952,8 @@ describe("project store · updateLineWithHistory auto-propagation", () => {
     });
 
     const a1 = useProjectStore.getState().lines.find((l) => l.id === "a1");
-    expect(a1?.backgroundText).toBe("yeah");
-    expect(a1?.backgroundWords).toBeUndefined();
+    expect(a1 && bgText(a1)).toBe("yeah");
+    expect(a1 && bgWords(a1)).toBeUndefined();
   });
 });
 
@@ -950,7 +973,7 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
   it("split on source: sibling 'I' and 'you' keep their original begin/end (different rhythm than source)", () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "A",
           text: "I love you",
           agentId: "v1",
@@ -962,8 +985,8 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
             { text: "love ", begin: 0.3, end: 0.6 },
             { text: "you", begin: 0.6, end: 1 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "B",
           text: "I love you",
           agentId: "v1",
@@ -976,7 +999,7 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
             { text: "love ", begin: 30.4, end: 30.7 },
             { text: "you", begin: 30.7, end: 31.2 },
           ],
-        },
+        }),
       ],
       groups: [{ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 }],
     });
@@ -991,24 +1014,24 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
     });
 
     const b = useProjectStore.getState().lines.find((l) => l.id === "B");
-    expect(b?.words).toHaveLength(4);
+    expect(b && mainWords(b)).toHaveLength(4);
     // Sibling B's "I" preserved exactly
-    expect(b?.words?.[0]).toEqual({ text: "I ", begin: 30, end: 30.4 });
+    expect((b && mainWords(b))?.[0]).toEqual({ text: "I ", begin: 30, end: 30.4 });
     // Sibling B's "you" preserved exactly
-    expect(b?.words?.[3]).toEqual({ text: "you", begin: 30.7, end: 31.2 });
+    expect((b && mainWords(b))?.[3]).toEqual({ text: "you", begin: 30.7, end: 31.2 });
     // The split lands inside B's love-slot proportionally
-    expect(b?.words?.[1].text).toBe("lo");
-    expect(b?.words?.[1].begin).toBeCloseTo(30.4);
-    expect(b?.words?.[1].end).toBeCloseTo(30.55);
-    expect(b?.words?.[2].text).toBe("ve ");
-    expect(b?.words?.[2].begin).toBeCloseTo(30.55);
-    expect(b?.words?.[2].end).toBeCloseTo(30.7);
+    expect((b && mainWords(b))?.[1].text).toBe("lo");
+    expect((b && mainWords(b))?.[1].begin).toBeCloseTo(30.4);
+    expect((b && mainWords(b))?.[1].end).toBeCloseTo(30.55);
+    expect((b && mainWords(b))?.[2].text).toBe("ve ");
+    expect((b && mainWords(b))?.[2].begin).toBeCloseTo(30.55);
+    expect((b && mainWords(b))?.[2].end).toBeCloseTo(30.7);
   });
 
   it("merge on source: sibling unchanged words keep their original timings", () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "A",
           text: "I love you",
           agentId: "v1",
@@ -1020,8 +1043,8 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
             { text: "love ", begin: 0.3, end: 0.6 },
             { text: "you", begin: 0.6, end: 1 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "B",
           text: "I love you",
           agentId: "v1",
@@ -1033,7 +1056,7 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
             { text: "love ", begin: 30.4, end: 30.7 },
             { text: "you", begin: 30.7, end: 31.2 },
           ],
-        },
+        }),
       ],
       groups: [{ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 }],
     });
@@ -1046,15 +1069,15 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
     });
 
     const b = useProjectStore.getState().lines.find((l) => l.id === "B");
-    expect(b?.words).toHaveLength(2);
-    expect(b?.words?.[0]).toEqual({ text: "I ", begin: 30, end: 30.4 });
-    expect(b?.words?.[1]).toEqual({ text: "loveyou", begin: 30.4, end: 31.2 });
+    expect(b && mainWords(b)).toHaveLength(2);
+    expect((b && mainWords(b))?.[0]).toEqual({ text: "I ", begin: 30, end: 30.4 });
+    expect((b && mainWords(b))?.[1]).toEqual({ text: "loveyou", begin: 30.4, end: 31.2 });
   });
 
   it("identical-rhythm siblings: unchanged-word timing preserved (matches source rhythm)", () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "A",
           text: "I love you",
           agentId: "v1",
@@ -1066,8 +1089,8 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
             { text: "love ", begin: 0.3, end: 0.6 },
             { text: "you", begin: 0.6, end: 1 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "B",
           text: "I love you",
           agentId: "v1",
@@ -1079,7 +1102,7 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
             { text: "love ", begin: 30.3, end: 30.6 },
             { text: "you", begin: 30.6, end: 31 },
           ],
-        },
+        }),
       ],
       groups: [{ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 }],
     });
@@ -1094,15 +1117,15 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
     });
 
     const b = useProjectStore.getState().lines.find((l) => l.id === "B");
-    expect(b?.words).toHaveLength(4);
-    expect(b?.words?.[0]).toEqual({ text: "I ", begin: 30, end: 30.3 });
-    expect(b?.words?.[3]).toEqual({ text: "you", begin: 30.6, end: 31 });
+    expect(b && mainWords(b)).toHaveLength(4);
+    expect((b && mainWords(b))?.[0]).toEqual({ text: "I ", begin: 30, end: 30.3 });
+    expect((b && mainWords(b))?.[3]).toEqual({ text: "you", begin: 30.6, end: 31 });
   });
 
   it("BG word split on source: sibling BG words preserve unchanged-word timings", () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "A",
           text: "main",
           agentId: "v1",
@@ -1114,8 +1137,8 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
             { text: "ah ", begin: 0, end: 0.3 },
             { text: "ah", begin: 0.3, end: 0.6 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "B",
           text: "main",
           agentId: "v1",
@@ -1127,7 +1150,7 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
             { text: "ah ", begin: 30, end: 30.4 },
             { text: "ah", begin: 30.4, end: 30.8 },
           ],
-        },
+        }),
       ],
       groups: [{ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 }],
     });
@@ -1141,22 +1164,22 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
     });
 
     const b = useProjectStore.getState().lines.find((l) => l.id === "B");
-    expect(b?.backgroundWords).toHaveLength(3);
+    expect(b && bgWords(b)).toHaveLength(3);
     // First "ah" preserved on sibling B
-    expect(b?.backgroundWords?.[0]).toEqual({ text: "ah ", begin: 30, end: 30.4 });
+    expect((b && bgWords(b))?.[0]).toEqual({ text: "ah ", begin: 30, end: 30.4 });
     // The new "a" + "h" split inside B's old second-ah slot
-    expect(b?.backgroundWords?.[1].text).toBe("a");
-    expect(b?.backgroundWords?.[1].begin).toBeCloseTo(30.4);
-    expect(b?.backgroundWords?.[1].end).toBeCloseTo(30.6);
-    expect(b?.backgroundWords?.[2].text).toBe("h");
-    expect(b?.backgroundWords?.[2].begin).toBeCloseTo(30.6);
-    expect(b?.backgroundWords?.[2].end).toBeCloseTo(30.8);
+    expect((b && bgWords(b))?.[1].text).toBe("a");
+    expect((b && bgWords(b))?.[1].begin).toBeCloseTo(30.4);
+    expect((b && bgWords(b))?.[1].end).toBeCloseTo(30.6);
+    expect((b && bgWords(b))?.[2].text).toBe("h");
+    expect((b && bgWords(b))?.[2].begin).toBeCloseTo(30.6);
+    expect((b && bgWords(b))?.[2].end).toBeCloseTo(30.8);
   });
 
   it("detached siblings are NOT touched by structural propagation", () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "A",
           text: "I love you",
           agentId: "v1",
@@ -1168,8 +1191,8 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
             { text: "love ", begin: 0.3, end: 0.6 },
             { text: "you", begin: 0.6, end: 1 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "B",
           text: "I love you",
           agentId: "v1",
@@ -1182,7 +1205,7 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
             { text: "love ", begin: 30.4, end: 30.7 },
             { text: "you", begin: 30.7, end: 31.2 },
           ],
-        },
+        }),
       ],
       groups: [{ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 }],
     });
@@ -1198,8 +1221,8 @@ describe("propagateWordChanges · smart sync preserves unchanged-word timing", (
 
     const b = useProjectStore.getState().lines.find((l) => l.id === "B");
     // Detached sibling untouched: original 3-word array preserved
-    expect(b?.words).toHaveLength(3);
-    expect(b?.words?.[1].text).toBe("love ");
+    expect(b && mainWords(b)).toHaveLength(3);
+    expect((b && mainWords(b))?.[1].text).toBe("love ");
     expect(b?.detached).toBe(true);
   });
 });
@@ -1215,7 +1238,7 @@ describe("applyWordCountChange · resolutions", () => {
   function setupChorus() {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "A",
           text: "I love you",
           agentId: "v1",
@@ -1227,8 +1250,8 @@ describe("applyWordCountChange · resolutions", () => {
             { text: "love ", begin: 0.3, end: 0.6 },
             { text: "you", begin: 0.6, end: 1 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "B",
           text: "I love you",
           agentId: "v1",
@@ -1240,7 +1263,7 @@ describe("applyWordCountChange · resolutions", () => {
             { text: "love ", begin: 30.4, end: 30.7 },
             { text: "you", begin: 30.7, end: 31.2 },
           ],
-        },
+        }),
       ],
       groups: [{ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 }],
     });
@@ -1259,11 +1282,11 @@ describe("applyWordCountChange · resolutions", () => {
     const after = useProjectStore.getState().lines;
     const a = after.find((l) => l.id === "A");
     const b = after.find((l) => l.id === "B");
-    expect(a?.words).toHaveLength(4);
-    expect(b?.words).toHaveLength(4);
+    expect(a && mainWords(a)).toHaveLength(4);
+    expect(b && mainWords(b)).toHaveLength(4);
     // Sibling B's "I" and "you" preserved
-    expect(b?.words?.[0]).toEqual({ text: "I ", begin: 30, end: 30.4 });
-    expect(b?.words?.[3]).toEqual({ text: "you", begin: 30.7, end: 31.2 });
+    expect((b && mainWords(b))?.[0]).toEqual({ text: "I ", begin: 30, end: 30.4 });
+    expect((b && mainWords(b))?.[3]).toEqual({ text: "you", begin: 30.7, end: 31.2 });
     // Neither is detached
     expect(a?.detached).toBeUndefined();
     expect(b?.detached).toBeUndefined();
@@ -1279,15 +1302,15 @@ describe("applyWordCountChange · resolutions", () => {
     expect(a?.instanceIdx).toBeUndefined();
     expect(a?.templateLineIdx).toBeUndefined();
     expect(a?.detached).toBeUndefined();
-    expect(a?.words).toHaveLength(4);
-    expect(b?.words).toHaveLength(3);
-    expect(b?.words?.[0]).toEqual({ text: "I ", begin: 30, end: 30.4 });
+    expect(a && mainWords(a)).toHaveLength(4);
+    expect(b && mainWords(b)).toHaveLength(3);
+    expect((b && mainWords(b))?.[0]).toEqual({ text: "I ", begin: 30, end: 30.4 });
   });
 
   it("'detach' clears stale begin/end when promoting a line-synced row to word-synced", () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "L1",
           text: "verse",
           agentId: "v1",
@@ -1296,8 +1319,8 @@ describe("applyWordCountChange · resolutions", () => {
           templateLineIdx: 0,
           begin: 5,
           end: 7,
-        },
-        {
+        }),
+        reconcileLine({
           id: "L2",
           text: "verse",
           agentId: "v1",
@@ -1306,16 +1329,15 @@ describe("applyWordCountChange · resolutions", () => {
           templateLineIdx: 0,
           begin: 30,
           end: 32,
-        },
+        }),
       ],
       groups: [{ id: "g1", label: "Verse", color: "#aaa", templateVersion: 1 }],
     });
     const newWords = [{ text: "verse", begin: 5, end: 7 }];
     useProjectStore.getState().applyWordCountChange("L1", newWords, "words", "detach");
     const after = useProjectStore.getState().lines.find((l) => l.id === "L1");
-    expect(after?.words).toEqual(newWords);
-    expect(after?.begin).toBeUndefined();
-    expect(after?.end).toBeUndefined();
+    expect(after && mainWords(after)).toEqual(newWords);
+    expect(after && isLineSynced(after)).toBe(false);
   });
 
   it("'cancel' is a no-op", () => {
@@ -1333,8 +1355,10 @@ describe("applyWordCountChange · resolutions", () => {
     ];
     useProjectStore.getState().applyWordCountChange("A", mergedWords, "words", "apply", { text: "I loveyou" });
     const after = useProjectStore.getState().lines;
-    expect(after.find((l) => l.id === "A")?.text).toBe("I loveyou");
-    expect(after.find((l) => l.id === "B")?.text).toBe("I loveyou");
+    const afterA = after.find((l) => l.id === "A");
+    const afterB = after.find((l) => l.id === "B");
+    expect(afterA && lineText(afterA)).toBe("I loveyou");
+    expect(afterB && lineText(afterB)).toBe("I loveyou");
   });
 
   it("detach with extraUpdates: text only changes on source, not siblings", () => {
@@ -1345,8 +1369,10 @@ describe("applyWordCountChange · resolutions", () => {
     ];
     useProjectStore.getState().applyWordCountChange("A", mergedWords, "words", "detach", { text: "I loveyou" });
     const after = useProjectStore.getState().lines;
-    expect(after.find((l) => l.id === "A")?.text).toBe("I loveyou");
-    expect(after.find((l) => l.id === "B")?.text).toBe("I love you"); // unchanged
+    const afterA = after.find((l) => l.id === "A");
+    const afterB = after.find((l) => l.id === "B");
+    expect(afterA && lineText(afterA)).toBe("I loveyou");
+    expect(afterB && lineText(afterB)).toBe("I love you"); // unchanged
   });
 
   it("detached siblings are skipped on apply", () => {
@@ -1357,14 +1383,14 @@ describe("applyWordCountChange · resolutions", () => {
     }));
     useProjectStore.getState().applyWordCountChange("A", splitWords, "words", "apply");
     const b = useProjectStore.getState().lines.find((l) => l.id === "B");
-    expect(b?.words).toHaveLength(3); // untouched, still 3 words
+    expect(b && mainWords(b)).toHaveLength(3); // untouched, still 3 words
     expect(b?.detached).toBe(true);
   });
 
   it("non-linked source: apply just writes to source, no siblings touched", () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "X",
           text: "I love",
           agentId: "v1",
@@ -1372,7 +1398,7 @@ describe("applyWordCountChange · resolutions", () => {
             { text: "I ", begin: 0, end: 0.3 },
             { text: "love", begin: 0.3, end: 1 },
           ],
-        },
+        }),
       ],
       groups: [],
     });
@@ -1387,13 +1413,13 @@ describe("applyWordCountChange · resolutions", () => {
       "apply",
     );
     const x = useProjectStore.getState().lines.find((l) => l.id === "X");
-    expect(x?.words).toHaveLength(3);
+    expect(x && mainWords(x)).toHaveLength(3);
   });
 
   it("backgroundWords field: 'apply' propagates BG structural change with smart-sync", () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "A",
           text: "main",
           agentId: "v1",
@@ -1405,8 +1431,8 @@ describe("applyWordCountChange · resolutions", () => {
             { text: "ah ", begin: 0, end: 0.3 },
             { text: "ah", begin: 0.3, end: 0.6 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "B",
           text: "main",
           agentId: "v1",
@@ -1418,7 +1444,7 @@ describe("applyWordCountChange · resolutions", () => {
             { text: "ah ", begin: 30, end: 30.4 },
             { text: "ah", begin: 30.4, end: 30.8 },
           ],
-        },
+        }),
       ],
       groups: [{ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 }],
     });
@@ -1433,19 +1459,23 @@ describe("applyWordCountChange · resolutions", () => {
       "apply",
     );
     const b = useProjectStore.getState().lines.find((l) => l.id === "B");
-    expect(b?.backgroundWords).toHaveLength(3);
-    expect(b?.backgroundWords?.[0]).toEqual({ text: "ah ", begin: 30, end: 30.4 });
+    expect(b && bgWords(b)).toHaveLength(3);
+    expect((b && bgWords(b))?.[0]).toEqual({ text: "ah ", begin: 30, end: 30.4 });
   });
 
   it("apply produces a single history entry covering source + all siblings (single undo restores)", () => {
     setupChorus();
     useProjectStore.getState().applyWordCountChange("A", splitWords, "words", "apply");
     const before = useProjectStore.getState().lines;
-    expect(before.find((l) => l.id === "A")?.words).toHaveLength(4);
-    expect(before.find((l) => l.id === "B")?.words).toHaveLength(4);
+    const beforeA = before.find((l) => l.id === "A");
+    const beforeB = before.find((l) => l.id === "B");
+    expect(beforeA && mainWords(beforeA)).toHaveLength(4);
+    expect(beforeB && mainWords(beforeB)).toHaveLength(4);
     useProjectStore.getState().undo();
     const after = useProjectStore.getState().lines;
-    expect(after.find((l) => l.id === "A")?.words).toHaveLength(3);
-    expect(after.find((l) => l.id === "B")?.words).toHaveLength(3);
+    const afterA = after.find((l) => l.id === "A");
+    const afterB = after.find((l) => l.id === "B");
+    expect(afterA && mainWords(afterA)).toHaveLength(3);
+    expect(afterB && mainWords(afterB)).toHaveLength(3);
   });
 });

--- a/src/stores/project.history.clone.test.ts
+++ b/src/stores/project.history.clone.test.ts
@@ -3,6 +3,8 @@
  */
 import { beforeEach, describe, expect, it } from "vitest";
 import { useProjectStore } from "@/stores/project";
+import { reconcileLine } from "@/domain/line/model";
+import { mainWords } from "@/domain/line/voices";
 
 // Pins the contract that history snapshots round-trip cleanly through whatever
 // deep-clone primitive project.ts uses. Pre-Task-3.3 the codebase used
@@ -20,37 +22,37 @@ describe("history snapshot deep-clone integrity", () => {
   it("undo restores nested word arrays without aliasing the post-state", () => {
     const store = useProjectStore.getState();
     store.setLinesWithHistory([
-      {
+      reconcileLine({
         id: "L1",
         text: "hello",
         agentId: "v1",
         words: [{ text: "hello", begin: 0, end: 1 }],
-      },
+      }),
     ]);
     store.updateLineWithHistory("L1", { words: [{ text: "hello!", begin: 0, end: 1 }] });
-    const beforeUndo = useProjectStore.getState().lines[0].words?.[0].text;
+    const beforeUndo = mainWords(useProjectStore.getState().lines[0])?.[0].text;
     expect(beforeUndo).toBe("hello!");
     store.undo();
-    expect(useProjectStore.getState().lines[0].words?.[0].text).toBe("hello");
+    expect(mainWords(useProjectStore.getState().lines[0])?.[0].text).toBe("hello");
     // Mutate the restored state object and confirm the next undo entry is
     // still independent (the clone wasn't a shallow alias).
-    const restored = useProjectStore.getState().lines[0].words;
+    const restored = mainWords(useProjectStore.getState().lines[0]);
     if (restored) restored[0].text = "MUTATED";
     store.redo();
-    expect(useProjectStore.getState().lines[0].words?.[0].text).toBe("hello!");
+    expect(mainWords(useProjectStore.getState().lines[0])?.[0].text).toBe("hello!");
   });
 
   it("undo restores groups[] alongside lines[]", () => {
     const store = useProjectStore.getState();
     store.addGroupWithLines({ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 }, [
-      {
+      reconcileLine({
         id: "L1",
         text: "x",
         agentId: "v1",
         groupId: "g1",
         instanceIdx: 0,
         templateLineIdx: 0,
-      },
+      }),
     ]);
     expect(useProjectStore.getState().groups).toHaveLength(1);
     store.removeGroup("g1");
@@ -63,7 +65,7 @@ describe("history snapshot deep-clone integrity", () => {
   it("undo and redo preserve identity of nested structures across multiple steps", () => {
     const store = useProjectStore.getState();
     store.setLinesWithHistory([
-      {
+      reconcileLine({
         id: "A",
         text: "a",
         agentId: "v1",
@@ -71,17 +73,17 @@ describe("history snapshot deep-clone integrity", () => {
           { text: "a ", begin: 0, end: 0.5 },
           { text: "b", begin: 0.5, end: 1 },
         ],
-      },
+      }),
     ]);
     store.updateLineWithHistory("A", { words: [{ text: "ab", begin: 0, end: 1 }] });
     store.updateLineWithHistory("A", { words: [{ text: "ABC", begin: 0, end: 1 }] });
     store.undo();
-    expect(useProjectStore.getState().lines[0].words?.[0].text).toBe("ab");
+    expect(mainWords(useProjectStore.getState().lines[0])?.[0].text).toBe("ab");
     store.undo();
-    expect(useProjectStore.getState().lines[0].words?.length).toBe(2);
+    expect(mainWords(useProjectStore.getState().lines[0])?.length).toBe(2);
     store.redo();
-    expect(useProjectStore.getState().lines[0].words?.[0].text).toBe("ab");
+    expect(mainWords(useProjectStore.getState().lines[0])?.[0].text).toBe("ab");
     store.redo();
-    expect(useProjectStore.getState().lines[0].words?.[0].text).toBe("ABC");
+    expect(mainWords(useProjectStore.getState().lines[0])?.[0].text).toBe("ABC");
   });
 });

--- a/src/stores/project.history.test.ts
+++ b/src/stores/project.history.test.ts
@@ -274,7 +274,7 @@ describe("commitPendingLineEdit", () => {
     useProjectStore.getState().commitPendingLineEdit(baseline);
 
     const committedIndex = useProjectStore.getState().historyIndex;
-    useProjectStore.getState().lines[0].text = "live mutation";
+    useProjectStore.getState().lines[0].main.text = "live mutation";
 
     expect(lineText(useProjectStore.getState().history[committedIndex].lines[0])).toBe("clone me edited");
   });
@@ -424,7 +424,7 @@ describe("commitPendingLineEdit · pre-dirty baseline seeding", () => {
     useProjectStore.getState().setLines([seedLine("a", { text: "C" })]);
     useProjectStore.getState().commitPendingLineEdit(baseline, true);
 
-    baseline[0].text = "live mutation";
+    baseline[0].main.text = "live mutation";
     useProjectStore.getState().undo();
     expect(lineText(useProjectStore.getState().lines[0])).toBe("B");
   });

--- a/src/stores/project.history.test.ts
+++ b/src/stores/project.history.test.ts
@@ -4,6 +4,8 @@
 import { useProjectStore } from "@/stores/project";
 import type { LinkGroup } from "@/domain/group/template";
 import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
+import { mainBounds } from "@/domain/line/bounds";
+import { bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { MAX_HISTORY_SIZE } from "@/stores/project/history-helpers";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -141,17 +143,17 @@ describe("updateLinesWithHistory", () => {
     useProjectStore.getState().setLinesWithHistory([seedLine("a", { text: "" })]);
 
     useProjectStore.getState().setLines([seedLine("a", { text: "our favorite song is on" })]);
-    expect(useProjectStore.getState().lines[0].text).toBe("our favorite song is on");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("our favorite song is on");
 
     useProjectStore.getState().updateLineWithHistory("a", { begin: 5, end: 7 });
     const placed = useProjectStore.getState().lines[0];
-    expect(placed.text).toBe("our favorite song is on");
-    expect(placed.begin).toBe(5);
+    expect(lineText(placed)).toBe("our favorite song is on");
+    expect(mainBounds(placed)?.begin).toBe(5);
 
     useProjectStore.getState().undo();
     const afterUndo = useProjectStore.getState().lines[0];
-    expect(afterUndo.text).toBe("our favorite song is on");
-    expect(afterUndo.begin).toBeUndefined();
+    expect(lineText(afterUndo)).toBe("our favorite song is on");
+    expect(mainBounds(afterUndo)?.begin).toBeUndefined();
   });
 
   it("snapshots pending edit before updateLinesWithHistory too", () => {
@@ -159,8 +161,8 @@ describe("updateLinesWithHistory", () => {
     useProjectStore.getState().setLines([seedLine("a", { text: "alpha edited" })]);
     useProjectStore.getState().updateLinesWithHistory([{ id: "a", updates: { begin: 1, end: 2 } }]);
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].text).toBe("alpha edited");
-    expect(useProjectStore.getState().lines[0].begin).toBeUndefined();
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("alpha edited");
+    expect(mainBounds(useProjectStore.getState().lines[0])?.begin).toBeUndefined();
   });
 
   it("clears words and background words via undefined updates and is undoable", () => {
@@ -180,13 +182,13 @@ describe("updateLinesWithHistory", () => {
     ]);
 
     const cleared = useProjectStore.getState().lines[0];
-    expect(cleared.words).toBeUndefined();
-    expect(cleared.backgroundWords).toBeUndefined();
+    expect(mainWords(cleared)).toBeUndefined();
+    expect(bgWords(cleared)).toBeUndefined();
 
     useProjectStore.getState().undo();
     const restored = useProjectStore.getState().lines[0];
-    expect(restored.words).toEqual([{ text: "hi", begin: 0, end: 1 }]);
-    expect(restored.backgroundWords).toEqual([{ text: "ah", begin: 0, end: 0.5 }]);
+    expect(mainWords(restored)).toEqual([{ text: "hi", begin: 0, end: 1 }]);
+    expect(bgWords(restored)).toEqual([{ text: "ah", begin: 0, end: 0.5 }]);
   });
 });
 
@@ -203,10 +205,10 @@ describe("commitPendingLineEdit", () => {
     useProjectStore.getState().commitPendingLineEdit(baseline);
 
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].text).toBe("hello");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("hello");
 
     useProjectStore.getState().redo();
-    expect(useProjectStore.getState().lines[0].text).toBe("hello world");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("hello world");
   });
 
   it("is a no-op when nothing changed since the last history entry", () => {
@@ -223,18 +225,18 @@ describe("commitPendingLineEdit", () => {
 
     useProjectStore.getState().undo();
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].text).toBe("one");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("one");
 
     const baseline = useProjectStore.getState().lines;
     useProjectStore.getState().setLines([seedLine("a", { text: "one edited" })]);
     useProjectStore.getState().commitPendingLineEdit(baseline);
 
-    expect(useProjectStore.getState().lines[0].text).toBe("one edited");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("one edited");
     expect(useProjectStore.getState().canRedo()).toBe(false);
     expect(useProjectStore.getState().historyIndex).toBe(useProjectStore.getState().history.length - 1);
 
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].text).toBe("one");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("one");
   });
 
   it("seeds the baseline entry when history is empty so undo can return to it", () => {
@@ -247,10 +249,10 @@ describe("commitPendingLineEdit", () => {
     useProjectStore.getState().commitPendingLineEdit(baseline);
 
     expect(useProjectStore.getState().canUndo()).toBe(true);
-    expect(useProjectStore.getState().lines[0].text).toBe("start typed");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("start typed");
 
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].text).toBe("start");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("start");
   });
 
   it("does not mutate the baseline array passed in", () => {
@@ -274,7 +276,7 @@ describe("commitPendingLineEdit", () => {
     const committedIndex = useProjectStore.getState().historyIndex;
     useProjectStore.getState().lines[0].text = "live mutation";
 
-    expect(useProjectStore.getState().history[committedIndex].lines[0].text).toBe("clone me edited");
+    expect(lineText(useProjectStore.getState().history[committedIndex].lines[0])).toBe("clone me edited");
   });
 
   it("never lets history exceed MAX_HISTORY_SIZE", () => {
@@ -337,9 +339,9 @@ describe("commitPendingLineEdit · pre-dirty baseline seeding", () => {
     useProjectStore.getState().commitPendingLineEdit(baseline, baselineWasDirty);
 
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].text).toBe("B");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("B");
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].text).toBe("A");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("A");
   });
 
   it("does not seed a duplicate baseline when the store was clean before the run", () => {
@@ -354,7 +356,7 @@ describe("commitPendingLineEdit · pre-dirty baseline seeding", () => {
 
     expect(useProjectStore.getState().history.length).toBe(lengthBefore + 1);
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].text).toBe("A");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("A");
   });
 
   it("treats an omitted baselineWasDirty as clean", () => {
@@ -378,7 +380,7 @@ describe("commitPendingLineEdit · pre-dirty baseline seeding", () => {
 
     expect(useProjectStore.getState().history).toHaveLength(2);
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].text).toBe("A");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("A");
   });
 
   it("truncates the redo branch when the dirty path commits mid-history", () => {
@@ -387,7 +389,7 @@ describe("commitPendingLineEdit · pre-dirty baseline seeding", () => {
     useProjectStore.getState().setLinesWithHistory([seedLine("a", { text: "three" })]);
     useProjectStore.getState().undo();
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].text).toBe("one");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("one");
 
     useProjectStore.getState().setLines([seedLine("a", { text: "one cross-view" })]);
     const baseline = useProjectStore.getState().lines;
@@ -395,11 +397,11 @@ describe("commitPendingLineEdit · pre-dirty baseline seeding", () => {
     useProjectStore.getState().commitPendingLineEdit(baseline, true);
 
     expect(useProjectStore.getState().canRedo()).toBe(false);
-    expect(useProjectStore.getState().lines[0].text).toBe("one typed");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("one typed");
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].text).toBe("one cross-view");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("one cross-view");
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].text).toBe("one");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("one");
   });
 
   it("does not mutate the baseline array on the dirty path", () => {
@@ -424,7 +426,7 @@ describe("commitPendingLineEdit · pre-dirty baseline seeding", () => {
 
     baseline[0].text = "live mutation";
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].text).toBe("B");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("B");
   });
 
   it("no-ops when isDirtySinceHistory is false even if baselineWasDirty is true", () => {

--- a/src/stores/project.line-sync-nudge.test.ts
+++ b/src/stores/project.line-sync-nudge.test.ts
@@ -3,6 +3,10 @@
  */
 import { beforeEach, describe, expect, it } from "vitest";
 import { INITIAL_STATE, useProjectStore } from "@/stores/project";
+import { reconcileLine } from "@/domain/line/model";
+import { mainBounds } from "@/domain/line/bounds";
+import { isLineSynced } from "@/domain/line/predicates";
+import { mainWords } from "@/domain/line/voices";
 
 // These tests pin the contract that nudging a line-synced row by writing
 // only `begin/end` (without `words`) keeps it line-synced. The previous bug
@@ -14,47 +18,47 @@ describe("project store · line-sync nudge granularity", () => {
 
   it("preserves line-sync when only begin/end change", () => {
     const store = useProjectStore.getState();
-    store.setLines([{ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 }]);
+    store.setLines([reconcileLine({ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 })]);
     store.updateLineWithHistory("L1", { begin: 5.05, end: 7.05 });
     const after = useProjectStore.getState().lines[0];
-    expect(after.words).toBeUndefined();
-    expect(after.begin).toBeCloseTo(5.05);
-    expect(after.end).toBeCloseTo(7.05);
+    expect(mainWords(after)).toBeUndefined();
+    expect(mainBounds(after)?.begin).toBeCloseTo(5.05);
+    expect(mainBounds(after)?.end).toBeCloseTo(7.05);
   });
 
   it("preserves line-sync across multiple consecutive nudges (no drift to word-sync)", () => {
     const store = useProjectStore.getState();
-    store.setLines([{ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 }]);
+    store.setLines([reconcileLine({ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 })]);
     for (let i = 0; i < 5; i++) {
       const cur = useProjectStore.getState().lines[0];
-      store.updateLineWithHistory("L1", { begin: (cur.begin as number) + 0.1, end: (cur.end as number) + 0.1 });
+      const bounds = mainBounds(cur);
+      store.updateLineWithHistory("L1", { begin: (bounds?.begin as number) + 0.1, end: (bounds?.end as number) + 0.1 });
     }
     const after = useProjectStore.getState().lines[0];
-    expect(after.words).toBeUndefined();
-    expect(after.begin).toBeCloseTo(5.5);
-    expect(after.end).toBeCloseTo(7.5);
+    expect(mainWords(after)).toBeUndefined();
+    expect(mainBounds(after)?.begin).toBeCloseTo(5.5);
+    expect(mainBounds(after)?.end).toBeCloseTo(7.5);
   });
 
   it("undo restores prior line-sync state with no synthetic words appearing", () => {
     const store = useProjectStore.getState();
-    store.setLinesWithHistory([{ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 }]);
+    store.setLinesWithHistory([reconcileLine({ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 })]);
     store.updateLineWithHistory("L1", { begin: 5.05, end: 7.05 });
     store.undo();
     const after = useProjectStore.getState().lines[0];
-    expect(after.words).toBeUndefined();
-    expect(after.begin).toBe(5);
-    expect(after.end).toBe(7);
+    expect(mainWords(after)).toBeUndefined();
+    expect(mainBounds(after)?.begin).toBe(5);
+    expect(mainBounds(after)?.end).toBe(7);
   });
 
   it("flips to word-sync only when an explicit words array is written", () => {
     const store = useProjectStore.getState();
-    store.setLines([{ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 }]);
+    store.setLines([reconcileLine({ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 })]);
     store.updateLineWithHistory("L1", { words: [{ text: "verse", begin: 5, end: 7 }] });
     const after = useProjectStore.getState().lines[0];
-    expect(after.words?.length).toBe(1);
+    expect(mainWords(after)?.length).toBe(1);
     // store auto-clears begin/end when words appear on a previously line-synced row
-    expect(after.begin).toBeUndefined();
-    expect(after.end).toBeUndefined();
+    expect(isLineSynced(after)).toBe(false);
   });
 });
 
@@ -73,7 +77,7 @@ describe("instance shift = nudging every selected word at once", () => {
   it("nudging all words in an instance shifts every word by the same delta", () => {
     const store = useProjectStore.getState();
     store.setLinesWithHistory([
-      {
+      reconcileLine({
         id: "A",
         text: "I love",
         agentId: "v1",
@@ -84,8 +88,8 @@ describe("instance shift = nudging every selected word at once", () => {
           { text: "I ", begin: 10, end: 10.3 },
           { text: "love", begin: 10.3, end: 10.8 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "B",
         text: "all night",
         agentId: "v1",
@@ -96,7 +100,7 @@ describe("instance shift = nudging every selected word at once", () => {
           { text: "all ", begin: 11, end: 11.4 },
           { text: "night", begin: 11.4, end: 12 },
         ],
-      },
+      }),
     ]);
     // Simulating what nudgeSelectedWords would output with all-instance selected:
     store.updateLinesWithHistory([
@@ -120,17 +124,19 @@ describe("instance shift = nudging every selected word at once", () => {
       },
     ]);
     const after = useProjectStore.getState().lines;
-    expect(after.find((l) => l.id === "A")?.words?.[0].begin).toBeCloseTo(10.5);
-    expect(after.find((l) => l.id === "B")?.words?.[1].end).toBeCloseTo(12.5);
+    const lineA = after.find((l) => l.id === "A");
+    const lineB = after.find((l) => l.id === "B");
+    expect(lineA && mainWords(lineA)?.[0].begin).toBeCloseTo(10.5);
+    expect(lineB && mainWords(lineB)?.[1].end).toBeCloseTo(12.5);
     // group structure preserved
-    expect(after.find((l) => l.id === "A")?.groupId).toBe("g1");
-    expect(after.find((l) => l.id === "B")?.instanceIdx).toBe(0);
+    expect(lineA?.groupId).toBe("g1");
+    expect(lineB?.instanceIdx).toBe(0);
   });
 
   it("only one instance shifts even when other instances exist", () => {
     const store = useProjectStore.getState();
     store.setLinesWithHistory([
-      {
+      reconcileLine({
         id: "A1",
         text: "x",
         agentId: "v1",
@@ -138,8 +144,8 @@ describe("instance shift = nudging every selected word at once", () => {
         instanceIdx: 0,
         templateLineIdx: 0,
         words: [{ text: "x", begin: 10, end: 11 }],
-      },
-      {
+      }),
+      reconcileLine({
         id: "A2",
         text: "x",
         agentId: "v1",
@@ -147,13 +153,15 @@ describe("instance shift = nudging every selected word at once", () => {
         instanceIdx: 1,
         templateLineIdx: 0,
         words: [{ text: "x", begin: 30, end: 31 }],
-      },
+      }),
     ]);
     // Only nudge instance 0
     store.updateLineWithHistory("A1", { words: [{ text: "x", begin: 10.5, end: 11.5 }] });
     const after = useProjectStore.getState().lines;
-    expect(after.find((l) => l.id === "A1")?.words?.[0].begin).toBeCloseTo(10.5);
+    const a1 = after.find((l) => l.id === "A1");
+    const a2 = after.find((l) => l.id === "A2");
+    expect(a1 && mainWords(a1)?.[0].begin).toBeCloseTo(10.5);
     // Instance 1 unchanged, proving shift is per-selection, not group-wide
-    expect(after.find((l) => l.id === "A2")?.words?.[0].begin).toBe(30);
+    expect(a2 && mainWords(a2)?.[0].begin).toBe(30);
   });
 });

--- a/src/stores/project.merge.test.ts
+++ b/src/stores/project.merge.test.ts
@@ -3,6 +3,7 @@
  */
 import { useProjectStore } from "@/stores/project";
 import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
+import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { beforeEach, describe, expect, it } from "vitest";
 
 beforeEach(() => {
@@ -29,7 +30,7 @@ function seedMainLine(overrides: Partial<LooseLine> = {}): LyricLine {
 
 describe("mergeSyllableGroupIntoWord", () => {
   function seedGroupedLine(): LyricLine {
-    return {
+    return reconcileLine({
       id: "line-1",
       text: "beautiful",
       agentId: "v1",
@@ -38,13 +39,13 @@ describe("mergeSyllableGroupIntoWord", () => {
         { text: "ti", begin: 0.3, end: 0.6, syllableGroupId: "g1" },
         { text: "ful", begin: 0.6, end: 0.9, syllableGroupId: "g1" },
       ],
-    };
+    });
   }
 
   it("collapses a syllable group into one word", () => {
     useProjectStore.getState().setLines([seedGroupedLine()]);
     useProjectStore.getState().mergeSyllableGroupIntoWord("line-1", "words", [0, 1, 2]);
-    const words = useProjectStore.getState().lines[0].words ?? [];
+    const words = mainWords(useProjectStore.getState().lines[0]) ?? [];
     expect(words).toHaveLength(1);
     expect(words[0].text).toBe("beautiful");
     expect(words[0].begin).toBe(0);
@@ -55,14 +56,14 @@ describe("mergeSyllableGroupIntoWord", () => {
   it("collapses the whole group when only one syllable is selected", () => {
     useProjectStore.getState().setLines([seedGroupedLine()]);
     useProjectStore.getState().mergeSyllableGroupIntoWord("line-1", "words", [1]);
-    const words = useProjectStore.getState().lines[0].words ?? [];
+    const words = mainWords(useProjectStore.getState().lines[0]) ?? [];
     expect(words.map((w) => w.text)).toEqual(["beautiful"]);
   });
 
   it("syncs line.text to the collapsed words", () => {
     useProjectStore.getState().setLines([seedGroupedLine()]);
     useProjectStore.getState().mergeSyllableGroupIntoWord("line-1", "words", [0]);
-    expect(useProjectStore.getState().lines[0].text).toBe("beautiful");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("beautiful");
   });
 
   it("leaves non-grouped words untouched and is a no-op on a non-grouped selection", () => {
@@ -74,7 +75,7 @@ describe("mergeSyllableGroupIntoWord", () => {
 
   it("collapses two groups touched by one multi-selection", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "abcd",
         agentId: "v1",
@@ -84,15 +85,15 @@ describe("mergeSyllableGroupIntoWord", () => {
           { text: "c", begin: 0.2, end: 0.3, syllableGroupId: "g2" },
           { text: "d", begin: 0.3, end: 0.4, syllableGroupId: "g2" },
         ],
-      },
+      }),
     ]);
     useProjectStore.getState().mergeSyllableGroupIntoWord("line-1", "words", [0, 3]);
-    expect((useProjectStore.getState().lines[0].words ?? []).map((w) => w.text)).toEqual(["ab", "cd"]);
+    expect((mainWords(useProjectStore.getState().lines[0]) ?? []).map((w) => w.text)).toEqual(["ab", "cd"]);
   });
 
   it("works on the background track and syncs backgroundText", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "main",
         agentId: "v1",
@@ -102,12 +103,12 @@ describe("mergeSyllableGroupIntoWord", () => {
           { text: "oh", begin: 1.2, end: 1.5, syllableGroupId: "b1" },
         ],
         backgroundText: "ooh",
-      },
+      }),
     ]);
     useProjectStore.getState().mergeSyllableGroupIntoWord("line-1", "backgroundWords", [0, 1]);
     const line = useProjectStore.getState().lines[0];
-    expect((line.backgroundWords ?? []).map((w) => w.text)).toEqual(["oooh"]);
-    expect(line.backgroundText).toBe("oooh");
+    expect((bgWords(line) ?? []).map((w) => w.text)).toEqual(["oooh"]);
+    expect(bgText(line)).toBe("oooh");
   });
 
   it("is undoable", () => {
@@ -115,7 +116,7 @@ describe("mergeSyllableGroupIntoWord", () => {
     useProjectStore.getState().mergeSyllableGroupIntoWord("line-1", "words", [0, 1, 2]);
     expect(useProjectStore.getState().canUndo()).toBe(true);
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].words ?? []).toHaveLength(3);
+    expect(mainWords(useProjectStore.getState().lines[0]) ?? []).toHaveLength(3);
   });
 });
 
@@ -123,7 +124,7 @@ describe("mergeSyllableGroupIntoWord · linked propagation", () => {
   function seedTwoLinkedInstances() {
     useProjectStore.getState().addGroup({ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 });
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "a0",
         text: "every",
         agentId: "v1",
@@ -135,8 +136,8 @@ describe("mergeSyllableGroupIntoWord · linked propagation", () => {
           { text: "er", begin: 0.3, end: 0.6, syllableGroupId: "g_a0" },
           { text: "y", begin: 0.6, end: 1, syllableGroupId: "g_a0" },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "a1",
         text: "every",
         agentId: "v1",
@@ -148,7 +149,7 @@ describe("mergeSyllableGroupIntoWord · linked propagation", () => {
           { text: "er", begin: 10.3, end: 10.6, syllableGroupId: "g_a1" },
           { text: "y", begin: 10.6, end: 11, syllableGroupId: "g_a1" },
         ],
-      },
+      }),
     ]);
   }
 
@@ -159,15 +160,15 @@ describe("mergeSyllableGroupIntoWord · linked propagation", () => {
     const lines = useProjectStore.getState().lines;
     const a0 = lines.find((l) => l.id === "a0");
     const a1 = lines.find((l) => l.id === "a1");
-    expect(a0?.words?.map((w) => w.text)).toEqual(["every"]);
-    expect(a1?.words?.map((w) => w.text)).toEqual(["every"]);
+    expect(a0 && mainWords(a0)?.map((w) => w.text)).toEqual(["every"]);
+    expect(a1 && mainWords(a1)?.map((w) => w.text)).toEqual(["every"]);
   });
 });
 
 describe("mergeSyllableGroupIntoWord · background provenance", () => {
   it("flips backgroundTextSource to manual after a background-track merge", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "main",
         agentId: "v1",
@@ -178,17 +179,17 @@ describe("mergeSyllableGroupIntoWord · background provenance", () => {
         ],
         backgroundText: "ooh",
         backgroundTextSource: "extraction",
-      },
+      }),
     ]);
     useProjectStore.getState().mergeSyllableGroupIntoWord("line-1", "backgroundWords", [0, 1]);
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundTextSource).toBe("manual");
-    expect((line.backgroundWords ?? []).map((w) => w.text)).toEqual(["oooh"]);
+    expect(bgSource(line)).toBe("manual");
+    expect((bgWords(line) ?? []).map((w) => w.text)).toEqual(["oooh"]);
   });
 
   it("leaves backgroundTextSource untouched when merging the main track", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "beautiful",
         agentId: "v1",
@@ -200,16 +201,16 @@ describe("mergeSyllableGroupIntoWord · background provenance", () => {
         backgroundWords: [{ text: "ooh", begin: 1, end: 1.5 }],
         backgroundText: "ooh",
         backgroundTextSource: "extraction",
-      },
+      }),
     ]);
     useProjectStore.getState().mergeSyllableGroupIntoWord("line-1", "words", [0, 1, 2]);
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("extraction");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("extraction");
   });
 
   it("flips linked siblings to manual when a background-track merge propagates", () => {
     useProjectStore.getState().addGroup({ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 });
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "a0",
         text: "main",
         agentId: "v1",
@@ -223,8 +224,8 @@ describe("mergeSyllableGroupIntoWord · background provenance", () => {
         ],
         backgroundText: "ooh",
         backgroundTextSource: "extraction",
-      },
-      {
+      }),
+      reconcileLine({
         id: "a1",
         text: "main",
         agentId: "v1",
@@ -238,18 +239,20 @@ describe("mergeSyllableGroupIntoWord · background provenance", () => {
         ],
         backgroundText: "ooh",
         backgroundTextSource: "extraction",
-      },
+      }),
     ]);
     useProjectStore.getState().mergeSyllableGroupIntoWord("a0", "backgroundWords", [0, 1]);
     const lines = useProjectStore.getState().lines;
-    expect(lines.find((l) => l.id === "a0")?.backgroundTextSource).toBe("manual");
-    expect(lines.find((l) => l.id === "a1")?.backgroundTextSource).toBe("manual");
-    expect(lines.find((l) => l.id === "a1")?.backgroundWords?.map((w) => w.text)).toEqual(["oooh"]);
+    const a0 = lines.find((l) => l.id === "a0");
+    const a1 = lines.find((l) => l.id === "a1");
+    expect(a0 && bgSource(a0)).toBe("manual");
+    expect(a1 && bgSource(a1)).toBe("manual");
+    expect(a1 && bgWords(a1)?.map((w) => w.text)).toEqual(["oooh"]);
   });
 
   it("undo restores the prior extraction provenance", () => {
     useProjectStore.getState().setLinesWithHistory([
-      {
+      reconcileLine({
         id: "line-1",
         text: "main",
         agentId: "v1",
@@ -260,12 +263,12 @@ describe("mergeSyllableGroupIntoWord · background provenance", () => {
         ],
         backgroundText: "ooh",
         backgroundTextSource: "extraction",
-      },
+      }),
     ]);
     useProjectStore.getState().mergeSyllableGroupIntoWord("line-1", "backgroundWords", [0, 1]);
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("extraction");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("extraction");
   });
 });
 
@@ -273,7 +276,7 @@ describe("mergeSyllableGroupIntoWord · background provenance", () => {
 
 describe("snapSyllablesFlush", () => {
   function seedGappedGroupLine(): LyricLine {
-    return {
+    return reconcileLine({
       id: "line-1",
       text: "beautiful",
       agentId: "v1",
@@ -282,7 +285,7 @@ describe("snapSyllablesFlush", () => {
         { text: "ti", begin: 0.5, end: 0.8, syllableGroupId: "g1" },
         { text: "ful", begin: 1.0, end: 1.3, syllableGroupId: "g1" },
       ],
-    };
+    });
   }
 
   it("closes internal gaps by extending each earlier syllable's end to the next begin", () => {
@@ -290,7 +293,7 @@ describe("snapSyllablesFlush", () => {
 
     useProjectStore.getState().snapSyllablesFlush("line-1", "words");
 
-    const words = useProjectStore.getState().lines[0].words ?? [];
+    const words = mainWords(useProjectStore.getState().lines[0]) ?? [];
     expect(words[0].end).toBe(words[1].begin);
     expect(words[1].end).toBe(words[2].begin);
     expect(words[0].begin).toBe(0);
@@ -310,7 +313,7 @@ describe("snapSyllablesFlush", () => {
 
   it("is a no-op when the syllable group is already flush", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "beautiful",
         agentId: "v1",
@@ -319,7 +322,7 @@ describe("snapSyllablesFlush", () => {
           { text: "ti", begin: 0.3, end: 0.6, syllableGroupId: "g1" },
           { text: "ful", begin: 0.6, end: 0.9, syllableGroupId: "g1" },
         ],
-      },
+      }),
     ]);
     const before = useProjectStore.getState().lines[0];
 
@@ -330,7 +333,7 @@ describe("snapSyllablesFlush", () => {
 
   it("works on the background track", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "main",
         agentId: "v1",
@@ -340,12 +343,12 @@ describe("snapSyllablesFlush", () => {
           { text: "oh", begin: 1.5, end: 1.7, syllableGroupId: "b1" },
         ],
         backgroundText: "oooh",
-      },
+      }),
     ]);
 
     useProjectStore.getState().snapSyllablesFlush("line-1", "backgroundWords");
 
-    const bg = useProjectStore.getState().lines[0].backgroundWords ?? [];
+    const bg = bgWords(useProjectStore.getState().lines[0]) ?? [];
     expect(bg[0].end).toBe(bg[1].begin);
     expect(bg[0].begin).toBe(1);
     expect(bg[1].begin).toBe(1.5);
@@ -354,7 +357,7 @@ describe("snapSyllablesFlush", () => {
   it("does not touch a linked sibling", () => {
     useProjectStore.getState().addGroup({ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 });
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "a0",
         text: "beau|ti|ful",
         agentId: "v1",
@@ -366,8 +369,8 @@ describe("snapSyllablesFlush", () => {
           { text: "ti", begin: 0.5, end: 0.8, syllableGroupId: "g_a0" },
           { text: "ful", begin: 1.0, end: 1.3, syllableGroupId: "g_a0" },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "a1",
         text: "beau|ti|ful",
         agentId: "v1",
@@ -379,7 +382,7 @@ describe("snapSyllablesFlush", () => {
           { text: "ti", begin: 10.5, end: 10.8, syllableGroupId: "g_a1" },
           { text: "ful", begin: 11.0, end: 11.3, syllableGroupId: "g_a1" },
         ],
-      },
+      }),
     ]);
     const a1Before = useProjectStore.getState().lines.find((l) => l.id === "a1");
 
@@ -388,7 +391,7 @@ describe("snapSyllablesFlush", () => {
     const lines = useProjectStore.getState().lines;
     const a0 = lines.find((l) => l.id === "a0");
     const a1 = lines.find((l) => l.id === "a1");
-    const a0Words = a0?.words ?? [];
+    const a0Words = (a0 && mainWords(a0)) ?? [];
     expect(a0Words[0].end).toBe(a0Words[1].begin);
     expect(a0Words[1].end).toBe(a0Words[2].begin);
     expect(a1).toBe(a1Before);
@@ -396,13 +399,13 @@ describe("snapSyllablesFlush", () => {
 
   it("is undoable", () => {
     useProjectStore.getState().setLines([seedGappedGroupLine()]);
-    const before = useProjectStore.getState().lines[0].words?.map((w) => ({ begin: w.begin, end: w.end }));
+    const before = mainWords(useProjectStore.getState().lines[0])?.map((w) => ({ begin: w.begin, end: w.end }));
 
     useProjectStore.getState().snapSyllablesFlush("line-1", "words");
     expect(useProjectStore.getState().canUndo()).toBe(true);
 
     useProjectStore.getState().undo();
-    const restored = useProjectStore.getState().lines[0].words?.map((w) => ({ begin: w.begin, end: w.end }));
+    const restored = mainWords(useProjectStore.getState().lines[0])?.map((w) => ({ begin: w.begin, end: w.end }));
     expect(restored).toEqual(before);
   });
 });
@@ -410,7 +413,7 @@ describe("snapSyllablesFlush", () => {
 describe("snapSyllablesFlush · background provenance", () => {
   function seedGappedBgLine() {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "main",
         agentId: "v1",
@@ -421,7 +424,7 @@ describe("snapSyllablesFlush · background provenance", () => {
         ],
         backgroundText: "oooh",
         backgroundTextSource: "extraction",
-      },
+      }),
     ]);
   }
 
@@ -429,14 +432,14 @@ describe("snapSyllablesFlush · background provenance", () => {
     seedGappedBgLine();
     useProjectStore.getState().snapSyllablesFlush("line-1", "backgroundWords");
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundTextSource).toBe("manual");
-    expect(line.backgroundWords?.[0].end).toBe(line.backgroundWords?.[1].begin);
-    expect(line.backgroundText).toBe("oo|oh");
+    expect(bgSource(line)).toBe("manual");
+    expect(bgWords(line)?.[0].end).toBe(bgWords(line)?.[1].begin);
+    expect(bgText(line)).toBe("oo|oh");
   });
 
   it("leaves backgroundTextSource untouched when snapping the main track", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "beautiful",
         agentId: "v1",
@@ -448,18 +451,18 @@ describe("snapSyllablesFlush · background provenance", () => {
         backgroundWords: [{ text: "ooh", begin: 2, end: 2.5 }],
         backgroundText: "ooh",
         backgroundTextSource: "extraction",
-      },
+      }),
     ]);
     useProjectStore.getState().snapSyllablesFlush("line-1", "words");
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("extraction");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("extraction");
   });
 
   it("undo restores the prior extraction provenance", () => {
     seedGappedBgLine();
     useProjectStore.getState().clearHistory();
     useProjectStore.getState().snapSyllablesFlush("line-1", "backgroundWords");
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("extraction");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("extraction");
   });
 });

--- a/src/stores/project.move.test.ts
+++ b/src/stores/project.move.test.ts
@@ -414,7 +414,12 @@ describe("moveWordToBg · linked propagation", () => {
       lines: state.lines.map((l) =>
         l.id === "a1"
           ? reconcileLine({
-              ...l,
+              id: "a1",
+              text: "hello world goodbye",
+              agentId: "v1",
+              groupId: "g1",
+              instanceIdx: 1,
+              templateLineIdx: 0,
               words: [
                 { text: "hello ", begin: 10, end: 11 },
                 { text: "goodbye", begin: 12, end: 13 },

--- a/src/stores/project.move.test.ts
+++ b/src/stores/project.move.test.ts
@@ -3,6 +3,8 @@
  */
 import { useProjectStore } from "@/stores/project";
 import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
+import { bgSource, bgText, bgWords, mainWords } from "@/domain/line/voices";
+import { isLineSynced } from "@/domain/line/predicates";
 import { computeSyllableGroups, getSyllablePositions } from "@/domain/word/syllable-groups";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -36,10 +38,10 @@ describe("moveWordToBg", () => {
     useProjectStore.getState().moveWordToBg("line-1", [2], 5, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.words?.map((w) => w.text)).toEqual(["hello ", "world"]);
-    expect(line.backgroundWords).toHaveLength(1);
-    expect(line.backgroundWords?.[0]).toEqual({ text: "goodbye", begin: 7, end: 8 });
-    expect(line.backgroundText).toBe("goodbye");
+    expect(mainWords(line)?.map((w) => w.text)).toEqual(["hello ", "world"]);
+    expect(bgWords(line)).toHaveLength(1);
+    expect(bgWords(line)?.[0]).toEqual({ text: "goodbye", begin: 7, end: 8 });
+    expect(bgText(line)).toBe("goodbye");
   });
 
   it("trims trailing space from the new last main word", () => {
@@ -48,7 +50,7 @@ describe("moveWordToBg", () => {
     useProjectStore.getState().moveWordToBg("line-1", [2], 5, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.words?.[1].text).toBe("world");
+    expect(mainWords(line)?.[1].text).toBe("world");
   });
 
   it("moves multiple selected words at once", () => {
@@ -57,9 +59,9 @@ describe("moveWordToBg", () => {
     useProjectStore.getState().moveWordToBg("line-1", [0, 2], 0, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.words?.map((w) => w.text)).toEqual(["world"]);
-    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["hello ", "goodbye"]);
-    expect(line.backgroundText).toBe("hello goodbye");
+    expect(mainWords(line)?.map((w) => w.text)).toEqual(["world"]);
+    expect(bgWords(line)?.map((w) => w.text)).toEqual(["hello ", "goodbye"]);
+    expect(bgText(line)).toBe("hello goodbye");
   });
 
   it("adds a trailing space to the previous last bg word when a new word lands at the end without breaking syllable bonds before it", () => {
@@ -76,8 +78,8 @@ describe("moveWordToBg", () => {
     useProjectStore.getState().moveWordToBg("line-1", [2], 7, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["ah", "ooh ", "goodbye"]);
-    expect(line.backgroundText).toBe("ah|ooh goodbye");
+    expect(bgWords(line)?.map((w) => w.text)).toEqual(["ah", "ooh ", "goodbye"]);
+    expect(bgText(line)).toBe("ah|ooh goodbye");
   });
 
   it("resolves overlap when moved word collides with an existing bg word", () => {
@@ -91,7 +93,7 @@ describe("moveWordToBg", () => {
     useProjectStore.getState().moveWordToBg("line-1", [2], 3, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    const bg = line.backgroundWords;
+    const bg = bgWords(line);
     if (!bg) throw new Error("backgroundWords missing");
     expect(bg).toHaveLength(2);
     for (let i = 1; i < bg.length; i++) {
@@ -107,7 +109,7 @@ describe("moveWordToBg · background provenance", () => {
     useProjectStore.getState().moveWordToBg("line-1", [2], 5, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundTextSource).toBe("manual");
+    expect(bgSource(line)).toBe("manual");
   });
 
   it("flips an extraction-sourced background to manual when more words are moved in", () => {
@@ -122,7 +124,7 @@ describe("moveWordToBg · background provenance", () => {
     useProjectStore.getState().moveWordToBg("line-1", [2], 0, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundTextSource).toBe("manual");
+    expect(bgSource(line)).toBe("manual");
   });
 });
 
@@ -140,10 +142,10 @@ describe("moveWordFromBg", () => {
     useProjectStore.getState().moveWordFromBg("line-1", [0], -7, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundWords).toBeUndefined();
-    expect(line.backgroundText).toBeUndefined();
-    expect(line.words?.find((w) => w.text.trimEnd() === "ooh")).toBeTruthy();
-    const ooh = line.words?.find((w) => w.text.trimEnd() === "ooh");
+    expect(bgWords(line)).toBeUndefined();
+    expect(bgText(line)).toBeUndefined();
+    expect(mainWords(line)?.find((w) => w.text.trimEnd() === "ooh")).toBeTruthy();
+    const ooh = mainWords(line)?.find((w) => w.text.trimEnd() === "ooh");
     expect(ooh?.begin).toBe(3);
     expect(ooh?.end).toBe(4);
   });
@@ -162,8 +164,8 @@ describe("moveWordFromBg", () => {
     useProjectStore.getState().moveWordFromBg("line-1", [1], 3, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["ah"]);
-    expect(line.backgroundText).toBe("ah");
+    expect(bgWords(line)?.map((w) => w.text)).toEqual(["ah"]);
+    expect(bgText(line)).toBe("ah");
   });
 
   it("moves multiple selected bg words at once", () => {
@@ -182,8 +184,8 @@ describe("moveWordFromBg", () => {
     useProjectStore.getState().moveWordFromBg("line-1", [0, 2], 0, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["ooh"]);
-    expect(line.words?.map((w) => w.text)).toEqual(["ah ", "yeah"]);
+    expect(bgWords(line)?.map((w) => w.text)).toEqual(["ooh"]);
+    expect(mainWords(line)?.map((w) => w.text)).toEqual(["ah ", "yeah"]);
   });
 });
 
@@ -200,9 +202,9 @@ describe("moveWordFromBg · background provenance", () => {
     useProjectStore.getState().moveWordFromBg("line-1", [0], -7, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundWords).toBeUndefined();
-    expect(line.backgroundText).toBeUndefined();
-    expect(line.backgroundTextSource).toBeUndefined();
+    expect(bgWords(line)).toBeUndefined();
+    expect(bgText(line)).toBeUndefined();
+    expect(bgSource(line)).toBeUndefined();
   });
 
   it("stamps backgroundTextSource manual on the remaining background", () => {
@@ -220,8 +222,8 @@ describe("moveWordFromBg · background provenance", () => {
     useProjectStore.getState().moveWordFromBg("line-1", [1], 3, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["ah"]);
-    expect(line.backgroundTextSource).toBe("manual");
+    expect(bgWords(line)?.map((w) => w.text)).toEqual(["ah"]);
+    expect(bgSource(line)).toBe("manual");
   });
 });
 
@@ -233,13 +235,13 @@ describe("cross-track moves and history", () => {
     const before = useProjectStore.getState().lines[0];
 
     useProjectStore.getState().moveWordToBg("line-1", [2], 5, DURATION);
-    expect(useProjectStore.getState().lines[0].backgroundWords).toBeTruthy();
+    expect(bgWords(useProjectStore.getState().lines[0])).toBeTruthy();
     expect(useProjectStore.getState().canUndo()).toBe(true);
 
     useProjectStore.getState().undo();
     const restored = useProjectStore.getState().lines[0];
-    expect(restored.words?.map((w) => w.text)).toEqual(before.words?.map((w) => w.text));
-    expect(restored.backgroundWords).toBeUndefined();
+    expect(mainWords(restored)?.map((w) => w.text)).toEqual(mainWords(before)?.map((w) => w.text));
+    expect(bgWords(restored)).toBeUndefined();
   });
 
   it("moveWordFromBg is undoable and redoable", () => {
@@ -252,17 +254,17 @@ describe("cross-track moves and history", () => {
 
     useProjectStore.getState().moveWordFromBg("line-1", [0], -7, DURATION);
     const after = useProjectStore.getState().lines[0];
-    expect(after.backgroundWords).toBeUndefined();
+    expect(bgWords(after)).toBeUndefined();
 
     useProjectStore.getState().undo();
     const undone = useProjectStore.getState().lines[0];
-    expect(undone.backgroundWords).toEqual([{ text: "ooh", begin: 10, end: 11 }]);
+    expect(bgWords(undone)).toEqual([{ text: "ooh", begin: 10, end: 11 }]);
     expect(useProjectStore.getState().canRedo()).toBe(true);
 
     useProjectStore.getState().redo();
     const redone = useProjectStore.getState().lines[0];
-    expect(redone.backgroundWords).toBeUndefined();
-    expect(redone.words?.find((w) => w.text.trimEnd() === "ooh")).toBeTruthy();
+    expect(bgWords(redone)).toBeUndefined();
+    expect(mainWords(redone)?.find((w) => w.text.trimEnd() === "ooh")).toBeTruthy();
   });
 
   it("does not push history when no words match the indices", () => {
@@ -278,7 +280,7 @@ describe("cross-track moves and history", () => {
 
   it("preserves pre-existing intra-group gaps when applyMoveToBg leaves group syllables behind", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "every world",
         agentId: "v1",
@@ -288,19 +290,19 @@ describe("cross-track moves and history", () => {
           { text: "y", begin: 0.5, end: 0.7, syllableGroupId: "g1" },
           { text: "world", begin: 0.7, end: 1 },
         ],
-      },
+      }),
     ]);
 
     useProjectStore.getState().moveWordToBg("line-1", [3], 10, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.words?.[0].end).toBe(0.2);
-    expect(line.words?.[1].begin).toBe(0.3);
+    expect(mainWords(line)?.[0].end).toBe(0.2);
+    expect(mainWords(line)?.[1].begin).toBe(0.3);
   });
 
   it("preserves pre-existing intra-group gaps when a move passes through applyMoveFromBg", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "every world",
         agentId: "v1",
@@ -311,19 +313,19 @@ describe("cross-track moves and history", () => {
         ],
         backgroundWords: [{ text: "ah", begin: 5, end: 5.5 }],
         backgroundText: "ah",
-      },
+      }),
     ]);
 
     useProjectStore.getState().moveWordFromBg("line-1", [0], 10, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.words?.[0].end).toBe(0.2);
-    expect(line.words?.[1].begin).toBe(0.3);
+    expect(mainWords(line)?.[0].end).toBe(0.2);
+    expect(mainWords(line)?.[1].begin).toBe(0.3);
   });
 
   it("clears line.begin/end when bg→main populates main from empty", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "ooh",
         agentId: "v1",
@@ -331,15 +333,14 @@ describe("cross-track moves and history", () => {
         end: 10,
         backgroundWords: [{ text: "ooh", begin: 6, end: 7 }],
         backgroundText: "ooh",
-      },
+      }),
     ]);
 
     useProjectStore.getState().moveWordFromBg("line-1", [0], 0, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.words?.length).toBe(1);
-    expect(line.begin).toBeUndefined();
-    expect(line.end).toBeUndefined();
+    expect(mainWords(line)?.length).toBe(1);
+    expect(isLineSynced(line)).toBe(false);
   });
 });
 
@@ -349,7 +350,7 @@ describe("moveWordToBg · linked propagation", () => {
   function seedTwoLinkedInstances() {
     useProjectStore.getState().addGroup({ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 });
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "a0",
         text: "hello world goodbye",
         agentId: "v1",
@@ -361,8 +362,8 @@ describe("moveWordToBg · linked propagation", () => {
           { text: "world ", begin: 1, end: 2 },
           { text: "goodbye", begin: 2, end: 3 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "a1",
         text: "hello world goodbye",
         agentId: "v1",
@@ -374,7 +375,7 @@ describe("moveWordToBg · linked propagation", () => {
           { text: "world ", begin: 11, end: 12 },
           { text: "goodbye", begin: 12, end: 13 },
         ],
-      },
+      }),
     ]);
   }
 
@@ -387,11 +388,11 @@ describe("moveWordToBg · linked propagation", () => {
     const a0 = lines.find((l) => l.id === "a0");
     const a1 = lines.find((l) => l.id === "a1");
 
-    expect(a0?.words?.map((w) => w.text)).toEqual(["hello ", "world"]);
-    expect(a0?.backgroundWords).toEqual([{ text: "goodbye", begin: 2, end: 3 }]);
+    expect(a0 && mainWords(a0)?.map((w) => w.text)).toEqual(["hello ", "world"]);
+    expect(a0 && bgWords(a0)).toEqual([{ text: "goodbye", begin: 2, end: 3 }]);
 
-    expect(a1?.words?.map((w) => w.text)).toEqual(["hello ", "world"]);
-    expect(a1?.backgroundWords).toEqual([{ text: "goodbye", begin: 12, end: 13 }]);
+    expect(a1 && mainWords(a1)?.map((w) => w.text)).toEqual(["hello ", "world"]);
+    expect(a1 && bgWords(a1)).toEqual([{ text: "goodbye", begin: 12, end: 13 }]);
   });
 
   it("does not propagate to detached siblings", () => {
@@ -403,8 +404,8 @@ describe("moveWordToBg · linked propagation", () => {
     useProjectStore.getState().moveWordToBg("a0", [2], 0, DURATION);
 
     const a1 = useProjectStore.getState().lines.find((l) => l.id === "a1");
-    expect(a1?.backgroundWords).toBeUndefined();
-    expect(a1?.words?.length).toBe(3);
+    expect(a1 && bgWords(a1)).toBeUndefined();
+    expect(a1 && mainWords(a1)?.length).toBe(3);
   });
 
   it("skips siblings whose word count differs (already out of sync)", () => {
@@ -426,8 +427,8 @@ describe("moveWordToBg · linked propagation", () => {
     useProjectStore.getState().moveWordToBg("a0", [2], 0, DURATION);
 
     const a1 = useProjectStore.getState().lines.find((l) => l.id === "a1");
-    expect(a1?.backgroundWords).toBeUndefined();
-    expect(a1?.words?.length).toBe(2);
+    expect(a1 && bgWords(a1)).toBeUndefined();
+    expect(a1 && mainWords(a1)?.length).toBe(2);
   });
 
   it("does not affect lines from other groups or standalone lines", () => {
@@ -435,7 +436,7 @@ describe("moveWordToBg · linked propagation", () => {
     useProjectStore.setState((state) => ({
       lines: [
         ...state.lines,
-        {
+        reconcileLine({
           id: "x",
           text: "hello world goodbye",
           agentId: "v1",
@@ -444,21 +445,21 @@ describe("moveWordToBg · linked propagation", () => {
             { text: "world ", begin: 21, end: 22 },
             { text: "goodbye", begin: 22, end: 23 },
           ],
-        },
+        }),
       ],
     }));
 
     useProjectStore.getState().moveWordToBg("a0", [2], 0, DURATION);
 
     const x = useProjectStore.getState().lines.find((l) => l.id === "x");
-    expect(x?.backgroundWords).toBeUndefined();
-    expect(x?.words?.length).toBe(3);
+    expect(x && bgWords(x)).toBeUndefined();
+    expect(x && mainWords(x)?.length).toBe(3);
   });
 
   it("expands the syllable group per-sibling, not against the source layout", () => {
     useProjectStore.getState().addGroup({ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 });
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "a0",
         text: "every",
         agentId: "v1",
@@ -470,8 +471,8 @@ describe("moveWordToBg · linked propagation", () => {
           { text: "er", begin: 0.3, end: 0.6, syllableGroupId: "g_a0" },
           { text: "y", begin: 0.6, end: 1, syllableGroupId: "g_a0" },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "a1",
         text: "ev er y",
         agentId: "v1",
@@ -483,7 +484,7 @@ describe("moveWordToBg · linked propagation", () => {
           { text: "er ", begin: 10.3, end: 10.6 },
           { text: "y", begin: 10.6, end: 11 },
         ],
-      },
+      }),
     ]);
 
     useProjectStore.getState().moveWordToBg("a0", [1], 5, DURATION);
@@ -492,11 +493,11 @@ describe("moveWordToBg · linked propagation", () => {
     const a0 = lines.find((l) => l.id === "a0");
     const a1 = lines.find((l) => l.id === "a1");
 
-    expect(a0?.words?.length).toBe(0);
-    expect(a0?.backgroundWords?.map((w) => w.text)).toEqual(["ev", "er", "y"]);
+    expect(a0 && mainWords(a0)?.length).toBe(0);
+    expect(a0 && bgWords(a0)?.map((w) => w.text)).toEqual(["ev", "er", "y"]);
 
-    expect(a1?.words?.map((w) => w.text.trimEnd())).toEqual(["ev", "y"]);
-    expect(a1?.backgroundWords?.map((w) => w.text)).toEqual(["er"]);
+    expect(a1 && mainWords(a1)?.map((w) => w.text.trimEnd())).toEqual(["ev", "y"]);
+    expect(a1 && bgWords(a1)?.map((w) => w.text)).toEqual(["er"]);
   });
 });
 
@@ -505,7 +506,7 @@ describe("moveWordToBg · linked propagation", () => {
 describe("cross-track moves auto-expand to syllable groupmates", () => {
   it("moveWordToBg expands a single-syllable selection to the whole syllable group", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "hello every world",
         agentId: "v1",
@@ -516,20 +517,20 @@ describe("cross-track moves auto-expand to syllable groupmates", () => {
           { text: "y", begin: 1.5, end: 1.8, syllableGroupId: "g_every" },
           { text: "world", begin: 1.8, end: 2.5 },
         ],
-      },
+      }),
     ]);
 
     useProjectStore.getState().moveWordToBg("line-1", [2], 5, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.words?.map((w) => w.text)).toEqual(["hello ", "world"]);
-    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["ev", "er", "y"]);
-    expect(getSyllablePositions(line.backgroundWords ?? [])).toEqual(["first", "middle", "last"]);
+    expect(mainWords(line)?.map((w) => w.text)).toEqual(["hello ", "world"]);
+    expect(bgWords(line)?.map((w) => w.text)).toEqual(["ev", "er", "y"]);
+    expect(getSyllablePositions(bgWords(line) ?? [])).toEqual(["first", "middle", "last"]);
   });
 
   it("moveWordFromBg expands a single-syllable bg selection to the whole syllable group", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "every",
         agentId: "v1",
@@ -540,22 +541,22 @@ describe("cross-track moves auto-expand to syllable groupmates", () => {
           { text: "y", begin: 5.5, end: 5.8, syllableGroupId: "g_every" },
         ],
         backgroundText: "every",
-      },
+      }),
     ]);
 
     useProjectStore.getState().moveWordFromBg("line-1", [1], -4, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.words?.map((w) => w.text)).toEqual(["ev", "er", "y"]);
-    expect(getSyllablePositions(line.words ?? [])).toEqual(["first", "middle", "last"]);
-    expect(line.backgroundWords).toBeUndefined();
+    expect(mainWords(line)?.map((w) => w.text)).toEqual(["ev", "er", "y"]);
+    expect(getSyllablePositions(mainWords(line) ?? [])).toEqual(["first", "middle", "last"]);
+    expect(bgWords(line)).toBeUndefined();
   });
 });
 
 describe("moveWordToBg clears line.begin/end when main empties", () => {
   it("clears begin/end on a TTML-imported line whose whole syllable-grouped word is moved to bg", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "beautiful",
         agentId: "v1",
@@ -564,23 +565,22 @@ describe("moveWordToBg clears line.begin/end when main empties", () => {
           { text: "ti", begin: 11.463, end: 13.58, syllableGroupId: "g_beautiful" },
           { text: "ful", begin: 13.58, end: 15.335, syllableGroupId: "g_beautiful" },
         ],
-      },
+      }),
     ]);
 
     useProjectStore.getState().moveWordToBg("line-1", [1], 5, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.words).toEqual([]);
-    expect(line.begin).toBeUndefined();
-    expect(line.end).toBeUndefined();
-    expect(line.backgroundWords?.length).toBe(3);
+    expect(mainWords(line)).toEqual([]);
+    expect(isLineSynced(line)).toBe(false);
+    expect(bgWords(line)?.length).toBe(3);
   });
 });
 
 describe("cross-track moves preserve syllable bonds", () => {
   it("moveWordToBg keeps remaining split-word syllables bonded", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "hello every world",
         agentId: "v1",
@@ -591,19 +591,19 @@ describe("cross-track moves preserve syllable bonds", () => {
           { text: "y ", begin: 1.5, end: 1.8 },
           { text: "world", begin: 1.8, end: 2.5 },
         ],
-      },
+      }),
     ]);
 
     useProjectStore.getState().moveWordToBg("line-1", [4], 5, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.words?.map((w) => w.text)).toEqual(["hello ", "ev", "er", "y"]);
-    expect(getSyllablePositions(line.words ?? [])).toEqual(["none", "first", "middle", "last"]);
+    expect(mainWords(line)?.map((w) => w.text)).toEqual(["hello ", "ev", "er", "y"]);
+    expect(getSyllablePositions(mainWords(line) ?? [])).toEqual(["none", "first", "middle", "last"]);
   });
 
   it("moveWordToBg keeps a whole syllable group bonded when all its indices move together", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "hello every world",
         agentId: "v1",
@@ -614,39 +614,39 @@ describe("cross-track moves preserve syllable bonds", () => {
           { text: "y ", begin: 1.5, end: 1.8 },
           { text: "world", begin: 1.8, end: 2.5 },
         ],
-      },
+      }),
     ]);
 
     useProjectStore.getState().moveWordToBg("line-1", [1, 2, 3], 5, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.words?.map((w) => w.text)).toEqual(["hello ", "world"]);
-    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["ev", "er", "y"]);
-    expect(getSyllablePositions(line.backgroundWords ?? [])).toEqual(["first", "middle", "last"]);
+    expect(mainWords(line)?.map((w) => w.text)).toEqual(["hello ", "world"]);
+    expect(bgWords(line)?.map((w) => w.text)).toEqual(["ev", "er", "y"]);
+    expect(getSyllablePositions(bgWords(line) ?? [])).toEqual(["first", "middle", "last"]);
   });
 
   it("moveWordFromBg adds trailing space to previously-last main word when receiving a new tail", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "hello",
         agentId: "v1",
         words: [{ text: "hello", begin: 0, end: 1 }],
         backgroundWords: [{ text: "world", begin: 2, end: 3 }],
         backgroundText: "world",
-      },
+      }),
     ]);
 
     useProjectStore.getState().moveWordFromBg("line-1", [0], 0, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.words?.map((w) => w.text)).toEqual(["hello ", "world"]);
-    expect(line.backgroundWords).toBeUndefined();
+    expect(mainWords(line)?.map((w) => w.text)).toEqual(["hello ", "world"]);
+    expect(bgWords(line)).toBeUndefined();
   });
 
   it("moveWordFromBg returns a syllable group from bg intact when the whole group flips", () => {
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "line-1",
         text: "every",
         agentId: "v1",
@@ -657,15 +657,15 @@ describe("cross-track moves preserve syllable bonds", () => {
           { text: "y", begin: 5.5, end: 5.8 },
         ],
         backgroundText: "every",
-      },
+      }),
     ]);
 
     useProjectStore.getState().moveWordFromBg("line-1", [0, 1, 2], -4, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.words?.map((w) => w.text)).toEqual(["ev", "er", "y"]);
-    expect(getSyllablePositions(line.words ?? [])).toEqual(["first", "middle", "last"]);
-    expect(line.backgroundWords).toBeUndefined();
+    expect(mainWords(line)?.map((w) => w.text)).toEqual(["ev", "er", "y"]);
+    expect(getSyllablePositions(mainWords(line) ?? [])).toEqual(["first", "middle", "last"]);
+    expect(bgWords(line)).toBeUndefined();
   });
 });
 
@@ -673,7 +673,7 @@ describe("moveWordFromBg · linked propagation", () => {
   function seedTwoLinkedInstancesWithBg() {
     useProjectStore.getState().addGroup({ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 });
     useProjectStore.getState().setLines([
-      {
+      reconcileLine({
         id: "a0",
         text: "hello world",
         agentId: "v1",
@@ -686,8 +686,8 @@ describe("moveWordFromBg · linked propagation", () => {
         ],
         backgroundWords: [{ text: "ooh", begin: 2, end: 3 }],
         backgroundText: "ooh",
-      },
-      {
+      }),
+      reconcileLine({
         id: "a1",
         text: "hello world",
         agentId: "v1",
@@ -700,7 +700,7 @@ describe("moveWordFromBg · linked propagation", () => {
         ],
         backgroundWords: [{ text: "ooh", begin: 12, end: 13 }],
         backgroundText: "ooh",
-      },
+      }),
     ]);
   }
 
@@ -713,11 +713,11 @@ describe("moveWordFromBg · linked propagation", () => {
     const a0 = lines.find((l) => l.id === "a0");
     const a1 = lines.find((l) => l.id === "a1");
 
-    expect(a0?.backgroundWords).toBeUndefined();
-    expect(a0?.words?.find((w) => w.text === "ooh")?.begin).toBe(2);
+    expect(a0 && bgWords(a0)).toBeUndefined();
+    expect(a0 && mainWords(a0)?.find((w) => w.text === "ooh")?.begin).toBe(2);
 
-    expect(a1?.backgroundWords).toBeUndefined();
-    expect(a1?.words?.find((w) => w.text === "ooh")?.begin).toBe(12);
+    expect(a1 && bgWords(a1)).toBeUndefined();
+    expect(a1 && mainWords(a1)?.find((w) => w.text === "ooh")?.begin).toBe(12);
   });
 });
 
@@ -738,8 +738,8 @@ describe("cross-track moves space the merge seam", () => {
     useProjectStore.getState().moveWordToBg("line-1", [2], 0, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundWords?.map((w) => w.text)).toEqual(["ah ", "goodbye ", "ooh"]);
-    const groups = computeSyllableGroups(line.backgroundWords ?? []);
+    expect(bgWords(line)?.map((w) => w.text)).toEqual(["ah ", "goodbye ", "ooh"]);
+    const groups = computeSyllableGroups(bgWords(line) ?? []);
     expect(groups.some((g) => g.startIndex <= 1 && g.endIndex >= 2)).toBe(false);
   });
 
@@ -758,8 +758,8 @@ describe("cross-track moves space the merge seam", () => {
     useProjectStore.getState().moveWordFromBg("line-1", [0], 0, DURATION);
 
     const line = useProjectStore.getState().lines[0];
-    expect(line.words?.map((w) => w.text)).toEqual(["hello ", "ooh ", "world"]);
-    const groups = computeSyllableGroups(line.words ?? []);
+    expect(mainWords(line)?.map((w) => w.text)).toEqual(["hello ", "ooh ", "world"]);
+    const groups = computeSyllableGroups(mainWords(line) ?? []);
     expect(groups.some((g) => g.startIndex <= 1 && g.endIndex >= 2)).toBe(false);
   });
 });

--- a/src/stores/project.propagation-opt-out.test.ts
+++ b/src/stores/project.propagation-opt-out.test.ts
@@ -2,6 +2,9 @@
  * @vitest-environment node
  */
 import type { LinkGroup } from "@/domain/group/template";
+import { mainBounds } from "@/domain/line/bounds";
+import { reconcileLine } from "@/domain/line/model";
+import { bgWords, lineText, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { useProjectStore } from "@/stores/project";
 import { commitTappedWord, splitIntoWordsWithMeta } from "@/utils/sync-helpers";
@@ -41,7 +44,7 @@ function seedTwoWordSyncedInstances() {
   useProjectStore.setState({
     groups: [seedGroup("g1")],
     lines: [
-      {
+      reconcileLine({
         id: "a0",
         text: "I love you",
         agentId: "v1",
@@ -49,8 +52,8 @@ function seedTwoWordSyncedInstances() {
         instanceIdx: 0,
         templateLineIdx: 0,
         words: INSTANCE_A_WORDS.map((w) => ({ ...w })),
-      },
-      {
+      }),
+      reconcileLine({
         id: "a1",
         text: "I love you",
         agentId: "v1",
@@ -58,7 +61,7 @@ function seedTwoWordSyncedInstances() {
         instanceIdx: 1,
         templateLineIdx: 0,
         words: INSTANCE_B_WORDS.map((w) => ({ ...w })),
-      },
+      }),
     ],
     isDirtySinceHistory: true,
   });
@@ -83,7 +86,7 @@ describe("updateLineWithHistory · propagateToSiblings: false", () => {
       .getState()
       .updateLineWithHistory("a0", { words: [{ text: "I ", begin: 5, end: 5.4 }] }, { propagateToSiblings: false });
 
-    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+    expect(mainWords(getLine("a1"))).toEqual(INSTANCE_B_WORDS);
   });
 
   it("does not retime a sibling when the source word count grows", () => {
@@ -92,7 +95,7 @@ describe("updateLineWithHistory · propagateToSiblings: false", () => {
     const grown: WordTiming[] = [...INSTANCE_A_WORDS, { text: "you", begin: 1.2, end: 1.6 }];
     useProjectStore.getState().updateLineWithHistory("a0", { words: grown }, { propagateToSiblings: false });
 
-    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+    expect(mainWords(getLine("a1"))).toEqual(INSTANCE_B_WORDS);
   });
 
   it("does not reorder a sibling's word texts when the source word order changes", () => {
@@ -105,7 +108,7 @@ describe("updateLineWithHistory · propagateToSiblings: false", () => {
     ];
     useProjectStore.getState().updateLineWithHistory("a0", { words: reordered }, { propagateToSiblings: false });
 
-    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+    expect(mainWords(getLine("a1"))).toEqual(INSTANCE_B_WORDS);
   });
 
   it("does not retime a sibling's background words", () => {
@@ -114,7 +117,7 @@ describe("updateLineWithHistory · propagateToSiblings: false", () => {
     const bgB: WordTiming[] = [{ text: "ah", begin: 20, end: 20.5 }];
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a0",
           text: "lead",
           agentId: "v1",
@@ -123,8 +126,8 @@ describe("updateLineWithHistory · propagateToSiblings: false", () => {
           templateLineIdx: 0,
           backgroundText: "ah",
           backgroundWords: bgA.map((w) => ({ ...w })),
-        },
-        {
+        }),
+        reconcileLine({
           id: "a1",
           text: "lead",
           agentId: "v1",
@@ -133,7 +136,7 @@ describe("updateLineWithHistory · propagateToSiblings: false", () => {
           templateLineIdx: 0,
           backgroundText: "ah",
           backgroundWords: bgB.map((w) => ({ ...w })),
-        },
+        }),
       ],
     });
 
@@ -148,7 +151,7 @@ describe("updateLineWithHistory · propagateToSiblings: false", () => {
       { propagateToSiblings: false },
     );
 
-    expect(getLine("a1").backgroundWords).toEqual(bgB);
+    expect(bgWords(getLine("a1"))).toEqual(bgB);
   });
 
   it("still writes the source line", () => {
@@ -157,7 +160,7 @@ describe("updateLineWithHistory · propagateToSiblings: false", () => {
 
     useProjectStore.getState().updateLineWithHistory("a0", { words: sourceWords }, { propagateToSiblings: false });
 
-    expect(getLine("a0").words).toEqual(sourceWords);
+    expect(mainWords(getLine("a0"))).toEqual(sourceWords);
   });
 
   it("still propagates structural word changes by default (option defaults to true)", () => {
@@ -165,11 +168,11 @@ describe("updateLineWithHistory · propagateToSiblings: false", () => {
 
     useProjectStore.getState().updateLineWithHistory("a0", { words: MERGED_WORDS });
 
-    expect(getLine("a1").words).toHaveLength(2);
+    expect(mainWords(getLine("a1"))).toHaveLength(2);
   });
 
   it("works for a non-grouped line (regression)", () => {
-    useProjectStore.setState({ lines: [{ id: "s", text: "standalone", agentId: "v1" }] });
+    useProjectStore.setState({ lines: [reconcileLine({ id: "s", text: "standalone", agentId: "v1" })] });
 
     useProjectStore
       .getState()
@@ -179,7 +182,7 @@ describe("updateLineWithHistory · propagateToSiblings: false", () => {
         { propagateToSiblings: false },
       );
 
-    expect(getLine("s").words).toEqual([{ text: "standalone", begin: 1, end: 2 }]);
+    expect(mainWords(getLine("s"))).toEqual([{ text: "standalone", begin: 1, end: 2 }]);
   });
 
   it("commits a single history entry that undo reverts", () => {
@@ -190,8 +193,8 @@ describe("updateLineWithHistory · propagateToSiblings: false", () => {
       .updateLineWithHistory("a0", { words: [{ text: "I ", begin: 5, end: 5.4 }] }, { propagateToSiblings: false });
     useProjectStore.getState().undo();
 
-    expect(getLine("a0").words).toEqual(INSTANCE_A_WORDS);
-    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+    expect(mainWords(getLine("a0"))).toEqual(INSTANCE_A_WORDS);
+    expect(mainWords(getLine("a1"))).toEqual(INSTANCE_B_WORDS);
   });
 });
 
@@ -205,7 +208,7 @@ describe("updateLinesWithHistory · propagateToSiblings: false", () => {
         propagateToSiblings: false,
       });
 
-    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+    expect(mainWords(getLine("a1"))).toEqual(INSTANCE_B_WORDS);
   });
 
   it("still propagates structural word changes by default", () => {
@@ -213,7 +216,7 @@ describe("updateLinesWithHistory · propagateToSiblings: false", () => {
 
     useProjectStore.getState().updateLinesWithHistory([{ id: "a0", updates: { words: MERGED_WORDS } }]);
 
-    expect(getLine("a1").words).toHaveLength(2);
+    expect(mainWords(getLine("a1"))).toHaveLength(2);
   });
 });
 
@@ -222,9 +225,9 @@ describe("instance resync · issue #96 reproduction", () => {
   // performs, using the real commitTappedWord helper.
   function tapResync(lineId: string, wordIndex: number, begin: number, end: number) {
     const line = getLine(lineId);
-    const { parts, trailingSpace } = splitIntoWordsWithMeta(line.text);
+    const { parts, trailingSpace } = splitIntoWordsWithMeta(lineText(line));
     const text = trailingSpace[wordIndex] ? `${parts[wordIndex]} ` : parts[wordIndex];
-    const updated = commitTappedWord(line.words ?? [], wordIndex, text, begin, end);
+    const updated = commitTappedWord(mainWords(line) ?? [], wordIndex, text, begin, end);
     useProjectStore
       .getState()
       .updateLineWithHistory(lineId, { words: updated }, { deriveText: false, propagateToSiblings: false });
@@ -237,7 +240,7 @@ describe("instance resync · issue #96 reproduction", () => {
     tapResync("a0", 1, 1.0, 1.3);
     tapResync("a0", 2, 1.5, 1.8);
 
-    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+    expect(mainWords(getLine("a1"))).toEqual(INSTANCE_B_WORDS);
   });
 
   it("the resynced instance A keeps its full word set with the new timing", () => {
@@ -247,7 +250,7 @@ describe("instance resync · issue #96 reproduction", () => {
     tapResync("a0", 1, 1.0, 1.3);
     tapResync("a0", 2, 1.5, 1.8);
 
-    expect(getLine("a0").words).toEqual([
+    expect(mainWords(getLine("a0"))).toEqual([
       { text: "I ", begin: 0.5, end: 1.0 },
       { text: "love ", begin: 1.0, end: 1.5 },
       { text: "you", begin: 1.5, end: 1.8 },
@@ -263,7 +266,7 @@ describe("instance resync · issue #96 reproduction", () => {
     ];
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a0",
           text: "I love you",
           agentId: "v1",
@@ -271,8 +274,8 @@ describe("instance resync · issue #96 reproduction", () => {
           instanceIdx: 0,
           templateLineIdx: 0,
           words: INSTANCE_A_WORDS.map((w) => ({ ...w })),
-        },
-        {
+        }),
+        reconcileLine({
           id: "a1",
           text: "I love you",
           agentId: "v1",
@@ -280,8 +283,8 @@ describe("instance resync · issue #96 reproduction", () => {
           instanceIdx: 1,
           templateLineIdx: 0,
           words: INSTANCE_B_WORDS.map((w) => ({ ...w })),
-        },
-        {
+        }),
+        reconcileLine({
           id: "a2",
           text: "I love you",
           agentId: "v1",
@@ -289,7 +292,7 @@ describe("instance resync · issue #96 reproduction", () => {
           instanceIdx: 2,
           templateLineIdx: 0,
           words: cWords.map((w) => ({ ...w })),
-        },
+        }),
       ],
     });
 
@@ -297,8 +300,8 @@ describe("instance resync · issue #96 reproduction", () => {
     tapResync("a0", 1, 1.0, 1.3);
     tapResync("a0", 2, 1.5, 1.8);
 
-    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
-    expect(getLine("a2").words).toEqual(cWords);
+    expect(mainWords(getLine("a1"))).toEqual(INSTANCE_B_WORDS);
+    expect(mainWords(getLine("a2"))).toEqual(cWords);
   });
 
   it("a single partial tap (the worst-case squash state) leaves the sibling intact", () => {
@@ -308,9 +311,9 @@ describe("instance resync · issue #96 reproduction", () => {
     // holds one word: this is the state that previously collapsed the sibling.
     tapResync("a0", 0, 0.5, 0.8);
 
-    expect(getLine("a0").words).toHaveLength(1);
-    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
-    expect(getLine("a1").words).toHaveLength(3);
+    expect(mainWords(getLine("a0"))).toHaveLength(1);
+    expect(mainWords(getLine("a1"))).toEqual(INSTANCE_B_WORDS);
+    expect(mainWords(getLine("a1"))).toHaveLength(3);
   });
 
   it("characterizes the bug: a resync left to propagate DOES squash the sibling", () => {
@@ -320,13 +323,13 @@ describe("instance resync · issue #96 reproduction", () => {
     // with no opt-out, so propagation fired on the transient one-word array and
     // collapsed the sibling. This is the behavior the opt-out must prevent.
     const line = getLine("a0");
-    const { parts, trailingSpace } = splitIntoWordsWithMeta(line.text);
+    const { parts, trailingSpace } = splitIntoWordsWithMeta(lineText(line));
     const text = trailingSpace[0] ? `${parts[0]} ` : parts[0];
-    const updated = commitTappedWord(line.words ?? [], 0, text, 0.5, 0.8);
+    const updated = commitTappedWord(mainWords(line) ?? [], 0, text, 0.5, 0.8);
     useProjectStore.getState().updateLineWithHistory("a0", { words: updated }, { deriveText: false });
 
-    expect(getLine("a1").words).toHaveLength(1);
-    expect(getLine("a1").words).not.toEqual(INSTANCE_B_WORDS);
+    expect(mainWords(getLine("a1"))).toHaveLength(1);
+    expect(mainWords(getLine("a1"))).not.toEqual(INSTANCE_B_WORDS);
   });
 });
 
@@ -341,7 +344,7 @@ describe("propagateToSiblings: false · edge cases", () => {
       .getState()
       .updateLineWithHistory("a0", { words: [{ text: "I ", begin: 5, end: 5.4 }] }, { propagateToSiblings: false });
 
-    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+    expect(mainWords(getLine("a1"))).toEqual(INSTANCE_B_WORDS);
   });
 
   it("does not throw and changes nothing for an unknown line id", () => {
@@ -350,15 +353,15 @@ describe("propagateToSiblings: false · edge cases", () => {
     expect(() =>
       useProjectStore.getState().updateLineWithHistory("nope", { words: [] }, { propagateToSiblings: false }),
     ).not.toThrow();
-    expect(getLine("a0").words).toEqual(INSTANCE_A_WORDS);
-    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+    expect(mainWords(getLine("a0"))).toEqual(INSTANCE_A_WORDS);
+    expect(mainWords(getLine("a1"))).toEqual(INSTANCE_B_WORDS);
   });
 
   it("handles a single-instance group with no siblings", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "solo",
           text: "I love you",
           agentId: "v1",
@@ -366,7 +369,7 @@ describe("propagateToSiblings: false · edge cases", () => {
           instanceIdx: 0,
           templateLineIdx: 0,
           words: INSTANCE_A_WORDS.map((w) => ({ ...w })),
-        },
+        }),
       ],
     });
 
@@ -375,7 +378,7 @@ describe("propagateToSiblings: false · edge cases", () => {
         .getState()
         .updateLineWithHistory("solo", { words: [{ text: "I ", begin: 5, end: 5.4 }] }, { propagateToSiblings: false }),
     ).not.toThrow();
-    expect(getLine("solo").words).toEqual([{ text: "I ", begin: 5, end: 5.4 }]);
+    expect(mainWords(getLine("solo"))).toEqual([{ text: "I ", begin: 5, end: 5.4 }]);
   });
 
   it("does not touch lines belonging to a different group", () => {
@@ -384,7 +387,7 @@ describe("propagateToSiblings: false · edge cases", () => {
     useProjectStore.setState((s) => ({
       lines: [
         ...s.lines,
-        {
+        reconcileLine({
           id: "x",
           text: "other",
           agentId: "v1",
@@ -392,7 +395,7 @@ describe("propagateToSiblings: false · edge cases", () => {
           instanceIdx: 0,
           templateLineIdx: 0,
           words: otherWords.map((w) => ({ ...w })),
-        },
+        }),
       ],
     }));
 
@@ -400,7 +403,7 @@ describe("propagateToSiblings: false · edge cases", () => {
       .getState()
       .updateLineWithHistory("a0", { words: [{ text: "I ", begin: 5, end: 5.4 }] }, { propagateToSiblings: false });
 
-    expect(getLine("x").words).toEqual(otherWords);
+    expect(mainWords(getLine("x"))).toEqual(otherWords);
   });
 
   it("leaves the sibling intact even when the sibling already diverged in word count", () => {
@@ -411,7 +414,7 @@ describe("propagateToSiblings: false · edge cases", () => {
     ];
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "a0",
           text: "I love you",
           agentId: "v1",
@@ -419,8 +422,8 @@ describe("propagateToSiblings: false · edge cases", () => {
           instanceIdx: 0,
           templateLineIdx: 0,
           words: INSTANCE_A_WORDS.map((w) => ({ ...w })),
-        },
-        {
+        }),
+        reconcileLine({
           id: "a1",
           text: "I love you",
           agentId: "v1",
@@ -428,7 +431,7 @@ describe("propagateToSiblings: false · edge cases", () => {
           instanceIdx: 1,
           templateLineIdx: 0,
           words: divergedB.map((w) => ({ ...w })),
-        },
+        }),
       ],
     });
 
@@ -436,7 +439,7 @@ describe("propagateToSiblings: false · edge cases", () => {
       .getState()
       .updateLineWithHistory("a0", { words: [{ text: "I ", begin: 5, end: 5.4 }] }, { propagateToSiblings: false });
 
-    expect(getLine("a1").words).toEqual(divergedB);
+    expect(mainWords(getLine("a1"))).toEqual(divergedB);
   });
 
   it("updateLinesWithHistory opt-out does not throw on an empty batch", () => {
@@ -446,15 +449,16 @@ describe("propagateToSiblings: false · edge cases", () => {
 
   it("updateLinesWithHistory opt-out spares the siblings of every batched line", () => {
     useProjectStore.getState().addGroup(seedGroup("g1"));
-    const mk = (id: string, templateLineIdx: number, instanceIdx: number, words: WordTiming[]) => ({
-      id,
-      text: "I love you",
-      agentId: "v1",
-      groupId: "g1",
-      instanceIdx,
-      templateLineIdx,
-      words: words.map((w) => ({ ...w })),
-    });
+    const mk = (id: string, templateLineIdx: number, instanceIdx: number, words: WordTiming[]) =>
+      reconcileLine({
+        id,
+        text: "I love you",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx,
+        templateLineIdx,
+        words: words.map((w) => ({ ...w })),
+      });
     useProjectStore.setState({
       lines: [
         mk("t0i0", 0, 0, INSTANCE_A_WORDS),
@@ -472,8 +476,8 @@ describe("propagateToSiblings: false · edge cases", () => {
       { propagateToSiblings: false },
     );
 
-    expect(getLine("t0i1").words).toEqual(INSTANCE_B_WORDS);
-    expect(getLine("t1i1").words).toEqual(INSTANCE_B_WORDS);
+    expect(mainWords(getLine("t0i1"))).toEqual(INSTANCE_B_WORDS);
+    expect(mainWords(getLine("t1i1"))).toEqual(INSTANCE_B_WORDS);
   });
 });
 
@@ -483,7 +487,7 @@ describe("timing nudges · do not propagate to siblings", () => {
 
     nudgeWordBegin(useProjectStore.getState().lines, 0, 1, 0.1, useProjectStore.getState().updateLineWithHistory);
 
-    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
+    expect(mainWords(getLine("a1"))).toEqual(INSTANCE_B_WORDS);
   });
 
   it("setWordBegin does not overwrite a sibling word whose text has diverged", () => {
@@ -493,7 +497,7 @@ describe("timing nudges · do not propagate to siblings", () => {
     useProjectStore.setState({
       groups: [seedGroup("g1")],
       lines: [
-        {
+        reconcileLine({
           id: "a0",
           text: "I love you",
           agentId: "v1",
@@ -501,8 +505,8 @@ describe("timing nudges · do not propagate to siblings", () => {
           instanceIdx: 0,
           templateLineIdx: 0,
           words: INSTANCE_A_WORDS.map((w) => ({ ...w })),
-        },
-        {
+        }),
+        reconcileLine({
           id: "a1",
           text: "I love you",
           agentId: "v1",
@@ -514,21 +518,21 @@ describe("timing nudges · do not propagate to siblings", () => {
             { text: "LOVE ", begin: 10.5, end: 11.0 },
             { text: "you", begin: 11.0, end: 11.5 },
           ],
-        },
+        }),
       ],
       isDirtySinceHistory: true,
     });
 
     setWordBegin(useProjectStore.getState().lines, 0, 0, 0.2, useProjectStore.getState().updateLineWithHistory);
 
-    expect(getLine("a1").words?.[1].text).toBe("LOVE ");
+    expect(mainWords(getLine("a1"))?.[1].text).toBe("LOVE ");
   });
 
   it("nudgeLineBegin on one line-synced instance leaves the sibling's bounds untouched", () => {
     useProjectStore.setState({
       groups: [seedGroup("g1")],
       lines: [
-        {
+        reconcileLine({
           id: "a0",
           text: "I love you",
           agentId: "v1",
@@ -537,8 +541,8 @@ describe("timing nudges · do not propagate to siblings", () => {
           templateLineIdx: 0,
           begin: 30,
           end: 32,
-        },
-        {
+        }),
+        reconcileLine({
           id: "a1",
           text: "I love you",
           agentId: "v1",
@@ -547,14 +551,14 @@ describe("timing nudges · do not propagate to siblings", () => {
           templateLineIdx: 0,
           begin: 60,
           end: 62,
-        },
+        }),
       ],
       isDirtySinceHistory: true,
     });
 
     nudgeLineBegin(useProjectStore.getState().lines, 0, 0.5, useProjectStore.getState().updateLineWithHistory);
 
-    expect(getLine("a1").begin).toBe(60);
-    expect(getLine("a1").end).toBe(62);
+    expect(mainBounds(getLine("a1"))?.begin).toBe(60);
+    expect(mainBounds(getLine("a1"))?.end).toBe(62);
   });
 });

--- a/src/stores/project.remove-background.test.ts
+++ b/src/stores/project.remove-background.test.ts
@@ -1,0 +1,278 @@
+/**
+ * @vitest-environment node
+ */
+import type { LinkGroup } from "@/domain/group/template";
+import { setBackground } from "@/domain/line/background";
+import { bgBounds } from "@/domain/line/bounds";
+import { type LooseLine, reconcileLine } from "@/domain/line/model";
+import { bgVoice, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { useProjectStore } from "@/stores/project";
+import { beforeEach, describe, expect, it } from "vitest";
+
+beforeEach(() => {
+  useProjectStore.getState().reset();
+  useProjectStore.getState().clearHistory();
+});
+
+function seedGroup(id: string): LinkGroup {
+  return { id, label: "Chorus", color: "#f472b6", templateVersion: 1 };
+}
+
+function seed(lines: LooseLine[], groups: LinkGroup[] = []) {
+  useProjectStore.setState({
+    groups,
+    lines: lines.map(reconcileLine),
+    isDirtySinceHistory: true,
+  });
+}
+
+function getLine(id: string) {
+  const line = useProjectStore.getState().lines.find((l) => l.id === id);
+  if (!line) throw new Error(`line ${id} not found`);
+  return line;
+}
+
+describe("project store · removeLineBackground · clears every bg state", () => {
+  it("removes an untimed background", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", backgroundText: "ooh" }]);
+    expect(bgVoice(getLine("L1"))).not.toBeNull();
+
+    useProjectStore.getState().removeLineBackground("L1");
+
+    expect(bgVoice(getLine("L1"))).toBeNull();
+  });
+
+  it("removes a word-synced background", () => {
+    seed([
+      {
+        id: "L1",
+        text: "Real line",
+        agentId: "v1",
+        words: [{ text: "Real line", begin: 0, end: 2 }],
+        backgroundText: "ooh aah",
+        backgroundWords: [
+          { text: "ooh ", begin: 1, end: 1.5 },
+          { text: "aah", begin: 1.5, end: 2 },
+        ],
+        backgroundTextSource: "extraction",
+      },
+    ]);
+    expect(bgWords(getLine("L1"))).toHaveLength(2);
+
+    useProjectStore.getState().removeLineBackground("L1");
+
+    expect(bgVoice(getLine("L1"))).toBeNull();
+    expect(bgWords(getLine("L1"))).toBeUndefined();
+  });
+
+  it("removes a line-synced background", () => {
+    const main = reconcileLine({
+      id: "L1",
+      text: "lead",
+      agentId: "v1",
+      words: [{ text: "lead", begin: 0, end: 2 }],
+    });
+    const withLineSyncedBg = setBackground(main, { text: "(ahh)", begin: 3.5, end: 4.5, source: "manual" });
+    useProjectStore.setState({ lines: [withLineSyncedBg], isDirtySinceHistory: true });
+    expect(bgBounds(getLine("L1"))).toEqual({ begin: 3.5, end: 4.5 });
+
+    useProjectStore.getState().removeLineBackground("L1");
+
+    expect(bgVoice(getLine("L1"))).toBeNull();
+    expect(bgBounds(getLine("L1"))).toBeNull();
+  });
+
+  it("keeps the main voice text and timing intact after removal", () => {
+    seed([
+      {
+        id: "L1",
+        text: "Real line",
+        agentId: "v1",
+        words: [
+          { text: "Real ", begin: 0, end: 1 },
+          { text: "line", begin: 1, end: 2 },
+        ],
+        backgroundText: "ooh",
+      },
+    ]);
+
+    useProjectStore.getState().removeLineBackground("L1");
+
+    const after = getLine("L1");
+    expect(bgVoice(after)).toBeNull();
+    expect(lineText(after)).toBe("Real line");
+    expect(mainWords(after)).toEqual([
+      { text: "Real ", begin: 0, end: 1 },
+      { text: "line", begin: 1, end: 2 },
+    ]);
+  });
+});
+
+describe("project store · removeLineBackground · history", () => {
+  it("pushes one history entry and undo restores the exact prior background", () => {
+    seed([
+      {
+        id: "L1",
+        text: "Real line",
+        agentId: "v1",
+        words: [{ text: "Real line", begin: 0, end: 2 }],
+        backgroundText: "ooh aah",
+        backgroundWords: [
+          { text: "ooh ", begin: 1, end: 1.5 },
+          { text: "aah", begin: 1.5, end: 2 },
+        ],
+        backgroundTextSource: "extraction",
+      },
+    ]);
+    const backgroundBefore = getLine("L1").background;
+    expect(useProjectStore.getState().canUndo()).toBe(false);
+
+    useProjectStore.getState().removeLineBackground("L1");
+    expect(bgVoice(getLine("L1"))).toBeNull();
+    expect(useProjectStore.getState().canUndo()).toBe(true);
+
+    useProjectStore.getState().undo();
+
+    expect(getLine("L1").background).toEqual(backgroundBefore);
+  });
+});
+
+describe("project store · removeLineBackground · linked siblings", () => {
+  function seedLinkedPair() {
+    seed(
+      [
+        {
+          id: "a0",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          backgroundText: "ooh ooh",
+          backgroundTextSource: "manual",
+        },
+        {
+          id: "a1",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          backgroundText: "ooh ooh",
+          backgroundTextSource: "manual",
+        },
+      ],
+      [seedGroup("g1")],
+    );
+  }
+
+  it("clears the background on both linked instances by default", () => {
+    seedLinkedPair();
+    expect(bgVoice(getLine("a0"))).not.toBeNull();
+    expect(bgVoice(getLine("a1"))).not.toBeNull();
+
+    useProjectStore.getState().removeLineBackground("a0");
+
+    expect(bgVoice(getLine("a0"))).toBeNull();
+    expect(bgVoice(getLine("a1"))).toBeNull();
+  });
+
+  it("clears only the target when propagateToSiblings is false", () => {
+    seedLinkedPair();
+
+    useProjectStore.getState().removeLineBackground("a0", { propagateToSiblings: false });
+
+    expect(bgVoice(getLine("a0"))).toBeNull();
+    expect(bgVoice(getLine("a1"))).not.toBeNull();
+  });
+
+  it("leaves a detached sibling untouched even with default propagation", () => {
+    seed(
+      [
+        {
+          id: "a0",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+          backgroundText: "ooh ooh",
+          backgroundTextSource: "manual",
+        },
+        {
+          id: "a1",
+          text: "Real line",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 1,
+          templateLineIdx: 0,
+          backgroundText: "ooh ooh",
+          backgroundTextSource: "manual",
+          detached: true,
+        },
+      ],
+      [seedGroup("g1")],
+    );
+
+    useProjectStore.getState().removeLineBackground("a0");
+
+    expect(bgVoice(getLine("a0"))).toBeNull();
+    expect(bgVoice(getLine("a1"))).not.toBeNull();
+  });
+});
+
+describe("project store · removeLineBackground · no-op paths", () => {
+  it("returns the same lines reference and adds no history when the line has no bg", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", words: [{ text: "Real line", begin: 0, end: 2 }] }]);
+    const linesBefore = useProjectStore.getState().lines;
+    const canUndoBefore = useProjectStore.getState().canUndo();
+
+    useProjectStore.getState().removeLineBackground("L1");
+
+    expect(useProjectStore.getState().lines).toBe(linesBefore);
+    expect(useProjectStore.getState().canUndo()).toBe(canUndoBefore);
+  });
+
+  it("is a no-op for a missing id", () => {
+    seed([{ id: "L1", text: "Real line", agentId: "v1", backgroundText: "ooh" }]);
+    const linesBefore = useProjectStore.getState().lines;
+
+    useProjectStore.getState().removeLineBackground("nope");
+
+    expect(useProjectStore.getState().lines).toBe(linesBefore);
+    expect(bgVoice(getLine("L1"))).not.toBeNull();
+  });
+});
+
+describe("project store · removeLineBackground · invariants", () => {
+  it("does not mutate the pre-removal line object", () => {
+    seed([
+      {
+        id: "L1",
+        text: "Real line",
+        agentId: "v1",
+        words: [{ text: "Real line", begin: 0, end: 2 }],
+        backgroundText: "ooh",
+      },
+    ]);
+    const before = getLine("L1");
+    const backgroundSnapshot = before.background;
+
+    useProjectStore.getState().removeLineBackground("L1");
+
+    expect(before.background).toBe(backgroundSnapshot);
+    expect(bgVoice(before)).not.toBeNull();
+  });
+
+  it("keeps unrelated lines reference-equal", () => {
+    seed([
+      { id: "L1", text: "Real line", agentId: "v1", backgroundText: "ooh" },
+      { id: "L2", text: "Other line", agentId: "v1", backgroundText: "aah" },
+    ]);
+    const l2Before = getLine("L2");
+
+    useProjectStore.getState().removeLineBackground("L1");
+
+    expect(getLine("L2")).toBe(l2Before);
+  });
+});

--- a/src/stores/project.sync-text.test.ts
+++ b/src/stores/project.sync-text.test.ts
@@ -1,4 +1,5 @@
 import { useProjectStore } from "@/stores/project";
+import { lineText, mainWords } from "@/domain/line/voices";
 import { createLine } from "@/test/factories";
 import { commitTappedWord } from "@/utils/sync-helpers";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -21,7 +22,7 @@ describe("sync incremental tap preserves line.text", () => {
     const words = commitTappedWord([], 0, "Hello ", 0, 1);
     useProjectStore.getState().updateLineWithHistory("l0", { words }, { deriveText: false });
 
-    expect(useProjectStore.getState().lines[0].text).toBe("Hello world how are you");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("Hello world how are you");
   });
 
   it("preserves text across a full word-by-word tap sequence", () => {
@@ -32,7 +33,7 @@ describe("sync incremental tap preserves line.text", () => {
     for (let i = 0; i < taps.length; i++) {
       words = commitTappedWord(words, i, taps[i], i * 0.5, i * 0.5 + 0.4);
       useProjectStore.getState().updateLineWithHistory("l0", { words }, { deriveText: false });
-      expect(useProjectStore.getState().lines[0].text).toBe("Hello world how are you");
+      expect(lineText(useProjectStore.getState().lines[0])).toBe("Hello world how are you");
     }
   });
 
@@ -45,10 +46,10 @@ describe("sync incremental tap preserves line.text", () => {
     words = commitTappedWord(words, 0, "Hello ", 0, 1);
     useProjectStore.getState().updateLineWithHistory("l0", { words }, { deriveText: false });
 
-    const partialPrev = [...(useProjectStore.getState().lines[0].words ?? [])];
+    const partialPrev = [...(mainWords(useProjectStore.getState().lines[0]) ?? [])];
     partialPrev[partialPrev.length - 1] = { ...partialPrev[partialPrev.length - 1], end: 2 };
     useProjectStore.getState().updateLine("l0", { words: partialPrev }, { deriveText: false });
 
-    expect(useProjectStore.getState().lines[0].text).toBe("Hello world");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("Hello world");
   });
 });

--- a/src/stores/project/groups-slice.ts
+++ b/src/stores/project/groups-slice.ts
@@ -1,5 +1,8 @@
 import { belongsToInstance } from "@/domain/instance/predicates";
+import { mainBounds } from "@/domain/line/bounds";
 import { type LyricLine, reconcileLine } from "@/domain/line/model";
+import { isLineSynced } from "@/domain/line/predicates";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import type { LinkGroup } from "@/domain/group/template";
 import { commitHistory } from "@/stores/project/history-helpers";
 import type { GroupActions, GroupsState, ProjectStore } from "@/stores/project/types";
@@ -190,16 +193,17 @@ const createGroupsSlice: StateCreator<ProjectStore, [], [], GroupsState & GroupA
       commitHistory(state, {
         lines: state.lines.map((line) => {
           if (line.groupId !== groupId || line.instanceIdx !== instanceIdx || line.detached) return line;
+          const lineBounds = isLineSynced(line) ? mainBounds(line) : null;
           return reconcileLine({
             ...line,
-            begin: line.begin !== undefined ? line.begin + deltaSeconds : undefined,
-            end: line.end !== undefined ? line.end + deltaSeconds : undefined,
-            words: line.words?.map((w) => ({
+            begin: lineBounds ? lineBounds.begin + deltaSeconds : undefined,
+            end: lineBounds ? lineBounds.end + deltaSeconds : undefined,
+            words: mainWords(line)?.map((w) => ({
               ...w,
               begin: w.begin + deltaSeconds,
               end: w.end + deltaSeconds,
             })),
-            backgroundWords: line.backgroundWords?.map((w) => ({
+            backgroundWords: bgWords(line)?.map((w) => ({
               ...w,
               begin: w.begin + deltaSeconds,
               end: w.end + deltaSeconds,

--- a/src/stores/project/groups-slice.ts
+++ b/src/stores/project/groups-slice.ts
@@ -1,6 +1,6 @@
 import { belongsToInstance } from "@/domain/instance/predicates";
 import { mainBounds } from "@/domain/line/bounds";
-import { type LyricLine, reconcileLine } from "@/domain/line/model";
+import { type LyricLine, reconcileLine, toFlat } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/line/predicates";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import type { LinkGroup } from "@/domain/group/template";
@@ -195,7 +195,7 @@ const createGroupsSlice: StateCreator<ProjectStore, [], [], GroupsState & GroupA
           if (line.groupId !== groupId || line.instanceIdx !== instanceIdx || line.detached) return line;
           const lineBounds = isLineSynced(line) ? mainBounds(line) : null;
           return reconcileLine({
-            ...line,
+            ...toFlat(line),
             begin: lineBounds ? lineBounds.begin + deltaSeconds : undefined,
             end: lineBounds ? lineBounds.end + deltaSeconds : undefined,
             words: mainWords(line)?.map((w) => ({

--- a/src/stores/project/lines-slice-helpers.move.test.ts
+++ b/src/stores/project/lines-slice-helpers.move.test.ts
@@ -3,6 +3,8 @@
  */
 import { describe, expect, it } from "vitest";
 import { type LooseLine, type LyricLine, reconcileLine } from "@/domain/line/model";
+import { bgSource, bgText, bgWords, mainWords } from "@/domain/line/voices";
+import { isLineSynced } from "@/domain/line/predicates";
 import { applyMoveFromBg, applyMoveToBg } from "@/stores/project/lines-slice-helpers";
 
 // -- Helpers -------------------------------------------------------------------
@@ -28,9 +30,9 @@ function mainLine(overrides: Partial<LooseLine> = {}): LyricLine {
 describe("applyMoveToBg", () => {
   it("stamps a manual provenance when creating a fresh background", () => {
     const result = applyMoveToBg(mainLine(), [2], 0, DURATION);
-    expect(result?.backgroundTextSource).toBe("manual");
-    expect(result?.backgroundWords?.map((w) => w.text)).toEqual(["goodbye"]);
-    expect(result?.backgroundText).toBe("goodbye");
+    expect(result && bgSource(result)).toBe("manual");
+    expect(result && bgWords(result)?.map((w) => w.text)).toEqual(["goodbye"]);
+    expect(result && bgText(result)).toBe("goodbye");
   });
 
   it("flips an extraction-sourced background to manual when merging words in", () => {
@@ -40,7 +42,7 @@ describe("applyMoveToBg", () => {
       backgroundTextSource: "extraction",
     });
     const result = applyMoveToBg(line, [2], 0, DURATION);
-    expect(result?.backgroundTextSource).toBe("manual");
+    expect(result && bgSource(result)).toBe("manual");
   });
 
   it("moves words into an existing background, keeping main timing intact", () => {
@@ -50,8 +52,8 @@ describe("applyMoveToBg", () => {
       backgroundTextSource: "manual",
     });
     const result = applyMoveToBg(line, [2], 0, DURATION);
-    expect(result?.words?.map((w) => w.text)).toEqual(["hello ", "world"]);
-    expect(result?.backgroundWords?.length).toBe(2);
+    expect(result && mainWords(result)?.map((w) => w.text)).toEqual(["hello ", "world"]);
+    expect(result && bgWords(result)?.length).toBe(2);
   });
 
   it("returns null when no indices match", () => {
@@ -87,9 +89,9 @@ describe("applyMoveFromBg", () => {
       backgroundTextSource: "extraction",
     });
     const result = applyMoveFromBg(line, [0], 0, DURATION);
-    expect(result?.backgroundWords).toBeUndefined();
-    expect(result?.backgroundText).toBeUndefined();
-    expect(result?.backgroundTextSource).toBeUndefined();
+    expect(result && bgWords(result)).toBeUndefined();
+    expect(result && bgText(result)).toBeUndefined();
+    expect(result && bgSource(result)).toBeUndefined();
   });
 
   it("stamps a manual provenance on the surviving background", () => {
@@ -102,9 +104,9 @@ describe("applyMoveFromBg", () => {
       backgroundTextSource: "extraction",
     });
     const result = applyMoveFromBg(line, [1], 0, DURATION);
-    expect(result?.backgroundWords?.map((w) => w.text)).toEqual(["ah"]);
-    expect(result?.backgroundText).toBe("ah");
-    expect(result?.backgroundTextSource).toBe("manual");
+    expect(result && bgWords(result)?.map((w) => w.text)).toEqual(["ah"]);
+    expect(result && bgText(result)).toBe("ah");
+    expect(result && bgSource(result)).toBe("manual");
   });
 
   it("returns null when no indices match", () => {
@@ -142,8 +144,7 @@ describe("applyMoveFromBg", () => {
       backgroundText: "ooh",
     });
     const result = applyMoveFromBg(line, [0], 0, DURATION);
-    expect(result?.words?.length).toBe(1);
-    expect(result?.begin).toBeUndefined();
-    expect(result?.end).toBeUndefined();
+    expect(result && mainWords(result)?.length).toBe(1);
+    expect(result && isLineSynced(result)).toBe(false);
   });
 });

--- a/src/stores/project/lines-slice-helpers.ts
+++ b/src/stores/project/lines-slice-helpers.ts
@@ -1,12 +1,14 @@
 import { getLinkScope, isLinkedSibling } from "@/domain/group/linking";
-import { applyBackground, CLEARED_BACKGROUND, manualBackgroundWordEdit } from "@/domain/line/background";
+import { applyBackground, CLEARED_BACKGROUND, manualBackgroundWordEdit, setBackground } from "@/domain/line/background";
 import { applyMainWordEdit } from "@/domain/line/main-words";
 import { type LyricLine, reconcileLine, toFlat } from "@/domain/line/model";
 import { reconstructLineText } from "@/domain/line/reconstruct-text";
-import { bgWords, mainWords } from "@/domain/line/voices";
+import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
 import { computeByGroupId, expandSelectionToGroupmates } from "@/domain/word/syllable-groups";
 import type { WordTiming } from "@/domain/word/timing";
+import { commitHistory } from "@/stores/project/history-helpers";
+import type { ProjectState } from "@/stores/project/types";
 import { getSplitCharacter } from "@/utils/split-character";
 import { resolveOverlapsForward, trimTrailingSpaceFromLast } from "@/utils/word-spaces";
 import { applySiblingWords } from "@/utils/word-diff";
@@ -224,6 +226,50 @@ function applyMarkWordsExplicit(lines: LyricLine[], targets: ExplicitTarget[], v
   return current;
 }
 
+// -- Nested-aware background write --------------------------------------------
+
+// The single chokepoint for the nested full-line replace + linked-sibling
+// background re-resolution. Replaces the target with nextLine, then (when
+// propagating and linked) mirrors the shared linked content onto each sibling
+// and re-resolves the sibling's background from nextLine's shared bg text +
+// source against the SIBLING's own main, so each sibling gets instance-specific
+// granularity. Word-level bg timings are never copied across instances.
+function commitNestedLineReplace(
+  state: ProjectState,
+  lineId: string,
+  nextLine: LyricLine,
+  propagateToSiblings: boolean,
+) {
+  const target = state.lines.find((l) => l.id === lineId);
+  if (!target) return state;
+  const linkScope = propagateToSiblings ? getLinkScope(target) : null;
+  const sharedText = bgText(nextLine);
+  const sharedSource = bgSource(nextLine);
+
+  const newLines = state.lines.map((line) => {
+    if (line.id === lineId) return nextLine;
+    if (!isLinkedSibling(line, linkScope)) return line;
+
+    const siblingWithText =
+      lineText(line) === lineText(nextLine) && line.agentId === nextLine.agentId
+        ? line
+        : reconcileLine({ ...toFlat(line), text: lineText(nextLine), agentId: nextLine.agentId });
+
+    return sharedText === undefined
+      ? setBackground(siblingWithText, null)
+      : applyBackground(siblingWithText, { text: sharedText, source: sharedSource ?? "manual" });
+  });
+
+  return commitHistory(state, { lines: newLines });
+}
+
 // -- Exports ------------------------------------------------------------------
 
-export { applyMarkWordsExplicit, applyMergeSyllableGroup, applyMoveFromBg, applyMoveToBg, fieldWords };
+export {
+  applyMarkWordsExplicit,
+  applyMergeSyllableGroup,
+  applyMoveFromBg,
+  applyMoveToBg,
+  commitNestedLineReplace,
+  fieldWords,
+};

--- a/src/stores/project/lines-slice-helpers.ts
+++ b/src/stores/project/lines-slice-helpers.ts
@@ -1,4 +1,5 @@
 import { getLinkScope, isLinkedSibling } from "@/domain/group/linking";
+import { propagateWordChanges } from "@/domain/group/smart-sync";
 import { applyBackground, CLEARED_BACKGROUND, manualBackgroundWordEdit, setBackground } from "@/domain/line/background";
 import { applyMainWordEdit } from "@/domain/line/main-words";
 import { type LyricLine, reconcileLine, toFlat } from "@/domain/line/model";
@@ -229,11 +230,12 @@ function applyMarkWordsExplicit(lines: LyricLine[], targets: ExplicitTarget[], v
 // -- Nested-aware background write --------------------------------------------
 
 // The single chokepoint for the nested full-line replace + linked-sibling
-// background re-resolution. Replaces the target with nextLine, then (when
-// propagating and linked) mirrors the shared linked content onto each sibling
-// and re-resolves the sibling's background from nextLine's shared bg text +
-// source against the SIBLING's own main, so each sibling gets instance-specific
-// granularity. Word-level bg timings are never copied across instances.
+// propagation. Replaces the target with nextLine, then (when propagating and
+// linked) for each sibling: propagates a main-word structural change via
+// smart-sync, mirrors the shared text + agentId, and re-resolves the sibling's
+// background from nextLine's shared bg text + source against the SIBLING's own
+// main. Each sibling gets instance-specific timing: word-level timings are never
+// copied across instances, only the shared content (text) and word structure.
 function commitNestedLineReplace(
   state: ProjectState,
   lineId: string,
@@ -243,6 +245,8 @@ function commitNestedLineReplace(
   const target = state.lines.find((l) => l.id === lineId);
   if (!target) return state;
   const linkScope = propagateToSiblings ? getLinkScope(target) : null;
+  const sourceWordsBefore = mainWords(target);
+  const sourceWordsAfter = mainWords(nextLine);
   const sharedText = bgText(nextLine);
   const sharedSource = bgSource(nextLine);
 
@@ -250,14 +254,21 @@ function commitNestedLineReplace(
     if (line.id === lineId) return nextLine;
     if (!isLinkedSibling(line, linkScope)) return line;
 
-    const siblingWithText =
-      lineText(line) === lineText(nextLine) && line.agentId === nextLine.agentId
-        ? line
-        : reconcileLine({ ...toFlat(line), text: lineText(nextLine), agentId: nextLine.agentId });
+    const propagatedWords = propagateWordChanges(sourceWordsAfter, sourceWordsBefore, mainWords(line));
+    const contentMatches =
+      propagatedWords === undefined && lineText(line) === lineText(nextLine) && line.agentId === nextLine.agentId;
+    const mirrored = contentMatches
+      ? line
+      : reconcileLine({
+          ...toFlat(line),
+          text: lineText(nextLine),
+          agentId: nextLine.agentId,
+          ...(propagatedWords !== undefined ? { words: propagatedWords } : {}),
+        });
 
     return sharedText === undefined
-      ? setBackground(siblingWithText, null)
-      : applyBackground(siblingWithText, { text: sharedText, source: sharedSource ?? "manual" });
+      ? setBackground(mirrored, null)
+      : applyBackground(mirrored, { text: sharedText, source: sharedSource ?? "manual" });
   });
 
   return commitHistory(state, { lines: newLines });

--- a/src/stores/project/lines-slice-helpers.ts
+++ b/src/stores/project/lines-slice-helpers.ts
@@ -226,4 +226,4 @@ function applyMarkWordsExplicit(lines: LyricLine[], targets: ExplicitTarget[], v
 
 // -- Exports ------------------------------------------------------------------
 
-export { applyMarkWordsExplicit, applyMergeSyllableGroup, applyMoveFromBg, applyMoveToBg };
+export { applyMarkWordsExplicit, applyMergeSyllableGroup, applyMoveFromBg, applyMoveToBg, fieldWords };

--- a/src/stores/project/lines-slice-helpers.ts
+++ b/src/stores/project/lines-slice-helpers.ts
@@ -1,7 +1,7 @@
 import { getLinkScope, isLinkedSibling } from "@/domain/group/linking";
 import { applyBackground, CLEARED_BACKGROUND, manualBackgroundWordEdit } from "@/domain/line/background";
 import { applyMainWordEdit } from "@/domain/line/main-words";
-import { type LyricLine, reconcileLine } from "@/domain/line/model";
+import { type LyricLine, reconcileLine, toFlat } from "@/domain/line/model";
 import { reconstructLineText } from "@/domain/line/reconstruct-text";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
@@ -26,8 +26,8 @@ function fieldWords(line: LyricLine, field: "words" | "backgroundWords"): WordTi
 // the backgroundWords track is a user edit, so it routes through the funnel and
 // stamps source "manual". A main-words write carries no provenance.
 function writeFieldWords(line: LyricLine, field: "words" | "backgroundWords", words: WordTiming[]): LyricLine {
-  if (field === "backgroundWords") return reconcileLine({ ...line, ...manualBackgroundWordEdit(words) });
-  return reconcileLine({ ...line, words });
+  if (field === "backgroundWords") return reconcileLine({ ...toFlat(line), ...manualBackgroundWordEdit(words) });
+  return reconcileLine({ ...toFlat(line), words });
 }
 
 function expandTargetsToSyllableGroups(targets: ExplicitTarget[], linesById: Map<string, LyricLine>): ExplicitTarget[] {
@@ -87,7 +87,7 @@ function applyMoveToBg(line: LyricLine, wordIndices: number[], timeDelta: number
   const remainingMain = trimTrailingSpaceFromLast(main.filter((_, i) => !indexSet.has(i)));
   const mergedBg = resolveOverlapsForward(mergeWordsIntoTrack(bgWords(line) ?? [], movedWords), duration);
 
-  return applyBackground(reconcileLine({ ...line, words: remainingMain }), {
+  return applyBackground(reconcileLine({ ...toFlat(line), words: remainingMain }), {
     words: mergedBg,
     text: reconstructLineText(mergedBg, getSplitCharacter()),
     source: "manual",
@@ -117,7 +117,7 @@ function applyMoveFromBg(
 
   const withMain = applyMainWordEdit(line, mergedMain);
   if (remainingBg.length === 0) {
-    return reconcileLine({ ...withMain, ...CLEARED_BACKGROUND });
+    return reconcileLine({ ...toFlat(withMain), ...CLEARED_BACKGROUND });
   }
   return applyBackground(withMain, {
     words: remainingBg,

--- a/src/stores/project/lines-slice-helpers.ts
+++ b/src/stores/project/lines-slice-helpers.ts
@@ -1,9 +1,8 @@
 import { getLinkScope, isLinkedSibling } from "@/domain/group/linking";
 import { propagateWordChanges } from "@/domain/group/smart-sync";
 import { applyBackground, CLEARED_BACKGROUND, manualBackgroundWordEdit, setBackground } from "@/domain/line/background";
-import { followMainGranularity } from "@/domain/line/follow-main-granularity";
 import { applyMainWordEdit } from "@/domain/line/main-words";
-import { type LooseLine, type LyricLine, reconcileLine, toFlat } from "@/domain/line/model";
+import { type LyricLine, reconcileLine, toFlat } from "@/domain/line/model";
 import { reconstructLineText } from "@/domain/line/reconstruct-text";
 import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
@@ -24,16 +23,6 @@ type ExplicitTarget = { lineId: string; field: "words" | "backgroundWords"; word
 // Single-source routing of a field-targeted word read through the voice seam.
 function fieldWords(line: LyricLine, field: "words" | "backgroundWords"): WordTiming[] | undefined {
   return field === "backgroundWords" ? bgWords(line) : mainWords(line);
-}
-
-// The reconcile chokepoint for the generic per-line update mutators. Merges the
-// flat update onto the existing line and lifts it to nested, then lets the
-// background follow main into word-synced granularity when this write is the
-// main-to-word transition. followMainGranularity is a no-op for every other
-// write (main already word-synced, after main not word-synced, or no
-// background), so this is safe to apply on every generic reconcile.
-function reconcileUpdate(prev: LyricLine, updates: Partial<LooseLine>): LyricLine {
-  return followMainGranularity(prev, reconcileLine({ ...toFlat(prev), ...updates }));
 }
 
 // A field-targeted word write that keeps background provenance coherent: writing
@@ -294,5 +283,4 @@ export {
   applyMoveToBg,
   commitNestedLineReplace,
   fieldWords,
-  reconcileUpdate,
 };

--- a/src/stores/project/lines-slice-helpers.ts
+++ b/src/stores/project/lines-slice-helpers.ts
@@ -1,8 +1,9 @@
 import { getLinkScope, isLinkedSibling } from "@/domain/group/linking";
 import { propagateWordChanges } from "@/domain/group/smart-sync";
 import { applyBackground, CLEARED_BACKGROUND, manualBackgroundWordEdit, setBackground } from "@/domain/line/background";
+import { followMainGranularity } from "@/domain/line/follow-main-granularity";
 import { applyMainWordEdit } from "@/domain/line/main-words";
-import { type LyricLine, reconcileLine, toFlat } from "@/domain/line/model";
+import { type LooseLine, type LyricLine, reconcileLine, toFlat } from "@/domain/line/model";
 import { reconstructLineText } from "@/domain/line/reconstruct-text";
 import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
@@ -23,6 +24,16 @@ type ExplicitTarget = { lineId: string; field: "words" | "backgroundWords"; word
 // Single-source routing of a field-targeted word read through the voice seam.
 function fieldWords(line: LyricLine, field: "words" | "backgroundWords"): WordTiming[] | undefined {
   return field === "backgroundWords" ? bgWords(line) : mainWords(line);
+}
+
+// The reconcile chokepoint for the generic per-line update mutators. Merges the
+// flat update onto the existing line and lifts it to nested, then lets the
+// background follow main into word-synced granularity when this write is the
+// main-to-word transition. followMainGranularity is a no-op for every other
+// write (main already word-synced, after main not word-synced, or no
+// background), so this is safe to apply on every generic reconcile.
+function reconcileUpdate(prev: LyricLine, updates: Partial<LooseLine>): LyricLine {
+  return followMainGranularity(prev, reconcileLine({ ...toFlat(prev), ...updates }));
 }
 
 // A field-targeted word write that keeps background provenance coherent: writing
@@ -283,4 +294,5 @@ export {
   applyMoveToBg,
   commitNestedLineReplace,
   fieldWords,
+  reconcileUpdate,
 };

--- a/src/stores/project/lines-slice-helpers.ts
+++ b/src/stores/project/lines-slice-helpers.ts
@@ -3,6 +3,7 @@ import { applyBackground, CLEARED_BACKGROUND, manualBackgroundWordEdit } from "@
 import { applyMainWordEdit } from "@/domain/line/main-words";
 import { type LyricLine, reconcileLine } from "@/domain/line/model";
 import { reconstructLineText } from "@/domain/line/reconstruct-text";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
 import { computeByGroupId, expandSelectionToGroupmates } from "@/domain/word/syllable-groups";
 import type { WordTiming } from "@/domain/word/timing";
@@ -15,6 +16,11 @@ import { applySiblingWords } from "@/utils/word-diff";
 type ExplicitTarget = { lineId: string; field: "words" | "backgroundWords"; wordIndex: number };
 
 // -- Helpers ------------------------------------------------------------------
+
+// Single-source routing of a field-targeted word read through the voice seam.
+function fieldWords(line: LyricLine, field: "words" | "backgroundWords"): WordTiming[] | undefined {
+  return field === "backgroundWords" ? bgWords(line) : mainWords(line);
+}
 
 // A field-targeted word write that keeps background provenance coherent: writing
 // the backgroundWords track is a user edit, so it routes through the funnel and
@@ -35,7 +41,7 @@ function expandTargetsToSyllableGroups(targets: ExplicitTarget[], linesById: Map
   const out: ExplicitTarget[] = [];
   for (const group of byLineField.values()) {
     const line = linesById.get(group.lineId);
-    const currentWords = line?.[group.field];
+    const currentWords = line ? fieldWords(line, group.field) : undefined;
     const expanded = currentWords ? expandSelectionToGroupmates(currentWords, group.indices) : group.indices;
     for (const idx of expanded) out.push({ lineId: group.lineId, field: group.field, wordIndex: idx });
   }
@@ -50,7 +56,7 @@ function applyExplicitTargetToLines(
 ): LyricLine[] {
   const target = lines.find((l) => l.id === lineId);
   if (!target) return lines;
-  const sourceBefore = target[field];
+  const sourceBefore = fieldWords(target, field);
   const linkScope = getLinkScope(target);
 
   return lines.map((line) => {
@@ -58,7 +64,7 @@ function applyExplicitTargetToLines(
       return writeFieldWords(line, field, newWords);
     }
     if (isLinkedSibling(line, linkScope)) {
-      const propagated = applySiblingWords(newWords, sourceBefore, line[field]);
+      const propagated = applySiblingWords(newWords, sourceBefore, fieldWords(line, field));
       if (propagated) return writeFieldWords(line, field, propagated);
     }
     return line;
@@ -66,9 +72,10 @@ function applyExplicitTargetToLines(
 }
 
 function applyMoveToBg(line: LyricLine, wordIndices: number[], timeDelta: number, duration: number): LyricLine | null {
-  if (!line.words) return null;
+  const main = mainWords(line);
+  if (!main) return null;
   const indexSet = new Set(wordIndices);
-  const movedWords = line.words.flatMap((word, index) => {
+  const movedWords = main.flatMap((word, index) => {
     if (!indexSet.has(index)) return [];
     const dur = word.end - word.begin;
     const newBegin = Math.max(0, Math.min(duration - dur, word.begin + timeDelta));
@@ -77,8 +84,8 @@ function applyMoveToBg(line: LyricLine, wordIndices: number[], timeDelta: number
 
   if (movedWords.length === 0) return null;
 
-  const remainingMain = trimTrailingSpaceFromLast(line.words.filter((_, i) => !indexSet.has(i)));
-  const mergedBg = resolveOverlapsForward(mergeWordsIntoTrack(line.backgroundWords ?? [], movedWords), duration);
+  const remainingMain = trimTrailingSpaceFromLast(main.filter((_, i) => !indexSet.has(i)));
+  const mergedBg = resolveOverlapsForward(mergeWordsIntoTrack(bgWords(line) ?? [], movedWords), duration);
 
   return applyBackground(reconcileLine({ ...line, words: remainingMain }), {
     words: mergedBg,
@@ -93,9 +100,10 @@ function applyMoveFromBg(
   timeDelta: number,
   duration: number,
 ): LyricLine | null {
-  if (!line.backgroundWords) return null;
+  const bg = bgWords(line);
+  if (!bg) return null;
   const indexSet = new Set(wordIndices);
-  const movedWords = line.backgroundWords.flatMap((word, index) => {
+  const movedWords = bg.flatMap((word, index) => {
     if (!indexSet.has(index)) return [];
     const dur = word.end - word.begin;
     const newBegin = Math.max(0, Math.min(duration - dur, word.begin + timeDelta));
@@ -104,8 +112,8 @@ function applyMoveFromBg(
 
   if (movedWords.length === 0) return null;
 
-  const remainingBg = trimTrailingSpaceFromLast(line.backgroundWords.filter((_, i) => !indexSet.has(i)));
-  const mergedMain = resolveOverlapsForward(mergeWordsIntoTrack(line.words ?? [], movedWords), duration);
+  const remainingBg = trimTrailingSpaceFromLast(bg.filter((_, i) => !indexSet.has(i)));
+  const mergedMain = resolveOverlapsForward(mergeWordsIntoTrack(mainWords(line) ?? [], movedWords), duration);
 
   const withMain = applyMainWordEdit(line, mergedMain);
   if (remainingBg.length === 0) {
@@ -126,7 +134,7 @@ function applyMergeSyllableGroup(
 ): LyricLine[] | null {
   const target = lines.find((l) => l.id === lineId);
   if (!target) return null;
-  const sourceWords = target[field];
+  const sourceWords = fieldWords(target, field);
   if (!sourceWords || sourceWords.length === 0) return null;
   const sourceCount = sourceWords.length;
   const selected = new Set(wordIndices.filter((i) => i >= 0 && i < sourceCount));
@@ -136,9 +144,9 @@ function applyMergeSyllableGroup(
   let mutated = false;
   const newLines = lines.map((line) => {
     const isSource = line.id === lineId;
-    const isSibling = !isSource && isLinkedSibling(line, linkScope) && line[field]?.length === sourceCount;
+    const isSibling = !isSource && isLinkedSibling(line, linkScope) && fieldWords(line, field)?.length === sourceCount;
     if (!isSource && !isSibling) return line;
-    const lineWords = line[field];
+    const lineWords = fieldWords(line, field);
     if (!lineWords) return line;
 
     const runs = computeByGroupId(lineWords);
@@ -194,7 +202,7 @@ function applyMarkWordsExplicit(lines: LyricLine[], targets: ExplicitTarget[], v
   for (const target of expandedTargets) {
     const line = linesById.get(target.lineId);
     if (!line) continue;
-    const currentWords = line[target.field];
+    const currentWords = fieldWords(line, target.field);
     if (!currentWords || target.wordIndex < 0 || target.wordIndex >= currentWords.length) continue;
     if ((currentWords[target.wordIndex].explicit === true) === value) continue;
 

--- a/src/stores/project/lines-slice.ts
+++ b/src/stores/project/lines-slice.ts
@@ -1,6 +1,6 @@
 import { extractLinkedFields, getLinkScope, isLinkedSibling } from "@/domain/group/linking";
 import { propagateWordChanges } from "@/domain/group/smart-sync";
-import { manualBackgroundWordEdit } from "@/domain/line/background";
+import { applyBackground, manualBackgroundWordEdit } from "@/domain/line/background";
 import { type LooseLine, reconcileLine, toFlat } from "@/domain/line/model";
 import { withDerivedText } from "@/domain/line/reconstruct-text";
 import { bgWords, mainWords } from "@/domain/line/voices";
@@ -12,6 +12,7 @@ import {
   applyMergeSyllableGroup,
   applyMoveFromBg,
   applyMoveToBg,
+  commitNestedLineReplace,
   fieldWords,
 } from "@/stores/project/lines-slice-helpers";
 import { applySyllableSplitToLines } from "@/stores/project/syllable-split-helpers";
@@ -121,6 +122,21 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
       }
 
       return commitHistory(state, { lines: newLines }, historyOptions);
+    }),
+
+  setLineWithHistory: (lineId, nextLine, options = {}) =>
+    set((state) => {
+      const { propagateToSiblings = true } = options;
+      return commitNestedLineReplace(state, lineId, nextLine, propagateToSiblings);
+    }),
+
+  applyLineBackground: (lineId, params, options = {}) =>
+    set((state) => {
+      const { propagateToSiblings = true } = options;
+      const target = state.lines.find((l) => l.id === lineId);
+      if (!target) return state;
+      const nextLine = applyBackground(target, params);
+      return commitNestedLineReplace(state, lineId, nextLine, propagateToSiblings);
     }),
 
   moveWordToBg: (lineId, wordIndices, timeDelta, duration) =>

--- a/src/stores/project/lines-slice.ts
+++ b/src/stores/project/lines-slice.ts
@@ -14,6 +14,7 @@ import {
   applyMoveToBg,
   commitNestedLineReplace,
   fieldWords,
+  reconcileUpdate,
 } from "@/stores/project/lines-slice-helpers";
 import { applySyllableSplitToLines } from "@/stores/project/syllable-split-helpers";
 import type { LineActions, LinesState, ProjectStore } from "@/stores/project/types";
@@ -45,7 +46,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
       return {
         lines: state.lines.map((line) => {
           if (line.id !== id) return line;
-          const reconciled = reconcileLine({ ...toFlat(line), ...updates });
+          const reconciled = reconcileUpdate(line, updates);
           return deriveText ? withDerivedText(reconciled, splitChar) : reconciled;
         }),
         isDirty: true,
@@ -66,7 +67,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
 
       const newLines = state.lines.map((line) => {
         if (line.id === id) {
-          return reconcileLine({ ...toFlat(line), ...updates });
+          return reconcileUpdate(line, updates);
         }
         if (isLinkedSibling(line, linkScope)) {
           const siblingUpdates: Partial<LooseLine> = { ...(linkedUpdates ?? {}) };
@@ -75,7 +76,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
           const propagatedBg = propagateWordChanges(sourceBgWordsAfter, sourceBgWordsBefore, bgWords(line));
           if (propagatedBg) siblingUpdates.backgroundWords = propagatedBg;
           if (Object.keys(siblingUpdates).length > 0) {
-            return reconcileLine({ ...toFlat(line), ...siblingUpdates });
+            return reconcileUpdate(line, siblingUpdates);
           }
         }
         return line;
@@ -102,7 +103,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
         const linkedUpdates = linkScope ? extractLinkedFields(lineUpdates) : null;
 
         if (targetIdx !== undefined && target) {
-          newLines[targetIdx] = reconcileLine({ ...toFlat(target), ...lineUpdates });
+          newLines[targetIdx] = reconcileUpdate(target, lineUpdates);
         }
 
         if (linkScope) {
@@ -115,8 +116,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
             if (propagatedWords) siblingUpdates.words = propagatedWords;
             const propagatedBg = propagateWordChanges(sourceBgAfter, sourceBgBefore, bgWords(line));
             if (propagatedBg) siblingUpdates.backgroundWords = propagatedBg;
-            if (Object.keys(siblingUpdates).length > 0)
-              newLines[i] = reconcileLine({ ...toFlat(line), ...siblingUpdates });
+            if (Object.keys(siblingUpdates).length > 0) newLines[i] = reconcileUpdate(line, siblingUpdates);
           }
         }
       }

--- a/src/stores/project/lines-slice.ts
+++ b/src/stores/project/lines-slice.ts
@@ -1,8 +1,9 @@
 import { extractLinkedFields, getLinkScope, isLinkedSibling } from "@/domain/group/linking";
 import { propagateWordChanges } from "@/domain/group/smart-sync";
 import { manualBackgroundWordEdit } from "@/domain/line/background";
-import { type LooseLine, reconcileLine } from "@/domain/line/model";
+import { type LooseLine, type LyricLine, reconcileLine } from "@/domain/line/model";
 import { withDerivedText } from "@/domain/line/reconstruct-text";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { closeIntraGroupGaps, expandSelectionToGroupmates } from "@/domain/word/syllable-groups";
 import type { WordTiming } from "@/domain/word/timing";
 import { commitHistory } from "@/stores/project/history-helpers";
@@ -24,6 +25,13 @@ function createLinesInitialState(): LinesState {
   return {
     lines: [],
   };
+}
+
+// -- Helpers ------------------------------------------------------------------
+
+// Single-source routing of a field-targeted word read through the voice seam.
+function fieldWords(line: LyricLine, field: "words" | "backgroundWords"): WordTiming[] | undefined {
+  return field === "backgroundWords" ? bgWords(line) : mainWords(line);
 }
 
 // -- Slice --------------------------------------------------------------------
@@ -56,9 +64,9 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
       const target = state.lines.find((l) => l.id === id);
       const linkScope = propagateToSiblings && target ? getLinkScope(target) : null;
       const linkedUpdates = linkScope ? extractLinkedFields(updates) : null;
-      const sourceWordsBefore = target?.words;
+      const sourceWordsBefore = target ? mainWords(target) : undefined;
       const sourceWordsAfter = updates.words;
-      const sourceBgWordsBefore = target?.backgroundWords;
+      const sourceBgWordsBefore = target ? bgWords(target) : undefined;
       const sourceBgWordsAfter = updates.backgroundWords;
 
       const newLines = state.lines.map((line) => {
@@ -67,9 +75,9 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
         }
         if (isLinkedSibling(line, linkScope)) {
           const siblingUpdates: Partial<LooseLine> = { ...(linkedUpdates ?? {}) };
-          const propagatedWords = propagateWordChanges(sourceWordsAfter, sourceWordsBefore, line.words);
+          const propagatedWords = propagateWordChanges(sourceWordsAfter, sourceWordsBefore, mainWords(line));
           if (propagatedWords) siblingUpdates.words = propagatedWords;
-          const propagatedBg = propagateWordChanges(sourceBgWordsAfter, sourceBgWordsBefore, line.backgroundWords);
+          const propagatedBg = propagateWordChanges(sourceBgWordsAfter, sourceBgWordsBefore, bgWords(line));
           if (propagatedBg) siblingUpdates.backgroundWords = propagatedBg;
           if (Object.keys(siblingUpdates).length > 0) {
             return reconcileLine({ ...line, ...siblingUpdates });
@@ -92,9 +100,9 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
         const targetIdx = indexById.get(id);
         const target = targetIdx !== undefined ? newLines[targetIdx] : undefined;
         const linkScope = propagateToSiblings && target ? getLinkScope(target) : null;
-        const sourceWordsBefore = target?.words;
+        const sourceWordsBefore = target ? mainWords(target) : undefined;
         const sourceWordsAfter = lineUpdates.words;
-        const sourceBgBefore = target?.backgroundWords;
+        const sourceBgBefore = target ? bgWords(target) : undefined;
         const sourceBgAfter = lineUpdates.backgroundWords;
         const linkedUpdates = linkScope ? extractLinkedFields(lineUpdates) : null;
 
@@ -108,9 +116,9 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
             if (line.id === id) continue;
             if (!isLinkedSibling(line, linkScope)) continue;
             const siblingUpdates: Partial<LooseLine> = { ...(linkedUpdates ?? {}) };
-            const propagatedWords = propagateWordChanges(sourceWordsAfter, sourceWordsBefore, line.words);
+            const propagatedWords = propagateWordChanges(sourceWordsAfter, sourceWordsBefore, mainWords(line));
             if (propagatedWords) siblingUpdates.words = propagatedWords;
-            const propagatedBg = propagateWordChanges(sourceBgAfter, sourceBgBefore, line.backgroundWords);
+            const propagatedBg = propagateWordChanges(sourceBgAfter, sourceBgBefore, bgWords(line));
             if (propagatedBg) siblingUpdates.backgroundWords = propagatedBg;
             if (Object.keys(siblingUpdates).length > 0) newLines[i] = reconcileLine({ ...line, ...siblingUpdates });
           }
@@ -123,16 +131,17 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
   moveWordToBg: (lineId, wordIndices, timeDelta, duration) =>
     set((state) => {
       const sourceLine = state.lines.find((l) => l.id === lineId);
-      if (!sourceLine?.words || wordIndices.length === 0) return state;
-      const sourceWordCount = sourceLine.words.length;
+      const sourceMain = sourceLine ? mainWords(sourceLine) : undefined;
+      if (!sourceLine || !sourceMain || wordIndices.length === 0) return state;
+      const sourceWordCount = sourceMain.length;
       const linkScope = getLinkScope(sourceLine);
 
       let mutated = false;
       const newLines = state.lines.map((line) => {
         const isSource = line.id === lineId;
-        const isSibling = !isSource && isLinkedSibling(line, linkScope) && line.words?.length === sourceWordCount;
+        const isSibling = !isSource && isLinkedSibling(line, linkScope) && mainWords(line)?.length === sourceWordCount;
         if (!isSource && !isSibling) return line;
-        const expanded = expandSelectionToGroupmates(line.words ?? [], wordIndices);
+        const expanded = expandSelectionToGroupmates(mainWords(line) ?? [], wordIndices);
         const updated = applyMoveToBg(line, expanded, timeDelta, duration);
         if (!updated) return line;
         mutated = true;
@@ -146,17 +155,17 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
   moveWordFromBg: (lineId, wordIndices, timeDelta, duration) =>
     set((state) => {
       const sourceLine = state.lines.find((l) => l.id === lineId);
-      if (!sourceLine?.backgroundWords || wordIndices.length === 0) return state;
-      const sourceBgCount = sourceLine.backgroundWords.length;
+      const sourceBg = sourceLine ? bgWords(sourceLine) : undefined;
+      if (!sourceLine || !sourceBg || wordIndices.length === 0) return state;
+      const sourceBgCount = sourceBg.length;
       const linkScope = getLinkScope(sourceLine);
 
       let mutated = false;
       const newLines = state.lines.map((line) => {
         const isSource = line.id === lineId;
-        const isSibling =
-          !isSource && isLinkedSibling(line, linkScope) && line.backgroundWords?.length === sourceBgCount;
+        const isSibling = !isSource && isLinkedSibling(line, linkScope) && bgWords(line)?.length === sourceBgCount;
         if (!isSource && !isSibling) return line;
-        const expanded = expandSelectionToGroupmates(line.backgroundWords ?? [], wordIndices);
+        const expanded = expandSelectionToGroupmates(bgWords(line) ?? [], wordIndices);
         const updated = applyMoveFromBg(line, expanded, timeDelta, duration);
         if (!updated) return line;
         mutated = true;
@@ -173,7 +182,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
       const target = state.lines.find((l) => l.id === lineId);
       if (!target) return state;
 
-      const sourceBefore = target[field];
+      const sourceBefore = fieldWords(target, field);
       const linkScope = getLinkScope(target);
 
       if (resolution === "detach") {
@@ -200,7 +209,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
           return reconcileLine({ ...line, ...extraUpdates, [field]: newWords });
         }
         if (isLinkedSibling(line, linkScope)) {
-          const propagated = applySiblingWords(newWords, sourceBefore, line[field]);
+          const propagated = applySiblingWords(newWords, sourceBefore, fieldWords(line, field));
           const siblingUpdates: Partial<LooseLine> = { ...(linkedExtras ?? {}) };
           if (propagated) siblingUpdates[field] = propagated;
           if (Object.keys(siblingUpdates).length > 0) return reconcileLine({ ...line, ...siblingUpdates });
@@ -216,7 +225,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
     const state = get();
     const target = state.lines.find((l) => l.id === lineId);
     if (!target) return;
-    const currentWords = target[field];
+    const currentWords = fieldWords(target, field);
     if (!currentWords || currentWords.length === 0) return;
 
     const filtered = wordIndices.filter((i) => i >= 0 && i < currentWords.length);
@@ -249,7 +258,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
     set((state) => {
       const target = state.lines.find((l) => l.id === lineId);
       if (!target) return state;
-      const lineWords = target[field];
+      const lineWords = fieldWords(target, field);
       if (!lineWords) return state;
       const snapped = closeIntraGroupGaps(lineWords);
       if (snapped === lineWords) return state;

--- a/src/stores/project/lines-slice.ts
+++ b/src/stores/project/lines-slice.ts
@@ -1,7 +1,7 @@
 import { extractLinkedFields, getLinkScope, isLinkedSibling } from "@/domain/group/linking";
 import { propagateWordChanges } from "@/domain/group/smart-sync";
 import { manualBackgroundWordEdit } from "@/domain/line/background";
-import { type LooseLine, type LyricLine, reconcileLine } from "@/domain/line/model";
+import { type LooseLine, reconcileLine } from "@/domain/line/model";
 import { withDerivedText } from "@/domain/line/reconstruct-text";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import { closeIntraGroupGaps, expandSelectionToGroupmates } from "@/domain/word/syllable-groups";
@@ -12,6 +12,7 @@ import {
   applyMergeSyllableGroup,
   applyMoveFromBg,
   applyMoveToBg,
+  fieldWords,
 } from "@/stores/project/lines-slice-helpers";
 import { applySyllableSplitToLines } from "@/stores/project/syllable-split-helpers";
 import type { LineActions, LinesState, ProjectStore } from "@/stores/project/types";
@@ -25,13 +26,6 @@ function createLinesInitialState(): LinesState {
   return {
     lines: [],
   };
-}
-
-// -- Helpers ------------------------------------------------------------------
-
-// Single-source routing of a field-targeted word read through the voice seam.
-function fieldWords(line: LyricLine, field: "words" | "backgroundWords"): WordTiming[] | undefined {
-  return field === "backgroundWords" ? bgWords(line) : mainWords(line);
 }
 
 // -- Slice --------------------------------------------------------------------

--- a/src/stores/project/lines-slice.ts
+++ b/src/stores/project/lines-slice.ts
@@ -1,7 +1,7 @@
 import { extractLinkedFields, getLinkScope, isLinkedSibling } from "@/domain/group/linking";
 import { propagateWordChanges } from "@/domain/group/smart-sync";
 import { manualBackgroundWordEdit } from "@/domain/line/background";
-import { type LooseLine, reconcileLine } from "@/domain/line/model";
+import { type LooseLine, reconcileLine, toFlat } from "@/domain/line/model";
 import { withDerivedText } from "@/domain/line/reconstruct-text";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import { closeIntraGroupGaps, expandSelectionToGroupmates } from "@/domain/word/syllable-groups";
@@ -44,7 +44,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
       return {
         lines: state.lines.map((line) => {
           if (line.id !== id) return line;
-          const reconciled = reconcileLine({ ...line, ...updates });
+          const reconciled = reconcileLine({ ...toFlat(line), ...updates });
           return deriveText ? withDerivedText(reconciled, splitChar) : reconciled;
         }),
         isDirty: true,
@@ -65,7 +65,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
 
       const newLines = state.lines.map((line) => {
         if (line.id === id) {
-          return reconcileLine({ ...line, ...updates });
+          return reconcileLine({ ...toFlat(line), ...updates });
         }
         if (isLinkedSibling(line, linkScope)) {
           const siblingUpdates: Partial<LooseLine> = { ...(linkedUpdates ?? {}) };
@@ -74,7 +74,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
           const propagatedBg = propagateWordChanges(sourceBgWordsAfter, sourceBgWordsBefore, bgWords(line));
           if (propagatedBg) siblingUpdates.backgroundWords = propagatedBg;
           if (Object.keys(siblingUpdates).length > 0) {
-            return reconcileLine({ ...line, ...siblingUpdates });
+            return reconcileLine({ ...toFlat(line), ...siblingUpdates });
           }
         }
         return line;
@@ -101,7 +101,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
         const linkedUpdates = linkScope ? extractLinkedFields(lineUpdates) : null;
 
         if (targetIdx !== undefined && target) {
-          newLines[targetIdx] = reconcileLine({ ...target, ...lineUpdates });
+          newLines[targetIdx] = reconcileLine({ ...toFlat(target), ...lineUpdates });
         }
 
         if (linkScope) {
@@ -114,7 +114,8 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
             if (propagatedWords) siblingUpdates.words = propagatedWords;
             const propagatedBg = propagateWordChanges(sourceBgAfter, sourceBgBefore, bgWords(line));
             if (propagatedBg) siblingUpdates.backgroundWords = propagatedBg;
-            if (Object.keys(siblingUpdates).length > 0) newLines[i] = reconcileLine({ ...line, ...siblingUpdates });
+            if (Object.keys(siblingUpdates).length > 0)
+              newLines[i] = reconcileLine({ ...toFlat(line), ...siblingUpdates });
           }
         }
       }
@@ -184,7 +185,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
           lines: state.lines.map((line) => {
             if (line.id !== lineId) return line;
             return reconcileLine({
-              ...line,
+              ...toFlat(line),
               ...extraUpdates,
               [field]: newWords,
               groupId: undefined,
@@ -200,13 +201,13 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
 
       const newLines = state.lines.map((line) => {
         if (line.id === lineId) {
-          return reconcileLine({ ...line, ...extraUpdates, [field]: newWords });
+          return reconcileLine({ ...toFlat(line), ...extraUpdates, [field]: newWords });
         }
         if (isLinkedSibling(line, linkScope)) {
           const propagated = applySiblingWords(newWords, sourceBefore, fieldWords(line, field));
           const siblingUpdates: Partial<LooseLine> = { ...(linkedExtras ?? {}) };
           if (propagated) siblingUpdates[field] = propagated;
-          if (Object.keys(siblingUpdates).length > 0) return reconcileLine({ ...line, ...siblingUpdates });
+          if (Object.keys(siblingUpdates).length > 0) return reconcileLine({ ...toFlat(line), ...siblingUpdates });
         }
         return line;
       });
@@ -257,7 +258,7 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
       const snapped = closeIntraGroupGaps(lineWords);
       if (snapped === lineWords) return state;
       const lineUpdate = field === "backgroundWords" ? manualBackgroundWordEdit(snapped) : { [field]: snapped };
-      const newLines = state.lines.map((l) => (l.id === lineId ? reconcileLine({ ...l, ...lineUpdate }) : l));
+      const newLines = state.lines.map((l) => (l.id === lineId ? reconcileLine({ ...toFlat(l), ...lineUpdate }) : l));
       return commitHistory(state, { lines: newLines });
     }),
 

--- a/src/stores/project/lines-slice.ts
+++ b/src/stores/project/lines-slice.ts
@@ -1,12 +1,12 @@
 import { extractLinkedFields, getLinkScope, isLinkedSibling } from "@/domain/group/linking";
 import { propagateWordChanges } from "@/domain/group/smart-sync";
-import { applyBackground, manualBackgroundWordEdit } from "@/domain/line/background";
+import { applyBackground, manualBackgroundWordEdit, setBackground } from "@/domain/line/background";
 import { type LooseLine, reconcileLine, toFlat } from "@/domain/line/model";
 import { reconcileUpdate } from "@/domain/line/reconcile-update";
 import { withDerivedText } from "@/domain/line/reconstruct-text";
-import { bgWords, mainWords } from "@/domain/line/voices";
+import { bgVoice, bgWords, mainWords } from "@/domain/line/voices";
+import { computeExplicitToggle } from "@/domain/word/explicit-toggle";
 import { closeIntraGroupGaps, expandSelectionToGroupmates } from "@/domain/word/syllable-groups";
-import type { WordTiming } from "@/domain/word/timing";
 import { commitHistory } from "@/stores/project/history-helpers";
 import {
   applyMarkWordsExplicit,
@@ -139,6 +139,15 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
       return commitNestedLineReplace(state, lineId, nextLine, propagateToSiblings);
     }),
 
+  removeLineBackground: (lineId, options = {}) =>
+    set((state) => {
+      const { propagateToSiblings = true } = options;
+      const target = state.lines.find((l) => l.id === lineId);
+      if (!target || bgVoice(target) === null) return state;
+      const nextLine = setBackground(target, null);
+      return commitNestedLineReplace(state, lineId, nextLine, propagateToSiblings);
+    }),
+
   moveWordToBg: (lineId, wordIndices, timeDelta, duration) =>
     set((state) => {
       const sourceLine = state.lines.find((l) => l.id === lineId);
@@ -233,29 +242,13 @@ const createLinesSlice: StateCreator<ProjectStore, [], [], LinesState & LineActi
 
   toggleWordExplicit: (lineId, field, wordIndices) => {
     if (wordIndices.length === 0) return;
-    const state = get();
-    const target = state.lines.find((l) => l.id === lineId);
+    const target = get().lines.find((l) => l.id === lineId);
     if (!target) return;
     const currentWords = fieldWords(target, field);
-    if (!currentWords || currentWords.length === 0) return;
-
-    const filtered = wordIndices.filter((i) => i >= 0 && i < currentWords.length);
-    const expanded = expandSelectionToGroupmates(currentWords, filtered).filter((i) => i < currentWords.length);
-    const indexSet = new Set(expanded);
-    if (indexSet.size === 0) return;
-
-    const allMarked = Array.from(indexSet).every((i) => currentWords[i].explicit === true);
-    const nextExplicit = !allMarked;
-
-    const newWords: WordTiming[] = currentWords.map((word, i) => {
-      if (!indexSet.has(i)) return word;
-      if (nextExplicit) return { ...word, explicit: true };
-      const { explicit: _explicit, ...rest } = word;
-      return rest;
-    });
-
-    const extraUpdates = field === "backgroundWords" ? manualBackgroundWordEdit(newWords) : {};
-    get().applyWordCountChange(lineId, newWords, field, "apply", extraUpdates);
+    if (!currentWords) return;
+    const computed = computeExplicitToggle(currentWords, field, wordIndices);
+    if (!computed) return;
+    get().applyWordCountChange(lineId, computed.newWords, field, "apply", computed.extraUpdates);
   },
 
   mergeSyllableGroupIntoWord: (lineId, field, wordIndices) =>

--- a/src/stores/project/lines-slice.ts
+++ b/src/stores/project/lines-slice.ts
@@ -2,6 +2,7 @@ import { extractLinkedFields, getLinkScope, isLinkedSibling } from "@/domain/gro
 import { propagateWordChanges } from "@/domain/group/smart-sync";
 import { applyBackground, manualBackgroundWordEdit } from "@/domain/line/background";
 import { type LooseLine, reconcileLine, toFlat } from "@/domain/line/model";
+import { reconcileUpdate } from "@/domain/line/reconcile-update";
 import { withDerivedText } from "@/domain/line/reconstruct-text";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import { closeIntraGroupGaps, expandSelectionToGroupmates } from "@/domain/word/syllable-groups";
@@ -14,7 +15,6 @@ import {
   applyMoveToBg,
   commitNestedLineReplace,
   fieldWords,
-  reconcileUpdate,
 } from "@/stores/project/lines-slice-helpers";
 import { applySyllableSplitToLines } from "@/stores/project/syllable-split-helpers";
 import type { LineActions, LinesState, ProjectStore } from "@/stores/project/types";

--- a/src/stores/project/split-identical.test.ts
+++ b/src/stores/project/split-identical.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { useProjectStore } from "@/stores/project";
+import { bgSource, bgWords, mainWords } from "@/domain/line/voices";
 import { createLine } from "@/test/factories";
 
 describe("project.splitSyllablesAcrossIdenticalWordsWithHistory", () => {
@@ -21,13 +22,13 @@ describe("project.splitSyllablesAcrossIdenticalWordsWithHistory", () => {
     });
 
     const after = useProjectStore.getState().lines;
-    expect(after[0].words).toHaveLength(2);
-    expect(after[1].words).toHaveLength(2);
+    expect(mainWords(after[0])).toHaveLength(2);
+    expect(mainWords(after[1])).toHaveLength(2);
 
     useProjectStore.getState().undo();
     const reverted = useProjectStore.getState().lines;
-    expect(reverted[0].words).toHaveLength(1);
-    expect(reverted[1].words).toHaveLength(1);
+    expect(mainWords(reverted[0])).toHaveLength(1);
+    expect(mainWords(reverted[1])).toHaveLength(1);
   });
 
   it("source word splits even when there are no other matches", () => {
@@ -40,7 +41,7 @@ describe("project.splitSyllablesAcrossIdenticalWordsWithHistory", () => {
       caseInsensitive: false,
     });
 
-    expect(useProjectStore.getState().lines[0].words).toHaveLength(2);
+    expect(mainWords(useProjectStore.getState().lines[0])).toHaveLength(2);
   });
 
   it("case-insensitive flag splits Capitalized siblings via the action", () => {
@@ -55,8 +56,8 @@ describe("project.splitSyllablesAcrossIdenticalWordsWithHistory", () => {
       caseInsensitive: true,
     });
     const after = useProjectStore.getState().lines;
-    expect(after[1].words).toHaveLength(2);
-    expect(after[1].words?.[0].text).toBe("Run");
+    expect(mainWords(after[1])).toHaveLength(2);
+    expect(mainWords(after[1])?.[0].text).toBe("Run");
   });
 
   it("is a no-op when splitPoints is empty", () => {
@@ -94,8 +95,8 @@ describe("project.splitSyllablesAcrossIdenticalWordsWithHistory · background pr
       caseInsensitive: false,
     });
     const line = useProjectStore.getState().lines[0];
-    expect(line.backgroundWords).toHaveLength(2);
-    expect(line.backgroundTextSource).toBe("manual");
+    expect(bgWords(line)).toHaveLength(2);
+    expect(bgSource(line)).toBe("manual");
   });
 
   it("leaves backgroundTextSource untouched when only the main track is split", () => {
@@ -114,7 +115,7 @@ describe("project.splitSyllablesAcrossIdenticalWordsWithHistory · background pr
       splitPoints: [3],
       caseInsensitive: false,
     });
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("extraction");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("extraction");
   });
 
   it("undo restores the prior extraction provenance", () => {
@@ -133,8 +134,8 @@ describe("project.splitSyllablesAcrossIdenticalWordsWithHistory · background pr
       splitPoints: [3],
       caseInsensitive: false,
     });
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("extraction");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("extraction");
   });
 });

--- a/src/stores/project/syllable-split-helpers.test.ts
+++ b/src/stores/project/syllable-split-helpers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { bgSource, bgText, bgWords, mainWords } from "@/domain/line/voices";
 import { createLine } from "@/test/factories";
 import { applySyllableSplitToLines } from "@/stores/project/syllable-split-helpers";
 
@@ -6,9 +7,9 @@ describe("applySyllableSplitToLines", () => {
   it("splits the source word", () => {
     const lines = [createLine({ id: "l1", words: [{ text: "running", begin: 0, end: 1 }] })];
     const result = applySyllableSplitToLines(lines, { lineId: "l1", wordIndex: 0, type: "word" }, [3], false);
-    expect(result[0].words).toHaveLength(2);
-    expect(result[0].words?.[0].text).toBe("run");
-    expect(result[0].words?.[1].text).toBe("ning");
+    expect(mainWords(result[0])).toHaveLength(2);
+    expect(mainWords(result[0])?.[0].text).toBe("run");
+    expect(mainWords(result[0])?.[1].text).toBe("ning");
   });
 
   it("splits identical words in other lines too", () => {
@@ -17,8 +18,8 @@ describe("applySyllableSplitToLines", () => {
       createLine({ id: "l2", words: [{ text: "running", begin: 2, end: 3 }] }),
     ];
     const result = applySyllableSplitToLines(lines, { lineId: "l1", wordIndex: 0, type: "word" }, [3], false);
-    expect(result[0].words).toHaveLength(2);
-    expect(result[1].words).toHaveLength(2);
+    expect(mainWords(result[0])).toHaveLength(2);
+    expect(mainWords(result[1])).toHaveLength(2);
   });
 
   it("gives each split word its own syllableGroupId", () => {
@@ -27,8 +28,8 @@ describe("applySyllableSplitToLines", () => {
       createLine({ id: "l2", words: [{ text: "running", begin: 2, end: 3 }] }),
     ];
     const result = applySyllableSplitToLines(lines, { lineId: "l1", wordIndex: 0, type: "word" }, [3], false);
-    const g1 = result[0].words?.[0].syllableGroupId;
-    const g2 = result[1].words?.[0].syllableGroupId;
+    const g1 = mainWords(result[0])?.[0].syllableGroupId;
+    const g2 = mainWords(result[1])?.[0].syllableGroupId;
     expect(g1).toBeTruthy();
     expect(g2).toBeTruthy();
     expect(g1).not.toBe(g2);
@@ -37,7 +38,7 @@ describe("applySyllableSplitToLines", () => {
   it("preserves trailing space on the last syllable when the source had one", () => {
     const lines = [createLine({ id: "l1", words: [{ text: "running ", begin: 0, end: 1 }] })];
     const result = applySyllableSplitToLines(lines, { lineId: "l1", wordIndex: 0, type: "word" }, [3], false);
-    expect(result[0].words?.[1].text).toBe("ning ");
+    expect(mainWords(result[0])?.[1].text).toBe("ning ");
   });
 
   it("case-insensitive flag finds Capitalized matches", () => {
@@ -46,9 +47,9 @@ describe("applySyllableSplitToLines", () => {
       createLine({ id: "l2", words: [{ text: "Running", begin: 2, end: 3 }] }),
     ];
     const result = applySyllableSplitToLines(lines, { lineId: "l1", wordIndex: 0, type: "word" }, [3], true);
-    expect(result[1].words).toHaveLength(2);
-    expect(result[1].words?.[0].text).toBe("Run");
-    expect(result[1].words?.[1].text).toBe("ning");
+    expect(mainWords(result[1])).toHaveLength(2);
+    expect(mainWords(result[1])?.[0].text).toBe("Run");
+    expect(mainWords(result[1])?.[1].text).toBe("ning");
   });
 
   it("returns the original lines reference unchanged when source line doesn't exist", () => {
@@ -69,7 +70,7 @@ describe("applySyllableSplitToLines", () => {
       }),
     ];
     const result = applySyllableSplitToLines(lines, { lineId: "l1", wordIndex: 0, type: "word" }, [1], false);
-    expect(result[0].words?.map((w) => w.text)).toEqual(["g", "o", "stop", "g", "o"]);
+    expect(mainWords(result[0])?.map((w) => w.text)).toEqual(["g", "o", "stop", "g", "o"]);
   });
 
   it("includes background-word matches", () => {
@@ -81,8 +82,8 @@ describe("applySyllableSplitToLines", () => {
       }),
     ];
     const result = applySyllableSplitToLines(lines, { lineId: "l1", wordIndex: 0, type: "word" }, [2], false);
-    expect(result[0].words).toHaveLength(2);
-    expect(result[0].backgroundWords).toHaveLength(2);
+    expect(mainWords(result[0])).toHaveLength(2);
+    expect(bgWords(result[0])).toHaveLength(2);
   });
 });
 
@@ -98,9 +99,9 @@ describe("applySyllableSplitToLines · background provenance", () => {
       }),
     ];
     const result = applySyllableSplitToLines(lines, { lineId: "l1", wordIndex: 0, type: "bg" }, [3], false);
-    expect(result[0].backgroundWords).toHaveLength(2);
-    expect(result[0].backgroundTextSource).toBe("manual");
-    expect(result[0].backgroundText).toBe("run|ning");
+    expect(bgWords(result[0])).toHaveLength(2);
+    expect(bgSource(result[0])).toBe("manual");
+    expect(bgText(result[0])).toBe("run|ning");
   });
 
   it("flips backgroundTextSource to manual when a main-word split also splits a matching background word", () => {
@@ -114,8 +115,8 @@ describe("applySyllableSplitToLines · background provenance", () => {
       }),
     ];
     const result = applySyllableSplitToLines(lines, { lineId: "l1", wordIndex: 0, type: "word" }, [2], false);
-    expect(result[0].backgroundWords).toHaveLength(2);
-    expect(result[0].backgroundTextSource).toBe("manual");
+    expect(bgWords(result[0])).toHaveLength(2);
+    expect(bgSource(result[0])).toBe("manual");
   });
 
   it("leaves backgroundTextSource untouched when only the main track is split", () => {
@@ -129,8 +130,8 @@ describe("applySyllableSplitToLines · background provenance", () => {
       }),
     ];
     const result = applySyllableSplitToLines(lines, { lineId: "l1", wordIndex: 0, type: "word" }, [3], false);
-    expect(result[0].words).toHaveLength(2);
-    expect(result[0].backgroundTextSource).toBe("extraction");
+    expect(mainWords(result[0])).toHaveLength(2);
+    expect(bgSource(result[0])).toBe("extraction");
   });
 
   it("flips a matching identical-word line's background track to manual", () => {
@@ -151,8 +152,8 @@ describe("applySyllableSplitToLines · background provenance", () => {
       }),
     ];
     const result = applySyllableSplitToLines(lines, { lineId: "l1", wordIndex: 0, type: "bg" }, [3], false);
-    expect(result[0].backgroundTextSource).toBe("manual");
-    expect(result[1].backgroundTextSource).toBe("manual");
-    expect(result[1].backgroundWords).toHaveLength(2);
+    expect(bgSource(result[0])).toBe("manual");
+    expect(bgSource(result[1])).toBe("manual");
+    expect(bgWords(result[1])).toHaveLength(2);
   });
 });

--- a/src/stores/project/syllable-split-helpers.ts
+++ b/src/stores/project/syllable-split-helpers.ts
@@ -1,5 +1,5 @@
 import { manualBackgroundWordEdit } from "@/domain/line/background";
-import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { reconcileLine, toFlat, type LyricLine } from "@/domain/line/model";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { findIdenticalWords, type IdenticalMatchSource } from "@/utils/identical-word-matcher";
@@ -44,7 +44,7 @@ function applyTargetsToLine(line: LyricLine, targets: SplitTarget[], splitPoints
   }
 
   return reconcileLine({
-    ...line,
+    ...toFlat(line),
     ...(mainTrack !== originalMain ? { words: mainTrack } : {}),
     ...(bgTrack && bgTrack !== originalBg ? manualBackgroundWordEdit(bgTrack) : {}),
   });

--- a/src/stores/project/syllable-split-helpers.ts
+++ b/src/stores/project/syllable-split-helpers.ts
@@ -1,5 +1,6 @@
 import { manualBackgroundWordEdit } from "@/domain/line/background";
 import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { findIdenticalWords, type IdenticalMatchSource } from "@/utils/identical-word-matcher";
 import { splitWordIntoSyllables } from "@/utils/single-word-syllable-split";
@@ -21,8 +22,10 @@ function replaceWordsAt(track: WordTiming[], wordIndex: number, replacement: Wor
 }
 
 function applyTargetsToLine(line: LyricLine, targets: SplitTarget[], splitPoints: number[]): LyricLine {
-  let mainTrack = line.words;
-  let bgTrack = line.backgroundWords;
+  const originalMain = mainWords(line);
+  const originalBg = bgWords(line);
+  let mainTrack = originalMain;
+  let bgTrack = originalBg;
 
   // Single descending sort across all targets is safe: projecting onto each
   // track preserves descending order, so per-track splice indices don't drift.
@@ -42,15 +45,15 @@ function applyTargetsToLine(line: LyricLine, targets: SplitTarget[], splitPoints
 
   return reconcileLine({
     ...line,
-    ...(mainTrack !== line.words ? { words: mainTrack } : {}),
-    ...(bgTrack && bgTrack !== line.backgroundWords ? manualBackgroundWordEdit(bgTrack) : {}),
+    ...(mainTrack !== originalMain ? { words: mainTrack } : {}),
+    ...(bgTrack && bgTrack !== originalBg ? manualBackgroundWordEdit(bgTrack) : {}),
   });
 }
 
 function findSourceTarget(lines: LyricLine[], source: IdenticalMatchSource): SplitTarget | null {
   const sourceLine = lines.find((line) => line.id === source.lineId);
   if (!sourceLine) return null;
-  const track = source.type === "word" ? sourceLine.words : sourceLine.backgroundWords;
+  const track = source.type === "word" ? mainWords(sourceLine) : bgWords(sourceLine);
   const word = track?.[source.wordIndex];
   if (!word) return null;
   return { lineId: source.lineId, wordIndex: source.wordIndex, type: source.type, word, reuseGroupId: true };

--- a/src/stores/project/types.ts
+++ b/src/stores/project/types.ts
@@ -1,5 +1,6 @@
 import type { Agent } from "@/domain/agent/model";
 import type { LineTemplate, LinkGroup } from "@/domain/group/template";
+import type { BackgroundParams } from "@/domain/line/background";
 import type { LooseLine, LyricLine } from "@/domain/line/model";
 import type { ProjectMetadata } from "@/domain/project/metadata";
 import type { SnapPoint } from "@/domain/snap-point/model";
@@ -138,6 +139,8 @@ interface LineActions {
     updates: Array<{ id: string; updates: Partial<LooseLine> }>,
     options?: { deriveText?: boolean; propagateToSiblings?: boolean },
   ) => void;
+  setLineWithHistory: (lineId: string, nextLine: LyricLine, options?: { propagateToSiblings?: boolean }) => void;
+  applyLineBackground: (lineId: string, params: BackgroundParams, options?: { propagateToSiblings?: boolean }) => void;
   moveWordToBg: (lineId: string, wordIndices: number[], timeDelta: number, duration: number) => void;
   moveWordFromBg: (lineId: string, wordIndices: number[], timeDelta: number, duration: number) => void;
   applyWordCountChange: (

--- a/src/stores/project/types.ts
+++ b/src/stores/project/types.ts
@@ -141,6 +141,7 @@ interface LineActions {
   ) => void;
   setLineWithHistory: (lineId: string, nextLine: LyricLine, options?: { propagateToSiblings?: boolean }) => void;
   applyLineBackground: (lineId: string, params: BackgroundParams, options?: { propagateToSiblings?: boolean }) => void;
+  removeLineBackground: (lineId: string, options?: { propagateToSiblings?: boolean }) => void;
   moveWordToBg: (lineId: string, wordIndices: number[], timeDelta: number, duration: number) => void;
   moveWordFromBg: (lineId: string, wordIndices: number[], timeDelta: number, duration: number) => void;
   applyWordCountChange: (

--- a/src/stores/project/types.ts
+++ b/src/stores/project/types.ts
@@ -1,6 +1,6 @@
 import type { Agent } from "@/domain/agent/model";
 import type { LineTemplate, LinkGroup } from "@/domain/group/template";
-import type { LyricLine } from "@/domain/line/model";
+import type { LooseLine, LyricLine } from "@/domain/line/model";
 import type { ProjectMetadata } from "@/domain/project/metadata";
 import type { SnapPoint } from "@/domain/snap-point/model";
 import type { WordTiming } from "@/domain/word/timing";
@@ -128,14 +128,14 @@ interface HistoryActions {
 interface LineActions {
   setLines: (lines: LyricLine[]) => void;
   setLinesWithHistory: (lines: LyricLine[], groups?: LinkGroup[]) => void;
-  updateLine: (id: string, updates: Partial<LyricLine>, options?: { deriveText?: boolean }) => void;
+  updateLine: (id: string, updates: Partial<LooseLine>, options?: { deriveText?: boolean }) => void;
   updateLineWithHistory: (
     id: string,
-    updates: Partial<LyricLine>,
+    updates: Partial<LooseLine>,
     options?: { deriveText?: boolean; propagateToSiblings?: boolean },
   ) => void;
   updateLinesWithHistory: (
-    updates: Array<{ id: string; updates: Partial<LyricLine> }>,
+    updates: Array<{ id: string; updates: Partial<LooseLine> }>,
     options?: { deriveText?: boolean; propagateToSiblings?: boolean },
   ) => void;
   moveWordToBg: (lineId: string, wordIndices: number[], timeDelta: number, duration: number) => void;
@@ -145,7 +145,7 @@ interface LineActions {
     newWords: WordTiming[],
     field: "words" | "backgroundWords",
     resolution: "apply" | "detach" | "cancel",
-    extraUpdates?: Partial<LyricLine>,
+    extraUpdates?: Partial<LooseLine>,
   ) => void;
   toggleWordExplicit: (lineId: string, field: "words" | "backgroundWords", wordIndices: number[]) => void;
   mergeSyllableGroupIntoWord: (lineId: string, field: "words" | "backgroundWords", wordIndices: number[]) => void;

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -66,6 +66,7 @@ interface SettingsState {
   confirmResetShortcuts: boolean;
   confirmGroupDissolution: boolean;
   confirmApplyToAllSyllableSplit: boolean;
+  confirmRemoveBackground: boolean;
   linkedDivergenceAction: LinkedDivergenceAction;
 
   previewRenderer: PreviewRenderer;
@@ -132,6 +133,7 @@ const DEFAULTS: SettingsState = {
   confirmResetShortcuts: true,
   confirmGroupDissolution: true,
   confirmApplyToAllSyllableSplit: true,
+  confirmRemoveBackground: true,
   linkedDivergenceAction: "ask",
 
   previewRenderer: "braccato",
@@ -188,6 +190,7 @@ const useSettingsStore = create<SettingsState & SettingsActions>()(
           confirmResetShortcuts: state.confirmResetShortcuts,
           confirmGroupDissolution: state.confirmGroupDissolution,
           confirmApplyToAllSyllableSplit: state.confirmApplyToAllSyllableSplit,
+          confirmRemoveBackground: state.confirmRemoveBackground,
           linkedDivergenceAction: state.linkedDivergenceAction,
           cobaltInstances: state.cobaltInstances,
           selectedCobaltInstanceId: state.selectedCobaltInstanceId,

--- a/src/test/file-size-budget.test.ts
+++ b/src/test/file-size-budget.test.ts
@@ -33,7 +33,6 @@ const BASELINE_OVER_BUDGET = new Set<string>([
   "views/timeline/timeline-context-menu.tsx",
   "views/timeline/timeline-info-panel.tsx",
   "views/sync/scrollable-line.tsx",
-  "views/timeline/line-row.tsx",
   // shortcut-definitions.ts is intentionally exempt: it is a flat declarative
   // list of keyboard shortcut definitions. Splitting it per scope would need
   // a re-export module (barrel files are banned here), which is negative value.

--- a/src/test/fixtures/ttml/bg-line-synced.ttml
+++ b/src/test/fixtures/ttml/bg-line-synced.ttml
@@ -1,0 +1,17 @@
+<tt xmlns="http://www.w3.org/ns/ttml"
+    xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
+    xmlns:itunes="http://music.apple.com/lyric-ttml-internal"
+    itunes:timing="Line"
+    xml:lang="en">
+  <head>
+    <metadata>
+      <ttm:agent type="person" xml:id="v1"/>
+    </metadata>
+  </head>
+  <body dur="00:25.400">
+    <div>
+      <p begin="00:18.234" end="00:21.891" itunes:key="L1" ttm:agent="v1">The club isn't the best place to find a lover<span ttm:role="x-bg"><span begin="00:19.000" end="00:21.000">(ooh ooh)</span></span></p>
+      <p begin="00:22.100" end="00:25.400" itunes:key="L2" ttm:agent="v1">So the bar is where I go<span ttm:role="x-bg"><span begin="00:23.000" end="00:24.500">(yeah yeah)</span></span></p>
+    </div>
+  </body>
+</tt>

--- a/src/test/fixtures/ttml/bg-mixed-granularity.ttml
+++ b/src/test/fixtures/ttml/bg-mixed-granularity.ttml
@@ -1,0 +1,17 @@
+<tt xmlns="http://www.w3.org/ns/ttml"
+    xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
+    xmlns:itunes="http://music.apple.com/lyric-ttml-internal"
+    itunes:timing="Word"
+    xml:lang="en">
+  <head>
+    <metadata>
+      <ttm:agent type="person" xml:id="v1"/>
+    </metadata>
+  </head>
+  <body dur="00:10.000">
+    <div>
+      <p begin="00:01.000" end="00:05.000" itunes:key="L1" ttm:agent="v1"><span begin="00:01.000" end="00:03.000">Sing </span><span begin="00:03.000" end="00:05.000">along</span><span ttm:role="x-bg"><span begin="00:03.500" end="00:04.500">(ahh)</span></span></p>
+      <p begin="00:06.000" end="00:10.000" itunes:key="L2" ttm:agent="v1">A line sung plainly<span ttm:role="x-bg"><span begin="00:07.000" end="00:08.000">(oh </span><span begin="00:08.000" end="00:09.000">no)</span></span></p>
+    </div>
+  </body>
+</tt>

--- a/src/test/fixtures/ttml/bg-untimed-text.ttml
+++ b/src/test/fixtures/ttml/bg-untimed-text.ttml
@@ -1,0 +1,17 @@
+<tt xmlns="http://www.w3.org/ns/ttml"
+    xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
+    xmlns:itunes="http://music.apple.com/lyric-ttml-internal"
+    itunes:timing="Word"
+    xml:lang="en">
+  <head>
+    <metadata>
+      <ttm:agent type="person" xml:id="v1"/>
+    </metadata>
+  </head>
+  <body dur="00:10.000">
+    <div>
+      <p begin="00:01.000" end="00:05.000" itunes:key="L1" ttm:agent="v1"><span begin="00:01.000" end="00:03.000">Hello </span><span begin="00:03.000" end="00:05.000">world</span><span ttm:role="x-bg">(ooh yeah)</span></p>
+      <p begin="00:06.000" end="00:10.000" itunes:key="L2" ttm:agent="v1">A plain spoken line<span ttm:role="x-bg">(backing)</span></p>
+    </div>
+  </body>
+</tt>

--- a/src/test/fixtures/ttml/bg-word-synced.ttml
+++ b/src/test/fixtures/ttml/bg-word-synced.ttml
@@ -1,0 +1,27 @@
+<tt xmlns="http://www.w3.org/ns/ttml"
+    xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
+    xmlns:itunes="http://music.apple.com/lyric-ttml-internal"
+    itunes:timing="Word"
+    xml:lang="en">
+  <head>
+    <metadata>
+      <ttm:agent type="person" xml:id="v1"/>
+    </metadata>
+  </head>
+  <body dur="00:42.000">
+    <div begin="00:30.000" end="00:42.000">
+      <p begin="00:30.000" end="00:34.500" itunes:key="L1" ttm:agent="v1">
+        <span begin="00:30.000" end="00:31.000">Take </span><span begin="00:31.000" end="00:32.000">me </span><span begin="00:32.000" end="00:33.500">higher</span>
+        <span ttm:role="x-bg" begin="00:33.500" end="00:34.500">
+          <span begin="00:33.500" end="00:34.000">(ooh </span><span begin="00:34.000" end="00:34.500">yeah)</span>
+        </span>
+      </p>
+      <p begin="00:35.000" end="00:40.000" itunes:key="L2" ttm:agent="v1">
+        <span begin="00:35.000" end="00:37.000">Light </span><span begin="00:37.000" end="00:40.000">'em</span>
+        <span ttm:role="x-bg">
+          <span begin="00:38.000" end="00:39.000">(burn </span><span begin="00:39.000" end="00:40.000">it)</span>
+        </span>
+      </p>
+    </div>
+  </body>
+</tt>

--- a/src/test/no-inline-derivations.test.ts
+++ b/src/test/no-inline-derivations.test.ts
@@ -51,7 +51,17 @@ const FORBIDDEN: ForbiddenPattern[] = [
   {
     name: "inline line-synced check",
     regex: /\.begin !== undefined &&\s*[\w.]+\.end !== undefined/,
-    use: "isLineSynced from @/domain/line/predicates",
+    use: "isLineSynced from @/domain/line/predicates (or isLineSyncedVoice / mainBounds / bgBounds for the voice form)",
+  },
+  {
+    name: "inline nested main-voice access",
+    regex: /\.main(?=[.?[])/,
+    use: "the voice seam (mainVoice / mainWords / lineText) from @/domain/line/voices",
+  },
+  {
+    name: "inline nested background-voice access",
+    regex: /\.background(?=[.?[])/,
+    use: "the voice seam (bgVoice / bgWords / bgText / bgSource) from @/domain/line/voices",
   },
   {
     name: "inline first-word-begin access",
@@ -62,6 +72,11 @@ const FORBIDDEN: ForbiddenPattern[] = [
     name: "inline last-word-end access",
     regex: /words\[words\.length - 1\]\.end\b/,
     use: "lastEnd from @/domain/word/bounds",
+  },
+  {
+    name: "inline background word-bounds access",
+    regex: /\.background(?:\?\.|\.)words\[[^\]]*\]\.(begin|end)\b/,
+    use: "voiceBounds / firstBegin / lastEnd from @/domain/voice and @/domain/word/bounds",
   },
   {
     name: "inline standalone check",

--- a/src/tour/tour-steps.ts
+++ b/src/tour/tour-steps.ts
@@ -1,4 +1,5 @@
 import type { DriveStep } from "driver.js";
+import { isLineSynced } from "@/domain/line/predicates";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { MOD_KEY } from "@/utils/platform";
@@ -26,7 +27,8 @@ const gateAudioLoaded = () => useAudioStore.getState().source !== null;
 const gateLyricsExist = () => useProjectStore.getState().lines.length > 0;
 const gateFirstLineSynced = () => {
   const lines = useProjectStore.getState().lines;
-  return lines.length > 0 && lines[0]?.begin !== undefined;
+  const firstLine = lines[0];
+  return firstLine !== undefined && isLineSynced(firstLine);
 };
 
 // -- Tour Steps ---------------------------------------------------------------

--- a/src/ui/settings/confirmations-section.browser.test.tsx
+++ b/src/ui/settings/confirmations-section.browser.test.tsx
@@ -41,4 +41,12 @@ describe("ConfirmationsSection", () => {
     toggle.click();
     expect(useSettingsStore.getState().confirmApplyToAllSyllableSplit).toBe(false);
   });
+
+  it("flips confirmRemoveBackground when its toggle is clicked", async () => {
+    await render(<ConfirmationsSection />);
+    expect(useSettingsStore.getState().confirmRemoveBackground).toBe(true);
+    const toggle = toggleForLabel("Confirm removing background vocals");
+    toggle.click();
+    expect(useSettingsStore.getState().confirmRemoveBackground).toBe(false);
+  });
 });

--- a/src/ui/settings/confirmations-section.tsx
+++ b/src/ui/settings/confirmations-section.tsx
@@ -48,6 +48,11 @@ const ConfirmationsSection: React.FC = () => {
           description="Show a warning when a syllable split would also apply to other identical words across the project."
           settingKey="confirmApplyToAllSyllableSplit"
         />
+        <ToggleSetting
+          label="Confirm removing background vocals"
+          description="Show a warning before removing a line's background vocals."
+          settingKey="confirmRemoveBackground"
+        />
       </div>
     </div>
   );

--- a/src/utils/background-vocal-extraction.test.ts
+++ b/src/utils/background-vocal-extraction.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import type { LyricLine } from "@/domain/line/model";
+import { mainBounds } from "@/domain/line/bounds";
+import { type LyricLine, reconcileLine } from "@/domain/line/model";
+import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { createLine } from "@/test/factories";
 import {
   classifyLine,
@@ -353,68 +355,68 @@ describe("classifyLine: returned shape", () => {
 
 describe("extractInlineFromLine", () => {
   it("extracts an inline group from an untimed line", () => {
-    const line: LyricLine = { id: "1", text: "Hello (ooh) world", agentId: "v1" };
+    const line: LyricLine = reconcileLine({ id: "1", text: "Hello (ooh) world", agentId: "v1" });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.text).toBe("Hello world");
-    expect(result.backgroundText).toBe("ooh");
+    expect(lineText(result)).toBe("Hello world");
+    expect(bgText(result)).toBe("ooh");
   });
 
   it("appends to existing backgroundText on an untimed line", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh)",
       agentId: "v1",
       backgroundText: "ah",
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.text).toBe("Hello");
-    expect(result.backgroundText).toBe("ah ooh");
+    expect(lineText(result)).toBe("Hello");
+    expect(bgText(result)).toBe("ah ooh");
   });
 
   it("sets backgroundText to just the extracted text when none exists", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh) world",
       agentId: "v1",
       backgroundText: undefined,
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.backgroundText).toBe("ooh");
+    expect(bgText(result)).toBe("ooh");
   });
 
   it("returns the same reference for a line with no parentheses", () => {
-    const line: LyricLine = { id: "1", text: "Hello world", agentId: "v1" };
+    const line: LyricLine = reconcileLine({ id: "1", text: "Hello world", agentId: "v1" });
     expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 
   it("returns the same reference for a standalone line", () => {
-    const line: LyricLine = { id: "1", text: "(ooh yeah)", agentId: "v1" };
+    const line: LyricLine = reconcileLine({ id: "1", text: "(ooh yeah)", agentId: "v1" });
     expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 
   it("returns the same reference for a skip line", () => {
-    const line: LyricLine = { id: "1", text: "Hello (ooh", agentId: "v1" };
+    const line: LyricLine = reconcileLine({ id: "1", text: "Hello (ooh", agentId: "v1" });
     expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 
   it("preserves begin and end on a line-synced line", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hi (ooh) there",
       agentId: "v1",
       begin: 1,
       end: 3,
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.text).toBe("Hi there");
-    expect(result.backgroundText).toBe("ooh");
-    expect(result.begin).toBe(1);
-    expect(result.end).toBe(3);
-    expect(result.words).toBeUndefined();
+    expect(lineText(result)).toBe("Hi there");
+    expect(bgText(result)).toBe("ooh");
+    expect(mainBounds(result)?.begin).toBe(1);
+    expect(mainBounds(result)?.end).toBe(3);
+    expect(mainWords(result)).toBeUndefined();
   });
 
   it("extracts an inline group from a word-synced line", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hi (ooh) there",
       agentId: "v1",
@@ -423,64 +425,64 @@ describe("extractInlineFromLine", () => {
         { text: "(ooh) ", begin: 1, end: 2 },
         { text: "there", begin: 2, end: 3 },
       ],
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result).not.toBe(line);
-    expect(result.text).toBe("Hi there");
-    expect(result.backgroundText).toBe("ooh");
-    expect(result.backgroundWords).toBeUndefined();
-    expect(result.words).toEqual([
+    expect(lineText(result)).toBe("Hi there");
+    expect(bgText(result)).toBe("ooh");
+    expect(bgWords(result)).toBeUndefined();
+    expect(mainWords(result)).toEqual([
       { text: "Hi ", begin: 0, end: 1 },
       { text: "there", begin: 2, end: 3 },
     ]);
   });
 
   it("does not mutate the input line", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh) world",
       agentId: "v1",
       backgroundText: "ah",
-    };
+    });
     extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(line.text).toBe("Hello (ooh) world");
-    expect(line.backgroundText).toBe("ah");
+    expect(lineText(line)).toBe("Hello (ooh) world");
+    expect(bgText(line)).toBe("ah");
   });
 
   it("returns the same reference for a line-synced line carrying manual background words", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hi (ooh) there",
       agentId: "v1",
       begin: 1,
       end: 3,
       backgroundWords: [{ text: "clap", begin: 1.2, end: 1.8 }],
-    };
+    });
     expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 
   it("returns the same reference for an untimed line carrying manual background words", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hi (ooh) there",
       agentId: "v1",
       backgroundWords: [{ text: "clap", begin: 1.2, end: 1.8 }],
-    };
+    });
     expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 
   it("still extracts a line-synced line when backgroundWords is an empty array", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hi (ooh) there",
       agentId: "v1",
       begin: 1,
       end: 3,
       backgroundWords: [],
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.text).toBe("Hi there");
-    expect(result.backgroundText).toBe("ooh");
+    expect(lineText(result)).toBe("Hi there");
+    expect(bgText(result)).toBe("ooh");
   });
 });
 
@@ -488,7 +490,7 @@ describe("extractInlineFromLine", () => {
 
 describe("extractInlineFromLine: word-synced extraction", () => {
   it("extracts a mid-line paren word and preserves survivor timing", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh) world",
       agentId: "v1",
@@ -497,20 +499,20 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "(ooh) ", begin: 1.2, end: 1.9 },
         { text: "world", begin: 1.9, end: 2.7 },
       ],
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result).not.toBe(line);
-    expect(result.text).toBe("Hello world");
-    expect(result.backgroundText).toBe("ooh");
-    expect(result.backgroundWords).toBeUndefined();
-    expect(result.words).toEqual([
+    expect(lineText(result)).toBe("Hello world");
+    expect(bgText(result)).toBe("ooh");
+    expect(bgWords(result)).toBeUndefined();
+    expect(mainWords(result)).toEqual([
       { text: "Hello ", begin: 0.5, end: 1.2 },
       { text: "world", begin: 1.9, end: 2.7 },
     ]);
   });
 
   it("extracts a trailing paren word and trims the last survivor's trailing space", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh)",
       agentId: "v1",
@@ -518,16 +520,16 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "Hello ", begin: 0, end: 1 },
         { text: "(ooh)", begin: 1, end: 2 },
       ],
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result).not.toBe(line);
-    expect(result.text).toBe("Hello");
-    expect(result.backgroundText).toBe("ooh");
-    expect(result.words).toEqual([{ text: "Hello", begin: 0, end: 1 }]);
+    expect(lineText(result)).toBe("Hello");
+    expect(bgText(result)).toBe("ooh");
+    expect(mainWords(result)).toEqual([{ text: "Hello", begin: 0, end: 1 }]);
   });
 
   it("extracts a multi-token group spanning several words", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh yeah) world",
       agentId: "v1",
@@ -537,19 +539,19 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "yeah) ", begin: 1.5, end: 2 },
         { text: "world", begin: 2, end: 3 },
       ],
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result).not.toBe(line);
-    expect(result.text).toBe("Hello world");
-    expect(result.backgroundText).toBe("ooh yeah");
-    expect(result.words).toEqual([
+    expect(lineText(result)).toBe("Hello world");
+    expect(bgText(result)).toBe("ooh yeah");
+    expect(mainWords(result)).toEqual([
       { text: "Hello ", begin: 0, end: 1 },
       { text: "world", begin: 2, end: 3 },
     ]);
   });
 
   it("returns the same reference when a paren is glued onto a word token", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello(ooh) world",
       agentId: "v1",
@@ -557,12 +559,12 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "Hello(ooh) ", begin: 0, end: 1 },
         { text: "world", begin: 1, end: 2 },
       ],
-    };
+    });
     expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 
   it("preserves explicit and syllableGroupId fields on survivors", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh) world",
       agentId: "v1",
@@ -571,16 +573,16 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "(ooh) ", begin: 1, end: 2 },
         { text: "world", begin: 2, end: 3, explicit: true, syllableGroupId: "g2" },
       ],
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.words).toEqual([
+    expect(mainWords(result)).toEqual([
       { text: "Hello ", begin: 0, end: 1, explicit: true, syllableGroupId: "g1" },
       { text: "world", begin: 2, end: 3, explicit: true, syllableGroupId: "g2" },
     ]);
   });
 
   it("extracts cleanly when the line has syllable-split words", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hel|lo (ooh) world",
       agentId: "v1",
@@ -590,12 +592,12 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "(ooh) ", begin: 1, end: 2 },
         { text: "world", begin: 2, end: 3 },
       ],
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result).not.toBe(line);
-    expect(result.text).toBe("Hel|lo world");
-    expect(result.backgroundText).toBe("ooh");
-    expect(result.words).toEqual([
+    expect(lineText(result)).toBe("Hel|lo world");
+    expect(bgText(result)).toBe("ooh");
+    expect(mainWords(result)).toEqual([
       { text: "Hel", begin: 0, end: 0.5 },
       { text: "lo ", begin: 0.5, end: 1 },
       { text: "world", begin: 2, end: 3 },
@@ -603,7 +605,7 @@ describe("extractInlineFromLine: word-synced extraction", () => {
   });
 
   it("returns the same reference when the line already has background words", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh) world",
       agentId: "v1",
@@ -613,12 +615,12 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "world", begin: 2, end: 3 },
       ],
       backgroundWords: [{ text: "ah", begin: 0, end: 1 }],
-    };
+    });
     expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 
   it("appends to existing backgroundText on a word-synced line", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh) world",
       agentId: "v1",
@@ -628,9 +630,9 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "(ooh) ", begin: 1, end: 2 },
         { text: "world", begin: 2, end: 3 },
       ],
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.backgroundText).toBe("ah ooh");
+    expect(bgText(result)).toBe("ah ooh");
   });
 
   it("does not mutate the input line or its words array", () => {
@@ -639,11 +641,11 @@ describe("extractInlineFromLine: word-synced extraction", () => {
       { text: "(ooh) ", begin: 1, end: 2 },
       { text: "world", begin: 2, end: 3 },
     ];
-    const line: LyricLine = { id: "1", text: "Hello (ooh) world", agentId: "v1", words };
+    const line: LyricLine = reconcileLine({ id: "1", text: "Hello (ooh) world", agentId: "v1", words });
     extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(line.text).toBe("Hello (ooh) world");
-    expect(line.words).toBe(words);
-    expect(line.words).toEqual([
+    expect(lineText(line)).toBe("Hello (ooh) world");
+    expect(mainWords(line)).toBe(words);
+    expect(mainWords(line)).toEqual([
       { text: "Hello ", begin: 0, end: 1 },
       { text: "(ooh) ", begin: 1, end: 2 },
       { text: "world", begin: 2, end: 3 },
@@ -651,7 +653,7 @@ describe("extractInlineFromLine: word-synced extraction", () => {
   });
 
   it("returns the same reference for a word-synced standalone line", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "(ooh yeah)",
       agentId: "v1",
@@ -659,7 +661,7 @@ describe("extractInlineFromLine: word-synced extraction", () => {
         { text: "(ooh ", begin: 0, end: 1 },
         { text: "yeah)", begin: 1, end: 2 },
       ],
-    };
+    });
     expect(extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false })).toBe(line);
   });
 });
@@ -672,8 +674,8 @@ describe("extractBackgroundVocals: specification table", () => {
       const lines = [createLine({ id: "1", text: "A (ooh) B" })];
       const result = extractBackgroundVocals(lines, { mergeStandaloneLines, preserveBrackets: false });
       expect(result).toHaveLength(1);
-      expect(result[0].text).toBe("A B");
-      expect(result[0].backgroundText).toBe("ooh");
+      expect(lineText(result[0])).toBe("A B");
+      expect(bgText(result[0])).toBe("ooh");
     }
   });
 
@@ -682,8 +684,8 @@ describe("extractBackgroundVocals: specification table", () => {
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("1");
-    expect(result[0].text).toBe("Real line");
-    expect(result[0].backgroundText).toBe("ooh yeah");
+    expect(lineText(result[0])).toBe("Real line");
+    expect(bgText(result[0])).toBe("ooh yeah");
   });
 
   it("leaves a standalone line in place when merge is disabled", () => {
@@ -703,8 +705,8 @@ describe("extractBackgroundVocals: specification table", () => {
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("1");
-    expect(result[0].text).toBe("Real line");
-    expect(result[0].backgroundText).toBe("ooh yeah");
+    expect(lineText(result[0])).toBe("Real line");
+    expect(bgText(result[0])).toBe("ooh yeah");
   });
 
   it("does not merge a leading standalone line with no valid predecessor", () => {
@@ -755,8 +757,8 @@ describe("extractBackgroundVocals: specification table", () => {
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("1");
-    expect(result[0].text).toBe("A B");
-    expect(result[0].backgroundText).toBe("ooh yeah");
+    expect(lineText(result[0])).toBe("A B");
+    expect(bgText(result[0])).toBe("ooh yeah");
   });
 });
 
@@ -794,8 +796,8 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("1");
-    expect(result[0].backgroundText).toBe("ooh yeah");
-    expect(result[0].backgroundWords).toBeUndefined();
+    expect(bgText(result[0])).toBe("ooh yeah");
+    expect(bgWords(result[0])).toBeUndefined();
   });
 
   it("carries word-synced standalone timing into an untimed predecessor with no background", () => {
@@ -813,11 +815,11 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("1");
-    expect(result[0].backgroundWords).toEqual([
+    expect(bgWords(result[0])).toEqual([
       { text: "ooh ", begin: 5.0, end: 5.6 },
       { text: "yeah", begin: 5.6, end: 6.2 },
     ]);
-    expect(result[0].backgroundText).toBe("ooh yeah");
+    expect(bgText(result[0])).toBe("ooh yeah");
   });
 
   it("appends carried words after the predecessor's existing background words", () => {
@@ -839,12 +841,12 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundWords).toEqual([
+    expect(bgWords(result[0])).toEqual([
       { text: "ah ", begin: 1.0, end: 1.5 },
       { text: "ooh ", begin: 5.0, end: 5.6 },
       { text: "yeah", begin: 5.6, end: 6.2 },
     ]);
-    expect(result[0].backgroundText).toBe("ah ooh yeah");
+    expect(bgText(result[0])).toBe("ah ooh yeah");
   });
 
   it("falls back to text-only when predecessor has background text but no words", () => {
@@ -861,8 +863,8 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundText).toBe("ah ooh yeah");
-    expect(result[0].backgroundWords).toBeUndefined();
+    expect(bgText(result[0])).toBe("ah ooh yeah");
+    expect(bgWords(result[0])).toBeUndefined();
   });
 
   it("seeds background words from a line-synced standalone via createInitialBgWords", () => {
@@ -872,12 +874,12 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundText).toBe("ooh");
-    const bgWords = result[0].backgroundWords;
-    expect(bgWords).toHaveLength(1);
-    expect(bgWords?.[0].text).toBe("ooh");
-    expect(bgWords?.[0].begin).toBe(4.0);
-    expect(bgWords?.[0].end).toBe(6.0);
+    expect(bgText(result[0])).toBe("ooh");
+    const bg = bgWords(result[0]);
+    expect(bg).toHaveLength(1);
+    expect(bg?.[0].text).toBe("ooh");
+    expect(bg?.[0].begin).toBe(4.0);
+    expect(bg?.[0].end).toBe(6.0);
   });
 
   it("spans the standalone time range across multiple words from a line-synced standalone", () => {
@@ -886,10 +888,10 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
       createLine({ id: "2", text: "(ooh yeah)", begin: 4.0, end: 6.0 }),
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
-    const bgWords = result[0].backgroundWords;
-    expect(bgWords).toHaveLength(2);
-    expect(bgWords?.[0].begin).toBe(4.0);
-    expect(bgWords?.[bgWords.length - 1].end).toBe(6.0);
+    const bg = bgWords(result[0]);
+    expect(bg).toHaveLength(2);
+    expect(bg?.[0].begin).toBe(4.0);
+    expect(bg?.[bg.length - 1].end).toBe(6.0);
   });
 
   it("does not merge an untimed standalone into a predecessor with timed background words", () => {
@@ -906,7 +908,7 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
     expect(result).toHaveLength(2);
     expect(result[0]).toBe(lines[0]);
     expect(result[1]).toBe(lines[1]);
-    expect(result[0].backgroundWords).toEqual([{ text: "ah", begin: 1.0, end: 1.5 }]);
+    expect(bgWords(result[0])).toEqual([{ text: "ah", begin: 1.0, end: 1.5 }]);
   });
 
   it("falls back to text-only when standalone word count does not match bg text", () => {
@@ -925,8 +927,8 @@ describe("extractBackgroundVocals: timing-aware standalone merge", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundText).toBe("ooh yeah");
-    expect(result[0].backgroundWords).toBeUndefined();
+    expect(bgText(result[0])).toBe("ooh yeah");
+    expect(bgWords(result[0])).toBeUndefined();
   });
 });
 
@@ -950,8 +952,8 @@ describe("extractBackgroundVocals: merge gate", () => {
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("1");
-    expect(result[0].text).toBe("Real");
-    expect(result[0].backgroundText).toBe("ooh yeah");
+    expect(lineText(result[0])).toBe("Real");
+    expect(bgText(result[0])).toBe("ooh yeah");
   });
 });
 
@@ -984,7 +986,7 @@ describe("extractBackgroundVocals: existing backgroundText", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundText).toBe("ah ooh");
+    expect(bgText(result[0])).toBe("ah ooh");
   });
 });
 
@@ -1000,10 +1002,10 @@ describe("extractBackgroundVocals: input not mutated", () => {
     const originalLength = lines.length;
     extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(lines).toHaveLength(originalLength);
-    expect(lines[0].text).toBe("A (ooh) B");
-    expect(lines[0].backgroundText).toBe("ah");
-    expect(lines[1].text).toBe("(yeah)");
-    expect(lines[2].text).toBe("Plain");
+    expect(lineText(lines[0])).toBe("A (ooh) B");
+    expect(bgText(lines[0])).toBe("ah");
+    expect(lineText(lines[1])).toBe("(yeah)");
+    expect(lineText(lines[2])).toBe("Plain");
   });
 
   it("does not mutate a timed standalone line or its words array", () => {
@@ -1015,16 +1017,16 @@ describe("extractBackgroundVocals: input not mutated", () => {
       createLine({ id: "1", text: "Real line" }),
       createLine({ id: "2", text: "(ooh yeah)", words: standaloneWords }),
     ];
-    const standaloneWordsRef = lines[1].words;
+    const standaloneWordsRef = mainWords(lines[1]);
     extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(lines).toHaveLength(2);
-    expect(lines[1].text).toBe("(ooh yeah)");
-    expect(lines[1].words).toBe(standaloneWordsRef);
-    expect(lines[1].words).toEqual([
+    expect(lineText(lines[1])).toBe("(ooh yeah)");
+    expect(mainWords(lines[1])).toBe(standaloneWordsRef);
+    expect(mainWords(lines[1])).toEqual([
       { text: "(ooh ", begin: 5.0, end: 5.6 },
       { text: "yeah)", begin: 5.6, end: 6.2 },
     ]);
-    expect(lines[0].backgroundWords).toBeUndefined();
+    expect(bgWords(lines[0])).toBeUndefined();
   });
 });
 
@@ -1043,8 +1045,8 @@ describe("extractBackgroundVocals: idempotence", () => {
     expect(second).toHaveLength(first.length);
     for (let i = 0; i < first.length; i++) {
       expect(second[i]).toBe(first[i]);
-      expect(second[i].text).toBe(first[i].text);
-      expect(second[i].backgroundText).toBe(first[i].backgroundText);
+      expect(lineText(second[i])).toBe(lineText(first[i]));
+      expect(bgText(second[i])).toBe(bgText(first[i]));
     }
   });
 
@@ -1073,8 +1075,8 @@ describe("extractBackgroundVocals: idempotence", () => {
     expect(second).toHaveLength(first.length);
     for (let i = 0; i < first.length; i++) {
       expect(second[i]).toBe(first[i]);
-      expect(second[i].backgroundText).toBe(first[i].backgroundText);
-      expect(second[i].backgroundWords).toEqual(first[i].backgroundWords);
+      expect(bgText(second[i])).toBe(bgText(first[i]));
+      expect(bgWords(second[i])).toEqual(bgWords(first[i]));
     }
   });
 });
@@ -1091,15 +1093,15 @@ describe("re-paste doubling", () => {
       { mergeStandaloneLines: true, preserveBrackets: false },
     );
     expect(first).toHaveLength(1);
-    expect(first[0].backgroundText).toBe("ooh");
-    expect(first[0].backgroundTextSource).toBe("extraction");
+    expect(bgText(first[0])).toBe("ooh");
+    expect(bgSource(first[0])).toBe("extraction");
 
     const second = extractBackgroundVocals([first[0], { id: "b", text: "(ooh)", agentId: "v1" }], {
       mergeStandaloneLines: true,
       preserveBrackets: false,
     });
     expect(second).toHaveLength(1);
-    expect(second[0].backgroundText).toBe("ooh");
+    expect(bgText(second[0])).toBe("ooh");
   });
 
   it("keeps manually entered background when a standalone line merges in", () => {
@@ -1110,8 +1112,8 @@ describe("re-paste doubling", () => {
       ],
       { mergeStandaloneLines: true, preserveBrackets: false },
     );
-    expect(merged[0].backgroundText).toBe("clap ooh");
-    expect(merged[0].backgroundTextSource).toBe("manual");
+    expect(bgText(merged[0])).toBe("clap ooh");
+    expect(bgSource(merged[0])).toBe("manual");
   });
 });
 
@@ -1119,53 +1121,53 @@ describe("re-paste doubling", () => {
 
 describe("extractInlineFromLine: provenance", () => {
   it("stamps extraction source on a freshly extracted untimed line", () => {
-    const line: LyricLine = { id: "1", text: "Hello (ooh) world", agentId: "v1" };
+    const line: LyricLine = reconcileLine({ id: "1", text: "Hello (ooh) world", agentId: "v1" });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.backgroundText).toBe("ooh");
-    expect(result.backgroundTextSource).toBe("extraction");
+    expect(bgText(result)).toBe("ooh");
+    expect(bgSource(result)).toBe("extraction");
   });
 
   it("replaces extraction-sourced background instead of appending on re-paste", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh)",
       agentId: "v1",
       backgroundText: "ooh",
       backgroundTextSource: "extraction",
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.text).toBe("Hello");
-    expect(result.backgroundText).toBe("ooh");
-    expect(result.backgroundTextSource).toBe("extraction");
+    expect(lineText(result)).toBe("Hello");
+    expect(bgText(result)).toBe("ooh");
+    expect(bgSource(result)).toBe("extraction");
   });
 
   it("appends onto manual background and keeps the manual source", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh)",
       agentId: "v1",
       backgroundText: "clap",
       backgroundTextSource: "manual",
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.backgroundText).toBe("clap ooh");
-    expect(result.backgroundTextSource).toBe("manual");
+    expect(bgText(result)).toBe("clap ooh");
+    expect(bgSource(result)).toBe("manual");
   });
 
   it("treats undefined provenance as manual and appends conservatively", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh)",
       agentId: "v1",
       backgroundText: "clap",
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.backgroundText).toBe("clap ooh");
-    expect(result.backgroundTextSource).toBe("manual");
+    expect(bgText(result)).toBe("clap ooh");
+    expect(bgSource(result)).toBe("manual");
   });
 
   it("stamps extraction source on a freshly extracted word-synced line", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh) world",
       agentId: "v1",
@@ -1174,14 +1176,14 @@ describe("extractInlineFromLine: provenance", () => {
         { text: "(ooh) ", begin: 1, end: 2 },
         { text: "world", begin: 2, end: 3 },
       ],
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.backgroundText).toBe("ooh");
-    expect(result.backgroundTextSource).toBe("extraction");
+    expect(bgText(result)).toBe("ooh");
+    expect(bgSource(result)).toBe("extraction");
   });
 
   it("replaces extraction-sourced background on a word-synced re-paste", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh) world",
       agentId: "v1",
@@ -1192,14 +1194,14 @@ describe("extractInlineFromLine: provenance", () => {
         { text: "(ooh) ", begin: 1, end: 2 },
         { text: "world", begin: 2, end: 3 },
       ],
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.backgroundText).toBe("ooh");
-    expect(result.backgroundTextSource).toBe("extraction");
+    expect(bgText(result)).toBe("ooh");
+    expect(bgSource(result)).toBe("extraction");
   });
 
   it("appends onto manual background on a word-synced line", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "1",
       text: "Hello (ooh) world",
       agentId: "v1",
@@ -1210,10 +1212,10 @@ describe("extractInlineFromLine: provenance", () => {
         { text: "(ooh) ", begin: 1, end: 2 },
         { text: "world", begin: 2, end: 3 },
       ],
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.backgroundText).toBe("clap ooh");
-    expect(result.backgroundTextSource).toBe("manual");
+    expect(bgText(result)).toBe("clap ooh");
+    expect(bgSource(result)).toBe("manual");
   });
 });
 
@@ -1223,8 +1225,8 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
   it("stamps extraction source when an untimed standalone merges into a clean predecessor", () => {
     const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh)" })];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
-    expect(result[0].backgroundText).toBe("ooh");
-    expect(result[0].backgroundTextSource).toBe("extraction");
+    expect(bgText(result[0])).toBe("ooh");
+    expect(bgSource(result[0])).toBe("extraction");
   });
 
   it("keeps manual source when a standalone merges into a manual-background predecessor", () => {
@@ -1233,8 +1235,8 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
       createLine({ id: "2", text: "(ooh)" }),
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
-    expect(result[0].backgroundText).toBe("ah ooh");
-    expect(result[0].backgroundTextSource).toBe("manual");
+    expect(bgText(result[0])).toBe("ah ooh");
+    expect(bgSource(result[0])).toBe("manual");
   });
 
   it("treats undefined-provenance background text as manual on standalone merge", () => {
@@ -1243,8 +1245,8 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
       createLine({ id: "2", text: "(ooh)" }),
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
-    expect(result[0].backgroundText).toBe("ah ooh");
-    expect(result[0].backgroundTextSource).toBe("manual");
+    expect(bgText(result[0])).toBe("ah ooh");
+    expect(bgSource(result[0])).toBe("manual");
   });
 
   it("replaces extraction-sourced background text on standalone re-merge", () => {
@@ -1253,8 +1255,8 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
       createLine({ id: "2", text: "(ooh)" }),
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
-    expect(result[0].backgroundText).toBe("ooh");
-    expect(result[0].backgroundTextSource).toBe("extraction");
+    expect(bgText(result[0])).toBe("ooh");
+    expect(bgSource(result[0])).toBe("extraction");
   });
 
   it("merges two standalone lines into a clean predecessor within one pass", () => {
@@ -1265,8 +1267,8 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundText).toBe("ooh ah");
-    expect(result[0].backgroundTextSource).toBe("extraction");
+    expect(bgText(result[0])).toBe("ooh ah");
+    expect(bgSource(result[0])).toBe("extraction");
   });
 
   it("carries timed standalone words and stamps extraction source on a clean predecessor", () => {
@@ -1282,11 +1284,11 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
       }),
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
-    expect(result[0].backgroundWords).toEqual([
+    expect(bgWords(result[0])).toEqual([
       { text: "ooh ", begin: 5.0, end: 5.6 },
       { text: "yeah", begin: 5.6, end: 6.2 },
     ]);
-    expect(result[0].backgroundTextSource).toBe("extraction");
+    expect(bgSource(result[0])).toBe("extraction");
   });
 
   it("combines timed standalone words onto manual background words and keeps manual source", () => {
@@ -1308,12 +1310,12 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
       }),
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
-    expect(result[0].backgroundWords).toEqual([
+    expect(bgWords(result[0])).toEqual([
       { text: "ah ", begin: 1.0, end: 1.5 },
       { text: "ooh ", begin: 5.0, end: 5.6 },
       { text: "yeah", begin: 5.6, end: 6.2 },
     ]);
-    expect(result[0].backgroundTextSource).toBe("manual");
+    expect(bgSource(result[0])).toBe("manual");
   });
 
   it("replaces extraction-sourced background words when a timed standalone re-merges", () => {
@@ -1339,11 +1341,11 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundWords).toEqual([
+    expect(bgWords(result[0])).toEqual([
       { text: "ooh ", begin: 5.0, end: 5.6 },
       { text: "yeah", begin: 5.6, end: 6.2 },
     ]);
-    expect(result[0].backgroundTextSource).toBe("extraction");
+    expect(bgSource(result[0])).toBe("extraction");
   });
 
   it("merges a timed standalone into an untimed extraction-sourced predecessor by replacement", () => {
@@ -1359,12 +1361,12 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
       }),
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
-    expect(result[0].backgroundText).toBe("ooh yeah");
-    expect(result[0].backgroundWords).toEqual([
+    expect(bgText(result[0])).toBe("ooh yeah");
+    expect(bgWords(result[0])).toEqual([
       { text: "ooh ", begin: 5.0, end: 5.6 },
       { text: "yeah", begin: 5.6, end: 6.2 },
     ]);
-    expect(result[0].backgroundTextSource).toBe("extraction");
+    expect(bgSource(result[0])).toBe("extraction");
   });
 
   it("merges an untimed standalone into a predecessor with extraction-sourced background words", () => {
@@ -1380,9 +1382,9 @@ describe("extractBackgroundVocals: standalone merge provenance", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundText).toBe("ooh");
-    expect(result[0].backgroundWords).toBeUndefined();
-    expect(result[0].backgroundTextSource).toBe("extraction");
+    expect(bgText(result[0])).toBe("ooh");
+    expect(bgWords(result[0])).toBeUndefined();
+    expect(bgSource(result[0])).toBe("extraction");
   });
 });
 
@@ -1393,9 +1395,9 @@ describe("extractBackgroundVocals: standalone merge disabled", () => {
     const lines = [createLine({ id: "1", text: "A (ooh) B" }), createLine({ id: "2", text: "(yeah)" })];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(result).toHaveLength(2);
-    expect(result[0].text).toBe("A B");
-    expect(result[0].backgroundText).toBe("ooh");
-    expect(result[0].backgroundTextSource).toBe("extraction");
+    expect(lineText(result[0])).toBe("A B");
+    expect(bgText(result[0])).toBe("ooh");
+    expect(bgSource(result[0])).toBe("extraction");
     expect(result[1]).toBe(lines[1]);
   });
 });
@@ -1418,8 +1420,8 @@ describe("extractBackgroundVocals: re-paste idempotence with provenance", () => 
     const first = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     const second = extractBackgroundVocals(first, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(second[0]).toBe(first[0]);
-    expect(second[0].backgroundText).toBe(first[0].backgroundText);
-    expect(second[0].backgroundTextSource).toBe("extraction");
+    expect(bgText(second[0])).toBe(bgText(first[0]));
+    expect(bgSource(second[0])).toBe("extraction");
   });
 });
 
@@ -1433,24 +1435,24 @@ describe("extractBackgroundVocals: re-paste idempotence with provenance", () => 
 
 describe("extractInlineFromLine: linked lines", () => {
   it("extracts an untimed inline group and keeps link metadata intact", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "l1",
       text: "Hello (ooh)",
       agentId: "v1",
       groupId: "g1",
       instanceIdx: 0,
       templateLineIdx: 0,
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.text).toBe("Hello");
-    expect(result.backgroundText).toBe("ooh");
+    expect(lineText(result)).toBe("Hello");
+    expect(bgText(result)).toBe("ooh");
     expect(result.groupId).toBe("g1");
     expect(result.instanceIdx).toBe(0);
     expect(result.templateLineIdx).toBe(0);
   });
 
   it("extracts a word-synced inline group and keeps link metadata intact", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "l1",
       text: "Hello (ooh)",
       agentId: "v1",
@@ -1461,11 +1463,11 @@ describe("extractInlineFromLine: linked lines", () => {
         { text: "Hello ", begin: 30, end: 31 },
         { text: "(ooh)", begin: 31, end: 32 },
       ],
-    };
+    });
     const result = extractInlineFromLine(line, { mergeStandaloneLines: false, preserveBrackets: false });
-    expect(result.text).toBe("Hello");
-    expect(result.backgroundText).toBe("ooh");
-    expect(result.words).toEqual([{ text: "Hello", begin: 30, end: 31 }]);
+    expect(lineText(result)).toBe("Hello");
+    expect(bgText(result)).toBe("ooh");
+    expect(mainWords(result)).toEqual([{ text: "Hello", begin: 30, end: 31 }]);
     expect(result.groupId).toBe("g1");
     expect(result.instanceIdx).toBe(1);
     expect(result.templateLineIdx).toBe(2);
@@ -1483,8 +1485,8 @@ describe("extractBackgroundVocals: linked sibling lines", () => {
 
     expect(result).toHaveLength(2);
     for (const line of result) {
-      expect(line.text).toBe("Hello");
-      expect(line.backgroundText).toBe("ooh");
+      expect(lineText(line)).toBe("Hello");
+      expect(bgText(line)).toBe("ooh");
       expect(line.groupId).toBe("g1");
       expect(line.templateLineIdx).toBe(0);
     }
@@ -1493,7 +1495,7 @@ describe("extractBackgroundVocals: linked sibling lines", () => {
   });
 
   it("extracts both word-synced linked siblings identically while keeping instance timing", () => {
-    const s0: LyricLine = {
+    const s0: LyricLine = reconcileLine({
       id: "s0",
       text: "Hello (ooh)",
       agentId: "v1",
@@ -1504,8 +1506,8 @@ describe("extractBackgroundVocals: linked sibling lines", () => {
         { text: "Hello ", begin: 0, end: 1 },
         { text: "(ooh)", begin: 1, end: 2 },
       ],
-    };
-    const s1: LyricLine = {
+    });
+    const s1: LyricLine = reconcileLine({
       id: "s1",
       text: "Hello (ooh)",
       agentId: "v1",
@@ -1516,17 +1518,17 @@ describe("extractBackgroundVocals: linked sibling lines", () => {
         { text: "Hello ", begin: 30, end: 31.5 },
         { text: "(ooh)", begin: 31.5, end: 33 },
       ],
-    };
+    });
 
     const result = extractBackgroundVocals([s0, s1], { mergeStandaloneLines: true, preserveBrackets: false });
 
     expect(result).toHaveLength(2);
-    expect(result[0].text).toBe("Hello");
-    expect(result[1].text).toBe("Hello");
-    expect(result[0].backgroundText).toBe("ooh");
-    expect(result[1].backgroundText).toBe("ooh");
-    expect(result[0].words).toEqual([{ text: "Hello", begin: 0, end: 1 }]);
-    expect(result[1].words).toEqual([{ text: "Hello", begin: 30, end: 31.5 }]);
+    expect(lineText(result[0])).toBe("Hello");
+    expect(lineText(result[1])).toBe("Hello");
+    expect(bgText(result[0])).toBe("ooh");
+    expect(bgText(result[1])).toBe("ooh");
+    expect(mainWords(result[0])).toEqual([{ text: "Hello", begin: 0, end: 1 }]);
+    expect(mainWords(result[1])).toEqual([{ text: "Hello", begin: 30, end: 31.5 }]);
     expect(result[0].groupId).toBe("g1");
     expect(result[1].groupId).toBe("g1");
     expect(result[0].templateLineIdx).toBe(0);
@@ -1561,22 +1563,22 @@ describe("preserveBrackets: text-only bg", () => {
     const lines = [createLine({ id: "1", text: "A (ooh) B" })];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
     expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("A B");
-    expect(result[0].backgroundText).toBe("(ooh)");
+    expect(lineText(result[0])).toBe("A B");
+    expect(bgText(result[0])).toBe("(ooh)");
   });
 
   it("wraps multiple inline groups on the same line in one outer pair", () => {
     const lines = [createLine({ id: "1", text: "A (ooh) (yeah) B" })];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
-    expect(result[0].text).toBe("A B");
-    expect(result[0].backgroundText).toBe("(ooh yeah)");
+    expect(lineText(result[0])).toBe("A B");
+    expect(bgText(result[0])).toBe("(ooh yeah)");
   });
 
   it("merges a standalone into prev with one outer pair", () => {
     const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh yeah)" })];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundText).toBe("(ooh yeah)");
+    expect(bgText(result[0])).toBe("(ooh yeah)");
   });
 
   it("merges multiple consecutive standalones into one outer pair", () => {
@@ -1587,15 +1589,15 @@ describe("preserveBrackets: text-only bg", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundText).toBe("(ooh yeah)");
+    expect(bgText(result[0])).toBe("(ooh yeah)");
   });
 
   it("merges inline-then-standalone same-pass into one outer pair", () => {
     const lines = [createLine({ id: "1", text: "A (ooh) B" }), createLine({ id: "2", text: "(yeah)" })];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
     expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("A B");
-    expect(result[0].backgroundText).toBe("(ooh yeah)");
+    expect(lineText(result[0])).toBe("A B");
+    expect(bgText(result[0])).toBe("(ooh yeah)");
   });
 
   it("appends a bracketed addition next to existing manual bg text", () => {
@@ -1610,7 +1612,7 @@ describe("preserveBrackets: text-only bg", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundText).toBe("ah (ooh)");
+    expect(bgText(result[0])).toBe("ah (ooh)");
   });
 
   it("groups multiple bracketed additions inside one pair after manual bg", () => {
@@ -1626,27 +1628,27 @@ describe("preserveBrackets: text-only bg", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundText).toBe("ah (ooh yeah)");
+    expect(bgText(result[0])).toBe("ah (ooh yeah)");
   });
 
   it("preserves backgroundTextSource as extraction for fresh additions", () => {
     const lines = [createLine({ id: "1", text: "A (ooh) B" })];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
-    expect(result[0].backgroundTextSource).toBe("extraction");
+    expect(bgSource(result[0])).toBe("extraction");
   });
 
   it("is idempotent on already-bracketed extracted bg (no double wrap)", () => {
     const lines = [createLine({ id: "1", text: "A (ooh) B" })];
     const once = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
     const twice = extractBackgroundVocals(once, { mergeStandaloneLines: true, preserveBrackets: true });
-    expect(twice[0].backgroundText).toBe("(ooh)");
-    expect(twice[0].text).toBe("A B");
+    expect(bgText(twice[0])).toBe("(ooh)");
+    expect(lineText(twice[0])).toBe("A B");
   });
 
   it("does not change main text under preserveBrackets", () => {
     const lines = [createLine({ id: "1", text: "A (ooh) (yeah) B" })];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
-    expect(result[0].text).toBe("A B");
+    expect(lineText(result[0])).toBe("A B");
   });
 
   it("does not peel a trailing ')' from manual bg text", () => {
@@ -1661,7 +1663,7 @@ describe("preserveBrackets: text-only bg", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundText).toBe("my note) (ooh)");
+    expect(bgText(result[0])).toBe("my note) (ooh)");
   });
 });
 
@@ -1672,25 +1674,25 @@ describe("preserveBrackets: invariants", () => {
     const lines = [createLine({ id: "1", text: "A (ooh) B" })];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("A B");
-    expect(result[0].backgroundText).toBe("ooh");
+    expect(lineText(result[0])).toBe("A B");
+    expect(bgText(result[0])).toBe("ooh");
   });
 
   it("regression: off-state standalone merge matches pre-task output", () => {
     const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh yeah)" })];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("Real line");
-    expect(result[0].backgroundText).toBe("ooh yeah");
+    expect(lineText(result[0])).toBe("Real line");
+    expect(bgText(result[0])).toBe("ooh yeah");
   });
 
   it("off-state and on-state produce different bg text for inline parens", () => {
     const lines = [createLine({ id: "1", text: "A (ooh) B" })];
     const off = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
     const on = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
-    expect(off[0].backgroundText).toBe("ooh");
-    expect(on[0].backgroundText).toBe("(ooh)");
-    expect(off[0].backgroundText).not.toBe(on[0].backgroundText);
+    expect(bgText(off[0])).toBe("ooh");
+    expect(bgText(on[0])).toBe("(ooh)");
+    expect(bgText(off[0])).not.toBe(bgText(on[0]));
   });
 
   it("paren-free line is reference-equality pass-through regardless of flag", () => {
@@ -1705,7 +1707,7 @@ describe("preserveBrackets: invariants", () => {
     const lines = [createLine({ id: "1", text: "A (ooh) (yeah) B" }), createLine({ id: "2", text: "(la)" })];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
     expect(result).toHaveLength(1);
-    const bg = result[0].backgroundText ?? "";
+    const bg = bgText(result[0]) ?? "";
     expect((bg.match(/\(/g) ?? []).length).toBe(1);
     expect((bg.match(/\)/g) ?? []).length).toBe(1);
     expect(bg).toBe("(ooh yeah la)");
@@ -1727,11 +1729,11 @@ describe("preserveBrackets: word-synced bg", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundWords).toEqual([
+    expect(bgWords(result[0])).toEqual([
       { text: "(ooh ", begin: 5.0, end: 5.6 },
       { text: "yeah)", begin: 5.6, end: 6.2 },
     ]);
-    expect(result[0].backgroundText).toBe("(ooh yeah)");
+    expect(bgText(result[0])).toBe("(ooh yeah)");
   });
 
   it("brackets a single-word standalone", () => {
@@ -1744,8 +1746,8 @@ describe("preserveBrackets: word-synced bg", () => {
       }),
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
-    expect(result[0].backgroundWords).toEqual([{ text: "(ooh)", begin: 5.0, end: 5.6 }]);
-    expect(result[0].backgroundText).toBe("(ooh)");
+    expect(bgWords(result[0])).toEqual([{ text: "(ooh)", begin: 5.0, end: 5.6 }]);
+    expect(bgText(result[0])).toBe("(ooh)");
   });
 
   it("merges a second standalone into the same outer pair, stripping seam brackets", () => {
@@ -1764,11 +1766,11 @@ describe("preserveBrackets: word-synced bg", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundWords).toEqual([
+    expect(bgWords(result[0])).toEqual([
       { text: "(ooh ", begin: 5.0, end: 5.5 },
       { text: "yeah)", begin: 5.6, end: 6.1 },
     ]);
-    expect(result[0].backgroundText).toBe("(ooh yeah)");
+    expect(bgText(result[0])).toBe("(ooh yeah)");
   });
 
   it("appends bracketed carry next to existing manual bg words without merging into manual pair", () => {
@@ -1788,7 +1790,7 @@ describe("preserveBrackets: word-synced bg", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundWords).toEqual([
+    expect(bgWords(result[0])).toEqual([
       { text: "ah ", begin: 1.0, end: 1.5 },
       { text: "(ooh)", begin: 5.0, end: 5.5 },
     ]);
@@ -1797,8 +1799,8 @@ describe("preserveBrackets: word-synced bg", () => {
   it("falls back to text-only addition when standalone has no words", () => {
     const lines = [createLine({ id: "1", text: "Real line" }), createLine({ id: "2", text: "(ooh)" })];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
-    expect(result[0].backgroundWords).toBeUndefined();
-    expect(result[0].backgroundText).toBe("(ooh)");
+    expect(bgWords(result[0])).toBeUndefined();
+    expect(bgText(result[0])).toBe("(ooh)");
   });
 
   it("off-state: word carry is unchanged (regression guard)", () => {
@@ -1814,11 +1816,11 @@ describe("preserveBrackets: word-synced bg", () => {
       }),
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: false });
-    expect(result[0].backgroundWords).toEqual([
+    expect(bgWords(result[0])).toEqual([
       { text: "ooh ", begin: 5.0, end: 5.6 },
       { text: "yeah", begin: 5.6, end: 6.2 },
     ]);
-    expect(result[0].backgroundText).toBe("ooh yeah");
+    expect(bgText(result[0])).toBe("ooh yeah");
   });
 
   it("does not fuse a manually-bracketed bg with a fresh bracketed carry", () => {
@@ -1838,7 +1840,7 @@ describe("preserveBrackets: word-synced bg", () => {
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundWords).toEqual([
+    expect(bgWords(result[0])).toEqual([
       { text: "(clap)", begin: 1.0, end: 1.5 },
       { text: "(ooh)", begin: 5.0, end: 5.5 },
     ]);
@@ -1859,7 +1861,7 @@ describe("preserveBrackets: word-synced invariants", () => {
       }),
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
-    const w = result[0].backgroundWords ?? [];
+    const w = bgWords(result[0]) ?? [];
     expect(w[0].begin).toBe(5.123);
     expect(w[0].end).toBe(5.617);
     expect(w[1].begin).toBe(5.617);
@@ -1881,7 +1883,7 @@ describe("preserveBrackets: word-synced invariants", () => {
       }),
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
-    expect(result[0].backgroundText).toBe("(ooh yeah)");
+    expect(bgText(result[0])).toBe("(ooh yeah)");
   });
 
   it("does not introduce parens in the main line text", () => {
@@ -1894,6 +1896,6 @@ describe("preserveBrackets: word-synced invariants", () => {
       }),
     ];
     const result = extractBackgroundVocals(lines, { mergeStandaloneLines: true, preserveBrackets: true });
-    expect(result[0].text).toBe("Real line");
+    expect(lineText(result[0])).toBe("Real line");
   });
 });

--- a/src/utils/background-vocal-extraction.test.ts
+++ b/src/utils/background-vocal-extraction.test.ts
@@ -430,7 +430,10 @@ describe("extractInlineFromLine", () => {
     expect(result).not.toBe(line);
     expect(lineText(result)).toBe("Hi there");
     expect(bgText(result)).toBe("ooh");
-    expect(bgWords(result)).toBeUndefined();
+    // The funnel now resolves the background to word-synced at creation against
+    // the word-synced survivors (main bounds [0,3], second half [1.5,3]),
+    // folding in what the former sync-panel effect did lazily.
+    expect(bgWords(result)).toEqual([{ text: "ooh", begin: 1.5, end: 3 }]);
     expect(mainWords(result)).toEqual([
       { text: "Hi ", begin: 0, end: 1 },
       { text: "there", begin: 2, end: 3 },
@@ -504,7 +507,10 @@ describe("extractInlineFromLine: word-synced extraction", () => {
     expect(result).not.toBe(line);
     expect(lineText(result)).toBe("Hello world");
     expect(bgText(result)).toBe("ooh");
-    expect(bgWords(result)).toBeUndefined();
+    // The funnel now resolves the background to word-synced at creation against
+    // the word-synced survivors (main bounds [0.5,2.7], second half [1.6,2.7]),
+    // folding in what the former sync-panel effect did lazily.
+    expect(bgWords(result)).toEqual([{ text: "ooh", begin: 1.6, end: 2.7 }]);
     expect(mainWords(result)).toEqual([
       { text: "Hello ", begin: 0.5, end: 1.2 },
       { text: "world", begin: 1.9, end: 2.7 },

--- a/src/utils/background-vocal-extraction.test.ts
+++ b/src/utils/background-vocal-extraction.test.ts
@@ -1087,8 +1087,8 @@ describe("re-paste doubling", () => {
   it("does not double background text when a standalone line is re-merged", () => {
     const first = extractBackgroundVocals(
       [
-        { id: "a", text: "hello", agentId: "v1" },
-        { id: "b", text: "(ooh)", agentId: "v1" },
+        reconcileLine({ id: "a", text: "hello", agentId: "v1" }),
+        reconcileLine({ id: "b", text: "(ooh)", agentId: "v1" }),
       ],
       { mergeStandaloneLines: true, preserveBrackets: false },
     );
@@ -1096,7 +1096,7 @@ describe("re-paste doubling", () => {
     expect(bgText(first[0])).toBe("ooh");
     expect(bgSource(first[0])).toBe("extraction");
 
-    const second = extractBackgroundVocals([first[0], { id: "b", text: "(ooh)", agentId: "v1" }], {
+    const second = extractBackgroundVocals([first[0], reconcileLine({ id: "b", text: "(ooh)", agentId: "v1" })], {
       mergeStandaloneLines: true,
       preserveBrackets: false,
     });
@@ -1107,8 +1107,14 @@ describe("re-paste doubling", () => {
   it("keeps manually entered background when a standalone line merges in", () => {
     const merged = extractBackgroundVocals(
       [
-        { id: "a", text: "hello", agentId: "v1", backgroundText: "clap", backgroundTextSource: "manual" },
-        { id: "b", text: "(ooh)", agentId: "v1" },
+        reconcileLine({
+          id: "a",
+          text: "hello",
+          agentId: "v1",
+          backgroundText: "clap",
+          backgroundTextSource: "manual",
+        }),
+        reconcileLine({ id: "b", text: "(ooh)", agentId: "v1" }),
       ],
       { mergeStandaloneLines: true, preserveBrackets: false },
     );

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -4,7 +4,9 @@ import { isLinked } from "@/domain/instance/predicates";
 import type { LyricLine } from "@/domain/line/model";
 import { reconcileLine } from "@/domain/line/model";
 import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
+import { mainBounds } from "@/domain/line/bounds";
 import { reconstructLineText, wordContentSpans } from "@/domain/line/reconstruct-text";
+import { bgSource, bgText as bgTextField, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { remapWordTextsPreservingTiming } from "@/domain/word/remap-text";
 import type { WordTiming } from "@/domain/word/timing";
 import { bracketWordList, joinBracketedCarriedWords } from "@/utils/background-vocal-brackets";
@@ -105,11 +107,12 @@ function classifyLine(text: string): LineClassification {
 // -- Extraction ---------------------------------------------------------------
 
 function extractInlineWordSynced(line: LyricLine, classified: LineClassification, options: ExtractOptions): LyricLine {
-  const words = line.words;
+  const words = mainWords(line);
   if (!words || words.length === 0) return line;
-  if (line.backgroundWords && line.backgroundWords.length > 0) return line;
+  const existingBgWords = bgWords(line);
+  if (existingBgWords && existingBgWords.length > 0) return line;
   const splitChar = getSplitCharacter();
-  if (reconstructLineText(words, splitChar) !== line.text) return line;
+  if (reconstructLineText(words, splitChar) !== lineText(line)) return line;
   const spans = wordContentSpans(words, splitChar);
   const survivors: WordTiming[] = [];
   for (let i = 0; i < words.length; i++) {
@@ -130,7 +133,7 @@ function extractInlineWordSynced(line: LyricLine, classified: LineClassification
   const trimmedSurvivors = survivors.map((word, i) =>
     i === survivors.length - 1 ? { ...word, text: word.text.replace(/ +$/, "") } : word,
   );
-  const base = line.backgroundTextSource === "extraction" ? undefined : line.backgroundText;
+  const base = bgSource(line) === "extraction" ? undefined : bgTextField(line);
   return applyBackground(
     reconcileLine({
       ...line,
@@ -145,11 +148,12 @@ function extractInlineWordSynced(line: LyricLine, classified: LineClassification
 }
 
 function extractInlineFromLine(line: LyricLine, options: ExtractOptions): LyricLine {
-  const classified = classifyLine(line.text);
+  const classified = classifyLine(lineText(line));
   if (classified.kind !== "inline") return line;
   if (isWordSynced(line)) return extractInlineWordSynced(line, classified, options);
-  if (line.backgroundWords && line.backgroundWords.length > 0) return line;
-  const base = line.backgroundTextSource === "extraction" ? undefined : line.backgroundText;
+  const existingBgWords = bgWords(line);
+  if (existingBgWords && existingBgWords.length > 0) return line;
+  const base = bgSource(line) === "extraction" ? undefined : bgTextField(line);
   return applyBackground(
     { ...line, text: classified.mainText },
     {
@@ -162,12 +166,13 @@ function extractInlineFromLine(line: LyricLine, options: ExtractOptions): LyricL
 // -- Whole-list transform -----------------------------------------------------
 
 function carriedBackgroundWords(standalone: LyricLine, bgText: string, preserveBrackets: boolean): WordTiming[] | null {
-  const words = standalone.words;
+  const words = mainWords(standalone);
   let carry: WordTiming[] | null;
+  const standaloneBounds = mainBounds(standalone);
   if (words && words.length > 0) {
     carry = remapWordTextsPreservingTiming(words, bgText);
-  } else if (isLineSynced(standalone)) {
-    carry = createInitialBgWords(bgText, standalone.begin, standalone.end);
+  } else if (isLineSynced(standalone) && standaloneBounds) {
+    carry = createInitialBgWords(bgText, standaloneBounds.begin, standaloneBounds.end);
   } else {
     carry = null;
   }
@@ -187,10 +192,10 @@ function mergeStandaloneInto(
   // prior pass, so the standalone line replaces it. Manual background is kept.
   // Extraction-sourced background produced earlier in this same pass (an
   // already-merged standalone) is fresh, so further standalones append to it.
-  const prevIsExtraction = prev.backgroundTextSource === "extraction";
+  const prevIsExtraction = bgSource(prev) === "extraction";
   const prevIsStaleExtraction = prevIsExtraction && !prevTrailingBracketFromSamePass;
-  const baseText = prevIsStaleExtraction ? undefined : prev.backgroundText;
-  const baseWords = prevIsStaleExtraction ? undefined : prev.backgroundWords;
+  const baseText = prevIsStaleExtraction ? undefined : bgTextField(prev);
+  const baseWords = prevIsStaleExtraction ? undefined : bgWords(prev);
   const carried = carriedBackgroundWords(standalone, bgText, options.preserveBrackets);
 
   // Source for a result that keeps the prev base: a surviving extraction base
@@ -232,7 +237,7 @@ function extractBackgroundVocals(lines: LyricLine[], options: ExtractOptions): L
   const result: LyricLine[] = [];
   const sameSessionWriteIndices = new Set<number>();
   for (const line of lines) {
-    const classified = classifyLine(line.text);
+    const classified = classifyLine(lineText(line));
     if (classified.kind === "inline") {
       const extracted = extractInlineFromLine(line, options);
       result.push(extracted);
@@ -244,8 +249,8 @@ function extractBackgroundVocals(lines: LyricLine[], options: ExtractOptions): L
       const prev = result[prevIndex];
       if (
         prev &&
-        prev.text.trim().length > 0 &&
-        classifyLine(prev.text).kind === "none" &&
+        lineText(prev).trim().length > 0 &&
+        classifyLine(lineText(prev)).kind === "none" &&
         !isLinked(prev) &&
         !isLinked(line)
       ) {
@@ -269,7 +274,7 @@ function extractBackgroundVocals(lines: LyricLine[], options: ExtractOptions): L
 }
 
 function lineHasInlineParens(line: LyricLine): boolean {
-  return classifyLine(line.text).kind === "inline";
+  return classifyLine(lineText(line)).kind === "inline";
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -1,8 +1,8 @@
 import { applyBackground } from "@/domain/line/background";
-import type { BackgroundSource } from "@/domain/line/background";
 import { isLinked } from "@/domain/instance/predicates";
 import type { LyricLine } from "@/domain/line/model";
-import { reconcileLine } from "@/domain/line/model";
+import { reconcileLine, toFlat } from "@/domain/line/model";
+import type { BackgroundSource } from "@/domain/voice/model";
 import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
 import { mainBounds } from "@/domain/line/bounds";
 import { reconstructLineText, wordContentSpans } from "@/domain/line/reconstruct-text";
@@ -136,7 +136,7 @@ function extractInlineWordSynced(line: LyricLine, classified: LineClassification
   const base = bgSource(line) === "extraction" ? undefined : bgTextField(line);
   return applyBackground(
     reconcileLine({
-      ...line,
+      ...toFlat(line),
       words: trimmedSurvivors,
       text: reconstructLineText(trimmedSurvivors, splitChar),
     }),
@@ -154,13 +154,10 @@ function extractInlineFromLine(line: LyricLine, options: ExtractOptions): LyricL
   const existingBgWords = bgWords(line);
   if (existingBgWords && existingBgWords.length > 0) return line;
   const base = bgSource(line) === "extraction" ? undefined : bgTextField(line);
-  return applyBackground(
-    { ...line, text: classified.mainText },
-    {
-      text: joinBackgroundText(base, classified.bgText, options.preserveBrackets, false),
-      source: base ? "manual" : "extraction",
-    },
-  );
+  return applyBackground(reconcileLine({ ...toFlat(line), text: classified.mainText }), {
+    text: joinBackgroundText(base, classified.bgText, options.preserveBrackets, false),
+    source: base ? "manual" : "extraction",
+  });
 }
 
 // -- Whole-list transform -----------------------------------------------------

--- a/src/utils/explicit-detection.test.ts
+++ b/src/utils/explicit-detection.test.ts
@@ -41,12 +41,12 @@ describe("findExplicitWords", () => {
   });
 
   it("detects a profanity in backgroundText with field='backgroundWords'", () => {
-    const line: LyricLine = {
+    const line: LyricLine = reconcileLine({
       id: "L1",
       text: "clean main",
       agentId: "v1",
       backgroundText: "oh shit",
-    };
+    });
     const result = findExplicitWords([line]);
     expect(result).toHaveLength(1);
     expect(result[0].field).toBe("backgroundWords");
@@ -164,7 +164,7 @@ describe("findExplicitWords · syllable-split words", () => {
 describe("findExplicitWords · linked instances", () => {
   function linkedChorusLines(): LyricLine[] {
     return [
-      {
+      reconcileLine({
         id: "C1",
         text: "I fuck you",
         agentId: "v1",
@@ -176,8 +176,8 @@ describe("findExplicitWords · linked instances", () => {
           { text: "fuck ", begin: 0.3, end: 0.6 },
           { text: "you", begin: 0.6, end: 1 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "C2",
         text: "I fuck you",
         agentId: "v1",
@@ -189,8 +189,8 @@ describe("findExplicitWords · linked instances", () => {
           { text: "fuck ", begin: 30.4, end: 30.7 },
           { text: "you", begin: 30.7, end: 31.2 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "C3",
         text: "I fuck you",
         agentId: "v1",
@@ -202,7 +202,7 @@ describe("findExplicitWords · linked instances", () => {
           { text: "fuck ", begin: 60.4, end: 60.7 },
           { text: "you", begin: 60.7, end: 61.2 },
         ],
-      },
+      }),
     ];
   }
 

--- a/src/utils/explicit-detection.ts
+++ b/src/utils/explicit-detection.ts
@@ -1,5 +1,7 @@
 import type { LinkGroup } from "@/domain/group/template";
 import type { LyricLine } from "@/domain/line/model";
+import { bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import type { WordTiming } from "@/domain/word/timing";
 import { splitIntoWordsWithMeta } from "@/utils/sync-helpers";
 import { englishDataset, englishRecommendedTransformers, RegExpMatcher } from "obscenity";
 
@@ -156,7 +158,7 @@ function scanField(
   }
 }
 
-function alreadyMarkedSet(words: LyricLine["words"] | undefined): Set<number> {
+function alreadyMarkedSet(words: WordTiming[] | undefined): Set<number> {
   const set = new Set<number>();
   if (!words) return set;
   for (let i = 0; i < words.length; i++) {
@@ -175,11 +177,13 @@ function findExplicitWords(lines: LyricLine[], groups: LinkGroup[] = []): Explic
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    if (line.text && line.text.trim().length > 0) {
-      scanField(line, i, "words", line.text, matcher, alreadyMarkedSet(line.words), raw);
+    const main = lineText(line);
+    if (main && main.trim().length > 0) {
+      scanField(line, i, "words", main, matcher, alreadyMarkedSet(mainWords(line)), raw);
     }
-    if (line.backgroundText && line.backgroundText.trim().length > 0) {
-      scanField(line, i, "backgroundWords", line.backgroundText, matcher, alreadyMarkedSet(line.backgroundWords), raw);
+    const background = bgText(line);
+    if (background && background.trim().length > 0) {
+      scanField(line, i, "backgroundWords", background, matcher, alreadyMarkedSet(bgWords(line)), raw);
     }
   }
 

--- a/src/utils/identical-word-matcher.ts
+++ b/src/utils/identical-word-matcher.ts
@@ -1,4 +1,5 @@
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 
 // -- Types --------------------------------------------------------------------
@@ -30,7 +31,7 @@ function normalizeText(text: string, caseInsensitive: boolean): string {
 function findSourceWord(lines: LyricLine[], source: IdenticalMatchSource): WordTiming | undefined {
   const sourceLine = lines.find((line) => line.id === source.lineId);
   if (!sourceLine) return undefined;
-  const track = source.type === "word" ? sourceLine.words : sourceLine.backgroundWords;
+  const track = source.type === "word" ? mainWords(sourceLine) : bgWords(sourceLine);
   return track?.[source.wordIndex];
 }
 
@@ -72,8 +73,8 @@ function findIdenticalWords(lines: LyricLine[], source: IdenticalMatchSource, op
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
     const line = lines[lineIndex];
     if (!line) continue;
-    collectTrackMatches(line, lineIndex, line.words, "word", source, options, targetText, minLength, matches);
-    collectTrackMatches(line, lineIndex, line.backgroundWords, "bg", source, options, targetText, minLength, matches);
+    collectTrackMatches(line, lineIndex, mainWords(line), "word", source, options, targetText, minLength, matches);
+    collectTrackMatches(line, lineIndex, bgWords(line), "bg", source, options, targetText, minLength, matches);
   }
   return matches;
 }

--- a/src/utils/lyrics-parsers.test.ts
+++ b/src/utils/lyrics-parsers.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { mainBounds } from "@/domain/line/bounds";
+import { isLineSynced } from "@/domain/line/predicates";
+import { lineText, mainWords } from "@/domain/line/voices";
 import { parseLyricsFile } from "@/utils/lyrics-parsers";
 
 describe("parseLyricsFile - plain LRC", () => {
@@ -10,16 +13,16 @@ describe("parseLyricsFile - plain LRC", () => {
     expect(result.hasTimingData).toBe(true);
     expect(result.lines).toHaveLength(2);
 
-    expect(result.lines[0].begin).toBeCloseTo(12.34, 2);
-    expect(result.lines[0].text).toBe("Hello world");
-    expect(result.lines[0].words).toBeUndefined();
-    expect(result.lines[0].end).toBeCloseTo(15.67, 2);
+    expect(mainBounds(result.lines[0])?.begin).toBeCloseTo(12.34, 2);
+    expect(lineText(result.lines[0])).toBe("Hello world");
+    expect(mainWords(result.lines[0])).toBeUndefined();
+    expect(mainBounds(result.lines[0])?.end).toBeCloseTo(15.67, 2);
 
     // The last line has no following line and no [length:] tag, so its end is
     // unknown: it parses as an untimed line rather than a begin-only line.
-    expect(result.lines[1].begin).toBeUndefined();
-    expect(result.lines[1].text).toBe("Next line");
-    expect(result.lines[1].words).toBeUndefined();
+    expect(mainBounds(result.lines[1])?.begin).toBeUndefined();
+    expect(lineText(result.lines[1])).toBe("Next line");
+    expect(mainWords(result.lines[1])).toBeUndefined();
   });
 
   it("extends the last line to the [length:] tag when present", () => {
@@ -28,8 +31,8 @@ describe("parseLyricsFile - plain LRC", () => {
 [00:15.67]Next line`;
     const result = parseLyricsFile("song.lrc", content);
 
-    expect(result.lines[1].begin).toBeCloseTo(15.67, 2);
-    expect(result.lines[1].end).toBeCloseTo(20.0, 2);
+    expect(mainBounds(result.lines[1])?.begin).toBeCloseTo(15.67, 2);
+    expect(mainBounds(result.lines[1])?.end).toBeCloseTo(20.0, 2);
   });
 
   it("extends the last line to the caller-supplied audio duration when there is no [length:] tag", () => {
@@ -37,8 +40,8 @@ describe("parseLyricsFile - plain LRC", () => {
 [00:15.67]Next line`;
     const result = parseLyricsFile("song.lrc", content, 25);
 
-    expect(result.lines[1].begin).toBeCloseTo(15.67, 2);
-    expect(result.lines[1].end).toBeCloseTo(25.0, 2);
+    expect(mainBounds(result.lines[1])?.begin).toBeCloseTo(15.67, 2);
+    expect(mainBounds(result.lines[1])?.end).toBeCloseTo(25.0, 2);
   });
 
   it("extracts metadata tags", () => {
@@ -59,9 +62,9 @@ describe("parseLyricsFile - plain LRC", () => {
 [00:20.00]Verse line`;
     const result = parseLyricsFile("song.lrc", content);
 
-    const chorusLines = result.lines.filter((l) => l.text === "Chorus line");
+    const chorusLines = result.lines.filter((l) => lineText(l) === "Chorus line");
     expect(chorusLines).toHaveLength(2);
-    expect(chorusLines.map((l) => l.begin).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([10, 30]);
+    expect(chorusLines.map((l) => mainBounds(l)?.begin).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([10, 30]);
   });
 });
 
@@ -74,19 +77,18 @@ describe("parseLyricsFile - enhanced LRC (eLRC)", () => {
     expect(result.lines).toHaveLength(2);
 
     const line1 = result.lines[0];
-    expect(line1.words).toBeDefined();
-    expect(line1.words).toHaveLength(2);
-    expect(line1.words?.[0].text).toBe("Hello ");
-    expect(line1.words?.[0].begin).toBeCloseTo(12.0, 2);
-    expect(line1.words?.[0].end).toBeCloseTo(12.5, 2);
-    expect(line1.words?.[1].text).toBe("world");
-    expect(line1.words?.[1].begin).toBeCloseTo(12.5, 2);
-    expect(line1.words?.[1].end).toBeCloseTo(15.0, 2);
+    expect(mainWords(line1)).toBeDefined();
+    expect(mainWords(line1)).toHaveLength(2);
+    expect(mainWords(line1)?.[0].text).toBe("Hello ");
+    expect(mainWords(line1)?.[0].begin).toBeCloseTo(12.0, 2);
+    expect(mainWords(line1)?.[0].end).toBeCloseTo(12.5, 2);
+    expect(mainWords(line1)?.[1].text).toBe("world");
+    expect(mainWords(line1)?.[1].begin).toBeCloseTo(12.5, 2);
+    expect(mainWords(line1)?.[1].end).toBeCloseTo(15.0, 2);
 
     // A word-synced line carries its timing in `words`, not at line level.
-    expect(line1.begin).toBeUndefined();
-    expect(line1.end).toBeUndefined();
-    expect(line1.text).toBe("Hello world");
+    expect(isLineSynced(line1)).toBe(false);
+    expect(lineText(line1)).toBe("Hello world");
   });
 
   it("uses a trailing sentinel tag as the last word's end", () => {
@@ -95,8 +97,8 @@ describe("parseLyricsFile - enhanced LRC (eLRC)", () => {
     const result = parseLyricsFile("song.lrc", content);
 
     expect(result.lines).toHaveLength(2);
-    expect(result.lines[0].words?.[1].end).toBeCloseTo(13.0, 2);
-    expect(result.lines[1].words?.[1].end).toBeCloseTo(16.0, 2);
+    expect(mainWords(result.lines[0])?.[1].end).toBeCloseTo(13.0, 2);
+    expect(mainWords(result.lines[1])?.[1].end).toBeCloseTo(16.0, 2);
   });
 
   it("preserves metadata tags alongside word timing", () => {
@@ -108,26 +110,26 @@ describe("parseLyricsFile - enhanced LRC (eLRC)", () => {
     expect(result.metadata.title).toBe("eLRC Test");
     expect(result.metadata.artist).toBe("Artist");
     expect(result.lines).toHaveLength(1);
-    expect(result.lines[0].words).toHaveLength(2);
+    expect(mainWords(result.lines[0])).toHaveLength(2);
   });
 
   it("uses the line timestamp as the first word's begin when no leading inline tag is present", () => {
     const content = "[00:12.00]Hello <00:12.50>world<00:13.00>";
     const result = parseLyricsFile("song.lrc", content);
 
-    expect(result.lines[0].words).toHaveLength(2);
-    expect(result.lines[0].words?.[0].text).toBe("Hello ");
-    expect(result.lines[0].words?.[0].begin).toBeCloseTo(12.0, 2);
-    expect(result.lines[0].words?.[0].end).toBeCloseTo(12.5, 2);
-    expect(result.lines[0].words?.[1].end).toBeCloseTo(13.0, 2);
+    expect(mainWords(result.lines[0])).toHaveLength(2);
+    expect(mainWords(result.lines[0])?.[0].text).toBe("Hello ");
+    expect(mainWords(result.lines[0])?.[0].begin).toBeCloseTo(12.0, 2);
+    expect(mainWords(result.lines[0])?.[0].end).toBeCloseTo(12.5, 2);
+    expect(mainWords(result.lines[0])?.[1].end).toBeCloseTo(13.0, 2);
   });
 
   it("rebuilds line text from word texts so no inline tags leak into display", () => {
     const content = "[00:12.00]<00:12.00>Hello <00:12.50>beautiful <00:13.00>world<00:13.50>";
     const result = parseLyricsFile("song.lrc", content);
 
-    expect(result.lines[0].text).toBe("Hello beautiful world");
-    expect(result.lines[0].words?.map((w) => w.text).join("")).toBe("Hello beautiful world");
+    expect(lineText(result.lines[0])).toBe("Hello beautiful world");
+    expect(mainWords(result.lines[0])?.map((w) => w.text).join("")).toBe("Hello beautiful world");
   });
 
   it("falls back to line-level timing and strips inline tags when a line has multiple line timestamps", () => {
@@ -135,12 +137,12 @@ describe("parseLyricsFile - enhanced LRC (eLRC)", () => {
 [00:20.00]Middle`;
     const result = parseLyricsFile("song.lrc", content);
 
-    const chorusLines = result.lines.filter((l) => l.text === "Hello world");
+    const chorusLines = result.lines.filter((l) => lineText(l) === "Hello world");
     expect(chorusLines).toHaveLength(2);
     for (const line of chorusLines) {
-      expect(line.words).toBeUndefined();
+      expect(mainWords(line)).toBeUndefined();
     }
-    expect(chorusLines.some((l) => l.text.includes("<"))).toBe(false);
+    expect(chorusLines.some((l) => lineText(l).includes("<"))).toBe(false);
   });
 });
 
@@ -160,7 +162,7 @@ describe("parseLyricsFile - TTML syllable-group inference", () => {
     const result = parseLyricsFile("song.ttml", content);
 
     expect(result.lines).toHaveLength(1);
-    const words = result.lines[0].words;
+    const words = mainWords(result.lines[0]);
     expect(words).toBeDefined();
     if (!words) return;
     expect(words.map((w) => w.text.trimEnd())).toEqual(["hello", "ev", "er", "y", "world"]);
@@ -185,7 +187,7 @@ describe("parseLyricsFile - TTML syllable-group inference", () => {
 </tt>`;
     const result = parseLyricsFile("song.ttml", content);
 
-    const words = result.lines[0].words;
+    const words = mainWords(result.lines[0]);
     expect(words).toBeDefined();
     if (!words) return;
     expect(words.every((w) => w.syllableGroupId === undefined)).toBe(true);
@@ -204,10 +206,10 @@ Second subtitle line`;
     const result = parseLyricsFile("song.srt", content);
 
     expect(result.lines).toHaveLength(2);
-    expect(result.lines[0].begin).toBeCloseTo(10.0, 2);
-    expect(result.lines[0].end).toBeCloseTo(12.5, 2);
-    expect(result.lines[0].text).toBe("First subtitle line");
-    expect(result.lines[1].begin).toBeCloseTo(13.0, 2);
-    expect(result.lines[1].end).toBeCloseTo(15.5, 2);
+    expect(mainBounds(result.lines[0])?.begin).toBeCloseTo(10.0, 2);
+    expect(mainBounds(result.lines[0])?.end).toBeCloseTo(12.5, 2);
+    expect(lineText(result.lines[0])).toBe("First subtitle line");
+    expect(mainBounds(result.lines[1])?.begin).toBeCloseTo(13.0, 2);
+    expect(mainBounds(result.lines[1])?.end).toBeCloseTo(15.5, 2);
   });
 });

--- a/src/utils/lyrics-parsers.test.ts
+++ b/src/utils/lyrics-parsers.test.ts
@@ -129,7 +129,11 @@ describe("parseLyricsFile - enhanced LRC (eLRC)", () => {
     const result = parseLyricsFile("song.lrc", content);
 
     expect(lineText(result.lines[0])).toBe("Hello beautiful world");
-    expect(mainWords(result.lines[0])?.map((w) => w.text).join("")).toBe("Hello beautiful world");
+    expect(
+      mainWords(result.lines[0])
+        ?.map((w) => w.text)
+        .join(""),
+    ).toBe("Hello beautiful world");
   });
 
   it("falls back to line-level timing and strips inline tags when a line has multiple line timestamps", () => {

--- a/src/utils/lyrics-parsers.ttml.test.ts
+++ b/src/utils/lyrics-parsers.ttml.test.ts
@@ -1,6 +1,14 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { bgBounds, mainBounds } from "@/domain/line/bounds";
+import { bgSource, bgText, bgVoice, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { isLineSynced, isWordSynced } from "@/domain/voice/predicates";
 import { parseLyricsFile } from "@/utils/lyrics-parsers";
+
+const FIXTURE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../test/fixtures/ttml");
+const ttmlFixture = (name: string) => readFileSync(resolve(FIXTURE_DIR, `${name}.ttml`), "utf-8");
 
 describe("parseLyricsFile - TTML with undeclared namespaces (AMLL)", () => {
   it("parses an AMLL export that uses <amll:meta> without declaring xmlns:amll", () => {
@@ -124,5 +132,132 @@ describe("parseLyricsFile - TTML background provenance", () => {
     const result = parseLyricsFile("song.ttml", content);
     expect(bgText(result.lines[0])).toBeUndefined();
     expect(bgSource(result.lines[0])).toBeUndefined();
+  });
+});
+
+describe("parseLyricsFile - TTML background granularity (A/B/C)", () => {
+  // Case A: x-bg with 2+ timed inner spans stays WORD-SYNCED verbatim. A
+  // multi-span authored background is never downgraded to line-synced.
+  describe("case A: word-synced x-bg (2+ timed spans)", () => {
+    it("keeps both lines' backgrounds word-synced verbatim", () => {
+      const result = parseLyricsFile("bg-word-synced.ttml", ttmlFixture("bg-word-synced"));
+      expect(result.lines).toHaveLength(2);
+
+      const [l1, l2] = result.lines;
+
+      const l1Bg = bgWords(l1)!;
+      expect(l1Bg).toBeDefined();
+      expect(l1Bg).toHaveLength(2);
+      expect(l1Bg[0].begin).toBeCloseTo(33.5, 3);
+      expect(l1Bg[0].end).toBeCloseTo(34.0, 3);
+      expect(l1Bg[1].begin).toBeCloseTo(34.0, 3);
+      expect(l1Bg[1].end).toBeCloseTo(34.5, 3);
+      expect(bgSource(l1)).toBe("manual");
+
+      const l2Bg = bgWords(l2)!;
+      expect(l2Bg).toBeDefined();
+      expect(l2Bg).toHaveLength(2);
+      expect(l2Bg[0].begin).toBeCloseTo(38.0, 3);
+      expect(l2Bg[0].end).toBeCloseTo(39.0, 3);
+      expect(l2Bg[1].begin).toBeCloseTo(39.0, 3);
+      expect(l2Bg[1].end).toBeCloseTo(40.0, 3);
+      expect(bgSource(l2)).toBe("manual");
+    });
+  });
+
+  // Case B (GitHub #122 regression anchor): x-bg with exactly ONE timed inner
+  // span is LINE-SYNCED, carrying that span's begin/end and text, NOT a
+  // one-element words array.
+  describe("case B: single-span x-bg is line-synced (#122 regression)", () => {
+    it("L1 single-span x-bg becomes a line-synced background", () => {
+      const result = parseLyricsFile("bg-line-synced.ttml", ttmlFixture("bg-line-synced"));
+      const l1 = result.lines[0];
+
+      expect(mainWords(l1)).toBeUndefined();
+      expect(bgWords(l1)).toBeUndefined();
+      expect(bgBounds(l1)).toEqual({ begin: 19, end: 21 });
+      expect(bgText(l1)).toBe("(ooh ooh)");
+      const voice = bgVoice(l1)!;
+      expect(voice).not.toBeNull();
+      expect(isLineSynced(voice)).toBe(true);
+      expect(bgSource(l1)).toBe("manual");
+    });
+
+    it("L2 single-span x-bg becomes a line-synced background", () => {
+      const result = parseLyricsFile("bg-line-synced.ttml", ttmlFixture("bg-line-synced"));
+      const l2 = result.lines[1];
+
+      expect(mainWords(l2)).toBeUndefined();
+      expect(bgWords(l2)).toBeUndefined();
+      expect(bgBounds(l2)).toEqual({ begin: 23, end: 24.5 });
+      expect(bgText(l2)).toBe("(yeah yeah)");
+      const voice = bgVoice(l2)!;
+      expect(voice).not.toBeNull();
+      expect(isLineSynced(voice)).toBe(true);
+      expect(bgSource(l2)).toBe("manual");
+    });
+  });
+
+  // Case C: x-bg with raw text and NO timed inner spans is untimed, then
+  // resolved against the main voice's granularity over its second half.
+  describe("case C: untimed x-bg text resolved against main", () => {
+    it("L1 untimed text over a word-synced main distributes over the second half", () => {
+      const result = parseLyricsFile("bg-untimed-text.ttml", ttmlFixture("bg-untimed-text"));
+      const l1 = result.lines[0];
+
+      const words = bgWords(l1)!;
+      expect(words).toBeDefined();
+      expect(words.length).toBeGreaterThan(0);
+      expect(words[0].begin).toBe(3);
+      expect(words[words.length - 1].end).toBe(5);
+      expect(bgText(l1)).toContain("ooh");
+      expect(bgText(l1)).toContain("yeah");
+      expect(bgSource(l1)).toBe("manual");
+    });
+
+    it("L2 untimed text over a line-synced main becomes line-synced over the second half", () => {
+      const result = parseLyricsFile("bg-untimed-text.ttml", ttmlFixture("bg-untimed-text"));
+      const l2 = result.lines[1];
+
+      expect(mainBounds(l2)).toEqual({ begin: 6, end: 10 });
+      expect(bgWords(l2)).toBeUndefined();
+      expect(bgBounds(l2)).toEqual({ begin: 8, end: 10 });
+      expect(bgText(l2)).toBe("(backing)");
+      expect(bgSource(l2)).toBe("manual");
+    });
+  });
+
+  // Mixed: authored granularity round-trips with no "correction". A line-synced
+  // bg over a word-synced main stays line-synced; a word-synced bg over a
+  // line-synced main stays word-synced.
+  describe("mixed granularity: no correction on import", () => {
+    it("L1 single-span line-synced bg stays line-synced even though main is word-synced", () => {
+      const result = parseLyricsFile("bg-mixed-granularity.ttml", ttmlFixture("bg-mixed-granularity"));
+      const l1 = result.lines[0];
+
+      expect(mainWords(l1)).toBeDefined();
+      expect(mainWords(l1)).toHaveLength(2);
+      expect(bgWords(l1)).toBeUndefined();
+      expect(bgBounds(l1)).toEqual({ begin: 3.5, end: 4.5 });
+      expect(bgText(l1)).toBe("(ahh)");
+      expect(isLineSynced(bgVoice(l1)!)).toBe(true);
+      expect(bgSource(l1)).toBe("manual");
+    });
+
+    it("L2 two-span word-synced bg stays word-synced even though main is line-synced", () => {
+      const result = parseLyricsFile("bg-mixed-granularity.ttml", ttmlFixture("bg-mixed-granularity"));
+      const l2 = result.lines[1];
+
+      expect(mainWords(l2)).toBeUndefined();
+      const words = bgWords(l2)!;
+      expect(words).toBeDefined();
+      expect(words).toHaveLength(2);
+      expect(words[0].begin).toBeCloseTo(7, 3);
+      expect(words[0].end).toBeCloseTo(8, 3);
+      expect(words[1].begin).toBeCloseTo(8, 3);
+      expect(words[1].end).toBeCloseTo(9, 3);
+      expect(isWordSynced(bgVoice(l2)!)).toBe(true);
+      expect(bgSource(l2)).toBe("manual");
+    });
   });
 });

--- a/src/utils/lyrics-parsers.ttml.test.ts
+++ b/src/utils/lyrics-parsers.ttml.test.ts
@@ -146,21 +146,26 @@ describe("parseLyricsFile - TTML background granularity (A/B/C)", () => {
       const [l1, l2] = result.lines;
 
       const l1Bg = bgWords(l1)!;
-      expect(l1Bg).toBeDefined();
       expect(l1Bg).toHaveLength(2);
       expect(l1Bg[0].begin).toBeCloseTo(33.5, 3);
       expect(l1Bg[0].end).toBeCloseTo(34.0, 3);
       expect(l1Bg[1].begin).toBeCloseTo(34.0, 3);
       expect(l1Bg[1].end).toBeCloseTo(34.5, 3);
+      // bounds come from the inner words, not the x-bg container's own begin/end
+      expect(bgBounds(l1)).toEqual({ begin: 33.5, end: 34.5 });
+      expect(bgText(l1)).toBe(l1Bg.map((w) => w.text).join(""));
+      expect(bgText(l1)).toBe("(ooh yeah) ");
       expect(bgSource(l1)).toBe("manual");
 
       const l2Bg = bgWords(l2)!;
-      expect(l2Bg).toBeDefined();
       expect(l2Bg).toHaveLength(2);
       expect(l2Bg[0].begin).toBeCloseTo(38.0, 3);
       expect(l2Bg[0].end).toBeCloseTo(39.0, 3);
       expect(l2Bg[1].begin).toBeCloseTo(39.0, 3);
       expect(l2Bg[1].end).toBeCloseTo(40.0, 3);
+      expect(bgBounds(l2)).toEqual({ begin: 38, end: 40 });
+      expect(bgText(l2)).toBe(l2Bg.map((w) => w.text).join(""));
+      expect(bgText(l2)).toBe("(burn it) ");
       expect(bgSource(l2)).toBe("manual");
     });
   });
@@ -206,7 +211,6 @@ describe("parseLyricsFile - TTML background granularity (A/B/C)", () => {
       const l1 = result.lines[0];
 
       const words = bgWords(l1)!;
-      expect(words).toBeDefined();
       expect(words.length).toBeGreaterThan(0);
       expect(words[0].begin).toBe(3);
       expect(words[words.length - 1].end).toBe(5);
@@ -250,7 +254,6 @@ describe("parseLyricsFile - TTML background granularity (A/B/C)", () => {
 
       expect(mainWords(l2)).toBeUndefined();
       const words = bgWords(l2)!;
-      expect(words).toBeDefined();
       expect(words).toHaveLength(2);
       expect(words[0].begin).toBeCloseTo(7, 3);
       expect(words[0].end).toBeCloseTo(8, 3);

--- a/src/utils/lyrics-parsers.ttml.test.ts
+++ b/src/utils/lyrics-parsers.ttml.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { parseLyricsFile } from "@/utils/lyrics-parsers";
 
 describe("parseLyricsFile - TTML with undeclared namespaces (AMLL)", () => {
@@ -10,13 +11,13 @@ describe("parseLyricsFile - TTML with undeclared namespaces (AMLL)", () => {
     expect(result.hasTimingData).toBe(true);
 
     const firstLine = result.lines[0];
-    expect(firstLine.words).toBeDefined();
-    expect(firstLine.words?.length).toBe(7);
-    expect(firstLine.words?.[0].text).toBe("Hell ");
-    expect(firstLine.words?.[0].begin).toBeCloseTo(1.277, 3);
-    expect(firstLine.words?.[6].text).toBe("man");
-    expect(firstLine.words?.[6].end).toBeCloseTo(2.621, 3);
-    expect(firstLine.text).toBe("Hell no, I can't be your man");
+    expect(mainWords(firstLine)).toBeDefined();
+    expect(mainWords(firstLine)?.length).toBe(7);
+    expect(mainWords(firstLine)?.[0].text).toBe("Hell ");
+    expect(mainWords(firstLine)?.[0].begin).toBeCloseTo(1.277, 3);
+    expect(mainWords(firstLine)?.[6].text).toBe("man");
+    expect(mainWords(firstLine)?.[6].end).toBeCloseTo(2.621, 3);
+    expect(lineText(firstLine)).toBe("Hell no, I can't be your man");
   });
 
   it("does not leak <amll:meta> content into lyrics text", () => {
@@ -24,9 +25,9 @@ describe("parseLyricsFile - TTML with undeclared namespaces (AMLL)", () => {
     const result = parseLyricsFile("song.ttml", content);
 
     expect(result.lines).toHaveLength(1);
-    expect(result.lines[0].text).toBe("Hello");
-    expect(result.lines[0].text).not.toContain("LEAKED_TITLE");
-    expect(result.lines[0].text).not.toContain("LEAKED_ARTIST");
+    expect(lineText(result.lines[0])).toBe("Hello");
+    expect(lineText(result.lines[0])).not.toContain("LEAKED_TITLE");
+    expect(lineText(result.lines[0])).not.toContain("LEAKED_ARTIST");
   });
 
   it("parses well-formed TTML identically (regression guard)", () => {
@@ -34,10 +35,10 @@ describe("parseLyricsFile - TTML with undeclared namespaces (AMLL)", () => {
     const result = parseLyricsFile("song.ttml", content);
 
     expect(result.lines).toHaveLength(1);
-    expect(result.lines[0].text).toBe("Hello world");
-    expect(result.lines[0].words).toHaveLength(2);
-    expect(result.lines[0].words?.[0].begin).toBeCloseTo(1.0, 3);
-    expect(result.lines[0].words?.[1].end).toBeCloseTo(2.0, 3);
+    expect(lineText(result.lines[0])).toBe("Hello world");
+    expect(mainWords(result.lines[0])).toHaveLength(2);
+    expect(mainWords(result.lines[0])?.[0].begin).toBeCloseTo(1.0, 3);
+    expect(mainWords(result.lines[0])?.[1].end).toBeCloseTo(2.0, 3);
   });
 
   it("tolerates an undeclared prefix used only in an attribute", () => {
@@ -45,7 +46,7 @@ describe("parseLyricsFile - TTML with undeclared namespaces (AMLL)", () => {
     const result = parseLyricsFile("song.ttml", content);
 
     expect(result.lines).toHaveLength(1);
-    expect(result.lines[0].text).toBe("Hello");
+    expect(lineText(result.lines[0])).toBe("Hello");
   });
 });
 
@@ -53,7 +54,7 @@ describe("parseLyricsFile - TTML word explicit attribute", () => {
   it('recognizes amll:obscene="true" on a word span', () => {
     const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:44.055" end="00:45.861" ttm:agent="v1"><span begin="00:44.055" end="00:44.192">Bot</span> <span begin="00:44.192" end="00:44.370">tom</span> <span begin="00:44.370" end="00:44.601">lip</span> <span begin="00:44.601" end="00:44.832" amll:obscene="true">curlin'</span></p></div></body></tt>`;
     const result = parseLyricsFile("song.ttml", content);
-    const words = result.lines[0].words!;
+    const words = mainWords(result.lines[0])!;
     expect(words[0].explicit).toBeUndefined();
     expect(words[3].text).toBe("curlin'");
     expect(words[3].explicit).toBe(true);
@@ -62,7 +63,7 @@ describe("parseLyricsFile - TTML word explicit attribute", () => {
   it('recognizes composer:explicit="true" on a word span', () => {
     const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:composer="https://composer.boidu.dev/ttml"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:02.000" ttm:agent="v1"><span begin="00:01.000" end="00:01.500">clean</span> <span begin="00:01.500" end="00:02.000" composer:explicit="true">dirty</span></p></div></body></tt>`;
     const result = parseLyricsFile("song.ttml", content);
-    const words = result.lines[0].words!;
+    const words = mainWords(result.lines[0])!;
     expect(words[0].explicit).toBeUndefined();
     expect(words[1].explicit).toBe(true);
   });
@@ -70,13 +71,13 @@ describe("parseLyricsFile - TTML word explicit attribute", () => {
   it("recognizes an unprefixed obscene attribute", () => {
     const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:02.000" ttm:agent="v1"><span begin="00:01.000" end="00:02.000" obscene="1">dirty</span></p></div></body></tt>`;
     const result = parseLyricsFile("song.ttml", content);
-    expect(result.lines[0].words![0].explicit).toBe(true);
+    expect(mainWords(result.lines[0])![0].explicit).toBe(true);
   });
 
   it('treats explicit="false" / "0" as not explicit', () => {
     const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:composer="https://composer.boidu.dev/ttml"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:02.000" ttm:agent="v1"><span begin="00:01.000" end="00:01.500" composer:explicit="false">clean</span> <span begin="00:01.500" end="00:02.000" composer:explicit="0">also</span></p></div></body></tt>`;
     const result = parseLyricsFile("song.ttml", content);
-    const words = result.lines[0].words!;
+    const words = mainWords(result.lines[0])!;
     expect(words[0].explicit).toBeUndefined();
     expect(words[1].explicit).toBeUndefined();
   });
@@ -85,11 +86,11 @@ describe("parseLyricsFile - TTML word explicit attribute", () => {
     const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:composer="https://composer.boidu.dev/ttml"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:02.500" ttm:agent="v1"><span begin="00:01.000" end="00:02.000">main</span><span ttm:role="x-bg"><span begin="00:02.000" end="00:02.250">oh</span> <span begin="00:02.250" end="00:02.500" composer:explicit="true">shit</span></span></p></div></body></tt>`;
     const result = parseLyricsFile("song.ttml", content);
     const line = result.lines[0];
-    expect(line.words![0].explicit).toBeUndefined();
-    expect(line.backgroundWords).toBeDefined();
-    expect(line.backgroundWords![0].explicit).toBeUndefined();
-    expect(line.backgroundWords![1].text).toContain("shit");
-    expect(line.backgroundWords![1].explicit).toBe(true);
+    expect(mainWords(line)![0].explicit).toBeUndefined();
+    expect(bgWords(line)).toBeDefined();
+    expect(bgWords(line)![0].explicit).toBeUndefined();
+    expect(bgWords(line)![1].text).toContain("shit");
+    expect(bgWords(line)![1].explicit).toBe(true);
   });
 });
 
@@ -98,30 +99,30 @@ describe("parseLyricsFile - TTML background provenance", () => {
     const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:02.500" ttm:agent="v1"><span begin="00:01.000" end="00:02.000">main</span><span ttm:role="x-bg"><span begin="00:02.000" end="00:02.250">oh</span> <span begin="00:02.250" end="00:02.500">yeah</span></span></p></div></body></tt>`;
     const result = parseLyricsFile("song.ttml", content);
     const line = result.lines[0];
-    expect(line.backgroundWords).toBeDefined();
-    expect(line.backgroundTextSource).toBe("manual");
+    expect(bgWords(line)).toBeDefined();
+    expect(bgSource(line)).toBe("manual");
   });
 
   it("stamps backgroundTextSource as manual on a line-synced line with x-bg text", () => {
     const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:03.000" ttm:agent="v1">main line<span ttm:role="x-bg">backing vocal</span></p></div></body></tt>`;
     const result = parseLyricsFile("song.ttml", content);
     const line = result.lines[0];
-    expect(line.text).toBe("main line");
-    expect(line.backgroundText).toBe("backing vocal");
-    expect(line.backgroundTextSource).toBe("manual");
+    expect(lineText(line)).toBe("main line");
+    expect(bgText(line)).toBe("backing vocal");
+    expect(bgSource(line)).toBe("manual");
   });
 
   it("leaves backgroundTextSource undefined on a line with no x-bg content", () => {
     const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:02.000" ttm:agent="v1"><span begin="00:01.000" end="00:01.500">Hello</span> <span begin="00:01.500" end="00:02.000">world</span></p></div></body></tt>`;
     const result = parseLyricsFile("song.ttml", content);
-    expect(result.lines[0].backgroundText).toBeUndefined();
-    expect(result.lines[0].backgroundTextSource).toBeUndefined();
+    expect(bgText(result.lines[0])).toBeUndefined();
+    expect(bgSource(result.lines[0])).toBeUndefined();
   });
 
   it("leaves backgroundTextSource undefined on a line-synced line with no x-bg content", () => {
     const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:03.000" ttm:agent="v1">just a plain line</p></div></body></tt>`;
     const result = parseLyricsFile("song.ttml", content);
-    expect(result.lines[0].backgroundText).toBeUndefined();
-    expect(result.lines[0].backgroundTextSource).toBeUndefined();
+    expect(bgText(result.lines[0])).toBeUndefined();
+    expect(bgSource(result.lines[0])).toBeUndefined();
   });
 });

--- a/src/utils/lyrics-parsers/srt.ts
+++ b/src/utils/lyrics-parsers/srt.ts
@@ -1,4 +1,5 @@
 import type { LyricLine } from "@/domain/line/model";
+import { isLineSynced } from "@/domain/line/predicates";
 import { generateLineId, type ParseResult } from "@/utils/lyrics-parsers/shared";
 
 // -- Helpers ------------------------------------------------------------------
@@ -58,7 +59,7 @@ function parseSrt(content: string, _fallbackDuration?: number): ParseResult {
   return {
     lines,
     metadata: {},
-    hasTimingData: lines.some((l) => l.begin !== undefined),
+    hasTimingData: lines.some((l) => isLineSynced(l)),
   };
 }
 

--- a/src/utils/lyrics-parsers/srt.ts
+++ b/src/utils/lyrics-parsers/srt.ts
@@ -1,4 +1,4 @@
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/line/predicates";
 import { generateLineId, type ParseResult } from "@/utils/lyrics-parsers/shared";
 
@@ -46,13 +46,15 @@ function parseSrt(content: string, _fallbackDuration?: number): ParseResult {
       .trim();
 
     if (text) {
-      lines.push({
-        id: generateLineId(),
-        text,
-        agentId: "v1",
-        begin,
-        end,
-      });
+      lines.push(
+        reconcileLine({
+          id: generateLineId(),
+          text,
+          agentId: "v1",
+          begin,
+          end,
+        }),
+      );
     }
   }
 

--- a/src/utils/lyrics-parsers/ttml.ts
+++ b/src/utils/lyrics-parsers/ttml.ts
@@ -1,11 +1,11 @@
 import type { Agent, AgentType } from "@/domain/agent/model";
+import { applyBackground, setBackground } from "@/domain/line/background";
 import type { LinkGroup } from "@/domain/group/template";
 import { reconcileLine, type LyricLine } from "@/domain/line/model";
 import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
 import { reconstructLineText } from "@/domain/line/reconstruct-text";
 import type { ProjectMetadata } from "@/domain/project/metadata";
 import { inferSyllableGroupIds } from "@/domain/word/syllable-groups";
-import type { WordTiming } from "@/domain/word/timing";
 import { getSplitCharacter } from "@/utils/split-character";
 import { declareMissingNamespaces, extractTimedWords, parseTtmlTimestamp } from "@/utils/lyrics-parsers/ttml-helpers";
 import { generateLineId, type ParseResult } from "@/utils/lyrics-parsers/shared";
@@ -13,6 +13,62 @@ import { generateLineId, type ParseResult } from "@/utils/lyrics-parsers/shared"
 // -- Constants ----------------------------------------------------------------
 
 const COMPOSER_NS = "https://composer.boidu.dev/ttml";
+const TTM_METADATA_NS = "http://www.w3.org/ns/ttml#metadata";
+
+// -- Background -----------------------------------------------------------------
+
+function roleOf(el: Element): string | null {
+  return el.getAttribute("ttm:role") || el.getAttributeNS(TTM_METADATA_NS, "role");
+}
+
+function findBackgroundContainer(p: Element): Element | null {
+  for (const span of p.getElementsByTagName("span")) {
+    if (roleOf(span) === "x-bg") return span;
+  }
+  return null;
+}
+
+function extractMainText(p: Element): string {
+  let text = "";
+  for (const node of p.childNodes) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      text += node.textContent ?? "";
+    } else if (node.nodeType === Node.ELEMENT_NODE && roleOf(node as Element) !== "x-bg") {
+      text += (node as Element).textContent ?? "";
+    }
+  }
+  return text.trim();
+}
+
+// Imported x-bg is authored content, so the granularity it was authored at is
+// preserved verbatim rather than "corrected" against the main voice:
+//   2+ timed spans -> word-synced (applyBackground returns words verbatim)
+//   1 timed span   -> line-synced, carrying that span's begin/end and text
+//                     directly (setBackground bypasses the resolver, which
+//                     would wrongly distribute it over a word-synced main)
+//   no timed spans -> untimed raw text, resolved against the main voice
+// Source is stamped "manual" so a later re-paste of parenthesised lyrics does
+// not double it and the provenance stays coherent.
+function attachBackground(line: LyricLine, bgContainer: Element): LyricLine {
+  const bgWords = inferSyllableGroupIds(extractTimedWords(bgContainer, null));
+
+  if (bgWords.length >= 2) {
+    return applyBackground(line, {
+      words: bgWords,
+      text: reconstructLineText(bgWords, getSplitCharacter()),
+      source: "manual",
+    });
+  }
+
+  if (bgWords.length === 1) {
+    const span = bgWords[0];
+    return setBackground(line, { text: span.text, begin: span.begin, end: span.end, source: "manual" });
+  }
+
+  const rawText = bgContainer.textContent?.trim();
+  if (!rawText) return line;
+  return applyBackground(line, { text: rawText, source: "manual" });
+}
 
 // -- TTML Parser --------------------------------------------------------------
 
@@ -104,83 +160,36 @@ function parseTtml(content: string, _fallbackDuration?: number): ParseResult {
         }
       : {};
 
-    // Find background vocal container (x-bg role)
-    // Note: use getElementsByTagName for namespace compatibility
-    const allSpansInP = p.getElementsByTagName("span");
-    let bgContainer: Element | null = null;
-    for (const span of allSpansInP) {
-      const role = span.getAttribute("ttm:role") || span.getAttributeNS("http://www.w3.org/ns/ttml#metadata", "role");
-      if (role === "x-bg") {
-        bgContainer = span;
-        break;
-      }
-    }
-
-    let backgroundText: string | undefined;
-    let backgroundWords: WordTiming[] | undefined;
-
-    if (bgContainer) {
-      backgroundWords = inferSyllableGroupIds(extractTimedWords(bgContainer, null));
-      if (backgroundWords.length > 0) {
-        backgroundText = reconstructLineText(backgroundWords, getSplitCharacter());
-      } else {
-        backgroundText = bgContainer.textContent || undefined;
-      }
-    }
-
-    // Imported background is authored content (not auto-extracted by this app);
-    // stamp it manual so a later re-paste of parenthesised lyrics does not
-    // double it, and so the provenance triple stays coherent.
-    const backgroundTextSource: "manual" | undefined =
-      backgroundText || (backgroundWords && backgroundWords.length > 0) ? "manual" : undefined;
+    const bgContainer = findBackgroundContainer(p);
 
     // Check for word-level timing (span elements NOT inside x-bg)
     const words = inferSyllableGroupIds(extractTimedWords(p, bgContainer));
 
+    let baseLine: LyricLine | null = null;
     if (words.length > 0) {
-      lines.push(
-        reconcileLine({
-          id: generateLineId(),
-          text: reconstructLineText(words, getSplitCharacter()),
-          agentId,
-          words,
-          backgroundText,
-          backgroundWords,
-          backgroundTextSource,
-          ...groupFields,
-        }),
-      );
+      baseLine = reconcileLine({
+        id: generateLineId(),
+        text: reconstructLineText(words, getSplitCharacter()),
+        agentId,
+        words,
+        ...groupFields,
+      });
     } else {
-      // Line-level timing only - extract text without bg content
-      let text = "";
-      for (const node of p.childNodes) {
-        if (node.nodeType === Node.TEXT_NODE) {
-          text += node.textContent ?? "";
-        } else if (node.nodeType === Node.ELEMENT_NODE) {
-          const el = node as Element;
-          const role = el.getAttribute("ttm:role") || el.getAttributeNS("http://www.w3.org/ns/ttml#metadata", "role");
-          if (role !== "x-bg") {
-            text += el.textContent ?? "";
-          }
-        }
-      }
-      text = text.trim();
-
+      const text = extractMainText(p);
       if (text) {
-        lines.push(
-          reconcileLine({
-            id: generateLineId(),
-            text,
-            agentId,
-            begin: begin || undefined,
-            end: end || undefined,
-            backgroundText,
-            backgroundWords,
-            backgroundTextSource,
-            ...groupFields,
-          }),
-        );
+        baseLine = reconcileLine({
+          id: generateLineId(),
+          text,
+          agentId,
+          begin: begin || undefined,
+          end: end || undefined,
+          ...groupFields,
+        });
       }
+    }
+
+    if (baseLine) {
+      lines.push(bgContainer ? attachBackground(baseLine, bgContainer) : baseLine);
     }
   }
 

--- a/src/utils/lyrics-parsers/ttml.ts
+++ b/src/utils/lyrics-parsers/ttml.ts
@@ -1,6 +1,7 @@
 import type { Agent, AgentType } from "@/domain/agent/model";
 import type { LinkGroup } from "@/domain/group/template";
 import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
 import { reconstructLineText } from "@/domain/line/reconstruct-text";
 import type { ProjectMetadata } from "@/domain/project/metadata";
 import { inferSyllableGroupIds } from "@/domain/word/syllable-groups";
@@ -186,7 +187,7 @@ function parseTtml(content: string, _fallbackDuration?: number): ParseResult {
   return {
     lines,
     metadata,
-    hasTimingData: lines.some((l) => l.begin !== undefined || l.words?.length),
+    hasTimingData: lines.some((l) => isLineSynced(l) || isWordSynced(l)),
     agents: agents.length > 0 ? agents : undefined,
     groups: groups.length > 0 ? groups : undefined,
   };

--- a/src/utils/lyrics-parsers/txt.ts
+++ b/src/utils/lyrics-parsers/txt.ts
@@ -1,3 +1,4 @@
+import { reconcileLine } from "@/domain/line/model";
 import { cleanSplitCharacters, getSplitCharacter } from "@/utils/split-character";
 import { generateLineId, type ParseResult } from "@/utils/lyrics-parsers/shared";
 
@@ -9,11 +10,11 @@ function parseTxt(content: string, _fallbackDuration?: number): ParseResult {
     if (text.length === 0) return [];
     const displayText = text.includes(getSplitCharacter()) ? cleanSplitCharacters(text) : text;
     return [
-      {
+      reconcileLine({
         id: generateLineId(),
         text: displayText,
         agentId: "v1",
-      },
+      }),
     ];
   });
 

--- a/src/utils/lyrics-text.test.ts
+++ b/src/utils/lyrics-text.test.ts
@@ -1,7 +1,9 @@
 /**
  * @vitest-environment node
  */
-import type { LyricLine } from "@/domain/line/model";
+import { mainBounds } from "@/domain/line/bounds";
+import { type LyricLine, reconcileLine } from "@/domain/line/model";
+import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { describe, expect, it } from "vitest";
 import { extractBackgroundVocals } from "@/utils/background-vocal-extraction";
 import { textToLyricLines } from "./lyrics-text";
@@ -9,7 +11,7 @@ import { textToLyricLines } from "./lyrics-text";
 describe("textToLyricLines · group attrs preservation", () => {
   it("keeps groupId/instanceIdx/templateLineIdx on exact-text match", () => {
     const existing: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "I love you",
         agentId: "v1",
@@ -21,7 +23,7 @@ describe("textToLyricLines · group attrs preservation", () => {
           { text: "love ", begin: 0.3, end: 0.6 },
           { text: "you", begin: 0.6, end: 1 },
         ],
-      },
+      }),
     ];
     const result = textToLyricLines("I love you", "v1", existing);
     expect(result).toHaveLength(1);
@@ -33,7 +35,7 @@ describe("textToLyricLines · group attrs preservation", () => {
 
   it("keeps the same id and group attrs on a position-based typo fix", () => {
     const existing: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "I love you",
         agentId: "v1",
@@ -45,12 +47,12 @@ describe("textToLyricLines · group attrs preservation", () => {
           { text: "love ", begin: 0.3, end: 0.6 },
           { text: "you", begin: 0.6, end: 1 },
         ],
-      },
+      }),
     ];
     const result = textToLyricLines("I luv you", "v1", existing);
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("L1");
-    expect(result[0].text).toBe("I luv you");
+    expect(lineText(result[0])).toBe("I luv you");
     expect(result[0].groupId).toBe("g1");
     expect(result[0].instanceIdx).toBe(0);
     expect(result[0].templateLineIdx).toBe(0);
@@ -58,7 +60,7 @@ describe("textToLyricLines · group attrs preservation", () => {
 
   it("preserves the detached flag on a position-based typo fix", () => {
     const existing: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "I love you",
         agentId: "v1",
@@ -66,7 +68,7 @@ describe("textToLyricLines · group attrs preservation", () => {
         instanceIdx: 0,
         templateLineIdx: 0,
         detached: true,
-      },
+      }),
     ];
     const result = textToLyricLines("I luv you", "v1", existing);
     expect(result[0].detached).toBe(true);
@@ -74,28 +76,28 @@ describe("textToLyricLines · group attrs preservation", () => {
 
   it("clears words/begin/end on position-based typo fix (timing is invalid for new text)", () => {
     const existing: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "I love",
         agentId: "v1",
         words: [{ text: "I love", begin: 0, end: 1 }],
-      },
+      }),
     ];
     const result = textToLyricLines("I luv", "v1", existing);
-    expect(result[0].words).toBeUndefined();
-    expect(result[0].begin).toBeUndefined();
-    expect(result[0].end).toBeUndefined();
+    expect(mainWords(result[0])).toBeUndefined();
+    expect(mainBounds(result[0])?.begin).toBeUndefined();
+    expect(mainBounds(result[0])?.end).toBeUndefined();
   });
 
   it("keeps backgroundText on a position-based typo fix", () => {
-    const existing: LyricLine[] = [{ id: "L1", text: "main", agentId: "v1", backgroundText: "ah ah" }];
+    const existing: LyricLine[] = [reconcileLine({ id: "L1", text: "main", agentId: "v1", backgroundText: "ah ah" })];
     const result = textToLyricLines("main edit", "v1", existing);
-    expect(result[0].backgroundText).toBe("ah ah");
+    expect(bgText(result[0])).toBe("ah ah");
   });
 
   it("returns brand-new lines (new ids, no group attrs) for genuinely new text", () => {
     const existing: LyricLine[] = [
-      { id: "L1", text: "first", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
+      reconcileLine({ id: "L1", text: "first", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
     ];
     const result = textToLyricLines("first\nsecond", "v1", existing);
     expect(result).toHaveLength(2);
@@ -106,8 +108,8 @@ describe("textToLyricLines · group attrs preservation", () => {
 
   it("does not steal an exact-match line that's already used by an earlier position", () => {
     const existing: LyricLine[] = [
-      { id: "L1", text: "chorus", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L2", text: "chorus", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
+      reconcileLine({ id: "L1", text: "chorus", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L2", text: "chorus", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 }),
     ];
     const result = textToLyricLines("chorus\nchorus", "v1", existing);
     expect(result[0].id).toBe("L1");
@@ -116,7 +118,7 @@ describe("textToLyricLines · group attrs preservation", () => {
 
   it("preserves words on every instance of repeated text (not just the first)", () => {
     const existing: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "chorus",
         agentId: "v1",
@@ -124,8 +126,8 @@ describe("textToLyricLines · group attrs preservation", () => {
         instanceIdx: 0,
         templateLineIdx: 0,
         words: [{ text: "chorus", begin: 10, end: 11 }],
-      },
-      {
+      }),
+      reconcileLine({
         id: "L2",
         text: "chorus",
         agentId: "v1",
@@ -133,18 +135,18 @@ describe("textToLyricLines · group attrs preservation", () => {
         instanceIdx: 1,
         templateLineIdx: 0,
         words: [{ text: "chorus", begin: 30, end: 31 }],
-      },
+      }),
     ];
     const result = textToLyricLines("chorus\nchorus", "v1", existing);
-    expect(result[0].words).toEqual(existing[0].words);
-    expect(result[0].words?.[0].begin).toBe(10);
-    expect(result[1].words).toEqual(existing[1].words);
-    expect(result[1].words?.[0].begin).toBe(30);
+    expect(mainWords(result[0])).toEqual(mainWords(existing[0]));
+    expect(mainWords(result[0])?.[0].begin).toBe(10);
+    expect(mainWords(result[1])).toEqual(mainWords(existing[1]));
+    expect(mainWords(result[1])?.[0].begin).toBe(30);
   });
 
   it("preserves word timings on the edited line when word count matches (single-word swap)", () => {
     const existing: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "I love you",
         agentId: "v1",
@@ -153,22 +155,22 @@ describe("textToLyricLines · group attrs preservation", () => {
           { text: "love ", begin: 0.4, end: 0.8 },
           { text: "you", begin: 0.8, end: 1.2 },
         ],
-      },
+      }),
     ];
     const result = textToLyricLines("I luv you", "v1", existing);
-    expect(result[0].text).toBe("I luv you");
-    expect(result[0].words).toBeDefined();
-    expect(result[0].words?.length).toBe(3);
-    expect(result[0].words?.[1].text).toBe("luv ");
-    expect(result[0].words?.[1].begin).toBe(0.4);
-    expect(result[0].words?.[1].end).toBe(0.8);
-    expect(result[0].words?.[0].begin).toBe(0);
-    expect(result[0].words?.[2].end).toBe(1.2);
+    expect(lineText(result[0])).toBe("I luv you");
+    expect(mainWords(result[0])).toBeDefined();
+    expect(mainWords(result[0])?.length).toBe(3);
+    expect(mainWords(result[0])?.[1].text).toBe("luv ");
+    expect(mainWords(result[0])?.[1].begin).toBe(0.4);
+    expect(mainWords(result[0])?.[1].end).toBe(0.8);
+    expect(mainWords(result[0])?.[0].begin).toBe(0);
+    expect(mainWords(result[0])?.[2].end).toBe(1.2);
   });
 
   it("clears words when the edited word count differs", () => {
     const existing: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "I love you",
         agentId: "v1",
@@ -177,25 +179,25 @@ describe("textToLyricLines · group attrs preservation", () => {
           { text: "love ", begin: 0.4, end: 0.8 },
           { text: "you", begin: 0.8, end: 1.2 },
         ],
-      },
+      }),
     ];
     const result = textToLyricLines("I really love you", "v1", existing);
-    expect(result[0].text).toBe("I really love you");
-    expect(result[0].words).toBeUndefined();
+    expect(lineText(result[0])).toBe("I really love you");
+    expect(mainWords(result[0])).toBeUndefined();
   });
 
   it("does NOT position-match across an insertion (typed line count > existing)", () => {
     const existing: LyricLine[] = [
-      { id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L1", text: "B", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 },
-      { id: "L2", text: "verse", agentId: "v1" },
+      reconcileLine({ id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L1", text: "B", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 }),
+      reconcileLine({ id: "L2", text: "verse", agentId: "v1" }),
     ];
     // User adds a new line "x" between A and B
     const result = textToLyricLines("A\nx\nB\nverse", "v1", existing);
     expect(result).toHaveLength(4);
     expect(result[0].id).toBe("L0");
     expect(result[1].id).not.toBe("L1");
-    expect(result[1].text).toBe("x");
+    expect(lineText(result[1])).toBe("x");
     expect(result[1].groupId).toBeUndefined();
     expect(result[2].id).toBe("L1");
     expect(result[3].id).toBe("L2");
@@ -203,9 +205,9 @@ describe("textToLyricLines · group attrs preservation", () => {
 
   it("does NOT position-match across a deletion (typed line count < existing)", () => {
     const existing: LyricLine[] = [
-      { id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L1", text: "B", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 },
-      { id: "L2", text: "verse", agentId: "v1" },
+      reconcileLine({ id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L1", text: "B", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 }),
+      reconcileLine({ id: "L2", text: "verse", agentId: "v1" }),
     ];
     // User deletes B
     const result = textToLyricLines("A\nverse", "v1", existing);
@@ -216,126 +218,134 @@ describe("textToLyricLines · group attrs preservation", () => {
 
   it("preserves an empty draft line when the user edits a sibling line", () => {
     const existing: LyricLine[] = [
-      { id: "A", text: "verse one", agentId: "v1" },
-      { id: "EMPTY", text: "", agentId: "v1" },
-      { id: "C", text: "verse three", agentId: "v1" },
+      reconcileLine({ id: "A", text: "verse one", agentId: "v1" }),
+      reconcileLine({ id: "EMPTY", text: "", agentId: "v1" }),
+      reconcileLine({ id: "C", text: "verse three", agentId: "v1" }),
     ];
     const result = textToLyricLines("verse one edited\n\nverse three", "v1", existing);
     expect(result).toHaveLength(3);
     expect(result[0].id).toBe("A");
-    expect(result[0].text).toBe("verse one edited");
+    expect(lineText(result[0])).toBe("verse one edited");
     expect(result[1].id).toBe("EMPTY");
-    expect(result[1].text).toBe("");
+    expect(lineText(result[1])).toBe("");
     expect(result[2].id).toBe("C");
-    expect(result[2].text).toBe("verse three");
+    expect(lineText(result[2])).toBe("verse three");
   });
 
   it("fills an empty draft line when user types into its position", () => {
     const existing: LyricLine[] = [
-      { id: "A", text: "first", agentId: "v1" },
-      { id: "DRAFT", text: "", agentId: "v1" },
+      reconcileLine({ id: "A", text: "first", agentId: "v1" }),
+      reconcileLine({ id: "DRAFT", text: "", agentId: "v1" }),
     ];
     const result = textToLyricLines("first\nfilled in", "v1", existing);
     expect(result).toHaveLength(2);
     expect(result[1].id).toBe("DRAFT");
-    expect(result[1].text).toBe("filled in");
+    expect(lineText(result[1])).toBe("filled in");
   });
 
   it("explicit blank line in textarea round-trips as text: ''", () => {
     const result = textToLyricLines("a\n\nb", "v1", []);
-    expect(result.map((l) => l.text)).toEqual(["a", "", "b"]);
+    expect(result.map((l) => lineText(l))).toEqual(["a", "", "b"]);
   });
 
   it("drops carried backgroundText when re-pasted text reintroduces parentheses (position match)", () => {
-    const existing: LyricLine[] = [{ id: "L1", text: "Hello world", agentId: "v1", backgroundText: "ooh" }];
+    const existing: LyricLine[] = [
+      reconcileLine({ id: "L1", text: "Hello world", agentId: "v1", backgroundText: "ooh" }),
+    ];
     const result = textToLyricLines("Hello (ooh) world", "v1", existing);
     expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("Hello (ooh) world");
-    expect(result[0].backgroundText).toBeUndefined();
-    expect(result[0].backgroundWords).toBeUndefined();
+    expect(lineText(result[0])).toBe("Hello (ooh) world");
+    expect(bgText(result[0])).toBeUndefined();
+    expect(bgWords(result[0])).toBeUndefined();
   });
 
   it("keeps carried backgroundText when re-pasted text has no parentheses", () => {
-    const existing: LyricLine[] = [{ id: "L1", text: "Hello world", agentId: "v1", backgroundText: "ooh" }];
+    const existing: LyricLine[] = [
+      reconcileLine({ id: "L1", text: "Hello world", agentId: "v1", backgroundText: "ooh" }),
+    ];
     const result = textToLyricLines("Hello there", "v1", existing);
-    expect(result[0].backgroundText).toBe("ooh");
+    expect(bgText(result[0])).toBe("ooh");
   });
 
   it("drops carried backgroundText on an exact-text match whose text contains parentheses", () => {
-    const existing: LyricLine[] = [{ id: "L1", text: "Hello (ooh) world", agentId: "v1", backgroundText: "ooh" }];
+    const existing: LyricLine[] = [
+      reconcileLine({ id: "L1", text: "Hello (ooh) world", agentId: "v1", backgroundText: "ooh" }),
+    ];
     const result = textToLyricLines("Hello (ooh) world", "v1", existing);
     expect(result[0].id).toBe("L1");
-    expect(result[0].text).toBe("Hello (ooh) world");
-    expect(result[0].backgroundText).toBeUndefined();
-    expect(result[0].backgroundWords).toBeUndefined();
+    expect(lineText(result[0])).toBe("Hello (ooh) world");
+    expect(bgText(result[0])).toBeUndefined();
+    expect(bgWords(result[0])).toBeUndefined();
   });
 
   it("drops carried backgroundWords when re-pasted text reintroduces parentheses", () => {
     const existing: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "Hello world",
         agentId: "v1",
         backgroundText: "ooh",
         backgroundWords: [{ text: "ooh", begin: 0, end: 0.5 }],
-      },
+      }),
     ];
     const result = textToLyricLines("Hello (ooh) world", "v1", existing);
-    expect(result[0].backgroundText).toBeUndefined();
-    expect(result[0].backgroundWords).toBeUndefined();
+    expect(bgText(result[0])).toBeUndefined();
+    expect(bgWords(result[0])).toBeUndefined();
   });
 
   it("clears the backgroundTextSource flag when a re-paste reintroduces parentheses", () => {
     const existing: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "Hello world",
         agentId: "v1",
         backgroundText: "ooh",
         backgroundWords: [{ text: "ooh", begin: 0, end: 0.5 }],
         backgroundTextSource: "extraction",
-      },
+      }),
     ];
     const result = textToLyricLines("Hello (ooh) world", "v1", existing);
-    expect(result[0].backgroundText).toBeUndefined();
-    expect(result[0].backgroundWords).toBeUndefined();
-    expect(result[0].backgroundTextSource).toBeUndefined();
+    expect(bgText(result[0])).toBeUndefined();
+    expect(bgWords(result[0])).toBeUndefined();
+    expect(bgSource(result[0])).toBeUndefined();
   });
 
   it("clears a manual-sourced background flag too on re-paste with parentheses", () => {
     const existing: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "Hello world",
         agentId: "v1",
         backgroundText: "ooh",
         backgroundTextSource: "manual",
-      },
+      }),
     ];
     const result = textToLyricLines("Hello (ooh) world", "v1", existing);
-    expect(result[0].backgroundTextSource).toBeUndefined();
+    expect(bgSource(result[0])).toBeUndefined();
   });
 
   it("produces a fresh unmatched line with parentheses without crashing or inventing backgroundText", () => {
     const result = textToLyricLines("Hello (ooh) world\nSecond line", "v1", []);
     expect(result).toHaveLength(2);
-    expect(result[0].text).toBe("Hello (ooh) world");
-    expect(result[0].backgroundText).toBeUndefined();
-    expect(result[0].backgroundWords).toBeUndefined();
+    expect(lineText(result[0])).toBe("Hello (ooh) world");
+    expect(bgText(result[0])).toBeUndefined();
+    expect(bgWords(result[0])).toBeUndefined();
   });
 
   it("re-pasting parenthesised lyrics over an already-extracted line does not double the background text", () => {
-    const existing: LyricLine[] = [{ id: "L1", text: "Hello world", agentId: "v1", backgroundText: "ooh" }];
+    const existing: LyricLine[] = [
+      reconcileLine({ id: "L1", text: "Hello world", agentId: "v1", backgroundText: "ooh" }),
+    ];
     const reparsed = textToLyricLines("Hello (ooh) world", "v1", existing);
     const extracted = extractBackgroundVocals(reparsed, { mergeStandaloneLines: false, preserveBrackets: false });
     expect(extracted).toHaveLength(1);
-    expect(extracted[0].text).toBe("Hello world");
-    expect(extracted[0].backgroundText).toBe("ooh");
+    expect(lineText(extracted[0])).toBe("Hello world");
+    expect(bgText(extracted[0])).toBe("ooh");
   });
 
   it("typo on first instance preserves the second instance's words", () => {
     const existing: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "chorus",
         agentId: "v1",
@@ -343,8 +353,8 @@ describe("textToLyricLines · group attrs preservation", () => {
         instanceIdx: 0,
         templateLineIdx: 0,
         words: [{ text: "chorus", begin: 10, end: 11 }],
-      },
-      {
+      }),
+      reconcileLine({
         id: "L2",
         text: "chorus",
         agentId: "v1",
@@ -352,24 +362,24 @@ describe("textToLyricLines · group attrs preservation", () => {
         instanceIdx: 1,
         templateLineIdx: 0,
         words: [{ text: "chorus", begin: 30, end: 31 }],
-      },
+      }),
     ];
     const result = textToLyricLines("choru\nchorus", "v1", existing);
     expect(result[0].id).toBe("L1");
-    expect(result[0].text).toBe("choru");
-    expect(result[0].words?.length).toBe(1);
-    expect(result[0].words?.[0].text).toBe("choru");
-    expect(result[0].words?.[0].begin).toBe(10);
+    expect(lineText(result[0])).toBe("choru");
+    expect(mainWords(result[0])?.length).toBe(1);
+    expect(mainWords(result[0])?.[0].text).toBe("choru");
+    expect(mainWords(result[0])?.[0].begin).toBe(10);
     expect(result[1].id).toBe("L2");
-    expect(result[1].text).toBe("chorus");
-    expect(result[1].words).toEqual(existing[1].words);
+    expect(lineText(result[1])).toBe("chorus");
+    expect(mainWords(result[1])).toEqual(mainWords(existing[1]));
   });
 });
 
 describe("textToLyricLines · split-character timing preservation", () => {
   it("preserves word timing on untouched split-character lines when a blank line is appended", () => {
     const existing: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L0",
         text: "Suara hujan",
         agentId: "v1",
@@ -377,8 +387,8 @@ describe("textToLyricLines · split-character timing preservation", () => {
           { text: "Suara ", begin: 0, end: 0.5 },
           { text: "hujan", begin: 0.5, end: 1 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "L1",
         text: "Dengar|lah rindu yang menyik|sa i|ni",
         agentId: "v1",
@@ -392,12 +402,12 @@ describe("textToLyricLines · split-character timing preservation", () => {
           { text: "i", begin: 2.2, end: 2.4 },
           { text: "ni", begin: 2.4, end: 2.6 },
         ],
-      },
+      }),
     ];
     const result = textToLyricLines("Suara hujan\nDengar|lah rindu yang menyik|sa i|ni\n", "v1", existing);
     expect(result).toHaveLength(3);
     expect(result[1].id).toBe("L1");
-    expect(result[1].text).toBe("Dengar|lah rindu yang menyik|sa i|ni");
-    expect(result[1].words).toEqual(existing[1].words);
+    expect(lineText(result[1])).toBe("Dengar|lah rindu yang menyik|sa i|ni");
+    expect(mainWords(result[1])).toEqual(mainWords(existing[1]));
   });
 });

--- a/src/utils/lyrics-text.ts
+++ b/src/utils/lyrics-text.ts
@@ -1,5 +1,5 @@
 import { CLEARED_BACKGROUND } from "@/domain/line/background";
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, toFlat, type LyricLine } from "@/domain/line/model";
 import { reconcileMatchedTiming } from "@/domain/line/reconcile-text";
 import { lineText } from "@/domain/line/voices";
 import { cleanSplitCharacters, stripSplitCharacter } from "@/utils/split-character";
@@ -46,16 +46,18 @@ function textToLyricLines(text: string, defaultAgentId: string, existingLines: L
       }
     }
 
-    return {
+    return reconcileLine({
       id: crypto.randomUUID(),
       text: cleanedText,
       agentId: defaultAgentId,
-    };
+    });
   });
 
   // Raw parentheses in `text` are the source of truth for background vocals;
   // a carried-over extracted backgroundText would double on re-extraction.
-  return mapped.map((line) => (/\([^)]*\)/.test(lineText(line)) ? { ...line, ...CLEARED_BACKGROUND } : line));
+  return mapped.map((line) =>
+    /\([^)]*\)/.test(lineText(line)) ? reconcileLine({ ...toFlat(line), ...CLEARED_BACKGROUND }) : line,
+  );
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/src/utils/lyrics-text.ts
+++ b/src/utils/lyrics-text.ts
@@ -1,6 +1,7 @@
 import { CLEARED_BACKGROUND } from "@/domain/line/background";
 import type { LyricLine } from "@/domain/line/model";
 import { reconcileMatchedTiming } from "@/domain/line/reconcile-text";
+import { lineText } from "@/domain/line/voices";
 import { cleanSplitCharacters, stripSplitCharacter } from "@/utils/split-character";
 
 // -- Helpers ------------------------------------------------------------------
@@ -8,7 +9,7 @@ import { cleanSplitCharacters, stripSplitCharacter } from "@/utils/split-charact
 function textToLyricLines(text: string, defaultAgentId: string, existingLines: LyricLine[] = []): LyricLine[] {
   const textToCandidates = new Map<string, LyricLine[]>();
   for (const line of existingLines) {
-    const key = stripSplitCharacter(line.text);
+    const key = stripSplitCharacter(lineText(line));
     let bucket = textToCandidates.get(key);
     if (!bucket) {
       bucket = [];
@@ -25,8 +26,8 @@ function textToLyricLines(text: string, defaultAgentId: string, existingLines: L
   // wrong existing line, so we generate a fresh id for any unmatched typed line.
   const allowPositionMatch = newLines.length === existingLines.length;
 
-  const mapped = newLines.map((lineText, index) => {
-    const trimmed = lineText.trim();
+  const mapped = newLines.map((typedLine, index) => {
+    const trimmed = typedLine.trim();
     const cleanedText = cleanSplitCharacters(trimmed);
     const matchText = stripSplitCharacter(cleanedText);
 
@@ -54,7 +55,7 @@ function textToLyricLines(text: string, defaultAgentId: string, existingLines: L
 
   // Raw parentheses in `text` are the source of truth for background vocals;
   // a carried-over extracted backgroundText would double on re-extraction.
-  return mapped.map((line) => (/\([^)]*\)/.test(line.text) ? { ...line, ...CLEARED_BACKGROUND } : line));
+  return mapped.map((line) => (/\([^)]*\)/.test(lineText(line)) ? { ...line, ...CLEARED_BACKGROUND } : line));
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/src/utils/sync-helpers.ts
+++ b/src/utils/sync-helpers.ts
@@ -1,7 +1,6 @@
 import { effectiveBounds } from "@/domain/line/bounds";
 import { isLineSynced } from "@/domain/line/predicates";
 import type { LyricLine } from "@/domain/line/model";
-import { bgText } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { useSettingsStore } from "@/stores/settings";
 import { formatTime } from "@/utils/format-time";
@@ -143,14 +142,6 @@ function createInitialBgWords(backgroundText: string, begin: number, end?: numbe
   return distributeWordsInLine(backgroundText, begin, resolvedEnd);
 }
 
-function createBgWordsFromLine(line: LyricLine): WordTiming[] | null {
-  const background = bgText(line);
-  if (!background) return null;
-  const timing = effectiveBounds(line);
-  if (!timing) return null;
-  return createInitialBgWords(background, (timing.begin + timing.end) / 2, timing.end);
-}
-
 // -- Tap and hold commit ------------------------------------------------------
 
 function commitTappedWord(
@@ -184,7 +175,6 @@ function commitHeldWord(existingWords: WordTiming[], wordIndex: number, text: st
 export {
   commitHeldWord,
   commitTappedWord,
-  createBgWordsFromLine,
   createInitialBgWords,
   distributeWordsInLine,
   getNudgeAmount,

--- a/src/utils/sync-helpers.ts
+++ b/src/utils/sync-helpers.ts
@@ -1,6 +1,7 @@
 import { effectiveBounds } from "@/domain/line/bounds";
 import { isLineSynced } from "@/domain/line/predicates";
 import type { LyricLine } from "@/domain/line/model";
+import { bgText } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { useSettingsStore } from "@/stores/settings";
 import { formatTime } from "@/utils/format-time";
@@ -143,10 +144,11 @@ function createInitialBgWords(backgroundText: string, begin: number, end?: numbe
 }
 
 function createBgWordsFromLine(line: LyricLine): WordTiming[] | null {
-  if (!line.backgroundText) return null;
+  const background = bgText(line);
+  if (!background) return null;
   const timing = effectiveBounds(line);
   if (!timing) return null;
-  return createInitialBgWords(line.backgroundText, (timing.begin + timing.end) / 2, timing.end);
+  return createInitialBgWords(background, (timing.begin + timing.end) / 2, timing.end);
 }
 
 // -- Tap and hold commit ------------------------------------------------------

--- a/src/utils/timing/bg-word-timing.ts
+++ b/src/utils/timing/bg-word-timing.ts
@@ -1,7 +1,8 @@
+import { bgWords } from "@/domain/line/voices";
 import { createWordTimingOps } from "@/utils/timing/word-timing-ops";
 
 const { nudgeBegin, setBegin, nudgeEnd, setEnd } = createWordTimingOps({
-  getWords: (line) => line.backgroundWords,
+  getWords: (line) => bgWords(line),
   updateKey: "backgroundWords",
 });
 

--- a/src/utils/timing/line-timing.ts
+++ b/src/utils/timing/line-timing.ts
@@ -1,10 +1,10 @@
 import { mainBounds } from "@/domain/line/bounds";
-import type { LyricLine } from "@/domain/line/model";
+import type { LooseLine, LyricLine } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/line/predicates";
 
 type UpdateLineWithHistory = (
   id: string,
-  updates: Partial<LyricLine>,
+  updates: Partial<LooseLine>,
   options?: { propagateToSiblings?: boolean },
 ) => void;
 

--- a/src/utils/timing/line-timing.ts
+++ b/src/utils/timing/line-timing.ts
@@ -1,4 +1,6 @@
+import { mainBounds } from "@/domain/line/bounds";
 import type { LyricLine } from "@/domain/line/model";
+import { isLineSynced } from "@/domain/line/predicates";
 
 type UpdateLineWithHistory = (
   id: string,
@@ -13,10 +15,12 @@ function nudgeLineBegin(
   updateLineWithHistory: UpdateLineWithHistory,
 ) {
   const line = lines[lineIdx];
-  if (line?.begin === undefined) return;
+  if (!line || !isLineSynced(line)) return;
+  const mb = mainBounds(line);
+  if (!mb) return;
 
-  const newBegin = Math.max(0, line.begin + delta);
-  const duration = line.end - line.begin;
+  const newBegin = Math.max(0, mb.begin + delta);
+  const duration = mb.end - mb.begin;
   updateLineWithHistory(line.id, { begin: newBegin, end: newBegin + duration }, { propagateToSiblings: false });
 }
 
@@ -27,9 +31,11 @@ function setLineBegin(
   updateLineWithHistory: UpdateLineWithHistory,
 ) {
   const line = lines[lineIdx];
-  if (line?.begin === undefined) return;
+  if (!line || !isLineSynced(line)) return;
+  const mb = mainBounds(line);
+  if (!mb) return;
 
-  const duration = line.end - line.begin;
+  const duration = mb.end - mb.begin;
   updateLineWithHistory(line.id, { begin: newBegin, end: newBegin + duration }, { propagateToSiblings: false });
 }
 

--- a/src/utils/timing/word-timing-ops.test.ts
+++ b/src/utils/timing/word-timing-ops.test.ts
@@ -1,4 +1,5 @@
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { createLine } from "@/test/factories";
 import { createWordTimingOps } from "@/utils/timing/word-timing-ops";
 import { describe, expect, it } from "vitest";
@@ -21,8 +22,8 @@ function captureUpdates() {
   return { calls, updateLineWithHistory };
 }
 
-const wordsOps = createWordTimingOps({ getWords: (line) => line.words, updateKey: "words" });
-const bgOps = createWordTimingOps({ getWords: (line) => line.backgroundWords, updateKey: "backgroundWords" });
+const wordsOps = createWordTimingOps({ getWords: (line) => mainWords(line), updateKey: "words" });
+const bgOps = createWordTimingOps({ getWords: (line) => bgWords(line), updateKey: "backgroundWords" });
 
 describe("createWordTimingOps: early returns", () => {
   it("nudgeBegin no-ops when line missing", () => {
@@ -164,7 +165,7 @@ describe("createWordTimingOps: write contract", () => {
       ],
     });
     wordsOps.setBegin([original], 0, 1, 1.5, updateLineWithHistory);
-    expect(calls[0].updates.words).not.toBe(original.words);
+    expect(calls[0].updates.words).not.toBe(mainWords(original));
   });
 
   it("does not mutate untouched words in the resulting array", () => {

--- a/src/utils/timing/word-timing-ops.test.ts
+++ b/src/utils/timing/word-timing-ops.test.ts
@@ -1,4 +1,4 @@
-import type { LyricLine } from "@/domain/line/model";
+import type { LooseLine } from "@/domain/line/model";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import { createLine } from "@/test/factories";
 import { createWordTimingOps } from "@/utils/timing/word-timing-ops";
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 
 interface CapturedUpdate {
   id: string;
-  updates: Partial<LyricLine>;
+  updates: Partial<LooseLine>;
   options?: { propagateToSiblings?: boolean };
 }
 
@@ -14,7 +14,7 @@ function captureUpdates() {
   const calls: CapturedUpdate[] = [];
   const updateLineWithHistory = (
     id: string,
-    updates: Partial<LyricLine>,
+    updates: Partial<LooseLine>,
     options?: { propagateToSiblings?: boolean },
   ) => {
     calls.push({ id, updates, options });

--- a/src/utils/timing/word-timing-ops.ts
+++ b/src/utils/timing/word-timing-ops.ts
@@ -1,11 +1,11 @@
-import type { LyricLine } from "@/domain/line/model";
+import type { LooseLine, LyricLine } from "@/domain/line/model";
 import type { WordTiming } from "@/domain/word/timing";
 
 // -- Types --------------------------------------------------------------------
 
 type UpdateLineWithHistory = (
   id: string,
-  updates: Partial<LyricLine>,
+  updates: Partial<LooseLine>,
   options?: { propagateToSiblings?: boolean },
 ) => void;
 
@@ -43,7 +43,7 @@ function createWordTimingOps(config: WordFieldConfig) {
     const word = updatedWords[wordIdx];
     updatedWords[wordIdx] = mutator({ word, prevWord: updatedWords[wordIdx - 1], nextWord: updatedWords[wordIdx + 1] });
 
-    updateLineWithHistory(line.id, { [updateKey]: updatedWords } as Partial<LyricLine>, {
+    updateLineWithHistory(line.id, { [updateKey]: updatedWords } as Partial<LooseLine>, {
       propagateToSiblings: false,
     });
   }

--- a/src/utils/timing/word-timing.ts
+++ b/src/utils/timing/word-timing.ts
@@ -1,7 +1,8 @@
+import { mainWords } from "@/domain/line/voices";
 import { createWordTimingOps } from "@/utils/timing/word-timing-ops";
 
 const { nudgeBegin, setBegin, nudgeEnd, setEnd } = createWordTimingOps({
-  getWords: (line) => line.words,
+  getWords: (line) => mainWords(line),
   updateKey: "words",
 });
 

--- a/src/utils/ttml.groups.test.ts
+++ b/src/utils/ttml.groups.test.ts
@@ -1,5 +1,7 @@
 import type { Agent } from "@/domain/agent/model";
 import type { LinkGroup } from "@/domain/group/template";
+import { reconcileLine } from "@/domain/line/model";
+import { lineText, mainWords } from "@/domain/line/voices";
 import type { ProjectMetadata } from "@/domain/project/metadata";
 import { parseLyricsFile } from "@/utils/lyrics-parsers";
 import { generateTTML } from "@/utils/ttml";
@@ -72,14 +74,14 @@ describe("ttml export · per-line group attrs", () => {
     id: string,
     extras: Partial<{ groupId: string; instanceIdx: number; templateLineIdx: number; detached: boolean }>,
   ) {
-    return {
+    return reconcileLine({
       id,
       text: "hello",
       agentId: "v1",
       begin: 0,
       end: 1,
       ...extras,
-    };
+    });
   }
 
   it("emits composer:groupId/instanceIdx/templateLineIdx on grouped lines", () => {
@@ -160,7 +162,7 @@ describe("ttml import · per-line group attrs", () => {
       metadata: baseMetadata,
       agents: baseAgents,
       lines: [
-        {
+        reconcileLine({
           id: "a",
           text: "I love you",
           agentId: "v1",
@@ -169,7 +171,7 @@ describe("ttml import · per-line group attrs", () => {
           groupId: "g1",
           instanceIdx: 2,
           templateLineIdx: 0,
-        },
+        }),
       ],
       groups,
       granularity: "line",
@@ -187,7 +189,7 @@ describe("ttml import · per-line group attrs", () => {
       metadata: baseMetadata,
       agents: baseAgents,
       lines: [
-        {
+        reconcileLine({
           id: "a",
           text: "yeah",
           agentId: "v1",
@@ -197,7 +199,7 @@ describe("ttml import · per-line group attrs", () => {
           instanceIdx: 0,
           templateLineIdx: 1,
           detached: true,
-        },
+        }),
       ],
       groups,
       granularity: "line",
@@ -211,7 +213,7 @@ describe("ttml import · per-line group attrs", () => {
       metadata: baseMetadata,
       agents: baseAgents,
       lines: [
-        {
+        reconcileLine({
           id: "a",
           text: "hi",
           agentId: "v1",
@@ -220,7 +222,7 @@ describe("ttml import · per-line group attrs", () => {
           groupId: "g1",
           instanceIdx: 0,
           templateLineIdx: 0,
-        },
+        }),
       ],
       groups: [],
       granularity: "line",
@@ -237,7 +239,7 @@ describe("ttml import · per-line group attrs", () => {
       </div></body>
     </tt>`;
     const result = parseLyricsFile("flat.ttml", flatTtml);
-    expect(result.lines[0].text).toBe("Hello");
+    expect(lineText(result.lines[0])).toBe("Hello");
     expect(result.lines[0].groupId).toBeUndefined();
     expect(result.groups).toBeUndefined();
   });
@@ -249,7 +251,7 @@ describe("ttml export · explicit word attribute", () => {
       metadata: baseMetadata,
       agents: baseAgents,
       lines: [
-        {
+        reconcileLine({
           id: "a",
           text: "clean dirty",
           agentId: "v1",
@@ -257,7 +259,7 @@ describe("ttml export · explicit word attribute", () => {
             { text: "clean ", begin: 1, end: 1.5 },
             { text: "dirty", begin: 1.5, end: 2, explicit: true },
           ],
-        },
+        }),
       ],
       granularity: "word",
     });
@@ -271,7 +273,7 @@ describe("ttml export · explicit word attribute", () => {
       metadata: baseMetadata,
       agents: baseAgents,
       lines: [
-        {
+        reconcileLine({
           id: "a",
           text: "main",
           agentId: "v1",
@@ -281,7 +283,7 @@ describe("ttml export · explicit word attribute", () => {
             { text: "oh ", begin: 2, end: 2.25 },
             { text: "shit", begin: 2.25, end: 2.5, explicit: true },
           ],
-        },
+        }),
       ],
       granularity: "word",
     });
@@ -294,7 +296,7 @@ describe("ttml export · explicit word attribute", () => {
   it("round-trip: AMLL amll:obscene import → export normalizes to composer:explicit", () => {
     const amll = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:02.000" ttm:agent="v1"><span begin="00:01.000" end="00:01.500">clean</span> <span begin="00:01.500" end="00:02.000" amll:obscene="true">dirty</span></p></div></body></tt>`;
     const imported = parseLyricsFile("amll.ttml", amll);
-    expect(imported.lines[0].words![1].explicit).toBe(true);
+    expect(mainWords(imported.lines[0])![1].explicit).toBe(true);
 
     const exported = generateTTML({
       metadata: baseMetadata,
@@ -306,6 +308,6 @@ describe("ttml export · explicit word attribute", () => {
     expect(exported).not.toContain("amll:obscene");
 
     const reimported = parseLyricsFile("re.ttml", exported);
-    expect(reimported.lines[0].words![1].explicit).toBe(true);
+    expect(mainWords(reimported.lines[0])![1].explicit).toBe(true);
   });
 });

--- a/src/utils/ttml.test.ts
+++ b/src/utils/ttml.test.ts
@@ -1,0 +1,260 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import type { Agent } from "@/domain/agent/model";
+import { applyBackground, setBackground } from "@/domain/line/background";
+import { bgBounds, mainBounds } from "@/domain/line/bounds";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { bgSource, bgText, bgVoice, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import type { ProjectMetadata } from "@/domain/project/metadata";
+import { isLineSynced as isLineSyncedVoice, isWordSynced as isWordSyncedVoice } from "@/domain/voice/predicates";
+import { formatTime } from "@/utils/format-time";
+import { parseLyricsFile } from "@/utils/lyrics-parsers";
+import { generateTTML } from "@/utils/ttml";
+
+const FIXTURE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../test/fixtures/ttml");
+const ttmlFixture = (name: string) => readFileSync(resolve(FIXTURE_DIR, `${name}.ttml`), "utf-8");
+
+const baseMetadata: ProjectMetadata = { title: "Test", artist: "", album: "", duration: 60 };
+const baseAgents: Agent[] = [{ id: "v1", type: "person", name: "Lead" }];
+
+// Derives the granularity a real caller would pass: "word" when any line has
+// main OR background word timing, matching the exporter's effectiveGranularity.
+function granularityOf(lines: LyricLine[]): "line" | "word" {
+  const anyWord = lines.some((l) => {
+    if (isWordSyncedVoice(l.main)) return true;
+    const bg = bgVoice(l);
+    return bg !== null && isWordSyncedVoice(bg);
+  });
+  return anyWord ? "word" : "line";
+}
+
+function exportLines(lines: LyricLine[], granularity: "line" | "word"): string {
+  return generateTTML({ metadata: baseMetadata, agents: baseAgents, lines, granularity });
+}
+
+// Pulls the timing attribute off the root <tt> element.
+function composerTimingOf(ttml: string): string | null {
+  return ttml.match(/composer:timing="([^"]+)"/)?.[1] ?? null;
+}
+
+describe("generateTTML · composer:timing from both voices", () => {
+  it('emits "Word" when only the background voice is word-synced (line-synced main)', () => {
+    let line = reconcileLine({ id: "l1", text: "Take me higher", agentId: "v1", begin: 2, end: 10 });
+    line = applyBackground(line, {
+      text: "(ooh yeah)",
+      words: [
+        { text: "(ooh ", begin: 3, end: 4 },
+        { text: "yeah)", begin: 4, end: 5 },
+      ],
+      source: "manual",
+    });
+
+    expect(isLineSyncedVoice(line.main)).toBe(true);
+    expect(isWordSyncedVoice(bgVoice(line)!)).toBe(true);
+
+    const ttml = exportLines([line], "line");
+    expect(composerTimingOf(ttml)).toBe("Word");
+  });
+
+  it('emits "Word" when only the main voice is word-synced (no background)', () => {
+    const line = reconcileLine({
+      id: "l1",
+      text: "Hello world",
+      agentId: "v1",
+      words: [
+        { text: "Hello ", begin: 1, end: 1.5 },
+        { text: "world", begin: 1.5, end: 2 },
+      ],
+    });
+
+    const ttml = exportLines([line], "line");
+    expect(composerTimingOf(ttml)).toBe("Word");
+  });
+
+  it('emits "Line" when neither voice is word-synced (line main + line bg)', () => {
+    const result = parseLyricsFile("bg-line-synced.ttml", ttmlFixture("bg-line-synced"));
+    for (const line of result.lines) {
+      expect(isWordSyncedVoice(line.main)).toBe(false);
+      expect(isWordSyncedVoice(bgVoice(line)!)).toBe(false);
+    }
+
+    const ttml = exportLines(result.lines, "line");
+    expect(composerTimingOf(ttml)).toBe("Line");
+  });
+
+  it('emits "Word" across lines when any single line has a word-synced background', () => {
+    const plain = reconcileLine({ id: "l1", text: "plain", agentId: "v1", begin: 0, end: 1 });
+    let withBgWords = reconcileLine({ id: "l2", text: "lead", agentId: "v1", begin: 2, end: 6 });
+    withBgWords = applyBackground(withBgWords, {
+      text: "(hey now)",
+      words: [
+        { text: "(hey ", begin: 3, end: 4 },
+        { text: "now)", begin: 4, end: 5 },
+      ],
+      source: "manual",
+    });
+
+    const ttml = exportLines([plain, withBgWords], "line");
+    expect(composerTimingOf(ttml)).toBe("Word");
+  });
+});
+
+describe("generateTTML · line-synced background bounds", () => {
+  it("emits the background's own bounds, not the main's, for a line-synced bg", () => {
+    let line = reconcileLine({ id: "l1", text: "main line", agentId: "v1", begin: 2, end: 10 });
+    line = setBackground(line, { text: "(backing)", begin: 3, end: 7, source: "manual" });
+
+    expect(mainBounds(line)).toEqual({ begin: 2, end: 10 });
+    expect(bgBounds(line)).toEqual({ begin: 3, end: 7 });
+
+    const ttml = exportLines([line], "line");
+    const xbg = ttml.match(/<span ttm:role="x-bg"><span begin="([^"]+)" end="([^"]+)">/);
+    expect(xbg).not.toBeNull();
+    expect(xbg![1]).toBe(formatTime(3));
+    expect(xbg![2]).toBe(formatTime(7));
+  });
+
+  it("preserves the bg-line-synced fixture's own bg bounds, distinct from the main line bounds", () => {
+    const result = parseLyricsFile("bg-line-synced.ttml", ttmlFixture("bg-line-synced"));
+    const ttml = exportLines(result.lines, "line");
+
+    const spans = [...ttml.matchAll(/<span ttm:role="x-bg"><span begin="([^"]+)" end="([^"]+)">/g)];
+    expect(spans).toHaveLength(2);
+
+    expect(spans[0][1]).toBe(formatTime(19));
+    expect(spans[0][2]).toBe(formatTime(21));
+    expect(spans[1][1]).toBe(formatTime(23));
+    expect(spans[1][2]).toBe(formatTime(24.5));
+
+    // The <p> begin/end stay the full main line bounds, distinct from the bg.
+    const ps = [...ttml.matchAll(/<p begin="([^"]+)" end="([^"]+)"/g)];
+    expect(ps[0][1]).toBe(formatTime(18.234));
+    expect(ps[0][2]).toBe(formatTime(21.891));
+    expect(ps[1][1]).toBe(formatTime(22.1));
+    expect(ps[1][2]).toBe(formatTime(25.4));
+  });
+
+  it("falls back to the line timing for an untimed background with no own bounds", () => {
+    let line = reconcileLine({ id: "l1", text: "main line", agentId: "v1", begin: 2, end: 8 });
+    line = setBackground(line, { text: "(untimed)", source: "manual" });
+
+    expect(bgBounds(line)).toBeNull();
+
+    const ttml = exportLines([line], "line");
+    const xbg = ttml.match(/<span ttm:role="x-bg"><span begin="([^"]+)" end="([^"]+)">/);
+    expect(xbg).not.toBeNull();
+    expect(xbg![1]).toBe(formatTime(2));
+    expect(xbg![2]).toBe(formatTime(8));
+  });
+});
+
+describe("generateTTML · background past main extends the <p> end", () => {
+  it("extends the <p> end and the x-bg span end when a line-synced bg runs past the main", () => {
+    let line = reconcileLine({ id: "l1", text: "main", agentId: "v1", begin: 2, end: 5 });
+    line = setBackground(line, { text: "(late)", begin: 6, end: 8, source: "manual" });
+
+    expect(mainBounds(line)).toEqual({ begin: 2, end: 5 });
+    expect(bgBounds(line)).toEqual({ begin: 6, end: 8 });
+
+    const ttml = exportLines([line], "line");
+
+    const p = ttml.match(/<p begin="([^"]+)" end="([^"]+)"/);
+    expect(p![1]).toBe(formatTime(2));
+    expect(p![2]).toBe(formatTime(8));
+
+    const xbg = ttml.match(/<span ttm:role="x-bg"><span begin="([^"]+)" end="([^"]+)">/);
+    expect(xbg![1]).toBe(formatTime(6));
+    expect(xbg![2]).toBe(formatTime(8));
+  });
+});
+
+describe("generateTTML · parse/export/parse round-trip", () => {
+  // The exporter intentionally trims the trailing space of the final word (no
+  // following word to separate from), and formatTime floors at millisecond
+  // precision. Neither is granularity or bounds correction, so text is compared
+  // trailing-space-insensitively and timing within a millisecond. The point of
+  // this suite is that NO voice is re-granularized on export.
+  // formatTime floors at millisecond precision, so a round-trip can shed up to
+  // 1ms. Two decimals (within 5ms) tolerates that while still catching any real
+  // bounds corruption, which is off by whole seconds.
+  const boundsClose = (got: ReturnType<typeof mainBounds>, want: ReturnType<typeof mainBounds>) => {
+    expect(got === null).toBe(want === null);
+    if (got !== null && want !== null) {
+      expect(got.begin).toBeCloseTo(want.begin, 2);
+      expect(got.end).toBeCloseTo(want.end, 2);
+    }
+  };
+
+  function assertWordsPreserved(got: ReturnType<typeof mainWords>, want: ReturnType<typeof mainWords>) {
+    expect(got === undefined).toBe(want === undefined);
+    if (got === undefined || want === undefined) return;
+    expect(got).toHaveLength(want.length);
+    for (let i = 0; i < want.length; i++) {
+      expect(got[i].text.trimEnd()).toBe(want[i].text.trimEnd());
+      expect(got[i].begin).toBeCloseTo(want[i].begin, 2);
+      expect(got[i].end).toBeCloseTo(want[i].end, 2);
+    }
+  }
+
+  function assertVoicePreserved(a: LyricLine, b: LyricLine) {
+    expect(lineText(b).trimEnd()).toBe(lineText(a).trimEnd());
+    expect(isWordSyncedVoice(b.main)).toBe(isWordSyncedVoice(a.main));
+    expect(isLineSyncedVoice(b.main)).toBe(isLineSyncedVoice(a.main));
+    assertWordsPreserved(mainWords(b), mainWords(a));
+    boundsClose(mainBounds(b), mainBounds(a));
+
+    expect((bgText(b) ?? "").trimEnd()).toBe((bgText(a) ?? "").trimEnd());
+    expect(bgSource(b)).toBe(bgSource(a));
+    boundsClose(bgBounds(b), bgBounds(a));
+    assertWordsPreserved(bgWords(b), bgWords(a));
+
+    const bgA = bgVoice(a);
+    const bgB = bgVoice(b);
+    expect(bgB === null).toBe(bgA === null);
+    if (bgA !== null && bgB !== null) {
+      expect(isWordSyncedVoice(bgB)).toBe(isWordSyncedVoice(bgA));
+      expect(isLineSyncedVoice(bgB)).toBe(isLineSyncedVoice(bgA));
+    }
+  }
+
+  function roundTrip(fixture: string) {
+    const model1 = parseLyricsFile(`${fixture}.ttml`, ttmlFixture(fixture)).lines;
+    const ttml = exportLines(model1, granularityOf(model1));
+    const model2 = parseLyricsFile(`${fixture}.ttml`, ttml).lines;
+
+    expect(model2).toHaveLength(model1.length);
+    for (let i = 0; i < model1.length; i++) {
+      assertVoicePreserved(model1[i], model2[i]);
+    }
+    return { model1, model2 };
+  }
+
+  it("word-main + word-bg round-trips with no correction", () => {
+    const { model1 } = roundTrip("bg-word-synced");
+    for (const line of model1) {
+      expect(isWordSyncedVoice(line.main)).toBe(true);
+      expect(isWordSyncedVoice(bgVoice(line)!)).toBe(true);
+    }
+  });
+
+  it("line-main + line-bg round-trips with no correction", () => {
+    const { model1 } = roundTrip("bg-line-synced");
+    for (const line of model1) {
+      expect(isLineSyncedVoice(line.main)).toBe(true);
+      expect(isLineSyncedVoice(bgVoice(line)!)).toBe(true);
+    }
+  });
+
+  it("word-main + line-bg (L1) and line-main + word-bg (L2) round-trip with no correction", () => {
+    const { model1 } = roundTrip("bg-mixed-granularity");
+
+    const [l1, l2] = model1;
+    expect(isWordSyncedVoice(l1.main)).toBe(true);
+    expect(isLineSyncedVoice(bgVoice(l1)!)).toBe(true);
+
+    expect(isLineSyncedVoice(l2.main)).toBe(true);
+    expect(isWordSyncedVoice(bgVoice(l2)!)).toBe(true);
+  });
+});

--- a/src/utils/ttml.ts
+++ b/src/utils/ttml.ts
@@ -5,6 +5,8 @@ import type { ProjectMetadata } from "@/domain/project/metadata";
 import { formatTime } from "@/utils/format-time";
 import { stripSplitCharacter } from "@/utils/split-character";
 import { effectiveBounds } from "@/domain/line/bounds";
+import { isWordSynced } from "@/domain/line/predicates";
+import { bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -33,7 +35,7 @@ function generateTTML({ metadata, agents, lines, groups, granularity, minify = f
   const nl = minify ? "" : "\n";
   const ind = (n: number) => (minify ? "" : "  ".repeat(n));
 
-  const effectiveGranularity = lines.some((l) => l.words?.length) ? "word" : "line";
+  const effectiveGranularity = lines.some((l) => isWordSynced(l)) ? "word" : "line";
 
   const parts: string[] = [];
 
@@ -84,32 +86,33 @@ function generateTTML({ metadata, agents, lines, groups, granularity, minify = f
       : "";
     let content = "";
 
-    if (granularity === "word" && line.words?.length) {
-      const words = line.words;
-      const wordCount = words.length;
+    const mainWordList = mainWords(line);
+    if (granularity === "word" && mainWordList?.length) {
+      const wordCount = mainWordList.length;
       for (let i = 0; i < wordCount; i++) {
-        const word = words[i];
+        const word = mainWordList[i];
         const text = word.text.trimEnd();
         const needsSpace = i < wordCount - 1 && word.text.endsWith(" ");
         content += `${emitWordSpan(word, text)}${needsSpace ? " " : ""}`;
       }
     } else {
-      content = escapeXml(stripSplitCharacter(line.text));
+      content = escapeXml(stripSplitCharacter(lineText(line)));
     }
 
-    if (line.backgroundText && line.backgroundWords?.length) {
-      const bgWords = line.backgroundWords;
-      const bgCount = bgWords.length;
+    const background = bgText(line);
+    const bgWordList = bgWords(line);
+    if (background && bgWordList?.length) {
+      const bgCount = bgWordList.length;
       let bgContent = "";
       for (let i = 0; i < bgCount; i++) {
-        const bgWord = bgWords[i];
+        const bgWord = bgWordList[i];
         const text = bgWord.text.trimEnd();
         const needsSpace = i < bgCount - 1 && bgWord.text.endsWith(" ");
         bgContent += `${emitWordSpan(bgWord, text)}${needsSpace ? " " : ""}`;
       }
       content += `<span ttm:role="x-bg">${bgContent}</span>`;
-    } else if (line.backgroundText) {
-      content += `<span ttm:role="x-bg"><span begin="${formatTime(timing.begin)}" end="${formatTime(timing.end)}">${escapeXml(line.backgroundText)}</span></span>`;
+    } else if (background) {
+      content += `<span ttm:role="x-bg"><span begin="${formatTime(timing.begin)}" end="${formatTime(timing.end)}">${escapeXml(background)}</span></span>`;
     }
 
     parts.push(

--- a/src/utils/ttml.ts
+++ b/src/utils/ttml.ts
@@ -4,9 +4,10 @@ import type { LyricLine } from "@/domain/line/model";
 import type { ProjectMetadata } from "@/domain/project/metadata";
 import { formatTime } from "@/utils/format-time";
 import { stripSplitCharacter } from "@/utils/split-character";
-import { effectiveBounds } from "@/domain/line/bounds";
+import { bgBounds, effectiveBounds } from "@/domain/line/bounds";
 import { isWordSynced } from "@/domain/line/predicates";
-import { bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { bgText, bgVoice, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { isWordSynced as isWordSyncedVoice } from "@/domain/voice/predicates";
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -35,7 +36,12 @@ function generateTTML({ metadata, agents, lines, groups, granularity, minify = f
   const nl = minify ? "" : "\n";
   const ind = (n: number) => (minify ? "" : "  ".repeat(n));
 
-  const effectiveGranularity = lines.some((l) => isWordSynced(l)) ? "word" : "line";
+  const hasWordTiming = (l: LyricLine) => {
+    if (isWordSynced(l)) return true;
+    const bg = bgVoice(l);
+    return bg !== null && isWordSyncedVoice(bg);
+  };
+  const effectiveGranularity = lines.some(hasWordTiming) ? "word" : "line";
 
   const parts: string[] = [];
 
@@ -112,7 +118,11 @@ function generateTTML({ metadata, agents, lines, groups, granularity, minify = f
       }
       content += `<span ttm:role="x-bg">${bgContent}</span>`;
     } else if (background) {
-      content += `<span ttm:role="x-bg"><span begin="${formatTime(timing.begin)}" end="${formatTime(timing.end)}">${escapeXml(background)}</span></span>`;
+      // A line-synced background carries its own window, which can differ from
+      // the main line's. Fall back to the line timing only when the background
+      // is genuinely untimed (no own bounds).
+      const bgB = bgBounds(line) ?? timing;
+      content += `<span ttm:role="x-bg"><span begin="${formatTime(bgB.begin)}" end="${formatTime(bgB.end)}">${escapeXml(background)}</span></span>`;
     }
 
     parts.push(

--- a/src/utils/word-divergence-flow.ts
+++ b/src/utils/word-divergence-flow.ts
@@ -1,9 +1,14 @@
 import { useDivergenceStore } from "@/stores/divergence-store";
 import { useProjectStore } from "@/stores/project";
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { showGroupActionToast } from "@/utils/group-toast";
 import { wouldDivergenceCauseRetiming } from "@/utils/word-diff";
+
+function wordsOfField(line: LyricLine, field: "words" | "backgroundWords"): WordTiming[] | undefined {
+  return field === "words" ? mainWords(line) : bgWords(line);
+}
 
 // Wraps a word-array write so that linked-line word-count changes prompt the
 // user (Apply / Detach / Cancel) when at least one sibling would have its
@@ -23,7 +28,7 @@ async function handleWordChangeWithDivergenceCheck(
   const target = lines.find((l) => l.id === lineId);
   if (!target) return;
 
-  const sourceBefore = target[field];
+  const sourceBefore = wordsOfField(target, field);
   const oldCount = sourceBefore?.length ?? 0;
   const isLinked = target.groupId !== undefined && target.templateLineIdx !== undefined && !target.detached;
   const countChanged = isLinked && newWords.length !== oldCount;
@@ -41,7 +46,12 @@ async function handleWordChangeWithDivergenceCheck(
   const groupId = target.groupId as string;
   const templateLineIdx = target.templateLineIdx as number;
   const affectedSiblingCount = lines.filter(
-    (l) => l.id !== lineId && l.groupId === groupId && l.templateLineIdx === templateLineIdx && !l.detached && l[field],
+    (l) =>
+      l.id !== lineId &&
+      l.groupId === groupId &&
+      l.templateLineIdx === templateLineIdx &&
+      !l.detached &&
+      wordsOfField(l, field),
   ).length;
   const groupLabel = useProjectStore.getState().groups.find((g) => g.id === groupId)?.label;
 

--- a/src/utils/word-divergence-flow.ts
+++ b/src/utils/word-divergence-flow.ts
@@ -1,6 +1,6 @@
 import { useDivergenceStore } from "@/stores/divergence-store";
 import { useProjectStore } from "@/stores/project";
-import type { LyricLine } from "@/domain/line/model";
+import type { LooseLine, LyricLine } from "@/domain/line/model";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { showGroupActionToast } from "@/utils/group-toast";
@@ -22,7 +22,7 @@ async function handleWordChangeWithDivergenceCheck(
   lineId: string,
   newWords: WordTiming[],
   field: "words" | "backgroundWords" = "words",
-  extraUpdates: Partial<LyricLine> = {},
+  extraUpdates: Partial<LooseLine> = {},
 ): Promise<void> {
   const lines = useProjectStore.getState().lines;
   const target = lines.find((l) => l.id === lineId);

--- a/src/views/edit.autoextract.browser.test.tsx
+++ b/src/views/edit.autoextract.browser.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { bgSource, bgText, lineText } from "@/domain/line/voices";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import { render } from "@/test/render";
@@ -39,14 +40,14 @@ describe("auto-extract background vocals on blur", () => {
 
     setTextareaValue(textarea, "Take me home (country roads)");
     await expect
-      .poll(() => useProjectStore.getState().lines.map((l) => l.text))
+      .poll(() => useProjectStore.getState().lines.map((l) => lineText(l)))
       .toEqual(["Take me home (country roads)"]);
 
     blurTextarea(textarea);
 
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Take me home");
-    expect(useProjectStore.getState().lines[0].backgroundText).toBe("country roads");
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("extraction");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Take me home");
+    expect(bgText(useProjectStore.getState().lines[0])).toBe("country roads");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("extraction");
   });
 
   it("reflects the extracted result in the textarea and preview after blur", async () => {
@@ -71,8 +72,8 @@ describe("auto-extract background vocals on blur", () => {
     setTextareaValue(textarea, "Take me home (country roads)");
     blurTextarea(textarea);
 
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Take me home (country roads)");
-    expect(useProjectStore.getState().lines[0].backgroundText).toBeUndefined();
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Take me home (country roads)");
+    expect(bgText(useProjectStore.getState().lines[0])).toBeUndefined();
     expect(textarea.value).toBe("Take me home (country roads)");
   });
 
@@ -87,8 +88,8 @@ describe("auto-extract background vocals on blur", () => {
     blurTextarea(textarea);
 
     await expect.poll(() => useProjectStore.getState().lines.length).toBe(1);
-    expect(useProjectStore.getState().lines[0].text).toBe("Real lyric line");
-    expect(useProjectStore.getState().lines[0].backgroundText).toBe("ooh yeah");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("Real lyric line");
+    expect(bgText(useProjectStore.getState().lines[0])).toBe("ooh yeah");
     await expect.poll(() => textarea.value).toBe("Real lyric line");
   });
 
@@ -102,7 +103,7 @@ describe("auto-extract background vocals on blur", () => {
     blurTextarea(textarea);
 
     await expect.poll(() => useProjectStore.getState().lines.length).toBe(2);
-    expect(useProjectStore.getState().lines[1].text).toBe("(ooh yeah)");
+    expect(lineText(useProjectStore.getState().lines[1])).toBe("(ooh yeah)");
   });
 });
 
@@ -118,10 +119,10 @@ describe("auto-extract on blur leaves history untouched when nothing changes", (
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     setTextareaValue(textarea, "Plain lyric line");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Plain lyric line");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Plain lyric line");
 
     blurTextarea(textarea);
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Plain lyric line");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Plain lyric line");
     const afterTypingRunIndex = useProjectStore.getState().historyIndex;
 
     blurTextarea(textarea);
@@ -155,14 +156,14 @@ describe("undo after auto-extract on blur", () => {
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     setTextareaValue(textarea, "Take me home (country roads)");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Take me home (country roads)");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Take me home (country roads)");
 
     blurTextarea(textarea);
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Take me home");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Take me home");
 
     useProjectStore.getState().undo();
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Take me home (country roads)");
-    expect(useProjectStore.getState().lines[0].backgroundText).toBeUndefined();
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Take me home (country roads)");
+    expect(bgText(useProjectStore.getState().lines[0])).toBeUndefined();
 
     useProjectStore.getState().undo();
     await expect.poll(() => useProjectStore.getState().lines.length).toBe(0);
@@ -175,14 +176,14 @@ describe("undo after auto-extract on blur", () => {
 
     setTextareaValue(textarea, "Take me home (country roads)");
     blurTextarea(textarea);
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Take me home");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Take me home");
 
     useProjectStore.getState().undo();
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Take me home (country roads)");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Take me home (country roads)");
 
     useProjectStore.getState().redo();
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Take me home");
-    expect(useProjectStore.getState().lines[0].backgroundText).toBe("country roads");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Take me home");
+    expect(bgText(useProjectStore.getState().lines[0])).toBe("country roads");
   });
 });
 
@@ -198,7 +199,7 @@ describe("auto-extract on blur preserves existing blur behavior", () => {
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     setTextareaValue(textarea, "Plain lyric line");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Plain lyric line");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Plain lyric line");
 
     blurTextarea(textarea);
 

--- a/src/views/edit.browser.test.tsx
+++ b/src/views/edit.browser.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { userEvent } from "vitest/browser";
+import { bgSource, bgText, bgWords, lineText } from "@/domain/line/voices";
 import { INITIAL_STATE as IMPORT_MODAL_INITIAL_STATE, useImportModalStore } from "@/stores/import-modal-store";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
@@ -67,8 +68,8 @@ describe("background vocal extraction", () => {
 
     await expect.poll(() => previewMainTexts(screen.container)).toContain("Hello world");
     await expect.poll(() => previewBackgroundTexts(screen.container)).toContain("ooh");
-    expect(useProjectStore.getState().lines[0].text).toBe("Hello world");
-    expect(useProjectStore.getState().lines[0].backgroundText).toBe("ooh");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("Hello world");
+    expect(bgText(useProjectStore.getState().lines[0])).toBe("ooh");
   });
 
   it("merges a standalone parenthesis line into the line above on bulk extract", async () => {
@@ -83,7 +84,7 @@ describe("background vocal extraction", () => {
     await button.click();
 
     await expect.poll(() => useProjectStore.getState().lines.length).toBe(1);
-    expect(useProjectStore.getState().lines[0].backgroundText).toBe("ooh yeah");
+    expect(bgText(useProjectStore.getState().lines[0])).toBe("ooh yeah");
     await expect.poll(() => previewMainTexts(screen.container)).toEqual(["Real lyric line"]);
     await expect.poll(() => previewBackgroundTexts(screen.container)).toContain("ooh yeah");
   });
@@ -99,9 +100,9 @@ describe("background vocal extraction", () => {
     await expect.element(pullButton).toBeInTheDocument();
     await pullButton.click();
 
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello world");
-    expect(useProjectStore.getState().lines[0].backgroundText).toBe("ooh");
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("extraction");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello world");
+    expect(bgText(useProjectStore.getState().lines[0])).toBe("ooh");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("extraction");
   });
 
   it("hides the per-line pull action when the line has no parentheses", async () => {
@@ -129,9 +130,9 @@ describe("background vocal extraction", () => {
     pasteIntoTextarea(textarea, "Hello (ooh) world\nSecond (ah) line");
 
     await expect
-      .poll(() => useProjectStore.getState().lines.map((l) => l.text))
+      .poll(() => useProjectStore.getState().lines.map((l) => lineText(l)))
       .toEqual(["Hello world", "Second line"]);
-    expect(useProjectStore.getState().lines.map((l) => l.backgroundText)).toEqual(["ooh", "ah"]);
+    expect(useProjectStore.getState().lines.map((l) => bgText(l))).toEqual(["ooh", "ah"]);
     await expect.poll(() => previewMainTexts(screen.container)).toEqual(["Hello world", "Second line"]);
     await expect.poll(() => previewBackgroundTexts(screen.container)).toEqual(["ooh", "ah"]);
   });
@@ -147,9 +148,9 @@ describe("background vocal extraction", () => {
     pasteIntoTextarea(textarea, "Hello (ooh) world\nSecond (ah) line");
 
     await expect
-      .poll(() => useProjectStore.getState().lines.map((l) => l.text))
+      .poll(() => useProjectStore.getState().lines.map((l) => lineText(l)))
       .toEqual(["Hello (ooh) world", "Second (ah) line"]);
-    expect(useProjectStore.getState().lines.every((l) => l.backgroundText === undefined)).toBe(true);
+    expect(useProjectStore.getState().lines.every((l) => bgText(l) === undefined)).toBe(true);
   });
 });
 
@@ -188,8 +189,8 @@ describe("manual background vocal editing", () => {
     await input.fill("ooh");
     await userEvent.keyboard("{Enter}");
 
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundText).toBe("ooh");
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
+    await expect.poll(() => bgText(useProjectStore.getState().lines[0])).toBe("ooh");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
   });
 
   it("flips an extraction-sourced background to manual when edited in the popover", async () => {
@@ -205,8 +206,8 @@ describe("manual background vocal editing", () => {
     await input.fill("aah");
     await userEvent.keyboard("{Enter}");
 
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundText).toBe("aah");
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
+    await expect.poll(() => bgText(useProjectStore.getState().lines[0])).toBe("aah");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
   });
 
   it("clears all three background fields when the popover text is emptied", async () => {
@@ -222,9 +223,9 @@ describe("manual background vocal editing", () => {
     await input.fill("");
     await userEvent.keyboard("{Enter}");
 
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundText).toBeUndefined();
-    expect(useProjectStore.getState().lines[0].backgroundWords).toBeUndefined();
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBeUndefined();
+    await expect.poll(() => bgText(useProjectStore.getState().lines[0])).toBeUndefined();
+    expect(bgWords(useProjectStore.getState().lines[0])).toBeUndefined();
+    expect(bgSource(useProjectStore.getState().lines[0])).toBeUndefined();
   });
 });
 

--- a/src/views/edit.detach.browser.test.tsx
+++ b/src/views/edit.detach.browser.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { LyricLine } from "@/domain/line/model";
 import { reconcileLine } from "@/domain/line/model";
+import { lineText } from "@/domain/line/voices";
 import { useProjectStore } from "@/stores/project";
 import { createGroup } from "@/test/factories";
 import { render } from "@/test/render";
@@ -46,7 +47,7 @@ describe("editor detach-confirm undo", () => {
     await confirmButton.click();
 
     await expect
-      .poll(() => useProjectStore.getState().lines.map((l) => l.text))
+      .poll(() => useProjectStore.getState().lines.map((l) => lineText(l)))
       .toEqual(["Verse one", "Verse two", "Verse one"]);
     expect(useProjectStore.getState().lines.some((l) => l.instanceIdx === 1)).toBe(false);
 

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -7,11 +7,10 @@ import { isAnyModalOpen } from "@/stores/modal-stack";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import { getAgentColor } from "@/domain/agent/colors";
-import { backgroundFields } from "@/domain/line/background";
 import type { LinkGroup } from "@/domain/group/template";
 import type { LyricLine } from "@/domain/line/model";
 import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
-import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { bgWords, lineText } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { Button } from "@/ui/button";
 import { Popover } from "@/ui/popover";
@@ -384,9 +383,7 @@ const EditPanel: React.FC = () => {
       words = remapWordTextsPreservingTiming(targetBgWords, newBgText) ?? undefined;
     }
 
-    useProjectStore
-      .getState()
-      .updateLineWithHistory(lineId, backgroundFields({ text: newBgText, words, source: "manual" }));
+    useProjectStore.getState().applyLineBackground(lineId, { text: newBgText, words, source: "manual" });
   }, []);
 
   const handleExtractLine = useCallback((lineId: string) => {
@@ -397,15 +394,7 @@ const EditPanel: React.FC = () => {
       preserveBrackets: useSettingsStore.getState().preserveBracketsOnExtraction,
     });
     if (extracted === target) return;
-    useProjectStore.getState().updateLineWithHistory(lineId, {
-      text: lineText(extracted),
-      words: mainWords(extracted),
-      ...backgroundFields({
-        text: bgText(extracted),
-        words: bgWords(extracted),
-        source: bgSource(extracted) ?? "manual",
-      }),
-    });
+    useProjectStore.getState().setLineWithHistory(lineId, extracted);
   }, []);
 
   const handleLineSelect = useCallback((lineNumber: number, shiftKey: boolean) => {

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -10,6 +10,8 @@ import { getAgentColor } from "@/domain/agent/colors";
 import { backgroundFields } from "@/domain/line/background";
 import type { LinkGroup } from "@/domain/group/template";
 import type { LyricLine } from "@/domain/line/model";
+import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
+import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { Button } from "@/ui/button";
 import { Popover } from "@/ui/popover";
@@ -57,8 +59,8 @@ const ImportSuccessBanner: React.FC<{
   onDismiss: () => void;
 }> = ({ result, filename, onDismiss }) => {
   const lineCount = result.lines.length;
-  const timedLineCount = result.lines.filter((l) => l.begin !== undefined).length;
-  const wordTimedCount = result.lines.filter((l) => l.words?.length).length;
+  const timedLineCount = result.lines.filter((l) => isLineSynced(l)).length;
+  const wordTimedCount = result.lines.filter((l) => isWordSynced(l)).length;
 
   return (
     <div className="flex items-center justify-between gap-2 px-3 py-2 text-sm rounded-lg bg-composer-accent/10 text-composer-accent-text">
@@ -299,7 +301,7 @@ const EditPanel: React.FC = () => {
   const mergeStandaloneBackgroundLines = useSettingsStore((s) => s.mergeStandaloneBackgroundLines);
   const preserveBracketsOnExtraction = useSettingsStore((s) => s.preserveBracketsOnExtraction);
 
-  const [rawText, setRawText] = useState(() => (lines.length > 0 ? lines.map((l) => l.text).join("\n") : ""));
+  const [rawText, setRawText] = useState(() => (lines.length > 0 ? lines.map((l) => lineText(l)).join("\n") : ""));
   const rawTextRef = useRef(rawText);
   rawTextRef.current = rawText;
   const linesSetByUs = useRef<LyricLine[] | null>(null);
@@ -318,7 +320,7 @@ const EditPanel: React.FC = () => {
       linesSetByUs.current = null;
       return;
     }
-    setRawText(lines.length > 0 ? lines.map((l) => l.text).join("\n") : "");
+    setRawText(lines.length > 0 ? lines.map((l) => lineText(l)).join("\n") : "");
   }, [lines]);
 
   const defaultAgentId = agents?.[0]?.id ?? "v1";
@@ -358,7 +360,7 @@ const EditPanel: React.FC = () => {
     useProjectStore.getState().setLinesWithHistory(nextLines, nextGroups);
     const committed = useProjectStore.getState().lines;
     linesSetByUs.current = committed;
-    setRawText(committed.map((line) => line.text).join("\n"));
+    setRawText(committed.map((line) => lineText(line)).join("\n"));
   }, []);
 
   const handleExtractBackgroundVocals = useCallback(() => {
@@ -376,9 +378,10 @@ const EditPanel: React.FC = () => {
     const newBgText = text || undefined;
     const target = useProjectStore.getState().lines.find((l) => l.id === lineId);
 
+    const targetBgWords = target ? bgWords(target) : undefined;
     let words: WordTiming[] | undefined;
-    if (newBgText && target?.backgroundWords?.length) {
-      words = remapWordTextsPreservingTiming(target.backgroundWords, newBgText) ?? undefined;
+    if (newBgText && targetBgWords?.length) {
+      words = remapWordTextsPreservingTiming(targetBgWords, newBgText) ?? undefined;
     }
 
     useProjectStore
@@ -395,12 +398,12 @@ const EditPanel: React.FC = () => {
     });
     if (extracted === target) return;
     useProjectStore.getState().updateLineWithHistory(lineId, {
-      text: extracted.text,
-      words: extracted.words,
+      text: lineText(extracted),
+      words: mainWords(extracted),
       ...backgroundFields({
-        text: extracted.backgroundText,
-        words: extracted.backgroundWords,
-        source: extracted.backgroundTextSource ?? "manual",
+        text: bgText(extracted),
+        words: bgWords(extracted),
+        source: bgSource(extracted) ?? "manual",
       }),
     });
   }, []);

--- a/src/views/edit.undo-lifecycle.browser.test.tsx
+++ b/src/views/edit.undo-lifecycle.browser.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { lineText } from "@/domain/line/voices";
 import { useProjectStore } from "@/stores/project";
 import { createLine } from "@/test/factories";
 import { render } from "@/test/render";
@@ -24,12 +25,12 @@ describe("editor undo run finalization lifecycle", () => {
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     setTextareaValue(textarea, "Hello world");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello world");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello world");
 
     await expect.poll(() => useProjectStore.getState().canUndo(), { timeout: 2000 }).toBe(true);
 
     useProjectStore.getState().undo();
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello");
     await expect.poll(() => textarea.value).toBe("Hello");
     await expect.poll(() => previewMainTexts(screen.container)).toEqual(["Hello"]);
   });
@@ -40,13 +41,13 @@ describe("editor undo run finalization lifecycle", () => {
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     setTextareaValue(textarea, "Hello there");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello there");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello there");
 
     await screen.unmount();
 
     expect(useProjectStore.getState().canUndo()).toBe(true);
 
     useProjectStore.getState().undo();
-    expect(useProjectStore.getState().lines[0].text).toBe("Hello");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("Hello");
   });
 });

--- a/src/views/edit.undo.browser.test.tsx
+++ b/src/views/edit.undo.browser.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { bgText, lineText } from "@/domain/line/voices";
 import { useModalStackStore } from "@/stores/modal-stack";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
@@ -90,17 +91,17 @@ describe("editor undo and redo", () => {
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     setTextareaValue(textarea, "Hello world");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello world");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello world");
 
     blurTextarea(textarea);
 
     useProjectStore.getState().undo();
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello");
     await expect.poll(() => textarea.value).toBe("Hello");
     await expect.poll(() => previewMainTexts(screen.container)).toEqual(["Hello"]);
 
     useProjectStore.getState().redo();
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello world");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello world");
     await expect.poll(() => textarea.value).toBe("Hello world");
     await expect.poll(() => previewMainTexts(screen.container)).toEqual(["Hello world"]);
   });
@@ -111,10 +112,10 @@ describe("editor undo and redo", () => {
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     setTextareaValue(textarea, "Hello there");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello there");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello there");
 
     pressUndo(textarea);
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello");
     await expect.poll(() => textarea.value).toBe("Hello");
   });
 
@@ -124,10 +125,10 @@ describe("editor undo and redo", () => {
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     setTextareaValue(textarea, "Hello again");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello again");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello again");
 
     pressUndo(textarea, { ctrl: true });
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello");
     await expect.poll(() => textarea.value).toBe("Hello");
   });
 
@@ -137,13 +138,13 @@ describe("editor undo and redo", () => {
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     setTextareaValue(textarea, "Hello world");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello world");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello world");
 
     pressUndo(textarea);
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello");
 
     pressRedo(textarea);
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello world");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello world");
     await expect.poll(() => textarea.value).toBe("Hello world");
   });
 
@@ -153,13 +154,13 @@ describe("editor undo and redo", () => {
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     setTextareaValue(textarea, "Hello world");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello world");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello world");
 
     pressUndo(textarea);
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello");
 
     pressRedo(textarea, { ctrlY: true });
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello world");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello world");
     await expect.poll(() => textarea.value).toBe("Hello world");
   });
 
@@ -171,7 +172,7 @@ describe("editor undo and redo", () => {
 
     pasteIntoTextarea(textarea, "First line\nSecond line\nThird line");
     await expect
-      .poll(() => useProjectStore.getState().lines.map((l) => l.text))
+      .poll(() => useProjectStore.getState().lines.map((l) => lineText(l)))
       .toEqual(["First line", "Second line", "Third line"]);
 
     pressUndo(textarea);
@@ -186,18 +187,18 @@ describe("editor undo and redo", () => {
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     setTextareaValue(textarea, "Start typed");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Start typed");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Start typed");
 
     pasteIntoTextarea(textarea, "Start typed\nPasted line");
     await expect
-      .poll(() => useProjectStore.getState().lines.map((l) => l.text))
+      .poll(() => useProjectStore.getState().lines.map((l) => lineText(l)))
       .toEqual(["Start typed", "Pasted line"]);
 
     pressUndo(textarea);
-    await expect.poll(() => useProjectStore.getState().lines.map((l) => l.text)).toEqual(["Start typed"]);
+    await expect.poll(() => useProjectStore.getState().lines.map((l) => lineText(l))).toEqual(["Start typed"]);
 
     pressUndo(textarea);
-    await expect.poll(() => useProjectStore.getState().lines.map((l) => l.text)).toEqual(["Start"]);
+    await expect.poll(() => useProjectStore.getState().lines.map((l) => lineText(l))).toEqual(["Start"]);
   });
 
   it("treats two blurred typing runs as two undo steps", async () => {
@@ -206,18 +207,18 @@ describe("editor undo and redo", () => {
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     setTextareaValue(textarea, "AB");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("AB");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("AB");
     blurTextarea(textarea);
 
     setTextareaValue(textarea, "ABC");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("ABC");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("ABC");
     blurTextarea(textarea);
 
     pressUndo(textarea);
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("AB");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("AB");
 
     pressUndo(textarea);
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("A");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("A");
   });
 });
 
@@ -234,11 +235,11 @@ describe("editor undo and redo without textarea focus", () => {
     document.body.focus();
 
     useProjectStore.getState().updateLineWithHistory("l1", { backgroundText: "ooh" });
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundText).toBe("ooh");
+    await expect.poll(() => bgText(useProjectStore.getState().lines[0])).toBe("ooh");
     expect(document.activeElement).not.toBe(textarea);
 
     dispatchWindowUndo();
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundText).toBe(undefined);
+    await expect.poll(() => bgText(useProjectStore.getState().lines[0])).toBe(undefined);
   });
 
   it("undoes via Ctrl+Z on window when focus is outside the textarea", async () => {
@@ -456,7 +457,7 @@ describe("editor undo edge cases", () => {
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     pressUndo(textarea);
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Untouched");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Untouched");
     expect(textarea.value).toBe("Untouched");
   });
 
@@ -466,15 +467,15 @@ describe("editor undo edge cases", () => {
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     setTextareaValue(textarea, "Base A");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Base A");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Base A");
     blurTextarea(textarea);
 
     setTextareaValue(textarea, "Base B");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Base B");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Base B");
     blurTextarea(textarea);
 
     pressUndo(textarea);
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Base A");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Base A");
     await expect.poll(() => textarea.value).toBe("Base A");
   });
 
@@ -510,7 +511,7 @@ describe("editor undo edge cases", () => {
     const textarea = screen.container.querySelector("textarea") as HTMLTextAreaElement;
 
     setTextareaValue(textarea, "Hello world");
-    await expect.poll(() => useProjectStore.getState().lines[0].text).toBe("Hello world");
+    await expect.poll(() => lineText(useProjectStore.getState().lines[0])).toBe("Hello world");
 
     const event = new KeyboardEvent("keydown", {
       key: "z",

--- a/src/views/edit/decide-edit-text-action.test.ts
+++ b/src/views/edit/decide-edit-text-action.test.ts
@@ -2,7 +2,8 @@
  * @vitest-environment node
  */
 import type { LinkGroup } from "@/domain/group/template";
-import type { LyricLine } from "@/domain/line/model";
+import { type LyricLine, reconcileLine } from "@/domain/line/model";
+import { lineText, mainWords } from "@/domain/line/voices";
 import { describe, expect, it } from "vitest";
 import { decideEditTextAction } from "./decide-edit-text-action";
 
@@ -10,15 +11,29 @@ const groupChorus: LinkGroup = { id: "g1", label: "Chorus", color: "#f472b6", te
 
 function chorusLines(): LyricLine[] {
   return [
-    { id: "c1a", text: "I love you", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-    { id: "c1b", text: "more than words", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 },
-    { id: "v1", text: "verse line", agentId: "v1" },
-    { id: "c2a", text: "I love you", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
-    { id: "c2b", text: "more than words", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 1 },
+    reconcileLine({ id: "c1a", text: "I love you", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+    reconcileLine({
+      id: "c1b",
+      text: "more than words",
+      agentId: "v1",
+      groupId: "g1",
+      instanceIdx: 0,
+      templateLineIdx: 1,
+    }),
+    reconcileLine({ id: "v1", text: "verse line", agentId: "v1" }),
+    reconcileLine({ id: "c2a", text: "I love you", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 }),
+    reconcileLine({
+      id: "c2b",
+      text: "more than words",
+      agentId: "v1",
+      groupId: "g1",
+      instanceIdx: 1,
+      templateLineIdx: 1,
+    }),
   ];
 }
 
-const baseText = (lines: LyricLine[]) => lines.map((l) => l.text).join("\n");
+const baseText = (lines: LyricLine[]) => lines.map((l) => lineText(l)).join("\n");
 
 describe("decideEditTextAction", () => {
   it("returns ignore-modal-pending when modal already open and skips all computation", () => {
@@ -57,8 +72,10 @@ describe("decideEditTextAction", () => {
     });
     expect(action.kind).toBe("apply");
     if (action.kind !== "apply") return;
-    expect(action.finalLines.find((l) => l.id === "c1a")?.text).toBe("I luv you");
-    expect(action.finalLines.find((l) => l.id === "c2a")?.text).toBe("I luv you");
+    const c1a = action.finalLines.find((l) => l.id === "c1a");
+    const c2a = action.finalLines.find((l) => l.id === "c2a");
+    expect(c1a && lineText(c1a)).toBe("I luv you");
+    expect(c2a && lineText(c2a)).toBe("I luv you");
   });
 
   it("returns apply for structural changes outside any group (no confirm)", () => {
@@ -74,7 +91,7 @@ describe("decideEditTextAction", () => {
     expect(action.kind).toBe("apply");
     if (action.kind !== "apply") return;
     expect(action.finalLines.length).toBe(lines.length + 1);
-    expect(action.finalLines[action.finalLines.length - 1].text).toBe("brand new outro");
+    expect(lineText(action.finalLines[action.finalLines.length - 1])).toBe("brand new outro");
   });
 
   it("returns needs-confirm when a chorus instance loses a row", () => {
@@ -111,8 +128,8 @@ describe("decideEditTextAction", () => {
 
   it("dedups labels when multiple impacted instances share a group", () => {
     const lines: LyricLine[] = [
-      { id: "a", text: "foo", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "b", text: "foo", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
+      reconcileLine({ id: "a", text: "foo", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "b", text: "foo", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 }),
     ];
     const action = decideEditTextAction({
       text: "",
@@ -129,7 +146,7 @@ describe("decideEditTextAction", () => {
 
   it("propagates a content edit to a sibling instance via apply", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "a",
         text: "I love you",
         agentId: "v1",
@@ -141,8 +158,8 @@ describe("decideEditTextAction", () => {
           { text: "love ", begin: 0.4, end: 0.8 },
           { text: "you", begin: 0.8, end: 1.2 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "b",
         text: "I love you",
         agentId: "v1",
@@ -154,7 +171,7 @@ describe("decideEditTextAction", () => {
           { text: "love ", begin: 30.5, end: 31.0 },
           { text: "you", begin: 31.0, end: 31.5 },
         ],
-      },
+      }),
     ];
     const action = decideEditTextAction({
       text: "I luv you\nI love you",
@@ -167,16 +184,16 @@ describe("decideEditTextAction", () => {
     if (action.kind !== "apply") return;
     const a = action.finalLines.find((l) => l.id === "a");
     const b = action.finalLines.find((l) => l.id === "b");
-    expect(a?.text).toBe("I luv you");
-    expect(a?.words?.[1].text).toBe("luv ");
-    expect(a?.words?.[1].begin).toBe(0.4);
-    expect(b?.text).toBe("I luv you");
-    expect(b?.words?.[1].text).toBe("luv ");
-    expect(b?.words?.[1].begin).toBe(30.5);
+    expect(a && lineText(a)).toBe("I luv you");
+    expect(a && mainWords(a)?.[1].text).toBe("luv ");
+    expect(a && mainWords(a)?.[1].begin).toBe(0.4);
+    expect(b && lineText(b)).toBe("I luv you");
+    expect(b && mainWords(b)?.[1].text).toBe("luv ");
+    expect(b && mainWords(b)?.[1].begin).toBe(30.5);
   });
 
   it("returns apply (with empty group cleanup unrelated) when impacted is empty even on length change outside group", () => {
-    const lines: LyricLine[] = [{ id: "a", text: "first", agentId: "v1" }];
+    const lines: LyricLine[] = [reconcileLine({ id: "a", text: "first", agentId: "v1" })];
     const action = decideEditTextAction({
       text: "first\nsecond",
       defaultAgentId: "v1",

--- a/src/views/edit/decide-edit-text-action.test.ts
+++ b/src/views/edit/decide-edit-text-action.test.ts
@@ -1,9 +1,11 @@
 /**
  * @vitest-environment node
  */
+import { applyBackground } from "@/domain/line/background";
+import { bgBounds } from "@/domain/line/bounds";
 import type { LinkGroup } from "@/domain/group/template";
 import { type LyricLine, reconcileLine } from "@/domain/line/model";
-import { lineText, mainWords } from "@/domain/line/voices";
+import { bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { describe, expect, it } from "vitest";
 import { decideEditTextAction } from "./decide-edit-text-action";
 
@@ -202,5 +204,57 @@ describe("decideEditTextAction", () => {
       modalPending: false,
     });
     expect(action.kind).toBe("apply");
+  });
+});
+
+describe("#122 audit: editing main text never resurrects a word-split background", () => {
+  it("keeps a line-synced background line-synced when its main text is edited", () => {
+    const lineSynced = applyBackground(
+      reconcileLine({ id: "L1", text: "lead vocal", agentId: "v1", begin: 0, end: 4 }),
+      {
+        text: "ooh",
+        source: "manual",
+      },
+    );
+    expect(bgBounds(lineSynced)).not.toBeNull();
+    expect(bgWords(lineSynced)).toBeUndefined();
+
+    const action = decideEditTextAction({
+      text: "lead vocals",
+      defaultAgentId: "v1",
+      lines: [lineSynced],
+      groups: [],
+      modalPending: false,
+    });
+
+    expect(action.kind).toBe("apply");
+    if (action.kind !== "apply") return;
+    const edited = action.finalLines[0];
+    expect(bgText(edited)).toBe("ooh");
+    expect(bgWords(edited)).toBeUndefined();
+  });
+
+  it("does not auto-split an untimed background when the main text is edited", () => {
+    const untimedBg = reconcileLine({
+      id: "L1",
+      text: "lead vocal",
+      agentId: "v1",
+      begin: 0,
+      end: 4,
+      backgroundText: "ooh",
+      backgroundTextSource: "manual",
+    });
+    const action = decideEditTextAction({
+      text: "lead vocals",
+      defaultAgentId: "v1",
+      lines: [untimedBg],
+      groups: [],
+      modalPending: false,
+    });
+    expect(action.kind).toBe("apply");
+    if (action.kind !== "apply") return;
+    const edited = action.finalLines[0];
+    expect(bgText(edited)).toBe("ooh");
+    expect(bgWords(edited)).toBeUndefined();
   });
 });

--- a/src/views/edit/diff-edit-text.test.ts
+++ b/src/views/edit/diff-edit-text.test.ts
@@ -1,7 +1,9 @@
 /**
  * @vitest-environment node
  */
-import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { mainBounds } from "@/domain/line/bounds";
+import { type LyricLine, reconcileLine } from "@/domain/line/model";
+import { bgSource, bgText, lineText, mainWords } from "@/domain/line/voices";
 import { describe, expect, it } from "vitest";
 import {
   detachInstancesFromLines,
@@ -13,8 +15,8 @@ import {
 describe("diffEditTextChange", () => {
   it("returns no updates and no structural change when nothing differs", () => {
     const lines: LyricLine[] = [
-      { id: "L1", text: "first", agentId: "v1" },
-      { id: "L2", text: "second", agentId: "v1" },
+      reconcileLine({ id: "L1", text: "first", agentId: "v1" }),
+      reconcileLine({ id: "L2", text: "second", agentId: "v1" }),
     ];
     const result = diffEditTextChange(lines, lines);
     expect(result.contentUpdates).toHaveLength(0);
@@ -22,8 +24,8 @@ describe("diffEditTextChange", () => {
   });
 
   it("emits a content update for a same-id text change", () => {
-    const old: LyricLine[] = [{ id: "L1", text: "I love you", agentId: "v1" }];
-    const next: LyricLine[] = [{ id: "L1", text: "I luv you", agentId: "v1" }];
+    const old: LyricLine[] = [reconcileLine({ id: "L1", text: "I love you", agentId: "v1" })];
+    const next: LyricLine[] = [reconcileLine({ id: "L1", text: "I luv you", agentId: "v1" })];
     const result = diffEditTextChange(old, next);
     expect(result.hasStructuralChange).toBe(false);
     expect(result.contentUpdates).toEqual([{ id: "L1", updates: { text: "I luv you" } }]);
@@ -31,14 +33,14 @@ describe("diffEditTextChange", () => {
 
   it("forwards explicit undefined for words when a word-synced source loses them", () => {
     const old: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "I love",
         agentId: "v1",
         words: [{ text: "I love", begin: 0, end: 1 }],
-      },
+      }),
     ];
-    const next: LyricLine[] = [{ id: "L1", text: "I luv", agentId: "v1" }];
+    const next: LyricLine[] = [reconcileLine({ id: "L1", text: "I luv", agentId: "v1" })];
     const result = diffEditTextChange(old, next);
     expect(result.hasStructuralChange).toBe(false);
     expect(result.contentUpdates).toHaveLength(1);
@@ -50,8 +52,8 @@ describe("diffEditTextChange", () => {
   });
 
   it("forwards explicit undefined for begin/end when a line-synced source loses them", () => {
-    const old: LyricLine[] = [{ id: "L1", text: "I love", agentId: "v1", begin: 0, end: 1 }];
-    const next: LyricLine[] = [{ id: "L1", text: "I luv", agentId: "v1" }];
+    const old: LyricLine[] = [reconcileLine({ id: "L1", text: "I love", agentId: "v1", begin: 0, end: 1 })];
+    const next: LyricLine[] = [reconcileLine({ id: "L1", text: "I luv", agentId: "v1" })];
     const result = diffEditTextChange(old, next);
     expect(result.contentUpdates).toHaveLength(1);
     const u = result.contentUpdates[0];
@@ -62,10 +64,10 @@ describe("diffEditTextChange", () => {
   });
 
   it("flags hasStructuralChange when length differs (insertion)", () => {
-    const old: LyricLine[] = [{ id: "L1", text: "first", agentId: "v1" }];
+    const old: LyricLine[] = [reconcileLine({ id: "L1", text: "first", agentId: "v1" })];
     const next: LyricLine[] = [
-      { id: "L1", text: "first", agentId: "v1" },
-      { id: "L2", text: "second", agentId: "v1" },
+      reconcileLine({ id: "L1", text: "first", agentId: "v1" }),
+      reconcileLine({ id: "L2", text: "second", agentId: "v1" }),
     ];
     const result = diffEditTextChange(old, next);
     expect(result.hasStructuralChange).toBe(true);
@@ -73,22 +75,22 @@ describe("diffEditTextChange", () => {
 
   it("flags hasStructuralChange when length differs (deletion)", () => {
     const old: LyricLine[] = [
-      { id: "L1", text: "first", agentId: "v1" },
-      { id: "L2", text: "second", agentId: "v1" },
+      reconcileLine({ id: "L1", text: "first", agentId: "v1" }),
+      reconcileLine({ id: "L2", text: "second", agentId: "v1" }),
     ];
-    const next: LyricLine[] = [{ id: "L1", text: "first", agentId: "v1" }];
+    const next: LyricLine[] = [reconcileLine({ id: "L1", text: "first", agentId: "v1" })];
     const result = diffEditTextChange(old, next);
     expect(result.hasStructuralChange).toBe(true);
   });
 
   it("flags hasStructuralChange when ids reorder", () => {
     const old: LyricLine[] = [
-      { id: "L1", text: "first", agentId: "v1" },
-      { id: "L2", text: "second", agentId: "v1" },
+      reconcileLine({ id: "L1", text: "first", agentId: "v1" }),
+      reconcileLine({ id: "L2", text: "second", agentId: "v1" }),
     ];
     const next: LyricLine[] = [
-      { id: "L2", text: "second", agentId: "v1" },
-      { id: "L1", text: "first", agentId: "v1" },
+      reconcileLine({ id: "L2", text: "second", agentId: "v1" }),
+      reconcileLine({ id: "L1", text: "first", agentId: "v1" }),
     ];
     const result = diffEditTextChange(old, next);
     expect(result.hasStructuralChange).toBe(true);
@@ -96,20 +98,20 @@ describe("diffEditTextChange", () => {
 
   it("flags hasStructuralChange when an id is replaced", () => {
     const old: LyricLine[] = [
-      { id: "L1", text: "first", agentId: "v1" },
-      { id: "L2", text: "second", agentId: "v1" },
+      reconcileLine({ id: "L1", text: "first", agentId: "v1" }),
+      reconcileLine({ id: "L2", text: "second", agentId: "v1" }),
     ];
     const next: LyricLine[] = [
-      { id: "L1", text: "first", agentId: "v1" },
-      { id: "L3", text: "second", agentId: "v1" },
+      reconcileLine({ id: "L1", text: "first", agentId: "v1" }),
+      reconcileLine({ id: "L3", text: "second", agentId: "v1" }),
     ];
     const result = diffEditTextChange(old, next);
     expect(result.hasStructuralChange).toBe(true);
   });
 
   it("emits backgroundText update when only background differs", () => {
-    const old: LyricLine[] = [{ id: "L1", text: "main", agentId: "v1" }];
-    const next: LyricLine[] = [{ id: "L1", text: "main", agentId: "v1", backgroundText: "ah" }];
+    const old: LyricLine[] = [reconcileLine({ id: "L1", text: "main", agentId: "v1" })];
+    const next: LyricLine[] = [reconcileLine({ id: "L1", text: "main", agentId: "v1", backgroundText: "ah" })];
     const result = diffEditTextChange(old, next);
     expect(result.hasStructuralChange).toBe(false);
     expect(result.contentUpdates).toEqual([{ id: "L1", updates: { backgroundText: "ah" } }]);
@@ -117,9 +119,15 @@ describe("diffEditTextChange", () => {
 
   it("emits a backgroundTextSource update when provenance is cleared", () => {
     const old: LyricLine[] = [
-      { id: "L1", text: "main", agentId: "v1", backgroundText: "ooh", backgroundTextSource: "extraction" },
+      reconcileLine({
+        id: "L1",
+        text: "main",
+        agentId: "v1",
+        backgroundText: "ooh",
+        backgroundTextSource: "extraction",
+      }),
     ];
-    const next: LyricLine[] = [{ id: "L1", text: "main", agentId: "v1" }];
+    const next: LyricLine[] = [reconcileLine({ id: "L1", text: "main", agentId: "v1" })];
     const result = diffEditTextChange(old, next);
     expect(result.contentUpdates).toHaveLength(1);
     const u = result.contentUpdates[0];
@@ -131,10 +139,10 @@ describe("diffEditTextChange", () => {
 
   it("does not emit updates for fields untouched by the new line", () => {
     const old: LyricLine[] = [
-      { id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
+      reconcileLine({ id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
     ];
     const next: LyricLine[] = [
-      { id: "L1", text: "a edited", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
+      reconcileLine({ id: "L1", text: "a edited", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
     ];
     const result = diffEditTextChange(old, next);
     expect(result.contentUpdates).toHaveLength(1);
@@ -145,12 +153,12 @@ describe("diffEditTextChange", () => {
 
   it("treats a length-equal mix of content edits as content-only", () => {
     const old: LyricLine[] = [
-      { id: "L1", text: "first", agentId: "v1" },
-      { id: "L2", text: "second", agentId: "v1" },
+      reconcileLine({ id: "L1", text: "first", agentId: "v1" }),
+      reconcileLine({ id: "L2", text: "second", agentId: "v1" }),
     ];
     const next: LyricLine[] = [
-      { id: "L1", text: "first edit", agentId: "v1" },
-      { id: "L2", text: "second", agentId: "v1" },
+      reconcileLine({ id: "L1", text: "first edit", agentId: "v1" }),
+      reconcileLine({ id: "L2", text: "second", agentId: "v1" }),
     ];
     const result = diffEditTextChange(old, next);
     expect(result.hasStructuralChange).toBe(false);
@@ -160,33 +168,33 @@ describe("diffEditTextChange", () => {
 
 describe("propagateContentUpdates", () => {
   it("returns input unchanged when there are no updates", () => {
-    const lines: LyricLine[] = [{ id: "L1", text: "a", agentId: "v1" }];
+    const lines: LyricLine[] = [reconcileLine({ id: "L1", text: "a", agentId: "v1" })];
     expect(propagateContentUpdates(lines, lines, [])).toBe(lines);
   });
 
   it("does nothing when the source line is not grouped", () => {
     const lines: LyricLine[] = [
-      { id: "L1", text: "edited", agentId: "v1" },
-      { id: "L2", text: "other", agentId: "v1" },
+      reconcileLine({ id: "L1", text: "edited", agentId: "v1" }),
+      reconcileLine({ id: "L2", text: "other", agentId: "v1" }),
     ];
     const out = propagateContentUpdates(lines, lines, [{ id: "L1", updates: { text: "edited" } }]);
-    expect(out[1].text).toBe("other");
+    expect(lineText(out[1])).toBe("other");
   });
 
   it("propagates text to linked siblings (same groupId + templateLineIdx)", () => {
     const lines: LyricLine[] = [
-      { id: "L1", text: "edited", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L2", text: "stale", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
+      reconcileLine({ id: "L1", text: "edited", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L2", text: "stale", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 }),
     ];
     const out = propagateContentUpdates(lines, lines, [{ id: "L1", updates: { text: "edited" } }]);
-    expect(out[0].text).toBe("edited");
-    expect(out[1].text).toBe("edited");
+    expect(lineText(out[0])).toBe("edited");
+    expect(lineText(out[1])).toBe("edited");
   });
 
   it("clears sibling words/begin/end when source clears them via text edit", () => {
     const lines: LyricLine[] = [
-      { id: "L1", text: "I luv", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      {
+      reconcileLine({ id: "L1", text: "I luv", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({
         id: "L2",
         text: "stale",
         agentId: "v1",
@@ -194,20 +202,20 @@ describe("propagateContentUpdates", () => {
         instanceIdx: 1,
         templateLineIdx: 0,
         words: [{ text: "I love", begin: 10, end: 11 }],
-      },
+      }),
     ];
     const out = propagateContentUpdates(lines, lines, [
       { id: "L1", updates: { text: "I luv", words: undefined, begin: undefined, end: undefined } },
     ]);
-    expect(out[1].text).toBe("I luv");
-    expect(out[1].words).toBeUndefined();
-    expect(out[1].begin).toBeUndefined();
-    expect(out[1].end).toBeUndefined();
+    expect(lineText(out[1])).toBe("I luv");
+    expect(mainWords(out[1])).toBeUndefined();
+    expect(mainBounds(out[1])?.begin).toBeUndefined();
+    expect(mainBounds(out[1])?.end).toBeUndefined();
   });
 
   it("propagates a cleared background provenance flag to linked siblings", () => {
     const old: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "main",
         agentId: "v1",
@@ -216,8 +224,8 @@ describe("propagateContentUpdates", () => {
         templateLineIdx: 0,
         backgroundText: "ooh",
         backgroundTextSource: "extraction",
-      },
-      {
+      }),
+      reconcileLine({
         id: "L2",
         text: "main",
         agentId: "v1",
@@ -226,21 +234,21 @@ describe("propagateContentUpdates", () => {
         templateLineIdx: 0,
         backgroundText: "ooh",
         backgroundTextSource: "extraction",
-      },
+      }),
     ];
     const next: LyricLine[] = [
-      { id: "L1", text: "main", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
+      reconcileLine({ id: "L1", text: "main", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
       old[1],
     ];
     const { contentUpdates } = diffEditTextChange(old, next);
     const out = propagateContentUpdates(old, next, contentUpdates);
-    expect(out[1].backgroundText).toBeUndefined();
-    expect(out[1].backgroundTextSource).toBeUndefined();
+    expect(bgText(out[1])).toBeUndefined();
+    expect(bgSource(out[1])).toBeUndefined();
   });
 
   it("propagates per-word text changes to siblings while preserving sibling word timings", () => {
     const oldLines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "I love you",
         agentId: "v1",
@@ -252,8 +260,8 @@ describe("propagateContentUpdates", () => {
           { text: "love ", begin: 10.4, end: 10.8 },
           { text: "you", begin: 10.8, end: 11.2 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "L2",
         text: "I love you",
         agentId: "v1",
@@ -265,7 +273,7 @@ describe("propagateContentUpdates", () => {
           { text: "love ", begin: 30.5, end: 31.0 },
           { text: "you", begin: 31.0, end: 31.5 },
         ],
-      },
+      }),
     ];
     const newLines: LyricLine[] = [
       reconcileLine({
@@ -285,50 +293,58 @@ describe("propagateContentUpdates", () => {
         id: "L1",
         updates: {
           text: "I luv you",
-          words: newLines[0].words,
+          words: mainWords(newLines[0]),
         },
       },
     ]);
 
-    expect(out[1].text).toBe("I luv you");
-    expect(out[1].words?.[1].text).toBe("luv ");
-    expect(out[1].words?.[1].begin).toBe(30.5);
-    expect(out[1].words?.[1].end).toBe(31.0);
-    expect(out[1].words?.[0].text).toBe("I ");
-    expect(out[1].words?.[0].begin).toBe(30);
+    expect(lineText(out[1])).toBe("I luv you");
+    expect(mainWords(out[1])?.[1].text).toBe("luv ");
+    expect(mainWords(out[1])?.[1].begin).toBe(30.5);
+    expect(mainWords(out[1])?.[1].end).toBe(31.0);
+    expect(mainWords(out[1])?.[0].text).toBe("I ");
+    expect(mainWords(out[1])?.[0].begin).toBe(30);
   });
 
   it("skips detached siblings", () => {
     const lines: LyricLine[] = [
-      { id: "L1", text: "edited", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L2", text: "stale", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0, detached: true },
+      reconcileLine({ id: "L1", text: "edited", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({
+        id: "L2",
+        text: "stale",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 1,
+        templateLineIdx: 0,
+        detached: true,
+      }),
     ];
     const out = propagateContentUpdates(lines, lines, [{ id: "L1", updates: { text: "edited" } }]);
-    expect(out[1].text).toBe("stale");
+    expect(lineText(out[1])).toBe("stale");
   });
 
   it("skips lines from other groups", () => {
     const lines: LyricLine[] = [
-      { id: "L1", text: "edited", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L2", text: "stale", agentId: "v1", groupId: "g2", instanceIdx: 0, templateLineIdx: 0 },
+      reconcileLine({ id: "L1", text: "edited", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L2", text: "stale", agentId: "v1", groupId: "g2", instanceIdx: 0, templateLineIdx: 0 }),
     ];
     const out = propagateContentUpdates(lines, lines, [{ id: "L1", updates: { text: "edited" } }]);
-    expect(out[1].text).toBe("stale");
+    expect(lineText(out[1])).toBe("stale");
   });
 
   it("skips siblings with a different templateLineIdx", () => {
     const lines: LyricLine[] = [
-      { id: "L1", text: "edited", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L2", text: "stale", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 1 },
+      reconcileLine({ id: "L1", text: "edited", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L2", text: "stale", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 1 }),
     ];
     const out = propagateContentUpdates(lines, lines, [{ id: "L1", updates: { text: "edited" } }]);
-    expect(out[1].text).toBe("stale");
+    expect(lineText(out[1])).toBe("stale");
   });
 
   it("does not touch the target line itself", () => {
     const lines: LyricLine[] = [
-      { id: "L1", text: "edited", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L2", text: "stale", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
+      reconcileLine({ id: "L1", text: "edited", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L2", text: "stale", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 }),
     ];
     const out = propagateContentUpdates(lines, lines, [{ id: "L1", updates: { text: "edited" } }]);
     expect(out[0]).toBe(lines[0]);
@@ -338,19 +354,19 @@ describe("propagateContentUpdates", () => {
 describe("findStructurallyImpactedInstances", () => {
   it("returns nothing when both sides have the same instance line ids", () => {
     const old: LyricLine[] = [
-      { id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L2", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 },
+      reconcileLine({ id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L2", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 }),
     ];
     expect(findStructurallyImpactedInstances(old, old)).toEqual([]);
   });
 
   it("flags an instance that lost a line", () => {
     const old: LyricLine[] = [
-      { id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L2", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 },
+      reconcileLine({ id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L2", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 }),
     ];
     const next: LyricLine[] = [
-      { id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
+      reconcileLine({ id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
     ];
     const impacted = findStructurallyImpactedInstances(old, next);
     expect(impacted).toEqual([{ groupId: "g1", instanceIdx: 0 }]);
@@ -358,7 +374,7 @@ describe("findStructurallyImpactedInstances", () => {
 
   it("flags an instance whose entire line set disappeared", () => {
     const old: LyricLine[] = [
-      { id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
+      reconcileLine({ id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 }),
     ];
     const next: LyricLine[] = [];
     expect(findStructurallyImpactedInstances(old, next)).toEqual([{ groupId: "g1", instanceIdx: 1 }]);
@@ -366,51 +382,51 @@ describe("findStructurallyImpactedInstances", () => {
 
   it("does not flag standalone insertions outside any group", () => {
     const old: LyricLine[] = [
-      { id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
+      reconcileLine({ id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
     ];
     const next: LyricLine[] = [
-      { id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L2", text: "added", agentId: "v1" },
+      reconcileLine({ id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L2", text: "added", agentId: "v1" }),
     ];
     expect(findStructurallyImpactedInstances(old, next)).toEqual([]);
   });
 
   it("flags an instance when a non-grouped line is inserted between its grouped lines", () => {
     const old: LyricLine[] = [
-      { id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L1", text: "B", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 },
+      reconcileLine({ id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L1", text: "B", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 }),
     ];
     const next: LyricLine[] = [
-      { id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "NEW", text: "x", agentId: "v1" },
-      { id: "L1", text: "B", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 },
+      reconcileLine({ id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "NEW", text: "x", agentId: "v1" }),
+      reconcileLine({ id: "L1", text: "B", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 }),
     ];
     expect(findStructurallyImpactedInstances(old, next)).toEqual([{ groupId: "g1", instanceIdx: 0 }]);
   });
 
   it("does not flag when a non-grouped line lives between two DIFFERENT instances", () => {
     const old: LyricLine[] = [
-      { id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L1", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
+      reconcileLine({ id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L1", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 }),
     ];
     const next: LyricLine[] = [
-      { id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "NEW", text: "x", agentId: "v1" },
-      { id: "L1", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
+      reconcileLine({ id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "NEW", text: "x", agentId: "v1" }),
+      reconcileLine({ id: "L1", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 }),
     ];
     expect(findStructurallyImpactedInstances(old, next)).toEqual([]);
   });
 
   it("dedups when both id-set and positional detection point at the same instance", () => {
     const old: LyricLine[] = [
-      { id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L1", text: "B", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 },
-      { id: "L2", text: "C", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 2 },
+      reconcileLine({ id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L1", text: "B", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 }),
+      reconcileLine({ id: "L2", text: "C", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 2 }),
     ];
     const next: LyricLine[] = [
-      { id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "NEW", text: "x", agentId: "v1" },
-      { id: "L2", text: "C", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 2 },
+      reconcileLine({ id: "L0", text: "A", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "NEW", text: "x", agentId: "v1" }),
+      reconcileLine({ id: "L2", text: "C", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 2 }),
     ];
     const impacted = findStructurallyImpactedInstances(old, next);
     expect(impacted).toHaveLength(1);
@@ -419,15 +435,15 @@ describe("findStructurallyImpactedInstances", () => {
 
   it("flags only the instance whose ids actually differ", () => {
     const old: LyricLine[] = [
-      { id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L2", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 },
-      { id: "L3", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
-      { id: "L4", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 1 },
+      reconcileLine({ id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L2", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 }),
+      reconcileLine({ id: "L3", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 }),
+      reconcileLine({ id: "L4", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 1 }),
     ];
     const next: LyricLine[] = [
-      { id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "L3", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
-      { id: "L4", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 1 },
+      reconcileLine({ id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "L3", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 }),
+      reconcileLine({ id: "L4", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 1 }),
     ];
     const impacted = findStructurallyImpactedInstances(old, next);
     expect(impacted).toEqual([{ groupId: "g1", instanceIdx: 0 }]);
@@ -437,16 +453,24 @@ describe("findStructurallyImpactedInstances", () => {
 describe("detachInstancesFromLines", () => {
   it("returns the same array when no instances impacted", () => {
     const lines: LyricLine[] = [
-      { id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
+      reconcileLine({ id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
     ];
     expect(detachInstancesFromLines(lines, [])).toBe(lines);
   });
 
   it("clears group attrs on all lines of impacted instances only", () => {
     const lines: LyricLine[] = [
-      { id: "L1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0, detached: true },
-      { id: "L2", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 },
-      { id: "L3", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 },
+      reconcileLine({
+        id: "L1",
+        text: "a",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 0,
+        templateLineIdx: 0,
+        detached: true,
+      }),
+      reconcileLine({ id: "L2", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 }),
+      reconcileLine({ id: "L3", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 1, templateLineIdx: 0 }),
     ];
     const out = detachInstancesFromLines(lines, [{ groupId: "g1", instanceIdx: 0 }]);
     expect(out[0].groupId).toBeUndefined();

--- a/src/views/edit/diff-edit-text.test.ts
+++ b/src/views/edit/diff-edit-text.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 import { mainBounds } from "@/domain/line/bounds";
-import { type LyricLine, reconcileLine } from "@/domain/line/model";
+import { type LyricLine, reconcileLine, toFlat } from "@/domain/line/model";
 import { bgSource, bgText, lineText, mainWords } from "@/domain/line/voices";
 import { describe, expect, it } from "vitest";
 import {
@@ -277,7 +277,7 @@ describe("propagateContentUpdates", () => {
     ];
     const newLines: LyricLine[] = [
       reconcileLine({
-        ...oldLines[0],
+        ...toFlat(oldLines[0]),
         text: "I luv you",
         words: [
           { text: "I ", begin: 10, end: 10.4 },

--- a/src/views/edit/diff-edit-text.ts
+++ b/src/views/edit/diff-edit-text.ts
@@ -1,7 +1,11 @@
 import { extractLinkedFields } from "@/domain/group/linking";
 import { propagateWordChanges } from "@/domain/group/smart-sync";
 import { isLinked } from "@/domain/instance/predicates";
+import { mainBounds } from "@/domain/line/bounds";
 import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
+import { isLineSynced } from "@/domain/line/predicates";
+import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import type { WordTiming } from "@/domain/word/timing";
 
 // -- Types --------------------------------------------------------------------
 
@@ -17,10 +21,39 @@ interface DiffResult {
 
 // -- Constants ----------------------------------------------------------------
 
-const TIMING_CLEAR_FIELDS = ["words", "begin", "end", "backgroundWords"] as const;
-const CONTENT_FIELDS = ["text", "agentId", "backgroundText", "backgroundTextSource"] as const;
+type TimingField = "words" | "begin" | "end" | "backgroundWords";
+type ContentField = "text" | "agentId" | "backgroundText" | "backgroundTextSource";
+
+const TIMING_CLEAR_FIELDS = ["words", "begin", "end", "backgroundWords"] as const satisfies readonly TimingField[];
+const CONTENT_FIELDS = ["text", "agentId", "backgroundText", "backgroundTextSource"] as const satisfies readonly ContentField[];
 
 // -- Helpers ------------------------------------------------------------------
+
+function readContentField(line: LyricLine, field: ContentField): string | undefined {
+  switch (field) {
+    case "text":
+      return lineText(line);
+    case "agentId":
+      return line.agentId;
+    case "backgroundText":
+      return bgText(line);
+    case "backgroundTextSource":
+      return bgSource(line);
+  }
+}
+
+function readTimingField(line: LyricLine, field: TimingField): unknown {
+  switch (field) {
+    case "words":
+      return mainWords(line);
+    case "begin":
+      return isLineSynced(line) ? mainBounds(line)?.begin : undefined;
+    case "end":
+      return isLineSynced(line) ? mainBounds(line)?.end : undefined;
+    case "backgroundWords":
+      return bgWords(line);
+  }
+}
 
 function diffEditTextChange(oldLines: LyricLine[], newLines: LyricLine[]): DiffResult {
   if (oldLines.length !== newLines.length) {
@@ -40,13 +73,14 @@ function diffEditTextChange(oldLines: LyricLine[], newLines: LyricLine[]): DiffR
     const updates: Partial<LyricLine> = {};
 
     for (const field of CONTENT_FIELDS) {
-      if (oldLine[field] !== newLine[field]) {
-        (updates as Record<string, unknown>)[field] = newLine[field];
+      const newValue = readContentField(newLine, field);
+      if (readContentField(oldLine, field) !== newValue) {
+        (updates as Record<string, unknown>)[field] = newValue;
       }
     }
 
     for (const field of TIMING_CLEAR_FIELDS) {
-      if (oldLine[field] !== undefined && newLine[field] === undefined) {
+      if (readTimingField(oldLine, field) !== undefined && readTimingField(newLine, field) === undefined) {
         (updates as Record<string, unknown>)[field] = undefined;
       }
     }
@@ -150,10 +184,10 @@ interface LinkedScope {
   groupId: string;
   templateLineIdx: number;
   linkedUpdate: Partial<LyricLine>;
-  sourceWordsBefore: LyricLine["words"];
-  sourceWordsAfter: LyricLine["words"];
-  sourceBgWordsBefore: LyricLine["backgroundWords"];
-  sourceBgWordsAfter: LyricLine["backgroundWords"];
+  sourceWordsBefore: WordTiming[] | undefined;
+  sourceWordsAfter: WordTiming[] | undefined;
+  sourceBgWordsBefore: WordTiming[] | undefined;
+  sourceBgWordsAfter: WordTiming[] | undefined;
 }
 
 function propagateContentUpdates(
@@ -188,10 +222,10 @@ function propagateContentUpdates(
       groupId: sourceNew.groupId,
       templateLineIdx: sourceNew.templateLineIdx,
       linkedUpdate,
-      sourceWordsBefore: sourceOld.words,
-      sourceWordsAfter: sourceNew.words,
-      sourceBgWordsBefore: sourceOld.backgroundWords,
-      sourceBgWordsAfter: sourceNew.backgroundWords,
+      sourceWordsBefore: mainWords(sourceOld),
+      sourceWordsAfter: mainWords(sourceNew),
+      sourceBgWordsBefore: bgWords(sourceOld),
+      sourceBgWordsAfter: bgWords(sourceNew),
     });
   }
 
@@ -206,12 +240,12 @@ function propagateContentUpdates(
       if (line.groupId !== scope.groupId) continue;
       if (line.templateLineIdx !== scope.templateLineIdx) continue;
       Object.assign(merged, scope.linkedUpdate);
-      const propagatedWords = propagateWordChanges(scope.sourceWordsAfter, scope.sourceWordsBefore, line.words);
+      const propagatedWords = propagateWordChanges(scope.sourceWordsAfter, scope.sourceWordsBefore, mainWords(line));
       if (propagatedWords) merged.words = propagatedWords;
       const propagatedBg = propagateWordChanges(
         scope.sourceBgWordsAfter,
         scope.sourceBgWordsBefore,
-        line.backgroundWords,
+        bgWords(line),
       );
       if (propagatedBg) merged.backgroundWords = propagatedBg;
     }

--- a/src/views/edit/diff-edit-text.ts
+++ b/src/views/edit/diff-edit-text.ts
@@ -2,7 +2,7 @@ import { extractLinkedFields } from "@/domain/group/linking";
 import { propagateWordChanges } from "@/domain/group/smart-sync";
 import { isLinked } from "@/domain/instance/predicates";
 import { mainBounds } from "@/domain/line/bounds";
-import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
+import { reconcileLine, toFlat, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/line/predicates";
 import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
@@ -11,7 +11,7 @@ import type { WordTiming } from "@/domain/word/timing";
 
 interface ContentUpdate {
   id: string;
-  updates: Partial<LyricLine>;
+  updates: Partial<LooseLine>;
 }
 
 interface DiffResult {
@@ -25,7 +25,12 @@ type TimingField = "words" | "begin" | "end" | "backgroundWords";
 type ContentField = "text" | "agentId" | "backgroundText" | "backgroundTextSource";
 
 const TIMING_CLEAR_FIELDS = ["words", "begin", "end", "backgroundWords"] as const satisfies readonly TimingField[];
-const CONTENT_FIELDS = ["text", "agentId", "backgroundText", "backgroundTextSource"] as const satisfies readonly ContentField[];
+const CONTENT_FIELDS = [
+  "text",
+  "agentId",
+  "backgroundText",
+  "backgroundTextSource",
+] as const satisfies readonly ContentField[];
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -70,7 +75,7 @@ function diffEditTextChange(oldLines: LyricLine[], newLines: LyricLine[]): DiffR
   for (let i = 0; i < oldLines.length; i++) {
     const oldLine = oldLines[i];
     const newLine = newLines[i];
-    const updates: Partial<LyricLine> = {};
+    const updates: Partial<LooseLine> = {};
 
     for (const field of CONTENT_FIELDS) {
       const newValue = readContentField(newLine, field);
@@ -183,7 +188,7 @@ function detachInstancesFromLines(lines: LyricLine[], instances: ImpactedInstanc
 interface LinkedScope {
   groupId: string;
   templateLineIdx: number;
-  linkedUpdate: Partial<LyricLine>;
+  linkedUpdate: Partial<LooseLine>;
   sourceWordsBefore: WordTiming[] | undefined;
   sourceWordsAfter: WordTiming[] | undefined;
   sourceBgWordsBefore: WordTiming[] | undefined;
@@ -242,15 +247,11 @@ function propagateContentUpdates(
       Object.assign(merged, scope.linkedUpdate);
       const propagatedWords = propagateWordChanges(scope.sourceWordsAfter, scope.sourceWordsBefore, mainWords(line));
       if (propagatedWords) merged.words = propagatedWords;
-      const propagatedBg = propagateWordChanges(
-        scope.sourceBgWordsAfter,
-        scope.sourceBgWordsBefore,
-        bgWords(line),
-      );
+      const propagatedBg = propagateWordChanges(scope.sourceBgWordsAfter, scope.sourceBgWordsBefore, bgWords(line));
       if (propagatedBg) merged.backgroundWords = propagatedBg;
     }
     if (Object.keys(merged).length === 0) return line;
-    return reconcileLine({ ...line, ...merged });
+    return reconcileLine({ ...toFlat(line), ...merged });
   });
 }
 

--- a/src/views/edit/parse-lyrics.test.ts
+++ b/src/views/edit/parse-lyrics.test.ts
@@ -1,15 +1,15 @@
 /**
  * @vitest-environment node
  */
-import type { LyricLine } from "@/domain/line/model";
+import { type LyricLine, reconcileLine } from "@/domain/line/model";
 import { parseLyrics } from "@/views/edit/parse-lyrics";
 import { describe, expect, it } from "vitest";
 
 describe("parseLyrics", () => {
   it("matches non-empty input lines to non-empty stored lines in order", () => {
     const lines: LyricLine[] = [
-      { id: "A", text: "verse one", agentId: "v1" },
-      { id: "B", text: "verse two", agentId: "v2" },
+      reconcileLine({ id: "A", text: "verse one", agentId: "v1" }),
+      reconcileLine({ id: "B", text: "verse two", agentId: "v2" }),
     ];
     const result = parseLyrics("verse one\nverse two", lines, "v1");
     expect(result).toHaveLength(2);
@@ -21,8 +21,8 @@ describe("parseLyrics", () => {
 
   it("renders blank input lines as isEmpty=true placeholders without consuming a stored line", () => {
     const lines: LyricLine[] = [
-      { id: "A", text: "verse one", agentId: "v1" },
-      { id: "B", text: "verse two", agentId: "v2" },
+      reconcileLine({ id: "A", text: "verse one", agentId: "v1" }),
+      reconcileLine({ id: "B", text: "verse two", agentId: "v2" }),
     ];
     const result = parseLyrics("verse one\n\nverse two", lines, "v1");
     expect(result).toHaveLength(3);
@@ -37,11 +37,11 @@ describe("parseLyrics", () => {
     // store made parseLyrics index off by one, causing every line after the
     // empty to render its predecessor's text.
     const lines: LyricLine[] = [
-      { id: "A", text: "Whoa", agentId: "v1" },
-      { id: "B", text: "Yeah", agentId: "v1" },
-      { id: "EMPTY", text: "", agentId: "v1" },
-      { id: "C", text: "Lit City", agentId: "v1" },
-      { id: "D", text: "Wave again", agentId: "v1" },
+      reconcileLine({ id: "A", text: "Whoa", agentId: "v1" }),
+      reconcileLine({ id: "B", text: "Yeah", agentId: "v1" }),
+      reconcileLine({ id: "EMPTY", text: "", agentId: "v1" }),
+      reconcileLine({ id: "C", text: "Lit City", agentId: "v1" }),
+      reconcileLine({ id: "D", text: "Wave again", agentId: "v1" }),
     ];
     const text = "Whoa\nYeah\n\nLit City\nWave again";
     const result = parseLyrics(text, lines, "v1");
@@ -64,7 +64,7 @@ describe("parseLyrics", () => {
 
   it("propagates groupId/instanceIdx/templateLineIdx from matched stored lines", () => {
     const lines: LyricLine[] = [
-      { id: "A", text: "x", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 2 },
+      reconcileLine({ id: "A", text: "x", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 2 }),
     ];
     const result = parseLyrics("x", lines, "v1");
     expect(result[0].groupId).toBe("g1");

--- a/src/views/edit/parse-lyrics.ts
+++ b/src/views/edit/parse-lyrics.ts
@@ -1,4 +1,6 @@
+import { mainBounds } from "@/domain/line/bounds";
 import type { LyricLine } from "@/domain/line/model";
+import { bgText, lineText } from "@/domain/line/voices";
 
 interface ParsedLine {
   lineNumber: number;
@@ -16,24 +18,24 @@ interface ParsedLine {
 
 function parseLyrics(text: string, lines: LyricLine[], defaultAgentId: string): ParsedLine[] {
   const textLines = text.split("\n");
-  const nonEmptyStored = lines.filter((l) => l.text !== "");
+  const nonEmptyStored = lines.filter((l) => lineText(l) !== "");
   let nonEmptyIndex = 0;
 
   return textLines.map((line, index) => {
     const trimmed = line.trim();
     const isEmpty = trimmed === "";
     const lyricLine = isEmpty ? undefined : nonEmptyStored[nonEmptyIndex++];
-    const hasTiming = lyricLine?.begin !== undefined || (lyricLine?.words?.length ?? 0) > 0;
+    const hasTiming = lyricLine !== undefined && mainBounds(lyricLine) !== null;
 
     return {
       lineNumber: index + 1,
       lineId: lyricLine?.id ?? "",
-      text: lyricLine?.text ?? line,
+      text: lyricLine !== undefined ? lineText(lyricLine) : line,
       isEmpty,
       hasBrackets: /\[.*?\]/.test(line),
       hasTiming,
       agentId: lyricLine?.agentId ?? defaultAgentId,
-      backgroundText: lyricLine?.backgroundText,
+      backgroundText: lyricLine !== undefined ? bgText(lyricLine) : undefined,
       groupId: lyricLine?.groupId,
       instanceIdx: lyricLine?.instanceIdx,
       templateLineIdx: lyricLine?.templateLineIdx,

--- a/src/views/lyrics-import-modal/lyrics-import-modal.browser.test.tsx
+++ b/src/views/lyrics-import-modal/lyrics-import-modal.browser.test.tsx
@@ -1,6 +1,8 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { userEvent } from "vitest/browser";
+import { reconcileLine } from "@/domain/line/model";
+import { bgText, lineText, mainWords } from "@/domain/line/voices";
 import type { LyricsSearchResult, ProviderName } from "@/domain/lyrics-search/result";
 import { useAudioStore } from "@/stores/audio";
 import { useImportModalStore } from "@/stores/import-modal-store";
@@ -218,7 +220,7 @@ describe("LyricsImportModal search section commit", () => {
   it("confirm-replace runs when project already has lines (cancel keeps existing)", async () => {
     useSettingsStore.setState({ confirmReplaceLyrics: true });
     useProjectStore.setState({
-      lines: [{ id: "existing", text: "Old line", agentId: "v1" }],
+      lines: [reconcileLine({ id: "existing", text: "Old line", agentId: "v1" })],
     });
     const screen = await render(withQueryClient(<LyricsImportModalHost />));
     openModal({ prefill: { track: "Bohemian" } });
@@ -230,7 +232,7 @@ describe("LyricsImportModal search section commit", () => {
     await expect.element(screen.getByText(/Replace existing lyrics/i)).toBeInTheDocument();
     await screen.getByRole("button", { name: /Cancel/i }).click();
     await expect.poll(() => useProjectStore.getState().lines.length).toBe(1);
-    expect(useProjectStore.getState().lines[0].text).toBe("Old line");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("Old line");
   });
 });
 
@@ -329,8 +331,8 @@ describe("LyricsImportModal settings integration", () => {
     await screen.getByRole("button", { name: /^Import$/ }).click();
     await expect.poll(() => useProjectStore.getState().lines.length).toBe(2);
     const lines = useProjectStore.getState().lines;
-    expect(lines[0].words).toBeDefined();
-    expect(lines[0].words?.length ?? 0).toBeGreaterThan(0);
+    expect(mainWords(lines[0])).toBeDefined();
+    expect(mainWords(lines[0])?.length ?? 0).toBeGreaterThan(0);
   });
 
   it("extracts inline parenthetical background when the setting is on", async () => {
@@ -343,7 +345,7 @@ describe("LyricsImportModal settings integration", () => {
     await screen.getByRole("button", { name: /^Import$/ }).click();
     await expect.poll(() => useProjectStore.getState().lines.length).toBe(1);
     const line = useProjectStore.getState().lines[0];
-    expect(line.text).toBe("Hello");
-    expect(line.backgroundText).toBe("world");
+    expect(lineText(line)).toBe("Hello");
+    expect(bgText(line)).toBe("world");
   });
 });

--- a/src/views/lyrics-import-modal/use-import-modal-actions.test.ts
+++ b/src/views/lyrics-import-modal/use-import-modal-actions.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { Agent } from "@/domain/agent/model";
-import type { LyricLine } from "@/domain/line/model";
+import { mainBounds } from "@/domain/line/bounds";
+import { type LyricLine, reconcileLine } from "@/domain/line/model";
+import { bgText, lineText, mainWords } from "@/domain/line/voices";
 import { useProjectStore } from "@/stores/project";
 import type { ParseResult } from "@/utils/lyrics-parsers/shared";
 import {
@@ -11,7 +13,7 @@ import {
 // -- Helpers ------------------------------------------------------------------
 
 function lineFactory(id: string, text: string, agentId = "v1"): LyricLine {
-  return { id, text, agentId };
+  return reconcileLine({ id, text, agentId });
 }
 
 function emptyParseResult(): ParseResult {
@@ -85,7 +87,7 @@ describe("importParsedLyrics confirm flow", () => {
     expect(result).toBe(false);
     expect(promptCount).toBe(1);
     expect(useProjectStore.getState().lines.length).toBe(1);
-    expect(useProjectStore.getState().lines[0].text).toBe("Old");
+    expect(lineText(useProjectStore.getState().lines[0])).toBe("Old");
   });
 
   it("replaces lines when the user confirms", async () => {
@@ -93,7 +95,7 @@ describe("importParsedLyrics confirm flow", () => {
     const result = await importParsedLyrics(parseResult(), buildContext({ confirm: async () => true }));
     expect(result).toBe(true);
     expect(useProjectStore.getState().lines.length).toBe(2);
-    expect(useProjectStore.getState().lines.map((l) => l.text)).toEqual(["Hello", "World"]);
+    expect(useProjectStore.getState().lines.map((l) => lineText(l))).toEqual(["Hello", "World"]);
   });
 });
 
@@ -103,37 +105,38 @@ describe("importParsedLyrics timing distribution", () => {
   it("does not distribute timing when audioDuration is zero and there is no timing data", async () => {
     await importParsedLyrics(parseResult({ hasTimingData: false }), buildContext({ audioDuration: 0 }));
     const lines = useProjectStore.getState().lines;
-    expect(lines[0].words).toBeUndefined();
-    expect(lines[0].begin).toBeUndefined();
-    expect(lines[0].end).toBeUndefined();
+    expect(mainWords(lines[0])).toBeUndefined();
+    expect(mainBounds(lines[0])?.begin).toBeUndefined();
+    expect(mainBounds(lines[0])?.end).toBeUndefined();
   });
 
   it("distributes timing across the audio when parsed lacks timing data", async () => {
     await importParsedLyrics(parseResult({ hasTimingData: false }), buildContext({ audioDuration: 120 }));
     const lines = useProjectStore.getState().lines;
-    expect(lines[0].words).toBeDefined();
-    expect(lines[0].words?.length).toBeGreaterThan(0);
-    const firstWord = lines[0].words?.[0];
+    expect(mainWords(lines[0])).toBeDefined();
+    expect(mainWords(lines[0])?.length).toBeGreaterThan(0);
+    const firstWord = mainWords(lines[0])?.[0];
     const lastLine = lines[lines.length - 1];
-    const lastWord = lastLine.words?.[lastLine.words.length - 1];
+    const lastWords = mainWords(lastLine);
+    const lastWord = lastWords?.[lastWords.length - 1];
     expect(firstWord?.begin).toBe(0);
     expect(lastWord?.end).toBeCloseTo(120, 3);
   });
 
   it("does not distribute when parsed already has timing data", async () => {
-    const timed: LyricLine = {
+    const timed: LyricLine = reconcileLine({
       id: "t",
       text: "Hi",
       agentId: "v1",
       words: [{ text: "Hi", begin: 1, end: 2 }],
-    };
+    });
     await importParsedLyrics(
       { lines: [timed], metadata: {}, hasTimingData: true },
       buildContext({ audioDuration: 60 }),
     );
     const stored = useProjectStore.getState().lines;
     expect(stored.length).toBe(1);
-    expect(stored[0].words).toEqual([{ text: "Hi", begin: 1, end: 2 }]);
+    expect(mainWords(stored[0])).toEqual([{ text: "Hi", begin: 1, end: 2 }]);
   });
 });
 
@@ -141,27 +144,27 @@ describe("importParsedLyrics timing distribution", () => {
 
 describe("importParsedLyrics background extraction", () => {
   it("applies background extraction when the flag is set", async () => {
-    const inline: LyricLine = { id: "x", text: "Hello (world)", agentId: "v1" };
+    const inline: LyricLine = reconcileLine({ id: "x", text: "Hello (world)", agentId: "v1" });
     await importParsedLyrics(
       { lines: [inline], metadata: {}, hasTimingData: false },
       buildContext({ applyBackgroundExtraction: true }),
     );
     const stored = useProjectStore.getState().lines;
     expect(stored.length).toBe(1);
-    expect(stored[0].text).toBe("Hello");
-    expect(stored[0].backgroundText).toBe("world");
+    expect(lineText(stored[0])).toBe("Hello");
+    expect(bgText(stored[0])).toBe("world");
   });
 
   it("passes original lines through when the flag is unset", async () => {
-    const inline: LyricLine = { id: "x", text: "Hello (world)", agentId: "v1" };
+    const inline: LyricLine = reconcileLine({ id: "x", text: "Hello (world)", agentId: "v1" });
     await importParsedLyrics(
       { lines: [inline], metadata: {}, hasTimingData: false },
       buildContext({ applyBackgroundExtraction: false }),
     );
     const stored = useProjectStore.getState().lines;
     expect(stored.length).toBe(1);
-    expect(stored[0].text).toBe("Hello (world)");
-    expect(stored[0].backgroundText).toBeUndefined();
+    expect(lineText(stored[0])).toBe("Hello (world)");
+    expect(bgText(stored[0])).toBeUndefined();
   });
 });
 

--- a/src/views/lyrics-import-modal/use-import-modal-actions.ts
+++ b/src/views/lyrics-import-modal/use-import-modal-actions.ts
@@ -1,4 +1,5 @@
 import type { Agent } from "@/domain/agent/model";
+import { reconcileLine, toFlat } from "@/domain/line/model";
 import type { ConfirmOptions } from "@/stores/confirm-store";
 import { useProjectStore } from "@/stores/project";
 import { extractBackgroundVocals } from "@/utils/background-vocal-extraction";
@@ -68,7 +69,7 @@ async function importParsedLyrics(parsed: ParseResult, ctx: ImportParsedLyricsCo
     : parsed.lines;
 
   if (!parsed.hasTimingData && ctx.audioDuration > 0) {
-    workingLines = distributeLinesTiming(workingLines, ctx.audioDuration);
+    workingLines = distributeLinesTiming(workingLines.map(toFlat), ctx.audioDuration).map(reconcileLine);
   }
 
   const store = useProjectStore.getState();

--- a/src/views/sync/syllable-splitter-apply-to-all.browser.test.tsx
+++ b/src/views/sync/syllable-splitter-apply-to-all.browser.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mainWords } from "@/domain/line/voices";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import { ConfirmModalHost } from "@/ui/confirm-modal";
@@ -212,7 +213,7 @@ describe("SyllableSplitter wiring", () => {
     await screen.getByLabelText("Apply to all identical words").click();
     await screen.getByRole("button", { name: "Split all" }).click();
     await screen.getByRole("button", { name: "Split" }).click();
-    await expect.poll(() => useProjectStore.getState().lines[1].words?.length).toBe(2);
+    await expect.poll(() => mainWords(useProjectStore.getState().lines[1])?.length).toBe(2);
   });
 
   it("leaves the project unchanged when the confirm modal is cancelled", async () => {
@@ -239,7 +240,7 @@ describe("SyllableSplitter wiring", () => {
     await screen.getByRole("button", { name: "Split point 3" }).click();
     await screen.getByLabelText("Apply to all identical words").click();
     await screen.getByRole("button", { name: "Split all" }).click();
-    await expect.poll(() => useProjectStore.getState().lines[1].words?.length).toBe(2);
+    await expect.poll(() => mainWords(useProjectStore.getState().lines[1])?.length).toBe(2);
   });
 
   it("routes through onSplit (not the store action) when apply-to-all is off", async () => {
@@ -264,7 +265,7 @@ describe("SyllableSplitter wiring", () => {
     await screen.getByRole("button", { name: "Split point 3" }).click();
     await screen.getByRole("button", { name: "Split Word" }).click();
     expect(onSplit).toHaveBeenCalledTimes(1);
-    expect(useProjectStore.getState().lines[1].words?.length).toBe(1);
+    expect(mainWords(useProjectStore.getState().lines[1])?.length).toBe(1);
   });
 
   it("persists checkbox state to syllableSplitDefaults after a successful split", async () => {

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -22,7 +22,6 @@ import {
   getNudgeAmount,
   type SyncState,
   convertLineToWord,
-  createBgWordsFromLine,
   getSyncedLineCount,
   getSyncedWordCount,
   getTotalWords,
@@ -135,19 +134,6 @@ const SyncPanel: React.FC = () => {
     triggerRippleAtCurrentPosition();
     handleHoldEndRaw();
   }, [handleHoldEndRaw, triggerRippleAtCurrentPosition]);
-
-  const updateLine = useProjectStore((s) => s.updateLine);
-
-  useEffect(() => {
-    for (const line of lines) {
-      if (bgText(line) && !bgWords(line)?.length) {
-        const seededBgWords = createBgWordsFromLine(line);
-        if (seededBgWords) {
-          updateLine(line.id, { backgroundWords: seededBgWords }, { deriveText: false });
-        }
-      }
-    }
-  }, [lines, updateLine]);
 
   // RAF animation loop for smooth word progress updates (reads audioElement.currentTime directly)
   useEffect(() => {

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/utils/animationVariants";
 import { isLinked } from "@/domain/instance/predicates";
 import { effectiveBounds, mainBounds } from "@/domain/line/bounds";
+import { reconcileLine, toFlat } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/line/predicates";
 import { bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import {
@@ -194,8 +195,9 @@ const SyncPanel: React.FC = () => {
     };
   }, [editMode]);
 
-  const totalWords = useMemo(() => getTotalWords(lines), [lines]);
-  const syncedWords = useMemo(() => getSyncedWordCount(lines), [lines]);
+  const flatLines = useMemo(() => lines.map(toFlat), [lines]);
+  const totalWords = useMemo(() => getTotalWords(flatLines), [flatLines]);
+  const syncedWords = useMemo(() => getSyncedWordCount(flatLines), [flatLines]);
   const syncedLines = useMemo(() => getSyncedLineCount(lines), [lines]);
 
   const progressText = granularity === "word" ? `${syncedWords}/${totalWords}` : `${syncedLines}/${lines.length}`;
@@ -205,7 +207,7 @@ const SyncPanel: React.FC = () => {
       if (newGranularity === granularity) return;
 
       if (newGranularity === "word" && hasLineTiming(lines)) {
-        const convertedLines = lines.map((line) => convertLineToWord(line));
+        const convertedLines = lines.map((line) => reconcileLine(convertLineToWord(toFlat(line))));
         setLinesWithHistory(convertedLines);
       }
 
@@ -514,7 +516,7 @@ const SyncPanel: React.FC = () => {
             </div>
           ) : (
             <SyncCarousel
-              lines={lines}
+              lines={flatLines}
               lineIndex={lineIndex}
               wordIndex={wordIndex}
               granularity={granularity}

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -14,7 +14,9 @@ import {
   syncPulseVariants,
 } from "@/utils/animationVariants";
 import { isLinked } from "@/domain/instance/predicates";
-import { effectiveBounds } from "@/domain/line/bounds";
+import { effectiveBounds, mainBounds } from "@/domain/line/bounds";
+import { isLineSynced } from "@/domain/line/predicates";
+import { bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import {
   getNudgeAmount,
   type SyncState,
@@ -137,10 +139,10 @@ const SyncPanel: React.FC = () => {
 
   useEffect(() => {
     for (const line of lines) {
-      if (line.backgroundText && !line.backgroundWords?.length) {
-        const bgWords = createBgWordsFromLine(line);
-        if (bgWords) {
-          updateLine(line.id, { backgroundWords: bgWords }, { deriveText: false });
+      if (bgText(line) && !bgWords(line)?.length) {
+        const seededBgWords = createBgWordsFromLine(line);
+        if (seededBgWords) {
+          updateLine(line.id, { backgroundWords: seededBgWords }, { deriveText: false });
         }
       }
     }
@@ -238,19 +240,21 @@ const SyncPanel: React.FC = () => {
   const currentLine = lines[lineIndex];
   const prevLine = lines[lineIndex - 1];
 
+  const currentMainWords = currentLine ? mainWords(currentLine) : undefined;
+  const prevMainWords = prevLine ? mainWords(prevLine) : undefined;
   const lastSyncedTime = useMemo(() => {
     if (granularity === "line") {
-      if (prevLine?.begin !== undefined) return prevLine.begin;
+      if (prevLine && isLineSynced(prevLine)) return mainBounds(prevLine)?.begin;
       return undefined;
     }
-    if (!currentLine?.words?.length) {
-      if (prevLine?.words?.length) {
-        return prevLine.words[prevLine.words.length - 1]?.begin;
+    if (!currentMainWords?.length) {
+      if (prevMainWords?.length) {
+        return prevMainWords[prevMainWords.length - 1]?.begin;
       }
       return undefined;
     }
-    return currentLine.words[currentLine.words.length - 1]?.begin;
-  }, [granularity, currentLine?.words, prevLine?.words, prevLine?.begin]);
+    return currentMainWords[currentMainWords.length - 1]?.begin;
+  }, [granularity, currentMainWords, prevMainWords, prevLine]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -439,6 +443,8 @@ const SyncPanel: React.FC = () => {
             {lines.map((line, index) => {
               const timing = effectiveBounds(line);
               const linkedGroup = line.groupId ? groups.find((g) => g.id === line.groupId) : undefined;
+              const lineWords = mainWords(line);
+              const lineBgWords = bgWords(line);
               const totalInstances = linkedGroup ? (instanceCountByGroup.get(linkedGroup.id) ?? 0) : 0;
               const linkInfo =
                 linkedGroup && line.instanceIdx !== undefined
@@ -454,12 +460,12 @@ const SyncPanel: React.FC = () => {
                   key={line.id}
                   lineId={line.id}
                   lineNumber={index + 1}
-                  text={line.text}
+                  text={lineText(line)}
                   isCurrent={editMode ? index === playingLineIndex : index === lineIndex}
                   agentId={line.agentId}
-                  backgroundText={line.backgroundText}
-                  backgroundWords={line.backgroundWords}
-                  words={line.words}
+                  backgroundText={bgText(line)}
+                  backgroundWords={lineBgWords}
+                  words={lineWords}
                   lineBegin={timing?.begin}
                   lineEnd={timing?.end}
                   granularity={granularity}

--- a/src/views/timeline/apply-paste-to-lines.test.ts
+++ b/src/views/timeline/apply-paste-to-lines.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "vitest";
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import type { WordTiming } from "@/domain/word/timing";
 import { applyPasteToLines } from "@/views/timeline/apply-paste-to-lines";
 import type { ClipboardData } from "@/views/timeline/selection-types";
 
 // -- Helpers ------------------------------------------------------------------
 
-const line = (id: string, words: LyricLine["words"], text: string): LyricLine =>
-  ({ id, agentId: "a", text, words }) as LyricLine;
+const line = (id: string, words: WordTiming[], text: string): LyricLine =>
+  reconcileLine({ id, agentId: "a", text, words });
 
 // -- Tests --------------------------------------------------------------------
 

--- a/src/views/timeline/apply-paste-to-lines.ts
+++ b/src/views/timeline/apply-paste-to-lines.ts
@@ -1,6 +1,7 @@
 import { manualBackgroundWordEdit } from "@/domain/line/background";
 import { mainWordEditFields } from "@/domain/line/main-words";
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
 import type { WordTiming } from "@/domain/word/timing";
 import type { ClipboardData, ClipboardEntry } from "@/views/timeline/selection-types";
@@ -55,10 +56,10 @@ function applyPasteToLines({
 
     const lineUpdates: Partial<LyricLine> = {};
     if (newWords.length > 0) {
-      Object.assign(lineUpdates, mainWordEditFields(mergeWordsIntoTrack(line.words ?? [], newWords)));
+      Object.assign(lineUpdates, mainWordEditFields(mergeWordsIntoTrack(mainWords(line) ?? [], newWords)));
     }
     if (newBgWords.length > 0) {
-      Object.assign(lineUpdates, manualBackgroundWordEdit(mergeWordsIntoTrack(line.backgroundWords ?? [], newBgWords)));
+      Object.assign(lineUpdates, manualBackgroundWordEdit(mergeWordsIntoTrack(bgWords(line) ?? [], newBgWords)));
     }
 
     updates.push({ id: line.id, updates: lineUpdates });

--- a/src/views/timeline/apply-paste-to-lines.ts
+++ b/src/views/timeline/apply-paste-to-lines.ts
@@ -1,6 +1,6 @@
 import { manualBackgroundWordEdit } from "@/domain/line/background";
 import { mainWordEditFields } from "@/domain/line/main-words";
-import type { LyricLine } from "@/domain/line/model";
+import type { LooseLine, LyricLine } from "@/domain/line/model";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
 import type { WordTiming } from "@/domain/word/timing";
@@ -18,7 +18,7 @@ interface PasteInput {
 
 interface LineUpdate {
   id: string;
-  updates: Partial<LyricLine>;
+  updates: Partial<LooseLine>;
 }
 
 // -- Functions ----------------------------------------------------------------
@@ -54,7 +54,7 @@ function applyPasteToLines({
       else newBgWords.push(newWord);
     }
 
-    const lineUpdates: Partial<LyricLine> = {};
+    const lineUpdates: Partial<LooseLine> = {};
     if (newWords.length > 0) {
       Object.assign(lineUpdates, mainWordEditFields(mergeWordsIntoTrack(mainWords(line) ?? [], newWords)));
     }

--- a/src/views/timeline/apply-word-deletion.test.ts
+++ b/src/views/timeline/apply-word-deletion.test.ts
@@ -1,14 +1,16 @@
 /**
  * @vitest-environment node
  */
-import type { LyricLine } from "@/domain/line/model";
+import { mainBounds } from "@/domain/line/bounds";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { describe, expect, it } from "vitest";
 import { applyWordDeletion, type DeletionSelection } from "./apply-word-deletion";
 
 describe("applyWordDeletion", () => {
   it("removes selected words from a word-timed line, leaving the line in place", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "l1",
         text: "I love you",
         agentId: "v1",
@@ -17,17 +19,17 @@ describe("applyWordDeletion", () => {
           { text: "love ", begin: 0.3, end: 0.6 },
           { text: "you", begin: 0.6, end: 1 },
         ],
-      },
+      }),
     ];
     const sel: DeletionSelection[] = [{ lineId: "l1", type: "word", wordIndex: 1 }];
     const result = applyWordDeletion(lines, sel);
     expect(result).toHaveLength(1);
-    expect(result[0].words?.map((w) => w.text)).toEqual(["I ", "you"]);
+    expect(mainWords(result[0])?.map((w) => w.text)).toEqual(["I ", "you"]);
   });
 
   it("leaves a word-timed line in place with empty words AND clears begin/end when ALL words are deleted", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "l1",
         text: "I love",
         agentId: "v1",
@@ -35,7 +37,7 @@ describe("applyWordDeletion", () => {
           { text: "I ", begin: 0, end: 0.3 },
           { text: "love", begin: 0.3, end: 0.6 },
         ],
-      },
+      }),
     ];
     const sel: DeletionSelection[] = [
       { lineId: "l1", type: "word", wordIndex: 0 },
@@ -43,44 +45,44 @@ describe("applyWordDeletion", () => {
     ];
     const result = applyWordDeletion(lines, sel);
     expect(result).toHaveLength(1);
-    expect(result[0].words).toEqual([]);
-    expect(result[0].begin).toBeUndefined();
-    expect(result[0].end).toBeUndefined();
-    expect(result[0].text).toBe("I love");
+    expect(mainWords(result[0])).toEqual([]);
+    expect(mainBounds(result[0])?.begin).toBeUndefined();
+    expect(mainBounds(result[0])?.end).toBeUndefined();
+    expect(lineText(result[0])).toBe("I love");
   });
 
   it("clears begin/end on a word-timed line with no line-level timing too", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "l1",
         text: "I",
         agentId: "v1",
         words: [{ text: "I", begin: 0, end: 1 }],
-      },
+      }),
     ];
     const sel: DeletionSelection[] = [{ lineId: "l1", type: "word", wordIndex: 0 }];
     const result = applyWordDeletion(lines, sel);
     expect(result).toHaveLength(1);
-    expect(result[0].words).toEqual([]);
-    expect(result[0].begin).toBeUndefined();
+    expect(mainWords(result[0])).toEqual([]);
+    expect(mainBounds(result[0])?.begin).toBeUndefined();
   });
 
   it("clears a line-synced line's timing (no longer renders as line-synced) when synthetic word is deleted", () => {
-    const lines: LyricLine[] = [{ id: "l1", text: "I love you", agentId: "v1", begin: 1, end: 2 }];
+    const lines: LyricLine[] = [reconcileLine({ id: "l1", text: "I love you", agentId: "v1", begin: 1, end: 2 })];
     const sel: DeletionSelection[] = [{ lineId: "l1", type: "word", wordIndex: 0 }];
     const result = applyWordDeletion(lines, sel);
     expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("I love you");
-    expect(result[0].words).toBeUndefined();
-    expect(result[0].begin).toBeUndefined();
-    expect(result[0].end).toBeUndefined();
+    expect(lineText(result[0])).toBe("I love you");
+    expect(mainWords(result[0])).toBeUndefined();
+    expect(mainBounds(result[0])?.begin).toBeUndefined();
+    expect(mainBounds(result[0])?.end).toBeUndefined();
   });
 
   it("clears multiple line-synced lines' timing when marquee-deleted (lines stay in project)", () => {
     const lines: LyricLine[] = [
-      { id: "l1", text: "first", agentId: "v1", begin: 0, end: 1 },
-      { id: "l2", text: "second", agentId: "v1", begin: 1, end: 2 },
-      { id: "l3", text: "third", agentId: "v1", begin: 2, end: 3 },
+      reconcileLine({ id: "l1", text: "first", agentId: "v1", begin: 0, end: 1 }),
+      reconcileLine({ id: "l2", text: "second", agentId: "v1", begin: 1, end: 2 }),
+      reconcileLine({ id: "l3", text: "third", agentId: "v1", begin: 2, end: 3 }),
     ];
     const sel: DeletionSelection[] = [
       { lineId: "l1", type: "word", wordIndex: 0 },
@@ -90,16 +92,16 @@ describe("applyWordDeletion", () => {
     const result = applyWordDeletion(lines, sel);
     expect(result).toHaveLength(3);
     for (const line of result) {
-      expect(line.begin).toBeUndefined();
-      expect(line.end).toBeUndefined();
-      expect(line.words).toBeUndefined();
+      expect(mainBounds(line)?.begin).toBeUndefined();
+      expect(mainBounds(line)?.end).toBeUndefined();
+      expect(mainWords(line)).toBeUndefined();
     }
   });
 
   it("preserves line ordering and edits multiple lines without removing any", () => {
     const lines: LyricLine[] = [
-      { id: "keep1", text: "intact", agentId: "v1", begin: 0, end: 1 },
-      {
+      reconcileLine({ id: "keep1", text: "intact", agentId: "v1", begin: 0, end: 1 }),
+      reconcileLine({
         id: "edit",
         text: "I love",
         agentId: "v1",
@@ -107,9 +109,9 @@ describe("applyWordDeletion", () => {
           { text: "I ", begin: 1, end: 1.3 },
           { text: "love", begin: 1.3, end: 1.6 },
         ],
-      },
-      { id: "drop", text: "to clear", agentId: "v1", begin: 2, end: 3 },
-      { id: "keep2", text: "intact 2", agentId: "v1", begin: 3, end: 4 },
+      }),
+      reconcileLine({ id: "drop", text: "to clear", agentId: "v1", begin: 2, end: 3 }),
+      reconcileLine({ id: "keep2", text: "intact 2", agentId: "v1", begin: 3, end: 4 }),
     ];
     const sel: DeletionSelection[] = [
       { lineId: "edit", type: "word", wordIndex: 0 },
@@ -117,35 +119,35 @@ describe("applyWordDeletion", () => {
     ];
     const result = applyWordDeletion(lines, sel);
     expect(result.map((l) => l.id)).toEqual(["keep1", "edit", "drop", "keep2"]);
-    expect(result[1].words?.map((w) => w.text)).toEqual(["love"]);
-    expect(result[2].begin).toBeUndefined();
-    expect(result[2].end).toBeUndefined();
-    expect(result[2].words).toBeUndefined();
-    expect(result[2].text).toBe("to clear");
+    expect(mainWords(result[1])?.map((w) => w.text)).toEqual(["love"]);
+    expect(mainBounds(result[2])?.begin).toBeUndefined();
+    expect(mainBounds(result[2])?.end).toBeUndefined();
+    expect(mainWords(result[2])).toBeUndefined();
+    expect(lineText(result[2])).toBe("to clear");
   });
 
   it("removes selected bg words and clears the bg fields when none remain", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "l1",
         text: "main",
         agentId: "v1",
         words: [{ text: "main", begin: 0, end: 1 }],
         backgroundText: "bg",
         backgroundWords: [{ text: "bg", begin: 0, end: 1 }],
-      },
+      }),
     ];
     const sel: DeletionSelection[] = [{ lineId: "l1", type: "bg", wordIndex: 0 }];
     const result = applyWordDeletion(lines, sel);
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundWords).toBeUndefined();
-    expect(result[0].backgroundText).toBeUndefined();
-    expect(result[0].words?.length).toBe(1);
+    expect(bgWords(result[0])).toBeUndefined();
+    expect(bgText(result[0])).toBeUndefined();
+    expect(mainWords(result[0])?.length).toBe(1);
   });
 
   it("does not remove the line when only some bg words are removed", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "l1",
         text: "main",
         agentId: "v1",
@@ -155,18 +157,18 @@ describe("applyWordDeletion", () => {
           { text: "oh", begin: 0, end: 0.5 },
           { text: "oh", begin: 0.5, end: 1 },
         ],
-      },
+      }),
     ];
     const sel: DeletionSelection[] = [{ lineId: "l1", type: "bg", wordIndex: 0 }];
     const result = applyWordDeletion(lines, sel);
     expect(result).toHaveLength(1);
-    expect(result[0].backgroundWords?.map((w) => w.text)).toEqual(["oh"]);
-    expect(result[0].backgroundText).toBe("oh");
+    expect(bgWords(result[0])?.map((w) => w.text)).toEqual(["oh"]);
+    expect(bgText(result[0])).toBe("oh");
   });
 
   it("clears backgroundTextSource when the deletion empties the background", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "l1",
         text: "main",
         agentId: "v1",
@@ -174,17 +176,17 @@ describe("applyWordDeletion", () => {
         backgroundText: "bg",
         backgroundWords: [{ text: "bg", begin: 0, end: 1 }],
         backgroundTextSource: "extraction",
-      },
+      }),
     ];
     const result = applyWordDeletion(lines, [{ lineId: "l1", type: "bg", wordIndex: 0 }]);
-    expect(result[0].backgroundWords).toBeUndefined();
-    expect(result[0].backgroundText).toBeUndefined();
-    expect(result[0].backgroundTextSource).toBeUndefined();
+    expect(bgWords(result[0])).toBeUndefined();
+    expect(bgText(result[0])).toBeUndefined();
+    expect(bgSource(result[0])).toBeUndefined();
   });
 
   it("stamps backgroundTextSource manual when a partial bg deletion leaves words behind", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "l1",
         text: "main",
         agentId: "v1",
@@ -195,16 +197,16 @@ describe("applyWordDeletion", () => {
           { text: "oh", begin: 0.5, end: 1 },
         ],
         backgroundTextSource: "extraction",
-      },
+      }),
     ];
     const result = applyWordDeletion(lines, [{ lineId: "l1", type: "bg", wordIndex: 0 }]);
-    expect(result[0].backgroundWords?.map((w) => w.text)).toEqual(["oh"]);
-    expect(result[0].backgroundTextSource).toBe("manual");
+    expect(bgWords(result[0])?.map((w) => w.text)).toEqual(["oh"]);
+    expect(bgSource(result[0])).toBe("manual");
   });
 
   it("leaves backgroundTextSource untouched when only main words are deleted", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "l1",
         text: "I love",
         agentId: "v1",
@@ -218,24 +220,24 @@ describe("applyWordDeletion", () => {
           { text: "oh", begin: 0.5, end: 1 },
         ],
         backgroundTextSource: "extraction",
-      },
+      }),
     ];
     const result = applyWordDeletion(lines, [{ lineId: "l1", type: "word", wordIndex: 0 }]);
-    expect(result[0].words?.map((w) => w.text)).toEqual(["love"]);
-    expect(result[0].backgroundWords?.length).toBe(2);
-    expect(result[0].backgroundTextSource).toBe("extraction");
+    expect(mainWords(result[0])?.map((w) => w.text)).toEqual(["love"]);
+    expect(bgWords(result[0])?.length).toBe(2);
+    expect(bgSource(result[0])).toBe("extraction");
   });
 
   it("leaves a word-timed line empty (not removed) when all main + bg words are deleted in one pass", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "l1",
         text: "I",
         agentId: "v1",
         words: [{ text: "I", begin: 0, end: 1 }],
         backgroundText: "ah",
         backgroundWords: [{ text: "ah", begin: 0, end: 1 }],
-      },
+      }),
     ];
     const sel: DeletionSelection[] = [
       { lineId: "l1", type: "word", wordIndex: 0 },
@@ -243,19 +245,19 @@ describe("applyWordDeletion", () => {
     ];
     const result = applyWordDeletion(lines, sel);
     expect(result).toHaveLength(1);
-    expect(result[0].words).toEqual([]);
-    expect(result[0].backgroundWords).toBeUndefined();
-    expect(result[0].begin).toBeUndefined();
-    expect(result[0].end).toBeUndefined();
+    expect(mainWords(result[0])).toEqual([]);
+    expect(bgWords(result[0])).toBeUndefined();
+    expect(mainBounds(result[0])?.begin).toBeUndefined();
+    expect(mainBounds(result[0])?.end).toBeUndefined();
   });
 
   it("returns the original array when there are no selections", () => {
-    const lines: LyricLine[] = [{ id: "l1", text: "x", agentId: "v1" }];
+    const lines: LyricLine[] = [reconcileLine({ id: "l1", text: "x", agentId: "v1" })];
     expect(applyWordDeletion(lines, [])).toBe(lines);
   });
 
   it("ignores selections referencing missing lines", () => {
-    const lines: LyricLine[] = [{ id: "l1", text: "x", agentId: "v1", begin: 0, end: 1 }];
+    const lines: LyricLine[] = [reconcileLine({ id: "l1", text: "x", agentId: "v1", begin: 0, end: 1 })];
     const sel: DeletionSelection[] = [{ lineId: "ghost", type: "word", wordIndex: 0 }];
     const result = applyWordDeletion(lines, sel);
     expect(result).toEqual(lines);
@@ -263,7 +265,7 @@ describe("applyWordDeletion", () => {
 
   it("preserves pre-existing intra-group gaps after deleting a non-group word", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "l1",
         text: "every world",
         agentId: "v1",
@@ -273,11 +275,11 @@ describe("applyWordDeletion", () => {
           { text: "y", begin: 0.5, end: 0.7, syllableGroupId: "g1" },
           { text: "world", begin: 0.7, end: 1 },
         ],
-      },
+      }),
     ];
     const result = applyWordDeletion(lines, [{ lineId: "l1", type: "word", wordIndex: 3 }]);
-    expect(result[0].words?.[0].end).toBe(0.2);
-    expect(result[0].words?.[1].begin).toBe(0.3);
+    expect(mainWords(result[0])?.[0].end).toBe(0.2);
+    expect(mainWords(result[0])?.[1].begin).toBe(0.3);
   });
 });
 
@@ -292,7 +294,7 @@ describe("applyWordDeletion", () => {
 describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", () => {
   it("strips group attrs when a single-line instance has its only word deleted", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "x",
         agentId: "v1",
@@ -300,7 +302,7 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
         instanceIdx: 1,
         templateLineIdx: 0,
         words: [{ text: "x", begin: 5, end: 6 }],
-      },
+      }),
     ];
     const result = applyWordDeletion(lines, [{ lineId: "L1", type: "word", wordIndex: 0 }]);
     expect(result[0].groupId).toBeUndefined();
@@ -308,16 +310,16 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
     expect(result[0].templateLineIdx).toBeUndefined();
     // Row remains as an empty placeholder (text and id preserved)
     expect(result[0].id).toBe("L1");
-    expect(result[0].text).toBe("x");
+    expect(lineText(result[0])).toBe("x");
     // Existing applyWordDeletion contract: words becomes [] after deleting all words
-    expect(result[0].words).toEqual([]);
-    expect(result[0].begin).toBeUndefined();
-    expect(result[0].end).toBeUndefined();
+    expect(mainWords(result[0])).toEqual([]);
+    expect(mainBounds(result[0])?.begin).toBeUndefined();
+    expect(mainBounds(result[0])?.end).toBeUndefined();
   });
 
   it("strips group attrs from ALL lines of a multi-line instance when every line is emptied", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "A1",
         text: "I love",
         agentId: "v1",
@@ -328,8 +330,8 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
           { text: "I ", begin: 5, end: 5.5 },
           { text: "love", begin: 5.5, end: 6 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "A2",
         text: "you",
         agentId: "v1",
@@ -337,7 +339,7 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
         instanceIdx: 1,
         templateLineIdx: 1,
         words: [{ text: "you", begin: 6, end: 7 }],
-      },
+      }),
     ];
     const result = applyWordDeletion(lines, [
       { lineId: "A1", type: "word", wordIndex: 0 },
@@ -352,7 +354,7 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
   it("keeps group attrs intact when only SOME lines of a multi-line instance are emptied", () => {
     // A1 gets emptied, A2 still has words. Instance is not fully empty → keep linked.
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "A1",
         text: "I love",
         agentId: "v1",
@@ -360,8 +362,8 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
         instanceIdx: 1,
         templateLineIdx: 0,
         words: [{ text: "I love", begin: 5, end: 6 }],
-      },
-      {
+      }),
+      reconcileLine({
         id: "A2",
         text: "you",
         agentId: "v1",
@@ -369,19 +371,21 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
         instanceIdx: 1,
         templateLineIdx: 1,
         words: [{ text: "you", begin: 6, end: 7 }],
-      },
+      }),
     ];
     const result = applyWordDeletion(lines, [{ lineId: "A1", type: "word", wordIndex: 0 }]);
     // A1 is now empty but A2 still has words → instance stays alive
     expect(result.find((l) => l.id === "A1")?.groupId).toBe("cannon");
     expect(result.find((l) => l.id === "A2")?.groupId).toBe("cannon");
-    expect(result.find((l) => l.id === "A1")?.words).toEqual([]);
-    expect(result.find((l) => l.id === "A2")?.words).toEqual([{ text: "you", begin: 6, end: 7 }]);
+    const a1 = result.find((l) => l.id === "A1");
+    const a2 = result.find((l) => l.id === "A2");
+    expect(a1 && mainWords(a1)).toEqual([]);
+    expect(a2 && mainWords(a2)).toEqual([{ text: "you", begin: 6, end: 7 }]);
   });
 
   it("strips group attrs when a single-line instance has only BG words and they all get deleted", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "main",
         agentId: "v1",
@@ -393,19 +397,19 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
           { text: "ah ", begin: 5, end: 5.5 },
           { text: "ah", begin: 5.5, end: 6 },
         ],
-      },
+      }),
     ];
     const result = applyWordDeletion(lines, [
       { lineId: "L1", type: "bg", wordIndex: 0 },
       { lineId: "L1", type: "bg", wordIndex: 1 },
     ]);
     expect(result[0].groupId).toBeUndefined();
-    expect(result[0].backgroundWords).toBeUndefined();
+    expect(bgWords(result[0])).toBeUndefined();
   });
 
   it("keeps group attrs when a line has main + bg and only one track is emptied (other still has content)", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "main",
         agentId: "v1",
@@ -415,18 +419,18 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
         words: [{ text: "main", begin: 5, end: 6 }],
         backgroundText: "ah",
         backgroundWords: [{ text: "ah", begin: 5, end: 5.5 }],
-      },
+      }),
     ];
     const result = applyWordDeletion(lines, [{ lineId: "L1", type: "word", wordIndex: 0 }]);
     // Main words gone but bg still present → not fully empty → instance stays
     expect(result[0].groupId).toBe("cannon");
-    expect(result[0].words).toEqual([]);
-    expect(result[0].backgroundWords?.length).toBe(1);
+    expect(mainWords(result[0])).toEqual([]);
+    expect(bgWords(result[0])?.length).toBe(1);
   });
 
   it("strips group attrs from a line-synced (no words, has begin/end) instance when its single line is deleted", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "verse",
         agentId: "v1",
@@ -435,18 +439,18 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
         templateLineIdx: 0,
         begin: 5,
         end: 7,
-      },
+      }),
     ];
     // Selecting wordIndex 0 on a line-synced row deletes the synthetic word AND clears begin/end
     const result = applyWordDeletion(lines, [{ lineId: "L1", type: "word", wordIndex: 0 }]);
     expect(result[0].groupId).toBeUndefined();
-    expect(result[0].begin).toBeUndefined();
-    expect(result[0].end).toBeUndefined();
+    expect(mainBounds(result[0])?.begin).toBeUndefined();
+    expect(mainBounds(result[0])?.end).toBeUndefined();
   });
 
   it("handles two separate instances both becoming empty in one deletion call", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "A1",
         text: "x",
         agentId: "v1",
@@ -454,8 +458,8 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
         instanceIdx: 0,
         templateLineIdx: 0,
         words: [{ text: "x", begin: 5, end: 6 }],
-      },
-      {
+      }),
+      reconcileLine({
         id: "B1",
         text: "y",
         agentId: "v1",
@@ -463,7 +467,7 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
         instanceIdx: 1,
         templateLineIdx: 0,
         words: [{ text: "y", begin: 10, end: 11 }],
-      },
+      }),
     ];
     const result = applyWordDeletion(lines, [
       { lineId: "A1", type: "word", wordIndex: 0 },
@@ -474,7 +478,7 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
 
   it("does NOT touch instances that weren't part of the deletion selection", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "A1",
         text: "x",
         agentId: "v1",
@@ -482,8 +486,8 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
         instanceIdx: 0,
         templateLineIdx: 0,
         words: [{ text: "x", begin: 5, end: 6 }],
-      },
-      {
+      }),
+      reconcileLine({
         id: "B1",
         text: "y",
         agentId: "v1",
@@ -491,7 +495,7 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
         instanceIdx: 1,
         templateLineIdx: 0,
         words: [{ text: "y", begin: 10, end: 11 }],
-      },
+      }),
     ];
     // Only delete A1's word, not B1's
     const result = applyWordDeletion(lines, [{ lineId: "A1", type: "word", wordIndex: 0 }]);
@@ -500,17 +504,19 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
   });
 
   it("non-grouped lines that get fully emptied: nothing to strip, just left as empty rows", () => {
-    const lines: LyricLine[] = [{ id: "L1", text: "x", agentId: "v1", words: [{ text: "x", begin: 5, end: 6 }] }];
+    const lines: LyricLine[] = [
+      reconcileLine({ id: "L1", text: "x", agentId: "v1", words: [{ text: "x", begin: 5, end: 6 }] }),
+    ];
     const result = applyWordDeletion(lines, [{ lineId: "L1", type: "word", wordIndex: 0 }]);
     expect(result[0].groupId).toBeUndefined();
-    expect(result[0].words).toEqual([]);
+    expect(mainWords(result[0])).toEqual([]);
     expect(result[0].id).toBe("L1");
-    expect(result[0].text).toBe("x");
+    expect(lineText(result[0])).toBe("x");
   });
 
   it("preserves the detached flag's semantics when stripping (detached lines also clear it)", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "x",
         agentId: "v1",
@@ -519,7 +525,7 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
         templateLineIdx: 0,
         detached: true,
         words: [{ text: "x", begin: 5, end: 6 }],
-      },
+      }),
     ];
     const result = applyWordDeletion(lines, [{ lineId: "L1", type: "word", wordIndex: 0 }]);
     expect(result[0].groupId).toBeUndefined();
@@ -528,7 +534,7 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
 
   it("partial deletion (some words remain): instance stays linked", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "I love you",
         agentId: "v1",
@@ -540,10 +546,10 @@ describe("applyWordDeletion · auto-cleanup of fully-empty grouped instances", (
           { text: "love ", begin: 5.3, end: 5.6 },
           { text: "you", begin: 5.6, end: 6 },
         ],
-      },
+      }),
     ];
     const result = applyWordDeletion(lines, [{ lineId: "L1", type: "word", wordIndex: 1 }]);
     expect(result[0].groupId).toBe("cannon");
-    expect(result[0].words?.length).toBe(2);
+    expect(mainWords(result[0])?.length).toBe(2);
   });
 });

--- a/src/views/timeline/apply-word-deletion.ts
+++ b/src/views/timeline/apply-word-deletion.ts
@@ -1,8 +1,10 @@
 import { isLinked } from "@/domain/instance/predicates";
 import { CLEARED_BACKGROUND, manualBackgroundWordEdit } from "@/domain/line/background";
+import { mainBounds } from "@/domain/line/bounds";
 import { isLineSynced } from "@/domain/line/predicates";
 import { reconstructLineText } from "@/domain/line/reconstruct-text";
 import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { getSplitCharacter } from "@/utils/split-character";
 import { absorbDeletedSyllablesIntoNeighbors } from "@/domain/word/syllable-groups";
 
@@ -14,10 +16,9 @@ interface DeletionSelection {
 
 function isLineFullyEmpty(line: LyricLine): boolean {
   return (
-    (line.words?.length ?? 0) === 0 &&
-    (line.backgroundWords?.length ?? 0) === 0 &&
-    line.begin === undefined &&
-    line.end === undefined
+    (mainWords(line)?.length ?? 0) === 0 &&
+    (bgWords(line)?.length ?? 0) === 0 &&
+    mainBounds(line) === null
   );
 }
 
@@ -46,24 +47,26 @@ function applyWordDeletion(lines: LyricLine[], selectedWords: ReadonlyArray<Dele
     const line = linesById.get(lineId);
     if (!line) continue;
 
-    const realMainCount = line.words?.length ?? 0;
+    const mainWordsArr = mainWords(line);
+    const realMainCount = mainWordsArr?.length ?? 0;
     const lineSynced = isLineSynced(line);
 
-    let nextMain = line.words;
+    let nextMain = mainWordsArr;
     let willHaveNoMainWords = realMainCount === 0;
     if (lineSynced && mainIdxs.has(0)) {
       nextMain = undefined;
       willHaveNoMainWords = true;
-    } else if (realMainCount > 0 && mainIdxs.size > 0 && line.words) {
-      const absorbed = absorbDeletedSyllablesIntoNeighbors(line.words, mainIdxs);
+    } else if (realMainCount > 0 && mainIdxs.size > 0 && mainWordsArr) {
+      const absorbed = absorbDeletedSyllablesIntoNeighbors(mainWordsArr, mainIdxs);
       nextMain = absorbed.filter((_, i) => !mainIdxs.has(i));
       willHaveNoMainWords = nextMain.length === 0;
     }
 
-    const bgEdited = (line.backgroundWords?.length ?? 0) > 0 && bgIdxs.size > 0 && line.backgroundWords !== undefined;
+    const bgWordsArr = bgWords(line);
+    const bgEdited = (bgWordsArr?.length ?? 0) > 0 && bgIdxs.size > 0 && bgWordsArr !== undefined;
     let bgFields: Partial<LyricLine> = {};
-    if (bgEdited && line.backgroundWords) {
-      const absorbed = absorbDeletedSyllablesIntoNeighbors(line.backgroundWords, bgIdxs);
+    if (bgEdited && bgWordsArr) {
+      const absorbed = absorbDeletedSyllablesIntoNeighbors(bgWordsArr, bgIdxs);
       const remaining = absorbed.filter((_, i) => !bgIdxs.has(i));
       bgFields = remaining.length > 0 ? manualBackgroundWordEdit(remaining) : CLEARED_BACKGROUND;
     }
@@ -71,7 +74,7 @@ function applyWordDeletion(lines: LyricLine[], selectedWords: ReadonlyArray<Dele
     const updatedLine = reconcileLine({
       ...line,
       words: nextMain,
-      text: nextMain && nextMain.length > 0 ? reconstructLineText(nextMain, splitChar) : line.text,
+      text: nextMain && nextMain.length > 0 ? reconstructLineText(nextMain, splitChar) : lineText(line),
       ...bgFields,
       ...(willHaveNoMainWords ? { begin: undefined, end: undefined } : {}),
     });

--- a/src/views/timeline/apply-word-deletion.ts
+++ b/src/views/timeline/apply-word-deletion.ts
@@ -3,7 +3,7 @@ import { CLEARED_BACKGROUND, manualBackgroundWordEdit } from "@/domain/line/back
 import { mainBounds } from "@/domain/line/bounds";
 import { isLineSynced } from "@/domain/line/predicates";
 import { reconstructLineText } from "@/domain/line/reconstruct-text";
-import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { reconcileLine, toFlat, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { getSplitCharacter } from "@/utils/split-character";
 import { absorbDeletedSyllablesIntoNeighbors } from "@/domain/word/syllable-groups";
@@ -15,11 +15,7 @@ interface DeletionSelection {
 }
 
 function isLineFullyEmpty(line: LyricLine): boolean {
-  return (
-    (mainWords(line)?.length ?? 0) === 0 &&
-    (bgWords(line)?.length ?? 0) === 0 &&
-    mainBounds(line) === null
-  );
+  return (mainWords(line)?.length ?? 0) === 0 && (bgWords(line)?.length ?? 0) === 0 && mainBounds(line) === null;
 }
 
 function applyWordDeletion(lines: LyricLine[], selectedWords: ReadonlyArray<DeletionSelection>): LyricLine[] {
@@ -64,7 +60,7 @@ function applyWordDeletion(lines: LyricLine[], selectedWords: ReadonlyArray<Dele
 
     const bgWordsArr = bgWords(line);
     const bgEdited = (bgWordsArr?.length ?? 0) > 0 && bgIdxs.size > 0 && bgWordsArr !== undefined;
-    let bgFields: Partial<LyricLine> = {};
+    let bgFields: Partial<LooseLine> = {};
     if (bgEdited && bgWordsArr) {
       const absorbed = absorbDeletedSyllablesIntoNeighbors(bgWordsArr, bgIdxs);
       const remaining = absorbed.filter((_, i) => !bgIdxs.has(i));
@@ -72,7 +68,7 @@ function applyWordDeletion(lines: LyricLine[], selectedWords: ReadonlyArray<Dele
     }
 
     const updatedLine = reconcileLine({
-      ...line,
+      ...toFlat(line),
       words: nextMain,
       text: nextMain && nextMain.length > 0 ? reconstructLineText(nextMain, splitChar) : lineText(line),
       ...bgFields,

--- a/src/views/timeline/build-candidate-lines.test.ts
+++ b/src/views/timeline/build-candidate-lines.test.ts
@@ -1,12 +1,13 @@
 /**
  * @vitest-environment node
  */
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordSelection } from "@/domain/selection/model";
 import { describe, expect, it } from "vitest";
 import { buildCandidateLines } from "./build-candidate-lines";
 
-const lineA: LyricLine = {
+const lineA: LyricLine = reconcileLine({
   id: "a",
   text: "I love you",
   agentId: "v1",
@@ -15,9 +16,9 @@ const lineA: LyricLine = {
     { text: "love ", begin: 1, end: 2 },
     { text: "you", begin: 2, end: 3 },
   ],
-};
+});
 
-const lineB: LyricLine = {
+const lineB: LyricLine = reconcileLine({
   id: "b",
   text: "and so do I",
   agentId: "v1",
@@ -27,21 +28,21 @@ const lineB: LyricLine = {
     { text: "do ", begin: 5, end: 6 },
     { text: "I", begin: 6, end: 7 },
   ],
-};
+});
 
-const lineWithBg: LyricLine = {
+const lineWithBg: LyricLine = reconcileLine({
   id: "c",
   text: "main",
   agentId: "v1",
   words: [{ text: "main", begin: 0, end: 1 }],
   backgroundText: "bg",
   backgroundWords: [{ text: "bg", begin: 0.5, end: 1 }],
-};
+});
 
 function selectAll(line: LyricLine, lineIndex: number): WordSelection[] {
   const sels: WordSelection[] = [];
-  (line.words ?? []).forEach((_, i) => sels.push({ lineId: line.id, lineIndex, wordIndex: i, type: "word" }));
-  (line.backgroundWords ?? []).forEach((_, i) => sels.push({ lineId: line.id, lineIndex, wordIndex: i, type: "bg" }));
+  (mainWords(line) ?? []).forEach((_, i) => sels.push({ lineId: line.id, lineIndex, wordIndex: i, type: "word" }));
+  (bgWords(line) ?? []).forEach((_, i) => sels.push({ lineId: line.id, lineIndex, wordIndex: i, type: "bg" }));
   return sels;
 }
 

--- a/src/views/timeline/build-candidate-lines.ts
+++ b/src/views/timeline/build-candidate-lines.ts
@@ -1,4 +1,5 @@
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordSelection } from "@/domain/selection/model";
 
 function buildCandidateLines(lines: LyricLine[], selectedWords: ReadonlyArray<WordSelection>): LyricLine[] | undefined {
@@ -22,8 +23,8 @@ function buildCandidateLines(lines: LyricLine[], selectedWords: ReadonlyArray<Wo
   for (const [lineId, { mainIdxs, bgIdxs, lineIndex }] of byLine) {
     const line = linesById.get(lineId);
     if (!line) return undefined;
-    const totalMain = line.words?.length ?? 0;
-    const totalBg = line.backgroundWords?.length ?? 0;
+    const totalMain = mainWords(line)?.length ?? 0;
+    const totalBg = bgWords(line)?.length ?? 0;
     if (mainIdxs.size !== totalMain) return undefined;
     if (bgIdxs.size !== totalBg) return undefined;
     candidates.push({ line, lineIndex });

--- a/src/views/timeline/copy-instance-to-clipboard.ts
+++ b/src/views/timeline/copy-instance-to-clipboard.ts
@@ -1,5 +1,6 @@
 import { belongsToInstance } from "@/domain/instance/predicates";
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import type { ClipboardData, ClipboardEntry } from "@/views/timeline/selection-types";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 
@@ -24,13 +25,15 @@ function copyInstanceToClipboardAndPreview(lines: LyricLine[], groupId: string, 
 
   for (const lineIdx of instanceLineIndices) {
     const line = lines[lineIdx];
-    if (line.words?.length) {
-      for (const word of line.words) {
+    const main = mainWords(line);
+    if (main?.length) {
+      for (const word of main) {
         entries.push({ word: { ...word }, lineOffset: lineIdx - minLineIndex, trackType: "word" });
       }
     }
-    if (line.backgroundWords?.length) {
-      for (const word of line.backgroundWords) {
+    const bg = bgWords(line);
+    if (bg?.length) {
+      for (const word of bg) {
         entries.push({ word: { ...word }, lineOffset: lineIdx - minLineIndex, trackType: "bg" });
       }
     }

--- a/src/views/timeline/decide-add-instance-placement.test.ts
+++ b/src/views/timeline/decide-add-instance-placement.test.ts
@@ -2,7 +2,8 @@
  * @vitest-environment node
  */
 import type { LineTemplate } from "@/domain/group/template";
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { mainWords } from "@/domain/line/voices";
 import { describe, expect, it } from "vitest";
 import { decideAddInstancePlacement, templateDuration } from "./decide-add-instance-placement";
 
@@ -18,26 +19,28 @@ const template: LineTemplate[] = [
   },
 ];
 
-const wordSyncedLine = (id: string, begin: number, end: number): LyricLine => ({
-  id,
-  text: "x",
-  agentId: "v1",
-  words: [{ text: "x", begin, end }],
-});
+const wordSyncedLine = (id: string, begin: number, end: number): LyricLine =>
+  reconcileLine({
+    id,
+    text: "x",
+    agentId: "v1",
+    words: [{ text: "x", begin, end }],
+  });
 
 // A grouped + word-timed line (a "real" group instance line): never fillable
-const groupedTimedLine = (id: string, gid: string, instIdx: number, begin: number, end: number): LyricLine => ({
-  id,
-  text: "x",
-  agentId: "v1",
-  groupId: gid,
-  instanceIdx: instIdx,
-  templateLineIdx: 0,
-  words: [{ text: "x", begin, end }],
-});
+const groupedTimedLine = (id: string, gid: string, instIdx: number, begin: number, end: number): LyricLine =>
+  reconcileLine({
+    id,
+    text: "x",
+    agentId: "v1",
+    groupId: gid,
+    instanceIdx: instIdx,
+    templateLineIdx: 0,
+    words: [{ text: "x", begin, end }],
+  });
 
 // A standalone untimed empty placeholder (no groupId, no words, no begin/end): fillable
-const emptyPlaceholderLine = (id: string, text = ""): LyricLine => ({ id, text, agentId: "v1" });
+const emptyPlaceholderLine = (id: string, text = ""): LyricLine => reconcileLine({ id, text, agentId: "v1" });
 
 describe("templateDuration", () => {
   it("returns the span between earliest begin and latest end across all template words", () => {
@@ -84,7 +87,7 @@ describe("decideAddInstancePlacement · fill path (matches paste-as-instance)", 
       const filled = result.updatedLines[1];
       expect(filled.groupId).toBe("cannon");
       expect(filled.instanceIdx).toBe(1);
-      expect(filled.words?.[0].begin).toBeCloseTo(20);
+      expect(mainWords(filled)?.[0].begin).toBeCloseTo(20);
     }
   });
 

--- a/src/views/timeline/decide-paste-instance-action.test.ts
+++ b/src/views/timeline/decide-paste-instance-action.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 import type { LineTemplate } from "@/domain/group/template";
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
 import { decidePasteInstanceAction } from "./decide-paste-instance-action";
 
@@ -25,7 +25,7 @@ const template: LineTemplate[] = [
 
 describe("decidePasteInstanceAction · invariants both paste flows must respect", () => {
   it("returns no-target when dropped in midair (negative hoveredLineIndex)", () => {
-    const lines: LyricLine[] = [{ id: "1", text: "x", agentId: "v1" }];
+    const lines: LyricLine[] = [reconcileLine({ id: "1", text: "x", agentId: "v1" })];
     const result = decidePasteInstanceAction({
       lines,
       groupId: "g1",
@@ -38,9 +38,9 @@ describe("decidePasteInstanceAction · invariants both paste flows must respect"
 
   it("fills in place when destination has N consecutive empty rows", () => {
     const lines: LyricLine[] = [
-      { id: "intro", text: "intro", agentId: "v1", words: [{ text: "intro", begin: 0, end: 5 }] },
-      { id: "empty1", text: "chorus a", agentId: "v1" },
-      { id: "empty2", text: "chorus b", agentId: "v1" },
+      reconcileLine({ id: "intro", text: "intro", agentId: "v1", words: [{ text: "intro", begin: 0, end: 5 }] }),
+      reconcileLine({ id: "empty1", text: "chorus a", agentId: "v1" }),
+      reconcileLine({ id: "empty2", text: "chorus b", agentId: "v1" }),
     ];
     const result = decidePasteInstanceAction({
       lines,
@@ -58,13 +58,13 @@ describe("decidePasteInstanceAction · invariants both paste flows must respect"
 
   it("requests confirmation to insert when destination row is occupied (no destructive default)", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "synced",
         text: "chorus a",
         agentId: "v1",
         words: [{ text: "chorus a", begin: 0, end: 1 }],
-      },
-      { id: "empty", text: "chorus b", agentId: "v1" },
+      }),
+      reconcileLine({ id: "empty", text: "chorus b", agentId: "v1" }),
     ];
     const result = decidePasteInstanceAction({
       lines,
@@ -81,15 +81,15 @@ describe("decidePasteInstanceAction · invariants both paste flows must respect"
 
   it("requests confirmation to insert when destination is partially empty (some rows already grouped)", () => {
     const lines: LyricLine[] = [
-      { id: "empty", text: "chorus a", agentId: "v1" },
-      {
+      reconcileLine({ id: "empty", text: "chorus a", agentId: "v1" }),
+      reconcileLine({
         id: "grouped",
         text: "chorus b",
         agentId: "v1",
         groupId: "other",
         instanceIdx: 0,
         templateLineIdx: 0,
-      },
+      }),
     ];
     const result = decidePasteInstanceAction({
       lines,
@@ -102,7 +102,7 @@ describe("decidePasteInstanceAction · invariants both paste flows must respect"
   });
 
   it("clamps negative cursorTime to 0 in the instanceStart it returns", () => {
-    const lines: LyricLine[] = [{ id: "x", text: "synced", agentId: "v1", begin: 0, end: 1 }];
+    const lines: LyricLine[] = [reconcileLine({ id: "x", text: "synced", agentId: "v1", begin: 0, end: 1 })];
     const result = decidePasteInstanceAction({
       lines,
       groupId: "g1",
@@ -116,7 +116,7 @@ describe("decidePasteInstanceAction · invariants both paste flows must respect"
   });
 
   it("requests confirmation when destination range overflows the project", () => {
-    const lines: LyricLine[] = [{ id: "empty1", text: "chorus a", agentId: "v1" }];
+    const lines: LyricLine[] = [reconcileLine({ id: "empty1", text: "chorus a", agentId: "v1" })];
     const result = decidePasteInstanceAction({
       lines,
       groupId: "g1",

--- a/src/views/timeline/delete-group-with-confirm.test.ts
+++ b/src/views/timeline/delete-group-with-confirm.test.ts
@@ -1,6 +1,8 @@
 /**
  * @vitest-environment node
  */
+import { reconcileLine } from "@/domain/line/model";
+import { lineText, mainWords } from "@/domain/line/voices";
 import { useConfirmStore } from "@/stores/confirm-store";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
@@ -20,7 +22,7 @@ function seedChorusGroup() {
   useProjectStore.setState({
     groups: [{ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 }],
     lines: [
-      {
+      reconcileLine({
         id: "a0",
         text: "I love you",
         agentId: "v1",
@@ -32,8 +34,8 @@ function seedChorusGroup() {
           { text: "love ", begin: 30.4, end: 30.8 },
           { text: "you", begin: 30.8, end: 31.2 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "a1",
         text: "I love you",
         agentId: "v1",
@@ -45,7 +47,7 @@ function seedChorusGroup() {
           { text: "love ", begin: 60.4, end: 60.8 },
           { text: "you", begin: 60.8, end: 61.2 },
         ],
-      },
+      }),
     ],
   });
 }
@@ -94,9 +96,9 @@ describe("deleteGroupWithConfirm · confirm accepted", () => {
     await done;
 
     const a0 = useProjectStore.getState().lines.find((l) => l.id === "a0");
-    expect(a0?.text).toBe("I love you");
-    expect(a0?.words?.[0].begin).toBe(30);
-    expect(a0?.words?.[2].end).toBe(31.2);
+    expect(a0 && lineText(a0)).toBe("I love you");
+    expect(a0 && mainWords(a0)?.[0].begin).toBe(30);
+    expect(a0 && mainWords(a0)?.[2].end).toBe(31.2);
   });
 
   it("closes the confirm modal once resolved", async () => {

--- a/src/views/timeline/drag-handlers.ts
+++ b/src/views/timeline/drag-handlers.ts
@@ -2,6 +2,7 @@ import { isWordSelected } from "@/domain/selection/identity";
 import { manualBackgroundWordEdit } from "@/domain/line/background";
 import { mainWordEditFields } from "@/domain/line/main-words";
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { useProjectStore } from "@/stores/project";
 import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
 import { applyWordMoveAcrossLines, type WordMove } from "@/domain/word/move-across-lines";
@@ -60,7 +61,7 @@ function expandSelectionsAcrossLines(lines: LyricLine[], selections: WordSelecti
   for (const sel of selections) {
     const line = linesById.get(sel.lineId);
     if (!line) continue;
-    const words = sel.type === "word" ? line.words : line.backgroundWords;
+    const words = sel.type === "word" ? mainWords(line) : bgWords(line);
     if (!words) continue;
     const expanded = expandSelectionToGroupmates(words, [sel.wordIndex]);
     for (const idx of expanded) {
@@ -109,7 +110,7 @@ function handleAltDuplicate(event: DragEndEvent, lines: LyricLine[], zoom: numbe
     const bgDups: WordTiming[] = [];
 
     for (const sel of selections) {
-      const wordsArray = sel.type === "word" ? line.words : line.backgroundWords;
+      const wordsArray = sel.type === "word" ? mainWords(line) : bgWords(line);
       const word = wordsArray?.[sel.wordIndex];
       if (!word) continue;
 
@@ -125,13 +126,13 @@ function handleAltDuplicate(event: DragEndEvent, lines: LyricLine[], zoom: numbe
     const lineUpdates: Partial<LyricLine> = {};
 
     if (wordDups.length > 0) {
-      const existing = line.words ?? [];
+      const existing = mainWords(line) ?? [];
       const hasOverlap = wordDups.some((dup) => existing.some((w) => boundsOverlap(dup, w)));
       if (!hasOverlap) Object.assign(lineUpdates, mainWordEditFields(mergeWordsIntoTrack(existing, wordDups)));
     }
 
     if (bgDups.length > 0) {
-      const existing = line.backgroundWords ?? [];
+      const existing = bgWords(line) ?? [];
       const hasOverlap = bgDups.some((dup) => existing.some((w) => boundsOverlap(dup, w)));
       if (!hasOverlap) Object.assign(lineUpdates, manualBackgroundWordEdit(mergeWordsIntoTrack(existing, bgDups)));
     }
@@ -170,11 +171,13 @@ function applySameLineReorder(
       const wordIndices = new Set(selections.flatMap((s) => (s.type === "word" ? [s.wordIndex] : [])));
       const bgIndices = new Set(selections.flatMap((s) => (s.type === "bg" ? [s.wordIndex] : [])));
 
-      if (wordIndices.size > 0 && line.words) {
-        Object.assign(lineUpdates, mainWordEditFields(reorderWordTrack(line.words, wordIndices, timeDelta, duration)));
+      const main = mainWords(line);
+      const bg = bgWords(line);
+      if (wordIndices.size > 0 && main) {
+        Object.assign(lineUpdates, mainWordEditFields(reorderWordTrack(main, wordIndices, timeDelta, duration)));
       }
-      if (bgIndices.size > 0 && line.backgroundWords) {
-        const reordered = reorderWordTrack(line.backgroundWords, bgIndices, timeDelta, duration);
+      if (bgIndices.size > 0 && bg) {
+        const reordered = reorderWordTrack(bg, bgIndices, timeDelta, duration);
         Object.assign(lineUpdates, manualBackgroundWordEdit(reordered));
       }
 
@@ -189,7 +192,7 @@ function applySameLineReorder(
 
   const line = lines.find((l) => l.id === activeData.lineId);
   if (!line) return;
-  const wordsArray = activeData.trackType === "word" ? line.words : line.backgroundWords;
+  const wordsArray = activeData.trackType === "word" ? mainWords(line) : bgWords(line);
   if (!wordsArray) return;
 
   const wordIndex = activeData.wordIndex;
@@ -232,7 +235,7 @@ function buildCrossLineMoves({
     if (sel.lineId !== activeData.lineId) continue;
     const sourceLine = linesById.get(sel.lineId);
     if (!sourceLine) continue;
-    const sourceArr = sel.type === "word" ? sourceLine.words : sourceLine.backgroundWords;
+    const sourceArr = sel.type === "word" ? mainWords(sourceLine) : bgWords(sourceLine);
     const source = sourceArr?.[sel.wordIndex];
     if (!source) continue;
 

--- a/src/views/timeline/drag-handlers.ts
+++ b/src/views/timeline/drag-handlers.ts
@@ -1,7 +1,7 @@
 import { isWordSelected } from "@/domain/selection/identity";
 import { manualBackgroundWordEdit } from "@/domain/line/background";
 import { mainWordEditFields } from "@/domain/line/main-words";
-import type { LyricLine } from "@/domain/line/model";
+import type { LooseLine, LyricLine } from "@/domain/line/model";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import { useProjectStore } from "@/stores/project";
 import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
@@ -96,7 +96,7 @@ function handleAltDuplicate(event: DragEndEvent, lines: LyricLine[], zoom: numbe
   const wordsToDuplicate = expandSelectionsAcrossLines(lines, resolveWordsToOperate(activeData, selectedWords));
 
   const timeDelta = delta.x / zoom;
-  const updates: Array<{ id: string; updates: Partial<LyricLine> }> = [];
+  const updates: Array<{ id: string; updates: Partial<LooseLine> }> = [];
 
   const grouped = groupSelectionsByLine(wordsToDuplicate);
   const linesById = new Map<string, LyricLine>();
@@ -123,7 +123,7 @@ function handleAltDuplicate(event: DragEndEvent, lines: LyricLine[], zoom: numbe
       else bgDups.push(dup);
     }
 
-    const lineUpdates: Partial<LyricLine> = {};
+    const lineUpdates: Partial<LooseLine> = {};
 
     if (wordDups.length > 0) {
       const existing = mainWords(line) ?? [];
@@ -159,7 +159,7 @@ function applySameLineReorder(
 ) {
   if (wordsToMove.length > 1) {
     const grouped = groupSelectionsByLine(wordsToMove);
-    const updates: Array<{ id: string; updates: Partial<LyricLine> }> = [];
+    const updates: Array<{ id: string; updates: Partial<LooseLine> }> = [];
     const linesById = new Map<string, LyricLine>();
     for (const l of lines) linesById.set(l.id, l);
 
@@ -167,7 +167,7 @@ function applySameLineReorder(
       const line = linesById.get(lineId);
       if (!line) continue;
 
-      const lineUpdates: Partial<LyricLine> = {};
+      const lineUpdates: Partial<LooseLine> = {};
       const wordIndices = new Set(selections.flatMap((s) => (s.type === "word" ? [s.wordIndex] : [])));
       const bgIndices = new Set(selections.flatMap((s) => (s.type === "bg" ? [s.wordIndex] : [])));
 

--- a/src/views/timeline/explicit-selection-toggle.test.ts
+++ b/src/views/timeline/explicit-selection-toggle.test.ts
@@ -3,7 +3,8 @@
  */
 import { useProjectStore } from "@/stores/project";
 import type { LinkGroup } from "@/domain/group/template";
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { mainWords } from "@/domain/line/voices";
 import { resolveExplicitSelectionToggle } from "@/views/timeline/explicit-selection-toggle";
 import type { WordSelection } from "@/domain/selection/model";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -15,7 +16,7 @@ function sel(lineId: string, wordIndex: number, type: "word" | "bg" = "word"): W
 describe("resolveExplicitSelectionToggle", () => {
   it("marks the whole word when a partially-marked syllable group is selected via one syllable", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "fu|cking yeah",
         agentId: "v1",
@@ -24,7 +25,7 @@ describe("resolveExplicitSelectionToggle", () => {
           { text: "cking ", begin: 0.2, end: 0.5 },
           { text: "yeah", begin: 0.5, end: 1 },
         ],
-      },
+      }),
     ];
     const result = resolveExplicitSelectionToggle(lines, [sel("L1", 0)]);
     expect(result.value).toBe(true);
@@ -33,7 +34,7 @@ describe("resolveExplicitSelectionToggle", () => {
 
   it("unmarks when every syllable of the selected word is already marked", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "fu|cking yeah",
         agentId: "v1",
@@ -42,7 +43,7 @@ describe("resolveExplicitSelectionToggle", () => {
           { text: "cking ", begin: 0.2, end: 0.5, explicit: true },
           { text: "yeah", begin: 0.5, end: 1 },
         ],
-      },
+      }),
     ];
     const result = resolveExplicitSelectionToggle(lines, [sel("L1", 1)]);
     expect(result.value).toBe(false);
@@ -51,7 +52,7 @@ describe("resolveExplicitSelectionToggle", () => {
 
   it("marks when the selected word is fully unmarked", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "fuck this",
         agentId: "v1",
@@ -59,7 +60,7 @@ describe("resolveExplicitSelectionToggle", () => {
           { text: "fuck ", begin: 0, end: 0.5 },
           { text: "this", begin: 0.5, end: 1 },
         ],
-      },
+      }),
     ];
     const result = resolveExplicitSelectionToggle(lines, [sel("L1", 0)]);
     expect(result.value).toBe(true);
@@ -68,7 +69,7 @@ describe("resolveExplicitSelectionToggle", () => {
 
   it("treats a multi-line selection as marked-only-if every expanded index is marked", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "A",
         text: "fuck this",
         agentId: "v1",
@@ -76,8 +77,8 @@ describe("resolveExplicitSelectionToggle", () => {
           { text: "fuck ", begin: 0, end: 0.5, explicit: true },
           { text: "this", begin: 0.5, end: 1 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "B",
         text: "shit happens",
         agentId: "v1",
@@ -85,7 +86,7 @@ describe("resolveExplicitSelectionToggle", () => {
           { text: "shit ", begin: 1, end: 1.5 },
           { text: "happens", begin: 1.5, end: 2 },
         ],
-      },
+      }),
     ];
     const result = resolveExplicitSelectionToggle(lines, [sel("A", 0), sel("B", 0)]);
     expect(result.value).toBe(true);
@@ -97,7 +98,7 @@ describe("resolveExplicitSelectionToggle", () => {
 
   it("maps a bg-type selection to the backgroundWords field", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "main",
         agentId: "v1",
@@ -107,7 +108,7 @@ describe("resolveExplicitSelectionToggle", () => {
           { text: "oh ", begin: 1, end: 1.25 },
           { text: "shit", begin: 1.25, end: 1.5 },
         ],
-      },
+      }),
     ];
     const result = resolveExplicitSelectionToggle(lines, [sel("L1", 1, "bg")]);
     expect(result.value).toBe(true);
@@ -116,7 +117,7 @@ describe("resolveExplicitSelectionToggle", () => {
 
   it("drops out-of-range and unknown-line selections", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "fuck this",
         agentId: "v1",
@@ -124,7 +125,7 @@ describe("resolveExplicitSelectionToggle", () => {
           { text: "fuck ", begin: 0, end: 0.5 },
           { text: "this", begin: 0.5, end: 1 },
         ],
-      },
+      }),
     ];
     const result = resolveExplicitSelectionToggle(lines, [sel("L1", 9), sel("ghost", 0), sel("L1", 0)]);
     expect(result.targets).toEqual([{ lineId: "L1", field: "words", wordIndex: 0 }]);
@@ -146,18 +147,20 @@ describe("resolveExplicitSelectionToggle → markWordsExplicit (keyboard flow, i
     const group: LinkGroup = { id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 };
     useProjectStore.getState().setGroups([group]);
     useProjectStore.getState().setLines(
-      [0, 1, 2].map((idx) => ({
-        id: `inst-${idx}`,
-        text: "fuck this",
-        agentId: "v1",
-        groupId: "g1",
-        instanceIdx: idx,
-        templateLineIdx: 0,
-        words: [
-          { text: "fuck ", begin: idx * 30, end: idx * 30 + 0.5, ...(explicit ? { explicit: true as const } : {}) },
-          { text: "this", begin: idx * 30 + 0.5, end: idx * 30 + 1 },
-        ],
-      })),
+      [0, 1, 2].map((idx) =>
+        reconcileLine({
+          id: `inst-${idx}`,
+          text: "fuck this",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: idx,
+          templateLineIdx: 0,
+          words: [
+            { text: "fuck ", begin: idx * 30, end: idx * 30 + 0.5, ...(explicit ? { explicit: true as const } : {}) },
+            { text: "this", begin: idx * 30 + 0.5, end: idx * 30 + 1 },
+          ],
+        }),
+      ),
     );
   }
 
@@ -171,7 +174,7 @@ describe("resolveExplicitSelectionToggle → markWordsExplicit (keyboard flow, i
     seedLinkedChorus();
     runToggle();
     const lines = useProjectStore.getState().lines;
-    expect(lines.every((l) => l.words?.[0].explicit === true)).toBe(true);
+    expect(lines.every((l) => mainWords(l)?.[0].explicit === true)).toBe(true);
   });
 
   it("reverts the whole batch with a single undo", () => {
@@ -179,13 +182,13 @@ describe("resolveExplicitSelectionToggle → markWordsExplicit (keyboard flow, i
     runToggle();
     useProjectStore.getState().undo();
     const lines = useProjectStore.getState().lines;
-    expect(lines.every((l) => l.words?.[0].explicit === undefined)).toBe(true);
+    expect(lines.every((l) => mainWords(l)?.[0].explicit === undefined)).toBe(true);
   });
 
   it("unmarks the batch when every selected word is already explicit", () => {
     seedLinkedChorus(true);
     runToggle();
     const lines = useProjectStore.getState().lines;
-    expect(lines.every((l) => l.words?.[0].explicit === undefined)).toBe(true);
+    expect(lines.every((l) => mainWords(l)?.[0].explicit === undefined)).toBe(true);
   });
 });

--- a/src/views/timeline/explicit-selection-toggle.ts
+++ b/src/views/timeline/explicit-selection-toggle.ts
@@ -1,4 +1,5 @@
 import type { LyricLine } from "@/domain/line/model";
+import { fieldWords } from "@/stores/project/lines-slice-helpers";
 import { expandSelectionToGroupmates } from "@/domain/word/syllable-groups";
 import type { WordSelection } from "@/domain/selection/model";
 
@@ -23,7 +24,8 @@ function resolveExplicitSelectionToggle(lines: LyricLine[], selection: WordSelec
 
   for (const w of selection) {
     const field: "words" | "backgroundWords" = w.type === "word" ? "words" : "backgroundWords";
-    const wordsArr = linesById.get(w.lineId)?.[field];
+    const line = linesById.get(w.lineId);
+    const wordsArr = line ? fieldWords(line, field) : undefined;
     if (!wordsArr || w.wordIndex < 0 || w.wordIndex >= wordsArr.length) continue;
     const key = `${w.lineId}:${field}`;
     const existing = groups.get(key);
@@ -35,7 +37,8 @@ function resolveExplicitSelectionToggle(lines: LyricLine[], selection: WordSelec
   let allMarked = true;
 
   for (const group of groups.values()) {
-    const wordsArr = linesById.get(group.lineId)?.[group.field];
+    const line = linesById.get(group.lineId);
+    const wordsArr = line ? fieldWords(line, group.field) : undefined;
     if (!wordsArr) continue;
     const expanded = expandSelectionToGroupmates(wordsArr, group.indices).filter((i) => i >= 0 && i < wordsArr.length);
     for (const idx of expanded) {

--- a/src/views/timeline/explicit-suggestions-banner.browser.test.tsx
+++ b/src/views/timeline/explicit-suggestions-banner.browser.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { mainWords } from "@/domain/line/voices";
 import { ExplicitSuggestionsBanner } from "@/views/timeline/explicit-suggestions-banner";
 import { useProjectStore } from "@/stores/project";
 import { createLine } from "@/test/factories";
@@ -28,7 +29,7 @@ describe("ExplicitSuggestionsBanner", () => {
     expect(screen.container.textContent ?? "").toContain("Possibly explicit word");
 
     await screen.getByRole("button", { name: /mark explicit/i }).click();
-    expect(useProjectStore.getState().lines[0].words?.[0].explicit).toBe(true);
+    expect(mainWords(useProjectStore.getState().lines[0])?.[0].explicit).toBe(true);
   });
 
   it("opens the review modal for multiple suggestions", async () => {
@@ -69,8 +70,8 @@ describe("ExplicitSuggestionsBanner", () => {
     await screen.getByRole("button", { name: /mark all/i }).click();
 
     const lines = useProjectStore.getState().lines;
-    expect(lines[0].words?.[0].explicit).toBe(true);
-    expect(lines[1].words?.[1].explicit).toBe(true);
+    expect(mainWords(lines[0])?.[0].explicit).toBe(true);
+    expect(mainWords(lines[1])?.[1].explicit).toBe(true);
   });
 
   it("dismissing the single suggestion hides the banner", async () => {

--- a/src/views/timeline/explicit-suggestions-banner.tsx
+++ b/src/views/timeline/explicit-suggestions-banner.tsx
@@ -1,3 +1,4 @@
+import { bgText, lineText } from "@/domain/line/voices";
 import { useProjectStore } from "@/stores/project";
 import { type ExplicitSuggestion, findExplicitWords } from "@/utils/explicit-detection";
 import { getExplicitSnippet } from "@/utils/explicit-snippet";
@@ -59,7 +60,7 @@ const ExplicitSuggestionsBanner: React.FC = () => {
       )}
       renderRow={(s) => {
         const line = lineMap.get(s.lineId);
-        const source = (s.field === "words" ? line?.text : line?.backgroundText) ?? "";
+        const source = (line ? (s.field === "words" ? lineText(line) : bgText(line)) : undefined) ?? "";
         return (
           <>
             <span className="text-sm text-composer-text">

--- a/src/views/timeline/fill-empty-lines-with-instance.test.ts
+++ b/src/views/timeline/fill-empty-lines-with-instance.test.ts
@@ -2,7 +2,8 @@
  * @vitest-environment node
  */
 import type { LineTemplate } from "@/domain/group/template";
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { describe, expect, it } from "vitest";
 import { fillEmptyLinesWithInstance, isEmptyFillable } from "./fill-empty-lines-with-instance";
 
@@ -25,29 +26,31 @@ const template: LineTemplate[] = [
 
 describe("isEmptyFillable", () => {
   it("returns true for a line with no words and no group", () => {
-    expect(isEmptyFillable({ id: "1", text: "anything", agentId: "v1" })).toBe(true);
+    expect(isEmptyFillable(reconcileLine({ id: "1", text: "anything", agentId: "v1" }))).toBe(true);
   });
 
   it("returns true for a line with empty words array and no group", () => {
-    expect(isEmptyFillable({ id: "1", text: "x", agentId: "v1", words: [] })).toBe(true);
+    expect(isEmptyFillable(reconcileLine({ id: "1", text: "x", agentId: "v1", words: [] }))).toBe(true);
   });
 
   it("returns false for a line that has words", () => {
-    expect(isEmptyFillable({ id: "1", text: "x", agentId: "v1", words: [{ text: "x", begin: 0, end: 1 }] })).toBe(
-      false,
-    );
+    expect(
+      isEmptyFillable(reconcileLine({ id: "1", text: "x", agentId: "v1", words: [{ text: "x", begin: 0, end: 1 }] })),
+    ).toBe(false);
   });
 
   it("returns false for a line that belongs to a group", () => {
     expect(
-      isEmptyFillable({
-        id: "1",
-        text: "x",
-        agentId: "v1",
-        groupId: "g1",
-        instanceIdx: 0,
-        templateLineIdx: 0,
-      }),
+      isEmptyFillable(
+        reconcileLine({
+          id: "1",
+          text: "x",
+          agentId: "v1",
+          groupId: "g1",
+          instanceIdx: 0,
+          templateLineIdx: 0,
+        }),
+      ),
     ).toBe(false);
   });
 });
@@ -55,10 +58,10 @@ describe("isEmptyFillable", () => {
 describe("fillEmptyLinesWithInstance · happy path", () => {
   it("fills exactly N consecutive empty lines and assigns group attrs", () => {
     const lines: LyricLine[] = [
-      { id: "intro", text: "intro", agentId: "v1", words: [{ text: "intro", begin: 0, end: 5 }] },
-      { id: "empty1", text: "Chorus line 1", agentId: "v1" },
-      { id: "empty2", text: "Chorus line 2", agentId: "v1" },
-      { id: "outro", text: "outro", agentId: "v1", words: [{ text: "outro", begin: 30, end: 35 }] },
+      reconcileLine({ id: "intro", text: "intro", agentId: "v1", words: [{ text: "intro", begin: 0, end: 5 }] }),
+      reconcileLine({ id: "empty1", text: "Chorus line 1", agentId: "v1" }),
+      reconcileLine({ id: "empty2", text: "Chorus line 2", agentId: "v1" }),
+      reconcileLine({ id: "outro", text: "outro", agentId: "v1", words: [{ text: "outro", begin: 30, end: 35 }] }),
     ];
     const result = fillEmptyLinesWithInstance({
       lines,
@@ -72,17 +75,17 @@ describe("fillEmptyLinesWithInstance · happy path", () => {
     expect(result.updatedLines?.[1].groupId).toBe("g1");
     expect(result.updatedLines?.[1].instanceIdx).toBe(0);
     expect(result.updatedLines?.[1].templateLineIdx).toBe(0);
-    expect(result.updatedLines?.[1].words?.[0].begin).toBe(10);
+    expect(result.updatedLines && mainWords(result.updatedLines[1])?.[0].begin).toBe(10);
     expect(result.updatedLines?.[2].templateLineIdx).toBe(1);
-    expect(result.updatedLines?.[2].words?.[0].begin).toBe(11);
+    expect(result.updatedLines && mainWords(result.updatedLines[2])?.[0].begin).toBe(11);
     expect(result.updatedLines?.[0].id).toBe("intro");
     expect(result.updatedLines?.[3].id).toBe("outro");
   });
 
   it("preserves the original line ids (in-place fill, not replacement)", () => {
     const lines: LyricLine[] = [
-      { id: "L_a", text: "anything", agentId: "v1" },
-      { id: "L_b", text: "anything else", agentId: "v1" },
+      reconcileLine({ id: "L_a", text: "anything", agentId: "v1" }),
+      reconcileLine({ id: "L_b", text: "anything else", agentId: "v1" }),
     ];
     const result = fillEmptyLinesWithInstance({
       lines,
@@ -98,8 +101,8 @@ describe("fillEmptyLinesWithInstance · happy path", () => {
 
   it("overwrites the line text to match the template (linked instances must match)", () => {
     const lines: LyricLine[] = [
-      { id: "L_a", text: "user typed something else", agentId: "v1" },
-      { id: "L_b", text: "and something different", agentId: "v1" },
+      reconcileLine({ id: "L_a", text: "user typed something else", agentId: "v1" }),
+      reconcileLine({ id: "L_b", text: "and something different", agentId: "v1" }),
     ];
     const result = fillEmptyLinesWithInstance({
       lines,
@@ -109,16 +112,16 @@ describe("fillEmptyLinesWithInstance · happy path", () => {
       instanceStart: 0,
     });
     expect(result.ok).toBe(true);
-    expect(result.updatedLines?.[0].text).toBe("Chorus line 1");
-    expect(result.updatedLines?.[1].text).toBe("Chorus line 2");
+    expect(result.updatedLines && lineText(result.updatedLines[0])).toBe("Chorus line 1");
+    expect(result.updatedLines && lineText(result.updatedLines[1])).toBe("Chorus line 2");
   });
 
   it("picks the next available instanceIdx for the group", () => {
     const lines: LyricLine[] = [
-      { id: "existing1", text: "x", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
-      { id: "existing2", text: "y", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 },
-      { id: "empty1", text: "Chorus line 1", agentId: "v1" },
-      { id: "empty2", text: "Chorus line 2", agentId: "v1" },
+      reconcileLine({ id: "existing1", text: "x", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 }),
+      reconcileLine({ id: "existing2", text: "y", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 }),
+      reconcileLine({ id: "empty1", text: "Chorus line 1", agentId: "v1" }),
+      reconcileLine({ id: "empty2", text: "Chorus line 2", agentId: "v1" }),
     ];
     const result = fillEmptyLinesWithInstance({
       lines,
@@ -148,7 +151,7 @@ describe("fillEmptyLinesWithInstance · background provenance", () => {
   ];
 
   it("carries backgroundTextSource from the template onto the filled line", () => {
-    const lines: LyricLine[] = [{ id: "empty1", text: "anything", agentId: "v1" }];
+    const lines: LyricLine[] = [reconcileLine({ id: "empty1", text: "anything", agentId: "v1" })];
     const result = fillEmptyLinesWithInstance({
       lines,
       groupId: "g1",
@@ -157,9 +160,9 @@ describe("fillEmptyLinesWithInstance · background provenance", () => {
       instanceStart: 10,
     });
     expect(result.ok).toBe(true);
-    expect(result.updatedLines?.[0].backgroundText).toBe("ooh");
-    expect(result.updatedLines?.[0].backgroundWords?.[0].begin).toBe(10);
-    expect(result.updatedLines?.[0].backgroundTextSource).toBe("extraction");
+    expect(result.updatedLines && bgText(result.updatedLines[0])).toBe("ooh");
+    expect(result.updatedLines && bgWords(result.updatedLines[0])?.[0].begin).toBe(10);
+    expect(result.updatedLines && bgSource(result.updatedLines[0])).toBe("extraction");
   });
 
   it("carries a manual-sourced flag from the template", () => {
@@ -171,7 +174,7 @@ describe("fillEmptyLinesWithInstance · background provenance", () => {
         backgroundTextSource: "manual",
       },
     ];
-    const lines: LyricLine[] = [{ id: "empty1", text: "anything", agentId: "v1" }];
+    const lines: LyricLine[] = [reconcileLine({ id: "empty1", text: "anything", agentId: "v1" })];
     const result = fillEmptyLinesWithInstance({
       lines,
       groupId: "g1",
@@ -179,13 +182,13 @@ describe("fillEmptyLinesWithInstance · background provenance", () => {
       startIndex: 0,
       instanceStart: 0,
     });
-    expect(result.updatedLines?.[0].backgroundTextSource).toBe("manual");
+    expect(result.updatedLines && bgSource(result.updatedLines[0])).toBe("manual");
   });
 
   it("leaves backgroundTextSource undefined when the template has no background", () => {
     const lines: LyricLine[] = [
-      { id: "empty1", text: "a", agentId: "v1" },
-      { id: "empty2", text: "b", agentId: "v1" },
+      reconcileLine({ id: "empty1", text: "a", agentId: "v1" }),
+      reconcileLine({ id: "empty2", text: "b", agentId: "v1" }),
     ];
     const result = fillEmptyLinesWithInstance({
       lines,
@@ -194,15 +197,20 @@ describe("fillEmptyLinesWithInstance · background provenance", () => {
       startIndex: 0,
       instanceStart: 0,
     });
-    expect(result.updatedLines?.[0].backgroundTextSource).toBeUndefined();
+    expect(result.updatedLines && bgSource(result.updatedLines[0])).toBeUndefined();
   });
 });
 
 describe("fillEmptyLinesWithInstance · refusal cases (no destructive insert)", () => {
   it("refuses when one of the target rows already has words", () => {
     const lines: LyricLine[] = [
-      { id: "empty1", text: "Chorus line 1", agentId: "v1" },
-      { id: "synced", text: "Chorus line 2", agentId: "v1", words: [{ text: "Chorus line 2", begin: 0, end: 1 }] },
+      reconcileLine({ id: "empty1", text: "Chorus line 1", agentId: "v1" }),
+      reconcileLine({
+        id: "synced",
+        text: "Chorus line 2",
+        agentId: "v1",
+        words: [{ text: "Chorus line 2", begin: 0, end: 1 }],
+      }),
     ];
     const result = fillEmptyLinesWithInstance({
       lines,
@@ -218,15 +226,15 @@ describe("fillEmptyLinesWithInstance · refusal cases (no destructive insert)", 
 
   it("refuses when one of the target rows already belongs to a group", () => {
     const lines: LyricLine[] = [
-      { id: "empty1", text: "Chorus line 1", agentId: "v1" },
-      {
+      reconcileLine({ id: "empty1", text: "Chorus line 1", agentId: "v1" }),
+      reconcileLine({
         id: "grouped",
         text: "Chorus line 2",
         agentId: "v1",
         groupId: "other",
         instanceIdx: 0,
         templateLineIdx: 0,
-      },
+      }),
     ];
     const result = fillEmptyLinesWithInstance({
       lines,
@@ -240,7 +248,7 @@ describe("fillEmptyLinesWithInstance · refusal cases (no destructive insert)", 
   });
 
   it("refuses when the destination range extends past the end of the project", () => {
-    const lines: LyricLine[] = [{ id: "empty1", text: "Chorus line 1", agentId: "v1" }];
+    const lines: LyricLine[] = [reconcileLine({ id: "empty1", text: "Chorus line 1", agentId: "v1" })];
     const result = fillEmptyLinesWithInstance({
       lines,
       groupId: "g1",
@@ -254,8 +262,8 @@ describe("fillEmptyLinesWithInstance · refusal cases (no destructive insert)", 
 
   it("refuses when startIndex is negative", () => {
     const lines: LyricLine[] = [
-      { id: "empty1", text: "x", agentId: "v1" },
-      { id: "empty2", text: "y", agentId: "v1" },
+      reconcileLine({ id: "empty1", text: "x", agentId: "v1" }),
+      reconcileLine({ id: "empty2", text: "y", agentId: "v1" }),
     ];
     const result = fillEmptyLinesWithInstance({
       lines,

--- a/src/views/timeline/fill-empty-lines-with-instance.ts
+++ b/src/views/timeline/fill-empty-lines-with-instance.ts
@@ -1,5 +1,6 @@
 import type { LineTemplate, LinkGroup } from "@/domain/group/template";
 import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { mainWords } from "@/domain/line/voices";
 
 interface FillResult {
   ok: boolean;
@@ -18,7 +19,8 @@ interface FillInput {
 }
 
 function isEmptyFillable(line: LyricLine): boolean {
-  return line.groupId === undefined && (!line.words || line.words.length === 0);
+  const words = mainWords(line);
+  return line.groupId === undefined && (!words || words.length === 0);
 }
 
 function fillEmptyLinesWithInstance(input: FillInput): FillResult {

--- a/src/views/timeline/fill-empty-lines-with-instance.ts
+++ b/src/views/timeline/fill-empty-lines-with-instance.ts
@@ -1,5 +1,5 @@
 import type { LineTemplate, LinkGroup } from "@/domain/group/template";
-import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { reconcileLine, toFlat, type LyricLine } from "@/domain/line/model";
 import { mainWords } from "@/domain/line/voices";
 
 interface FillResult {
@@ -47,7 +47,7 @@ function fillEmptyLinesWithInstance(input: FillInput): FillResult {
     if (idx < startIndex || idx >= startIndex + template.length) return line;
     const tplLine = template[idx - startIndex];
     return reconcileLine({
-      ...line,
+      ...toFlat(line),
       text: tplLine.text,
       agentId: tplLine.agentId,
       groupId,

--- a/src/views/timeline/group-banner.tsx
+++ b/src/views/timeline/group-banner.tsx
@@ -1,5 +1,6 @@
 import { useProjectStore } from "@/stores/project";
 import type { LinkGroup } from "@/domain/group/template";
+import { mainWords } from "@/domain/line/voices";
 import { Button } from "@/ui/button";
 import { buildGroupPingVariants } from "@/utils/animationVariants";
 import { cn } from "@/utils/cn";
@@ -154,8 +155,9 @@ const GroupBannerComponent: React.FC<GroupBannerProps> = ({
     const ticks: Array<{ idx: number; leftPct: number; widthPct: number }> = [];
     for (const line of allLines) {
       if (line.groupId !== group.id || line.instanceIdx !== instanceIdx) continue;
-      if (!line.words?.length) continue;
-      for (const w of line.words) {
+      const words = mainWords(line);
+      if (!words?.length) continue;
+      for (const w of words) {
         const startPct = ((w.begin - instanceStart) / span) * 100;
         const endPct = ((w.end - instanceStart) / span) * 100;
         const widthPct = Math.max(0.4, endPct - startPct);

--- a/src/views/timeline/group-ops.test.ts
+++ b/src/views/timeline/group-ops.test.ts
@@ -57,7 +57,7 @@ describe("createGroupFromSelection", () => {
 describe("instanceToTemplate", () => {
   it("converts an instance's lines into relative-offset templates", () => {
     const ls: LyricLine[] = [
-      {
+      reconcileLine({
         id: "a",
         text: "I love you",
         agentId: "v1",
@@ -69,8 +69,8 @@ describe("instanceToTemplate", () => {
           { text: "love ", begin: 30.4, end: 30.9 },
           { text: "you", begin: 30.9, end: 32 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "b",
         text: "yeah",
         agentId: "v1",
@@ -78,7 +78,7 @@ describe("instanceToTemplate", () => {
         instanceIdx: 0,
         templateLineIdx: 1,
         words: [{ text: "yeah", begin: 32, end: 33 }],
-      },
+      }),
     ];
 
     const tpl = instanceToTemplate(ls, "g1", 0);
@@ -92,7 +92,7 @@ describe("instanceToTemplate", () => {
 
   it("uses earliest bg-word begin as the start anchor when bg precedes main", () => {
     const ls: LyricLine[] = [
-      {
+      reconcileLine({
         id: "a",
         text: "hi",
         agentId: "v1",
@@ -101,7 +101,7 @@ describe("instanceToTemplate", () => {
         templateLineIdx: 0,
         backgroundWords: [{ text: "yeah", begin: 28, end: 29 }],
         words: [{ text: "hi", begin: 30, end: 31 }],
-      },
+      }),
     ];
     const tpl = instanceToTemplate(ls, "g1", 0);
     expect(tpl[0].words?.[0].relativeBegin).toBeCloseTo(2);
@@ -110,7 +110,7 @@ describe("instanceToTemplate", () => {
 
   it("carries backgroundTextSource from a real line into the template", () => {
     const ls: LyricLine[] = [
-      {
+      reconcileLine({
         id: "a",
         text: "main",
         agentId: "v1",
@@ -121,7 +121,7 @@ describe("instanceToTemplate", () => {
         backgroundText: "ooh",
         backgroundWords: [{ text: "ooh", begin: 30, end: 30.5 }],
         backgroundTextSource: "extraction",
-      },
+      }),
     ];
     const tpl = instanceToTemplate(ls, "g1", 0);
     expect(tpl[0].backgroundTextSource).toBe("extraction");
@@ -129,7 +129,7 @@ describe("instanceToTemplate", () => {
 
   it("carries a manual-sourced background flag into the template", () => {
     const ls: LyricLine[] = [
-      {
+      reconcileLine({
         id: "a",
         text: "main",
         agentId: "v1",
@@ -139,7 +139,7 @@ describe("instanceToTemplate", () => {
         words: [{ text: "main", begin: 30, end: 31 }],
         backgroundText: "ooh",
         backgroundTextSource: "manual",
-      },
+      }),
     ];
     const tpl = instanceToTemplate(ls, "g1", 0);
     expect(tpl[0].backgroundTextSource).toBe("manual");
@@ -147,7 +147,7 @@ describe("instanceToTemplate", () => {
 
   it("leaves backgroundTextSource undefined for a line with no background", () => {
     const ls: LyricLine[] = [
-      {
+      reconcileLine({
         id: "a",
         text: "main",
         agentId: "v1",
@@ -155,7 +155,7 @@ describe("instanceToTemplate", () => {
         instanceIdx: 0,
         templateLineIdx: 0,
         words: [{ text: "main", begin: 30, end: 31 }],
-      },
+      }),
     ];
     const tpl = instanceToTemplate(ls, "g1", 0);
     expect(tpl[0].backgroundTextSource).toBeUndefined();
@@ -163,7 +163,7 @@ describe("instanceToTemplate", () => {
 
   it("uses word-derived start anchor even when line.begin/end is stale (regression)", () => {
     const ls: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "x",
         agentId: "v1",
@@ -174,7 +174,7 @@ describe("instanceToTemplate", () => {
           { text: "hello ", begin: 5, end: 6 },
           { text: "world", begin: 6, end: 7 },
         ],
-      },
+      }),
     ];
     const template = instanceToTemplate(ls, "g1", 0);
     expect(template).toHaveLength(1);

--- a/src/views/timeline/group-ops.ts
+++ b/src/views/timeline/group-ops.ts
@@ -3,6 +3,7 @@ import { linesOfInstance } from "@/domain/instance/enumerate";
 import { mainBounds } from "@/domain/line/bounds";
 import type { LineTemplate, LinkGroup, WordTemplate } from "@/domain/group/template";
 import type { LyricLine } from "@/domain/line/model";
+import { bgSource, bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { GROUP_COLORS, pickNextGroupColor } from "@/utils/group-colors";
 
 // -- Types ---------------------------------------------------------------------
@@ -112,12 +113,12 @@ function instanceToTemplate(lines: LyricLine[], groupId: string, instanceIdx: nu
   const templates: LineTemplate[] = [];
 
   for (const line of matched) {
-    const tplWords: WordTemplate[] | undefined = line.words?.map((w) => ({
+    const tplWords: WordTemplate[] | undefined = mainWords(line)?.map((w) => ({
       text: w.text,
       relativeBegin: w.begin - startTime,
       relativeEnd: w.end - startTime,
     }));
-    const tplBgWords: WordTemplate[] | undefined = line.backgroundWords?.map((w) => ({
+    const tplBgWords: WordTemplate[] | undefined = bgWords(line)?.map((w) => ({
       text: w.text,
       relativeBegin: w.begin - startTime,
       relativeEnd: w.end - startTime,
@@ -125,14 +126,14 @@ function instanceToTemplate(lines: LyricLine[], groupId: string, instanceIdx: nu
 
     const lineBounds = mainBounds(line);
     templates.push({
-      text: line.text,
+      text: lineText(line),
       agentId: line.agentId,
       relativeBegin: lineBounds ? lineBounds.begin - startTime : undefined,
       relativeEnd: lineBounds ? lineBounds.end - startTime : undefined,
       words: tplWords,
-      backgroundText: line.backgroundText,
+      backgroundText: bgText(line),
       backgroundWords: tplBgWords,
-      backgroundTextSource: line.backgroundTextSource,
+      backgroundTextSource: bgSource(line),
     });
   }
   return templates;

--- a/src/views/timeline/line-bg-lane.tsx
+++ b/src/views/timeline/line-bg-lane.tsx
@@ -2,12 +2,12 @@ import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { backgroundFields } from "@/domain/line/background";
 import type { LyricLine } from "@/domain/line/model";
-import { placeVoice } from "@/domain/line/place-voice";
 import { bgText, bgWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { useSettingsStore } from "@/stores/settings";
 import { cn } from "@/utils/cn";
 import { findInsertionSlot } from "@/utils/word-spaces";
+import { placeVoiceAtPlayhead } from "@/views/timeline/place-voice-at-playhead";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { WordTrack } from "@/views/timeline/word-track";
 import { useDroppable } from "@dnd-kit/core";
@@ -42,15 +42,7 @@ const PlaceBgButton: React.FC<{ lineId: string }> = ({ lineId }) => {
   const placeBackground = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      const line = useProjectStore.getState().lines.find((l) => l.id === lineId);
-      if (!line) return;
-      const currentTime = useAudioStore.getState().currentTime;
-      const wordDuration = useSettingsStore.getState().defaultWordDuration;
-      // Placing one instance is a per-instance timing write; propagating would
-      // clear or re-resolve linked siblings' backgrounds (regression vs the old path).
-      useProjectStore.getState().setLineWithHistory(lineId, placeVoice(line, "background", currentTime, wordDuration), {
-        propagateToSiblings: false,
-      });
+      placeVoiceAtPlayhead(lineId, "background");
     },
     [lineId],
   );

--- a/src/views/timeline/line-bg-lane.tsx
+++ b/src/views/timeline/line-bg-lane.tsx
@@ -1,7 +1,6 @@
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { backgroundFields } from "@/domain/line/background";
-import { bgBounds } from "@/domain/line/bounds";
 import type { LyricLine } from "@/domain/line/model";
 import { placeVoice } from "@/domain/line/place-voice";
 import { bgText, bgWords } from "@/domain/line/voices";
@@ -80,12 +79,9 @@ const LineBgLane: React.FC<LineBgLaneProps> = ({
   dragShiftPx,
   onUpdateBgWord,
 }) => {
-  const zoom = useTimelineStore((s) => s.zoom);
   const bg = bgWords(line);
   const bgTextValue = bgText(line);
-  const bgWindow = bgBounds(line);
   const hasBgWords = bg && bg.length > 0;
-  const isLineSyncedBg = bgWindow !== null && !hasBgWords;
   const laneShift = dragShiftPx !== 0 ? `translateX(${dragShiftPx}px)` : undefined;
 
   const { setNodeRef: setBgDropRef, isOver: isOverBg } = useDroppable({
@@ -113,45 +109,6 @@ const LineBgLane: React.FC<LineBgLaneProps> = ({
           height={rowHeight}
           onUpdateWord={onUpdateBgWord}
         />
-      </div>
-    );
-  }
-
-  if (isLineSyncedBg) {
-    const labelText = bgTextValue ?? "";
-    return (
-      <div
-        ref={setBgDropRef}
-        className={cn(
-          "relative opacity-70 transition-colors border-t border-composer-border/50",
-          isOverBg ? "bg-composer-accent/10" : "bg-composer-bg-elevated/25",
-        )}
-        style={{ height: rowHeight, transform: laneShift }}
-        onContextMenu={(e) => {
-          e.preventDefault();
-          const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-          const time = (e.clientX - rect.left) / useTimelineStore.getState().zoom;
-          useTimelineStore.getState().setContextMenu({
-            x: e.clientX,
-            y: e.clientY,
-            target: { kind: "track", lineId: line.id, lineIndex, time, type: "bg" },
-          });
-        }}
-      >
-        <div
-          data-testid="bg-line-bar"
-          className="absolute top-1 bottom-1 flex items-center px-2 rounded text-[10px] font-medium text-composer-bg overflow-hidden select-text"
-          style={{
-            left: bgWindow.begin * zoom,
-            width: (bgWindow.end - bgWindow.begin) * zoom,
-            background: color,
-          }}
-        >
-          <span className="truncate">
-            {labelText.slice(0, BG_BAR_TEXT_LIMIT)}
-            {labelText.length > BG_BAR_TEXT_LIMIT ? "..." : ""}
-          </span>
-        </div>
       </div>
     );
   }

--- a/src/views/timeline/line-bg-lane.tsx
+++ b/src/views/timeline/line-bg-lane.tsx
@@ -1,0 +1,207 @@
+import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
+import { backgroundFields } from "@/domain/line/background";
+import { bgBounds } from "@/domain/line/bounds";
+import type { LyricLine } from "@/domain/line/model";
+import { placeVoice } from "@/domain/line/place-voice";
+import { bgText, bgWords } from "@/domain/line/voices";
+import type { WordTiming } from "@/domain/word/timing";
+import { useSettingsStore } from "@/stores/settings";
+import { cn } from "@/utils/cn";
+import { findInsertionSlot } from "@/utils/word-spaces";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+import { WordTrack } from "@/views/timeline/word-track";
+import { useDroppable } from "@dnd-kit/core";
+import { IconPlus } from "@tabler/icons-react";
+import { useCallback } from "react";
+
+// -- Types ---------------------------------------------------------------------
+
+interface LineBgLaneProps {
+  line: LyricLine;
+  lineIndex: number;
+  color: string;
+  duration: number;
+  rowHeight: number;
+  dragShiftPx: number;
+  onUpdateBgWord: (
+    wordIndex: number,
+    updates: Partial<WordTiming>,
+    adjacentIndex?: number,
+    adjacentUpdates?: Partial<WordTiming>,
+  ) => void;
+}
+
+// -- Constants -----------------------------------------------------------------
+
+const BG_DROP_ZONE_HEIGHT = 24;
+const BG_BAR_TEXT_LIMIT = 40;
+
+// -- PlaceBgButton -------------------------------------------------------------
+
+const PlaceBgButton: React.FC<{ lineId: string }> = ({ lineId }) => {
+  const placeBackground = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      const line = useProjectStore.getState().lines.find((l) => l.id === lineId);
+      if (!line) return;
+      const currentTime = useAudioStore.getState().currentTime;
+      const wordDuration = useSettingsStore.getState().defaultWordDuration;
+      // Placing one instance is a per-instance timing write; propagating would
+      // clear or re-resolve linked siblings' backgrounds (regression vs the old path).
+      useProjectStore.getState().setLineWithHistory(lineId, placeVoice(line, "background", currentTime, wordDuration), {
+        propagateToSiblings: false,
+      });
+    },
+    [lineId],
+  );
+
+  return (
+    <button
+      type="button"
+      data-bg-place="true"
+      onClick={placeBackground}
+      className="shrink-0 flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium text-composer-text-muted hover:text-composer-text hover:bg-composer-button cursor-pointer transition-colors"
+    >
+      <IconPlus size={12} />
+      Place
+    </button>
+  );
+};
+
+// -- Component -----------------------------------------------------------------
+
+const LineBgLane: React.FC<LineBgLaneProps> = ({
+  line,
+  lineIndex,
+  color,
+  duration,
+  rowHeight,
+  dragShiftPx,
+  onUpdateBgWord,
+}) => {
+  const zoom = useTimelineStore((s) => s.zoom);
+  const bg = bgWords(line);
+  const bgTextValue = bgText(line);
+  const bgWindow = bgBounds(line);
+  const hasBgWords = bg && bg.length > 0;
+  const isLineSyncedBg = bgWindow !== null && !hasBgWords;
+  const laneShift = dragShiftPx !== 0 ? `translateX(${dragShiftPx}px)` : undefined;
+
+  const { setNodeRef: setBgDropRef, isOver: isOverBg } = useDroppable({
+    id: `bg-drop-${line.id}`,
+    data: { lineId: line.id, lineIndex },
+  });
+
+  if (hasBgWords) {
+    return (
+      <div
+        ref={setBgDropRef}
+        className={cn(
+          "relative opacity-70 transition-colors border-t border-composer-border/50",
+          isOverBg ? "bg-composer-accent/10" : "bg-composer-bg-elevated/25",
+        )}
+        style={{ transform: laneShift }}
+      >
+        <WordTrack
+          lineId={line.id}
+          lineIndex={lineIndex}
+          words={bg}
+          color={color}
+          trackType="bg"
+          duration={duration}
+          height={rowHeight}
+          onUpdateWord={onUpdateBgWord}
+        />
+      </div>
+    );
+  }
+
+  if (isLineSyncedBg) {
+    const labelText = bgTextValue ?? "";
+    return (
+      <div
+        ref={setBgDropRef}
+        className={cn(
+          "relative opacity-70 transition-colors border-t border-composer-border/50",
+          isOverBg ? "bg-composer-accent/10" : "bg-composer-bg-elevated/25",
+        )}
+        style={{ height: rowHeight, transform: laneShift }}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+          const time = (e.clientX - rect.left) / useTimelineStore.getState().zoom;
+          useTimelineStore.getState().setContextMenu({
+            x: e.clientX,
+            y: e.clientY,
+            target: { kind: "track", lineId: line.id, lineIndex, time, type: "bg" },
+          });
+        }}
+      >
+        <div
+          data-testid="bg-line-bar"
+          className="absolute top-1 bottom-1 flex items-center px-2 rounded text-[10px] font-medium text-composer-bg overflow-hidden select-text"
+          style={{
+            left: bgWindow.begin * zoom,
+            width: (bgWindow.end - bgWindow.begin) * zoom,
+            background: color,
+          }}
+        >
+          <span className="truncate">
+            {labelText.slice(0, BG_BAR_TEXT_LIMIT)}
+            {labelText.length > BG_BAR_TEXT_LIMIT ? "..." : ""}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={setBgDropRef}
+      className={cn(
+        "flex items-center gap-1 px-2 text-xs font-mono transition-colors border-t border-composer-border/30 cursor-pointer",
+        isOverBg
+          ? "bg-composer-accent/20 text-composer-text"
+          : "text-composer-text-muted/50 bg-composer-bg-elevated/25",
+      )}
+      style={{ height: BG_DROP_ZONE_HEIGHT }}
+      onDoubleClick={(e) => {
+        const localZoom = useTimelineStore.getState().zoom;
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        const time = (e.clientX - rect.left) / localZoom;
+        const audioDuration = useAudioStore.getState().duration;
+        const wordDuration = useSettingsStore.getState().defaultWordDuration;
+        const slot = findInsertionSlot([], time, wordDuration, audioDuration);
+        if (!slot) return;
+        const newWord: WordTiming = { text: "...", begin: slot.begin, end: slot.end };
+        useProjectStore
+          .getState()
+          .updateLineWithHistory(line.id, backgroundFields({ text: newWord.text, words: [newWord], source: "manual" }));
+        useTimelineStore.getState().setEditingWord({ lineId: line.id, wordIndex: 0, type: "bg" });
+      }}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        const localZoom = useTimelineStore.getState().zoom;
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        const time = (e.clientX - rect.left) / localZoom;
+        useTimelineStore.getState().setContextMenu({
+          x: e.clientX,
+          y: e.clientY,
+          target: { kind: "track", lineId: line.id, lineIndex, time, type: "bg" },
+        });
+      }}
+    >
+      <span className="truncate">
+        {bgTextValue
+          ? `${bgTextValue.slice(0, BG_BAR_TEXT_LIMIT)}${bgTextValue.length > BG_BAR_TEXT_LIMIT ? "..." : ""}`
+          : "BG"}
+      </span>
+      {bgTextValue && <PlaceBgButton lineId={line.id} />}
+    </div>
+  );
+};
+
+// -- Exports -------------------------------------------------------------------
+
+export { LineBgLane };

--- a/src/views/timeline/line-row.browser.test.tsx
+++ b/src/views/timeline/line-row.browser.test.tsx
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { LineRow } from "@/views/timeline/line-row";
+import { mainBounds } from "@/domain/line/bounds";
+import { bgSource, bgWords } from "@/domain/line/voices";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
@@ -41,8 +43,8 @@ describe("LineRow", () => {
     expect(placeButton).toBeDefined();
     placeButton?.click();
     const updated = useProjectStore.getState().lines.find((l) => l.id === line.id);
-    expect(updated?.begin).toBeCloseTo(5, 5);
-    expect((updated?.end ?? 0) > 5).toBe(true);
+    expect(updated && mainBounds(updated)?.begin).toBeCloseTo(5, 5);
+    expect(((updated && mainBounds(updated)?.end) ?? 0) > 5).toBe(true);
   });
 
   it("does not show the Place button for a line that already has words", async () => {
@@ -127,7 +129,7 @@ describe("LineRow", () => {
     expect(dropZone).toBeDefined();
     dropZone?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, clientX: 100 }));
 
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundWords?.length).toBe(1);
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
+    await expect.poll(() => bgWords(useProjectStore.getState().lines[0])?.length).toBe(1);
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
   });
 });

--- a/src/views/timeline/line-row.browser.test.tsx
+++ b/src/views/timeline/line-row.browser.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { LineRow } from "@/views/timeline/line-row";
 import { setBackground } from "@/domain/line/background";
 import { bgBounds, mainBounds } from "@/domain/line/bounds";
+import { getEffectiveLines } from "@/domain/line/effective-words";
 import { reconcileLine } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/voice/predicates";
 import { bgSource, bgText, bgVoice, bgWords, lineText } from "@/domain/line/voices";
@@ -204,11 +205,14 @@ describe("LineRow · place line keeps linked sibling background", () => {
   });
 });
 
-// Task 8.2: the background lane renders three timing states. An untimed bg shows
-// a Place button that line-syncs it; a line-synced bg renders a single bar (no
-// word blocks); a word-synced bg keeps its WordTrack word blocks. The Place
-// write is per-instance and must not touch a linked sibling's background.
-describe("LineRow · background lane three timing states", () => {
+// The background lane mirrors the main lane. An untimed bg shows a Place button
+// that line-syncs it; a line-synced bg renders as a single WordTrack block,
+// identical to a line-synced main (no bespoke bar); a word-synced bg keeps its
+// WordTrack word blocks. The Place write is per-instance and must not touch a
+// linked sibling's background. LineRow receives effective lines in production
+// (the timeline runs getEffectiveLines upstream), so the line-synced cases pass
+// their input through getEffectiveLines to match that data flow.
+describe("LineRow · background lane timing states", () => {
   function getLine(id: string) {
     const line = useProjectStore.getState().lines.find((l) => l.id === id);
     if (!line) throw new Error(`line ${id} not found`);
@@ -247,26 +251,40 @@ describe("LineRow · background lane three timing states", () => {
     expect(bgSource(getLine("l1"))).toBe("manual");
   });
 
-  it("renders a single bar for a line-synced background and no bg word blocks", async () => {
+  it("renders a line-synced background as one bg WordTrack block and no bespoke bar", async () => {
     const main = createLine({ id: "l1", text: "main here", words: [createWord({ text: "main", begin: 0, end: 1 })] });
-    const line = setBackground(main, { text: "ooh ooh", begin: 3, end: 5, source: "manual" });
-    useProjectStore.setState({ lines: [line] });
+    const rawLine = setBackground(main, { text: "ooh ooh", begin: 3, end: 5, source: "manual" });
+    useProjectStore.setState({ lines: [rawLine] });
+    const line = getEffectiveLines([rawLine])[0];
 
     const screen = await render(
       <LineRow line={line} lineIndex={0} duration={30} onUpdateWord={() => {}} onUpdateBgWord={() => {}} />,
       { dndContext: true },
     );
 
-    const bars = screen.container.querySelectorAll("[data-testid='bg-line-bar']");
-    expect(bars.length).toBe(1);
-    const bar = bars[0] as HTMLElement;
-    const zoom = useTimelineStore.getState().zoom;
-    expect(bar.style.left).toBe(`${3 * zoom}px`);
-    expect(bar.style.width).toBe(`${(5 - 3) * zoom}px`);
-    expect(bar.textContent).toContain("ooh ooh");
+    expect(screen.container.querySelectorAll("[data-testid='bg-line-bar']").length).toBe(0);
+    // one main word block plus one synthesized bg word block, both real WordTrack blocks
+    expect(screen.container.querySelectorAll("[data-word-block]").length).toBe(2);
 
     expect(bgBounds(getLine("l1"))).toEqual({ begin: 3, end: 5 });
     expect(bgWords(getLine("l1"))).toBeUndefined();
+  });
+
+  it("renders a line-synced bg block as the same element type as a line-synced main block", async () => {
+    const rawMain = createLine({ id: "lm", text: "main here", begin: 0, end: 2 });
+    const rawWithBg = setBackground(rawMain, { text: "ooh", begin: 3, end: 5, source: "manual" });
+    useProjectStore.setState({ lines: [rawWithBg] });
+    const line = getEffectiveLines([rawWithBg])[0];
+
+    const screen = await render(
+      <LineRow line={line} lineIndex={0} duration={30} onUpdateWord={() => {}} onUpdateBgWord={() => {}} />,
+      { dndContext: true },
+    );
+
+    const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
+    expect(blocks.length).toBe(2);
+    expect(blocks[0].tagName).toBe(blocks[1].tagName);
+    expect(screen.container.querySelectorAll("[data-testid='bg-line-bar']").length).toBe(0);
   });
 
   it("keeps rendering word blocks for a word-synced background (regression guard)", async () => {

--- a/src/views/timeline/line-row.browser.test.tsx
+++ b/src/views/timeline/line-row.browser.test.tsx
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { LineRow } from "@/views/timeline/line-row";
-import { mainBounds } from "@/domain/line/bounds";
+import { setBackground } from "@/domain/line/background";
+import { bgBounds, mainBounds } from "@/domain/line/bounds";
 import { reconcileLine } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/voice/predicates";
-import { bgSource, bgVoice, bgWords, lineText } from "@/domain/line/voices";
+import { bgSource, bgText, bgVoice, bgWords, lineText } from "@/domain/line/voices";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
@@ -191,6 +192,147 @@ describe("LineRow · place line keeps linked sibling background", () => {
     const wordCount = splitIntoWordsWithMeta(lineText(getLine("target"))).parts.length;
     await expect.poll(() => isLineSynced(getLine("target").main)).toBe(true);
     expect(mainBounds(getLine("target"))).toEqual({
+      begin: placeTime,
+      end: placeTime + Math.max(wordCount, 1) * wordDuration,
+    });
+
+    expect(bgVoice(getLine("sibling"))).toEqual(siblingBgBefore);
+    expect(bgWords(getLine("sibling"))).toEqual([
+      { text: "ooh ", begin: 20, end: 20.5 },
+      { text: "ooh", begin: 20.5, end: 21 },
+    ]);
+  });
+});
+
+// Task 8.2: the background lane renders three timing states. An untimed bg shows
+// a Place button that line-syncs it; a line-synced bg renders a single bar (no
+// word blocks); a word-synced bg keeps its WordTrack word blocks. The Place
+// write is per-instance and must not touch a linked sibling's background.
+describe("LineRow · background lane three timing states", () => {
+  function getLine(id: string) {
+    const line = useProjectStore.getState().lines.find((l) => l.id === id);
+    if (!line) throw new Error(`line ${id} not found`);
+    return line;
+  }
+
+  function bgPlaceButton(container: HTMLElement) {
+    return Array.from(container.querySelectorAll("button")).find((b) => b.textContent === "Place" && b.dataset.bgPlace);
+  }
+
+  it("shows a Place button for an untimed background and clicking it line-syncs the background", async () => {
+    const placeTime = 7;
+    useAudioStore.setState({ currentTime: placeTime });
+    const line = createLine({ id: "l1", text: "main here", backgroundText: "ooh ooh ooh" });
+    useProjectStore.setState({ lines: [line] });
+
+    const screen = await render(
+      <LineRow line={line} lineIndex={0} duration={30} onUpdateWord={() => {}} onUpdateBgWord={() => {}} />,
+      { dndContext: true },
+    );
+
+    const placeButton = bgPlaceButton(screen.container);
+    expect(placeButton).toBeDefined();
+    placeButton?.click();
+
+    const wordDuration = useSettingsStore.getState().defaultWordDuration;
+    const wordCount = splitIntoWordsWithMeta("ooh ooh ooh").parts.length;
+    await expect
+      .poll(() => bgBounds(getLine("l1")))
+      .toEqual({
+        begin: placeTime,
+        end: placeTime + Math.max(wordCount, 1) * wordDuration,
+      });
+    expect(bgWords(getLine("l1"))).toBeUndefined();
+    expect(bgText(getLine("l1"))).toBe("ooh ooh ooh");
+    expect(bgSource(getLine("l1"))).toBe("manual");
+  });
+
+  it("renders a single bar for a line-synced background and no bg word blocks", async () => {
+    const main = createLine({ id: "l1", text: "main here", words: [createWord({ text: "main", begin: 0, end: 1 })] });
+    const line = setBackground(main, { text: "ooh ooh", begin: 3, end: 5, source: "manual" });
+    useProjectStore.setState({ lines: [line] });
+
+    const screen = await render(
+      <LineRow line={line} lineIndex={0} duration={30} onUpdateWord={() => {}} onUpdateBgWord={() => {}} />,
+      { dndContext: true },
+    );
+
+    const bars = screen.container.querySelectorAll("[data-testid='bg-line-bar']");
+    expect(bars.length).toBe(1);
+    const bar = bars[0] as HTMLElement;
+    const zoom = useTimelineStore.getState().zoom;
+    expect(bar.style.left).toBe(`${3 * zoom}px`);
+    expect(bar.style.width).toBe(`${(5 - 3) * zoom}px`);
+    expect(bar.textContent).toContain("ooh ooh");
+
+    expect(bgBounds(getLine("l1"))).toEqual({ begin: 3, end: 5 });
+    expect(bgWords(getLine("l1"))).toBeUndefined();
+  });
+
+  it("keeps rendering word blocks for a word-synced background (regression guard)", async () => {
+    const line = createLine({
+      id: "l1",
+      text: "main here",
+      words: [createWord({ text: "main", begin: 0, end: 1 })],
+      backgroundText: "(echo)",
+      backgroundWords: [createWord({ text: "(echo)", begin: 2, end: 3 })],
+    });
+    useProjectStore.setState({ lines: [line] });
+
+    const screen = await render(
+      <LineRow line={line} lineIndex={0} duration={30} onUpdateWord={() => {}} onUpdateBgWord={() => {}} />,
+      { dndContext: true },
+    );
+
+    expect(screen.container.querySelectorAll("[data-testid='bg-line-bar']").length).toBe(0);
+    expect(screen.container.querySelectorAll("[data-word-block]").length).toBe(2);
+  });
+
+  it("placing a background via the bg Place button leaves a linked sibling's background untouched", async () => {
+    const placeTime = 6;
+    const group = createGroup({ id: "g1" });
+    const target = reconcileLine({
+      id: "target",
+      text: "I love you",
+      agentId: "v1",
+      groupId: "g1",
+      instanceIdx: 0,
+      templateLineIdx: 0,
+      backgroundText: "ah ah",
+      backgroundTextSource: "manual",
+    });
+    const sibling = reconcileLine({
+      id: "sibling",
+      text: "I love you",
+      agentId: "v1",
+      groupId: "g1",
+      instanceIdx: 1,
+      templateLineIdx: 0,
+      backgroundText: "ooh ooh",
+      backgroundWords: [
+        { text: "ooh ", begin: 20, end: 20.5 },
+        { text: "ooh", begin: 20.5, end: 21 },
+      ],
+      backgroundTextSource: "manual",
+    });
+    useProjectStore.setState({ groups: [group], lines: [target, sibling] });
+    useAudioStore.setState({ currentTime: placeTime });
+    const siblingBgBefore = bgVoice(getLine("sibling"));
+    expect(siblingBgBefore).not.toBeNull();
+
+    const screen = await render(
+      <LineRow line={target} lineIndex={0} duration={30} onUpdateWord={() => {}} onUpdateBgWord={() => {}} />,
+      { dndContext: true },
+    );
+
+    const placeButton = bgPlaceButton(screen.container);
+    expect(placeButton).toBeDefined();
+    placeButton?.click();
+
+    const wordDuration = useSettingsStore.getState().defaultWordDuration;
+    const wordCount = splitIntoWordsWithMeta("ah ah").parts.length;
+    await expect.poll(() => isLineSynced(getLine("target").background!)).toBe(true);
+    expect(bgBounds(getLine("target"))).toEqual({
       begin: placeTime,
       end: placeTime + Math.max(wordCount, 1) * wordDuration,
     });

--- a/src/views/timeline/line-row.browser.test.tsx
+++ b/src/views/timeline/line-row.browser.test.tsx
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { LineRow } from "@/views/timeline/line-row";
 import { mainBounds } from "@/domain/line/bounds";
-import { bgSource, bgWords } from "@/domain/line/voices";
+import { reconcileLine } from "@/domain/line/model";
+import { isLineSynced } from "@/domain/voice/predicates";
+import { bgSource, bgVoice, bgWords, lineText } from "@/domain/line/voices";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
-import { createLine, createWord } from "@/test/factories";
+import { createGroup, createLine, createWord } from "@/test/factories";
 import { render } from "@/test/render";
+import { splitIntoWordsWithMeta } from "@/utils/sync-helpers";
 
 describe("LineRow", () => {
   it("renders one word block per word on a synced line", async () => {
@@ -131,5 +135,70 @@ describe("LineRow", () => {
 
     await expect.poll(() => bgWords(useProjectStore.getState().lines[0])?.length).toBe(1);
     expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
+  });
+});
+
+// End-to-end lock for the Task 8.1 fix at its real UI call site. The store-level
+// regression hardcodes { propagateToSiblings: false }; this test drives the
+// actual "Place" button in SyncLineButton, so it fails if anyone drops that
+// option from the call site (which would clobber a linked sibling's background).
+describe("LineRow · place line keeps linked sibling background", () => {
+  function getLine(id: string) {
+    const line = useProjectStore.getState().lines.find((l) => l.id === id);
+    if (!line) throw new Error(`line ${id} not found`);
+    return line;
+  }
+
+  it("placing an untimed line via the Place button leaves a linked sibling's background untouched", async () => {
+    const placeTime = 5;
+    const group = createGroup({ id: "g1" });
+    const target = reconcileLine({
+      id: "target",
+      text: "I love you",
+      agentId: "v1",
+      groupId: "g1",
+      instanceIdx: 0,
+      templateLineIdx: 0,
+    });
+    const sibling = reconcileLine({
+      id: "sibling",
+      text: "I love you",
+      agentId: "v1",
+      groupId: "g1",
+      instanceIdx: 1,
+      templateLineIdx: 0,
+      backgroundText: "ooh ooh",
+      backgroundWords: [
+        { text: "ooh ", begin: 20, end: 20.5 },
+        { text: "ooh", begin: 20.5, end: 21 },
+      ],
+      backgroundTextSource: "manual",
+    });
+    useProjectStore.setState({ groups: [group], lines: [target, sibling] });
+    useAudioStore.setState({ currentTime: placeTime });
+    const siblingBgBefore = bgVoice(getLine("sibling"));
+    expect(siblingBgBefore).not.toBeNull();
+
+    const screen = await render(
+      <LineRow line={target} lineIndex={0} duration={30} onUpdateWord={() => {}} onUpdateBgWord={() => {}} />,
+      { dndContext: true },
+    );
+    const placeButton = Array.from(screen.container.querySelectorAll("button")).find((b) => b.textContent === "Place");
+    expect(placeButton).toBeDefined();
+    placeButton?.click();
+
+    const wordDuration = useSettingsStore.getState().defaultWordDuration;
+    const wordCount = splitIntoWordsWithMeta(lineText(getLine("target"))).parts.length;
+    await expect.poll(() => isLineSynced(getLine("target").main)).toBe(true);
+    expect(mainBounds(getLine("target"))).toEqual({
+      begin: placeTime,
+      end: placeTime + Math.max(wordCount, 1) * wordDuration,
+    });
+
+    expect(bgVoice(getLine("sibling"))).toEqual(siblingBgBefore);
+    expect(bgWords(getLine("sibling"))).toEqual([
+      { text: "ooh ", begin: 20, end: 20.5 },
+      { text: "ooh", begin: 20.5, end: 21 },
+    ]);
   });
 });

--- a/src/views/timeline/line-row.tsx
+++ b/src/views/timeline/line-row.tsx
@@ -2,7 +2,6 @@ import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { getAgentColor } from "@/domain/agent/colors";
 import type { LyricLine } from "@/domain/line/model";
-import { placeVoice } from "@/domain/line/place-voice";
 import { lineText, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { useSettingsStore } from "@/stores/settings";
@@ -11,6 +10,7 @@ import { stripSplitCharacter } from "@/utils/split-character";
 import { findInsertionSlot } from "@/utils/word-spaces";
 import { GutterAgentPicker } from "@/views/timeline/gutter-agent-picker";
 import { LineBgLane } from "@/views/timeline/line-bg-lane";
+import { placeVoiceAtPlayhead } from "@/views/timeline/place-voice-at-playhead";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { WordTrack } from "@/views/timeline/word-track";
 import { useDroppable } from "@dnd-kit/core";
@@ -43,15 +43,7 @@ const SyncLineButton: React.FC<{ lineId: string }> = ({ lineId }) => {
   const selectLineWords = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      const line = useProjectStore.getState().lines.find((l) => l.id === lineId);
-      if (!line) return;
-      const currentTime = useAudioStore.getState().currentTime;
-      const wordDuration = useSettingsStore.getState().defaultWordDuration;
-      // Placing one instance is a per-instance timing write; propagating would
-      // clear or re-resolve linked siblings' backgrounds (regression vs the old path).
-      useProjectStore.getState().setLineWithHistory(lineId, placeVoice(line, "main", currentTime, wordDuration), {
-        propagateToSiblings: false,
-      });
+      placeVoiceAtPlayhead(lineId, "main");
     },
     [lineId],
   );

--- a/src/views/timeline/line-row.tsx
+++ b/src/views/timeline/line-row.tsx
@@ -3,12 +3,12 @@ import { useProjectStore } from "@/stores/project";
 import { getAgentColor } from "@/domain/agent/colors";
 import { backgroundFields } from "@/domain/line/background";
 import type { LyricLine } from "@/domain/line/model";
+import { placeVoice } from "@/domain/line/place-voice";
 import { bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { useSettingsStore } from "@/stores/settings";
 import { cn } from "@/utils/cn";
 import { stripSplitCharacter } from "@/utils/split-character";
-import { splitIntoWordsWithMeta } from "@/utils/sync-helpers";
 import { findInsertionSlot } from "@/utils/word-spaces";
 import { GutterAgentPicker } from "@/views/timeline/gutter-agent-picker";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
@@ -43,20 +43,17 @@ const BG_DROP_ZONE_HEIGHT = 24;
 
 // -- AddWordsButton ------------------------------------------------------------
 
-const SyncLineButton: React.FC<{ lineId: string; wordCount: number }> = ({ lineId, wordCount }) => {
+const SyncLineButton: React.FC<{ lineId: string }> = ({ lineId }) => {
   const selectLineWords = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
+      const line = useProjectStore.getState().lines.find((l) => l.id === lineId);
+      if (!line) return;
       const currentTime = useAudioStore.getState().currentTime;
       const wordDuration = useSettingsStore.getState().defaultWordDuration;
-      const lineDuration = Math.max(wordCount, 1) * wordDuration;
-
-      useProjectStore.getState().updateLineWithHistory(lineId, {
-        begin: currentTime,
-        end: currentTime + lineDuration,
-      });
+      useProjectStore.getState().setLineWithHistory(lineId, placeVoice(line, "main", currentTime, wordDuration));
     },
-    [lineId, wordCount],
+    [lineId],
   );
 
   return (
@@ -234,9 +231,7 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
                   {displayText.slice(0, 60)}
                   {displayText.length > 60 ? "..." : ""}
                 </span>
-                {displayText.length > 0 && (
-                  <SyncLineButton lineId={line.id} wordCount={splitIntoWordsWithMeta(lineText(line)).parts.length} />
-                )}
+                {displayText.length > 0 && <SyncLineButton lineId={line.id} />}
               </div>
             </div>
           )}

--- a/src/views/timeline/line-row.tsx
+++ b/src/views/timeline/line-row.tsx
@@ -51,6 +51,8 @@ const SyncLineButton: React.FC<{ lineId: string }> = ({ lineId }) => {
       if (!line) return;
       const currentTime = useAudioStore.getState().currentTime;
       const wordDuration = useSettingsStore.getState().defaultWordDuration;
+      // Placing one instance is a per-instance timing write; propagating would
+      // clear or re-resolve linked siblings' backgrounds (regression vs the old path).
       useProjectStore.getState().setLineWithHistory(lineId, placeVoice(line, "main", currentTime, wordDuration), {
         propagateToSiblings: false,
       });

--- a/src/views/timeline/line-row.tsx
+++ b/src/views/timeline/line-row.tsx
@@ -51,7 +51,9 @@ const SyncLineButton: React.FC<{ lineId: string }> = ({ lineId }) => {
       if (!line) return;
       const currentTime = useAudioStore.getState().currentTime;
       const wordDuration = useSettingsStore.getState().defaultWordDuration;
-      useProjectStore.getState().setLineWithHistory(lineId, placeVoice(line, "main", currentTime, wordDuration));
+      useProjectStore.getState().setLineWithHistory(lineId, placeVoice(line, "main", currentTime, wordDuration), {
+        propagateToSiblings: false,
+      });
     },
     [lineId],
   );

--- a/src/views/timeline/line-row.tsx
+++ b/src/views/timeline/line-row.tsx
@@ -1,16 +1,16 @@
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { getAgentColor } from "@/domain/agent/colors";
-import { backgroundFields } from "@/domain/line/background";
 import type { LyricLine } from "@/domain/line/model";
 import { placeVoice } from "@/domain/line/place-voice";
-import { bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { lineText, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { useSettingsStore } from "@/stores/settings";
 import { cn } from "@/utils/cn";
 import { stripSplitCharacter } from "@/utils/split-character";
 import { findInsertionSlot } from "@/utils/word-spaces";
 import { GutterAgentPicker } from "@/views/timeline/gutter-agent-picker";
+import { LineBgLane } from "@/views/timeline/line-bg-lane";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { WordTrack } from "@/views/timeline/word-track";
 import { useDroppable } from "@dnd-kit/core";
@@ -37,11 +37,7 @@ interface LineRowProps {
   ) => void;
 }
 
-// -- Constants -----------------------------------------------------------------
-
-const BG_DROP_ZONE_HEIGHT = 24;
-
-// -- AddWordsButton ------------------------------------------------------------
+// -- SyncLineButton ------------------------------------------------------------
 
 const SyncLineButton: React.FC<{ lineId: string }> = ({ lineId }) => {
   const selectLineWords = useCallback(
@@ -79,10 +75,7 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
   const groups = useProjectStore((s) => s.groups);
   const groupColor = line.groupId ? groups.find((g) => g.id === line.groupId)?.color : undefined;
   const main = mainWords(line);
-  const bg = bgWords(line);
-  const bgTextValue = bgText(line);
   const displayText = stripSplitCharacter(lineText(line));
-  const hasBgWords = bg && bg.length > 0;
   const hasMainWords = main && main.length > 0;
 
   const rowHeight = useTimelineStore((s) => s.rowHeights[line.id] ?? s.defaultRowHeight);
@@ -108,11 +101,6 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
       cleanupRef.current?.();
     };
   }, []);
-
-  const { setNodeRef: setBgDropRef, isOver: isOverBg } = useDroppable({
-    id: `bg-drop-${line.id}`,
-    data: { lineId: line.id, lineIndex },
-  });
 
   const { setNodeRef: setMainDropRef, isOver: isOverMain } = useDroppable({
     id: `main-drop-${line.id}`,
@@ -241,68 +229,15 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
           )}
         </div>
 
-        {hasBgWords ? (
-          <div
-            ref={setBgDropRef}
-            className={cn(
-              "relative opacity-70 transition-colors border-t border-composer-border/50",
-              isOverBg ? "bg-composer-accent/10" : "bg-composer-bg-elevated/25",
-            )}
-            style={{ transform: dragShiftPx !== 0 ? `translateX(${dragShiftPx}px)` : undefined }}
-          >
-            <WordTrack
-              lineId={line.id}
-              lineIndex={lineIndex}
-              words={bg!}
-              color={color}
-              trackType="bg"
-              duration={duration}
-              height={rowHeight}
-              onUpdateWord={onUpdateBgWord}
-            />
-          </div>
-        ) : (
-          <div
-            ref={setBgDropRef}
-            className={cn(
-              "flex items-center px-2 text-xs font-mono truncate transition-colors border-t border-composer-border/30 cursor-pointer",
-              isOverBg
-                ? "bg-composer-accent/20 text-composer-text"
-                : "text-composer-text-muted/50 bg-composer-bg-elevated/25",
-            )}
-            style={{ height: BG_DROP_ZONE_HEIGHT }}
-            onDoubleClick={(e) => {
-              const zoom = useTimelineStore.getState().zoom;
-              const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-              const time = (e.clientX - rect.left) / zoom;
-              const audioDuration = useAudioStore.getState().duration;
-              const wordDuration = useSettingsStore.getState().defaultWordDuration;
-              const slot = findInsertionSlot([], time, wordDuration, audioDuration);
-              if (!slot) return;
-              const newWord: WordTiming = { text: "...", begin: slot.begin, end: slot.end };
-              useProjectStore
-                .getState()
-                .updateLineWithHistory(
-                  line.id,
-                  backgroundFields({ text: newWord.text, words: [newWord], source: "manual" }),
-                );
-              useTimelineStore.getState().setEditingWord({ lineId: line.id, wordIndex: 0, type: "bg" });
-            }}
-            onContextMenu={(e) => {
-              e.preventDefault();
-              const zoom = useTimelineStore.getState().zoom;
-              const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-              const time = (e.clientX - rect.left) / zoom;
-              useTimelineStore.getState().setContextMenu({
-                x: e.clientX,
-                y: e.clientY,
-                target: { kind: "track", lineId: line.id, lineIndex, time, type: "bg" },
-              });
-            }}
-          >
-            {bgTextValue ? `${bgTextValue.slice(0, 40)}${bgTextValue.length > 40 ? "..." : ""}` : "BG"}
-          </div>
-        )}
+        <LineBgLane
+          line={line}
+          lineIndex={lineIndex}
+          color={color}
+          duration={duration}
+          rowHeight={rowHeight}
+          dragShiftPx={dragShiftPx}
+          onUpdateBgWord={onUpdateBgWord}
+        />
       </div>
 
       <div

--- a/src/views/timeline/line-row.tsx
+++ b/src/views/timeline/line-row.tsx
@@ -3,6 +3,7 @@ import { useProjectStore } from "@/stores/project";
 import { getAgentColor } from "@/domain/agent/colors";
 import { backgroundFields } from "@/domain/line/background";
 import type { LyricLine } from "@/domain/line/model";
+import { bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { useSettingsStore } from "@/stores/settings";
 import { cn } from "@/utils/cn";
@@ -76,9 +77,12 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
   const color = getAgentColor(line.agentId);
   const groups = useProjectStore((s) => s.groups);
   const groupColor = line.groupId ? groups.find((g) => g.id === line.groupId)?.color : undefined;
-  const displayText = stripSplitCharacter(line.text);
-  const hasBgWords = line.backgroundWords && line.backgroundWords.length > 0;
-  const hasMainWords = line.words && line.words.length > 0;
+  const main = mainWords(line);
+  const bg = bgWords(line);
+  const bgTextValue = bgText(line);
+  const displayText = stripSplitCharacter(lineText(line));
+  const hasBgWords = bg && bg.length > 0;
+  const hasMainWords = main && main.length > 0;
 
   const rowHeight = useTimelineStore((s) => s.rowHeights[line.id] ?? s.defaultRowHeight);
   const defaultRowHeight = useTimelineStore((s) => s.defaultRowHeight);
@@ -180,7 +184,7 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
             <WordTrack
               lineId={line.id}
               lineIndex={lineIndex}
-              words={line.words!}
+              words={main!}
               color={color}
               trackType="word"
               duration={duration}
@@ -231,7 +235,7 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
                   {displayText.length > 60 ? "..." : ""}
                 </span>
                 {displayText.length > 0 && (
-                  <SyncLineButton lineId={line.id} wordCount={splitIntoWordsWithMeta(line.text).parts.length} />
+                  <SyncLineButton lineId={line.id} wordCount={splitIntoWordsWithMeta(lineText(line)).parts.length} />
                 )}
               </div>
             </div>
@@ -250,7 +254,7 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
             <WordTrack
               lineId={line.id}
               lineIndex={lineIndex}
-              words={line.backgroundWords!}
+              words={bg!}
               color={color}
               trackType="bg"
               duration={duration}
@@ -297,8 +301,8 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
               });
             }}
           >
-            {line.backgroundText
-              ? `${line.backgroundText.slice(0, 40)}${line.backgroundText.length > 40 ? "..." : ""}`
+            {bgTextValue
+              ? `${bgTextValue.slice(0, 40)}${bgTextValue.length > 40 ? "..." : ""}`
               : "BG"}
           </div>
         )}

--- a/src/views/timeline/line-row.tsx
+++ b/src/views/timeline/line-row.tsx
@@ -301,9 +301,7 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
               });
             }}
           >
-            {bgTextValue
-              ? `${bgTextValue.slice(0, 40)}${bgTextValue.length > 40 ? "..." : ""}`
-              : "BG"}
+            {bgTextValue ? `${bgTextValue.slice(0, 40)}${bgTextValue.length > 40 ? "..." : ""}` : "BG"}
           </div>
         )}
       </div>

--- a/src/views/timeline/paste-preview.tsx
+++ b/src/views/timeline/paste-preview.tsx
@@ -4,6 +4,7 @@ import { useModalStackStore } from "@/stores/modal-stack";
 import { useProjectStore } from "@/stores/project";
 import type { LineTemplate } from "@/domain/group/template";
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { boundsOverlap } from "@/domain/word/overlap";
 import { cn } from "@/utils/cn";
 import { applyPasteToLines } from "@/views/timeline/apply-paste-to-lines";
@@ -286,7 +287,7 @@ function checkOverlaps(
     if (newEnd <= newBegin) return true;
 
     const line = lines[lineIdx];
-    const wordsArray = entry.trackType === "word" ? line.words : line.backgroundWords;
+    const wordsArray = entry.trackType === "word" ? mainWords(line) : bgWords(line);
     if (!wordsArray) continue;
 
     for (const existing of wordsArray) {
@@ -328,7 +329,7 @@ function computeGhosts(
 
     let overlaps = outOfBounds;
     if (targetLine && !outOfBounds) {
-      const wordsArray = isBg ? targetLine.backgroundWords : targetLine.words;
+      const wordsArray = isBg ? bgWords(targetLine) : mainWords(targetLine);
       if (wordsArray) {
         for (const existing of wordsArray) {
           if (boundsOverlap({ begin: newBegin, end: newEnd }, existing)) {
@@ -346,7 +347,8 @@ function computeGhosts(
       trackTop = layoutEnd;
       trackHeight = defaultRowHeight;
     } else {
-      const hasBg = !!(targetLine.backgroundWords && targetLine.backgroundWords.length > 0);
+      const targetBgWords = bgWords(targetLine);
+      const hasBg = !!(targetBgWords && targetBgWords.length > 0);
       const bgHeight = hasBg ? (targetPos.height - 1) / 2 : BG_DROP_ZONE_HEIGHT;
       const mainHeight = targetPos.height - 1 - bgHeight;
       if (isBg) {

--- a/src/views/timeline/place-voice-at-playhead.test.ts
+++ b/src/views/timeline/place-voice-at-playhead.test.ts
@@ -1,0 +1,199 @@
+/**
+ * @vitest-environment node
+ */
+import type { LinkGroup } from "@/domain/group/template";
+import { bgBounds, mainBounds } from "@/domain/line/bounds";
+import { type LooseLine, reconcileLine } from "@/domain/line/model";
+import { isLineSynced } from "@/domain/line/predicates";
+import { bgVoice } from "@/domain/line/voices";
+import { isLineSynced as isLineSyncedVoice } from "@/domain/voice/predicates";
+import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
+import { placeVoiceAtPlayhead } from "@/views/timeline/place-voice-at-playhead";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// -- Constants -----------------------------------------------------------------
+
+const PLAYHEAD = 5;
+const DUR = 0.3;
+
+// -- Helpers -------------------------------------------------------------------
+
+beforeEach(() => {
+  useProjectStore.getState().reset();
+  useProjectStore.getState().clearHistory();
+  useAudioStore.setState({ currentTime: PLAYHEAD });
+  useSettingsStore.setState({ defaultWordDuration: DUR });
+});
+
+function seedGroup(id: string): LinkGroup {
+  return { id, label: "Chorus", color: "#f472b6", templateVersion: 1 };
+}
+
+function seed(lines: LooseLine[], groups: LinkGroup[] = []) {
+  useProjectStore.setState({
+    groups,
+    lines: lines.map(reconcileLine),
+    isDirtySinceHistory: true,
+  });
+}
+
+function getLine(id: string) {
+  const line = useProjectStore.getState().lines.find((l) => l.id === id);
+  if (!line) throw new Error(`line ${id} not found`);
+  return line;
+}
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("placeVoiceAtPlayhead", () => {
+  describe("main", () => {
+    it("makes the line main line-synced over [currentTime, currentTime + wordCount*dur]", () => {
+      seed([{ id: "L1", text: "hello there world", agentId: "v1" }]);
+
+      placeVoiceAtPlayhead("L1", "main");
+
+      const after = getLine("L1");
+      expect(isLineSynced(after)).toBe(true);
+      const bounds = mainBounds(after);
+      expect(bounds?.begin).toBeCloseTo(PLAYHEAD, 9);
+      expect(bounds?.end).toBeCloseTo(PLAYHEAD + 3 * DUR, 9);
+    });
+
+    it("reads the live playhead time and word duration at call time", () => {
+      seed([{ id: "L1", text: "one two", agentId: "v1" }]);
+      useAudioStore.setState({ currentTime: 12 });
+      useSettingsStore.setState({ defaultWordDuration: 0.5 });
+
+      placeVoiceAtPlayhead("L1", "main");
+
+      const bounds = mainBounds(getLine("L1"));
+      expect(bounds?.begin).toBeCloseTo(12, 9);
+      expect(bounds?.end).toBeCloseTo(12 + 2 * 0.5, 9);
+    });
+
+    it("does not create a background when none exists", () => {
+      seed([{ id: "L1", text: "a b", agentId: "v1" }]);
+
+      placeVoiceAtPlayhead("L1", "main");
+
+      expect(bgVoice(getLine("L1"))).toBeNull();
+    });
+  });
+
+  describe("background", () => {
+    it("makes the bg line-synced over [currentTime, currentTime + wordCount*dur]", () => {
+      seed([{ id: "L1", text: "lead", agentId: "v1", backgroundText: "oh oh oh" }]);
+
+      placeVoiceAtPlayhead("L1", "background");
+
+      const after = getLine("L1");
+      const bg = bgVoice(after);
+      expect(bg).not.toBeNull();
+      expect(bg && isLineSyncedVoice(bg)).toBe(true);
+      const bounds = bgBounds(after);
+      expect(bounds?.begin).toBeCloseTo(PLAYHEAD, 9);
+      expect(bounds?.end).toBeCloseTo(PLAYHEAD + 3 * DUR, 9);
+    });
+
+    it("leaves the main voice untouched when placing the background", () => {
+      seed([{ id: "L1", text: "lead", agentId: "v1", backgroundText: "oh oh" }]);
+
+      placeVoiceAtPlayhead("L1", "background");
+
+      expect(mainBounds(getLine("L1"))).toBeNull();
+    });
+
+    it("is a no-op when the line has no background text", () => {
+      seed([{ id: "L1", text: "lead vocals", agentId: "v1" }]);
+      const before = getLine("L1");
+
+      placeVoiceAtPlayhead("L1", "background");
+
+      expect(getLine("L1")).toBe(before);
+      expect(bgVoice(getLine("L1"))).toBeNull();
+    });
+
+    it("is a no-op when the background text is empty", () => {
+      seed([{ id: "L1", text: "lead", agentId: "v1", backgroundText: "" }]);
+      const before = getLine("L1");
+
+      placeVoiceAtPlayhead("L1", "background");
+
+      expect(getLine("L1")).toBe(before);
+    });
+  });
+
+  describe("per-instance invariant", () => {
+    function seedLinkedPair(backgroundText?: string) {
+      seed(
+        [
+          {
+            id: "a0",
+            text: "Real line",
+            agentId: "v1",
+            groupId: "g1",
+            instanceIdx: 0,
+            templateLineIdx: 0,
+            ...(backgroundText !== undefined ? { backgroundText, backgroundTextSource: "manual" } : {}),
+          },
+          {
+            id: "a1",
+            text: "Real line",
+            agentId: "v1",
+            groupId: "g1",
+            instanceIdx: 1,
+            templateLineIdx: 0,
+            ...(backgroundText !== undefined ? { backgroundText, backgroundTextSource: "manual" } : {}),
+          },
+        ],
+        [seedGroup("g1")],
+      );
+    }
+
+    it("placing main on one instance does not change the linked sibling", () => {
+      seedLinkedPair();
+      const siblingBefore = getLine("a1");
+
+      placeVoiceAtPlayhead("a0", "main");
+
+      expect(isLineSynced(getLine("a0"))).toBe(true);
+      expect(getLine("a1")).toBe(siblingBefore);
+      expect(mainBounds(getLine("a1"))).toBeNull();
+    });
+
+    it("placing background on one instance does not change the linked sibling", () => {
+      seedLinkedPair("ooh ooh");
+      const siblingBefore = getLine("a1");
+
+      placeVoiceAtPlayhead("a0", "background");
+
+      const targetBg = bgVoice(getLine("a0"));
+      expect(targetBg && isLineSyncedVoice(targetBg)).toBe(true);
+      expect(getLine("a1")).toBe(siblingBefore);
+      expect(bgBounds(getLine("a1"))).toBeNull();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("is a no-op for a missing lineId", () => {
+      seed([{ id: "L1", text: "hello", agentId: "v1" }]);
+      const linesBefore = useProjectStore.getState().lines;
+
+      placeVoiceAtPlayhead("nope", "main");
+
+      expect(useProjectStore.getState().lines).toBe(linesBefore);
+    });
+
+    it("treats an empty-text line as one word for main placement", () => {
+      seed([{ id: "L1", text: "", agentId: "v1" }]);
+
+      placeVoiceAtPlayhead("L1", "main");
+
+      const bounds = mainBounds(getLine("L1"));
+      expect(bounds?.begin).toBeCloseTo(PLAYHEAD, 9);
+      expect(bounds?.end).toBeCloseTo(PLAYHEAD + DUR, 9);
+    });
+  });
+});

--- a/src/views/timeline/place-voice-at-playhead.ts
+++ b/src/views/timeline/place-voice-at-playhead.ts
@@ -1,0 +1,24 @@
+import { placeVoice } from "@/domain/line/place-voice";
+import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
+
+// -- Operation ----------------------------------------------------------------
+
+// Places one voice (main or background) at the current playhead time for a
+// single line instance. This is a per-instance timing write: it must NOT
+// propagate to linked siblings, or their backgrounds get cleared or re-resolved
+// (regression vs the pre-voice-model path).
+function placeVoiceAtPlayhead(lineId: string, voice: "main" | "background"): void {
+  const line = useProjectStore.getState().lines.find((l) => l.id === lineId);
+  if (!line) return;
+  const currentTime = useAudioStore.getState().currentTime;
+  const wordDuration = useSettingsStore.getState().defaultWordDuration;
+  useProjectStore
+    .getState()
+    .setLineWithHistory(lineId, placeVoice(line, voice, currentTime, wordDuration), { propagateToSiblings: false });
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { placeVoiceAtPlayhead };

--- a/src/views/timeline/remove-background-with-confirm.test.ts
+++ b/src/views/timeline/remove-background-with-confirm.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @vitest-environment node
+ */
+import type { LinkGroup } from "@/domain/group/template";
+import { reconcileLine } from "@/domain/line/model";
+import { bgVoice } from "@/domain/line/voices";
+import { useConfirmStore } from "@/stores/confirm-store";
+import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { removeBackgroundWithConfirm } from "./remove-background-with-confirm";
+
+beforeEach(() => {
+  useProjectStore.getState().reset();
+  useProjectStore.getState().clearHistory();
+  useConfirmStore.setState({ isOpen: false, options: null, resolve: null, queue: [] });
+  useSettingsStore.setState({ confirmRemoveBackground: true });
+});
+
+function seedGroup(id: string): LinkGroup {
+  return { id, label: "Chorus", color: "#f472b6", templateVersion: 1 };
+}
+
+function seedStandalone() {
+  useProjectStore.setState({
+    lines: [reconcileLine({ id: "L1", text: "Real line", agentId: "v1", backgroundText: "ooh" })],
+  });
+}
+
+function seedLinkedPair() {
+  useProjectStore.setState({
+    groups: [seedGroup("g1")],
+    lines: [
+      reconcileLine({
+        id: "a0",
+        text: "Real line",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 0,
+        templateLineIdx: 0,
+        backgroundText: "ooh ooh",
+        backgroundTextSource: "manual",
+      }),
+      reconcileLine({
+        id: "a1",
+        text: "Real line",
+        agentId: "v1",
+        groupId: "g1",
+        instanceIdx: 1,
+        templateLineIdx: 0,
+        backgroundText: "ooh ooh",
+        backgroundTextSource: "manual",
+      }),
+    ],
+  });
+}
+
+function getLine(id: string) {
+  const line = useProjectStore.getState().lines.find((l) => l.id === id);
+  if (!line) throw new Error(`line ${id} not found`);
+  return line;
+}
+
+function descriptionText(): string {
+  const description = useConfirmStore.getState().options?.description as ReactNode;
+  return typeof description === "string" ? description : "";
+}
+
+describe("removeBackgroundWithConfirm · confirm accepted", () => {
+  it("removes the background once the confirm resolves true", async () => {
+    seedStandalone();
+
+    const done = removeBackgroundWithConfirm("L1");
+    expect(useConfirmStore.getState().isOpen).toBe(true);
+    useConfirmStore.getState().resolveAndClose(true, false);
+    await done;
+
+    expect(bgVoice(getLine("L1"))).toBeNull();
+    expect(useConfirmStore.getState().isOpen).toBe(false);
+  });
+
+  it("clears every linked instance's background when accepted", async () => {
+    seedLinkedPair();
+
+    const done = removeBackgroundWithConfirm("a0");
+    useConfirmStore.getState().resolveAndClose(true, false);
+    await done;
+
+    expect(bgVoice(getLine("a0"))).toBeNull();
+    expect(bgVoice(getLine("a1"))).toBeNull();
+  });
+});
+
+describe("removeBackgroundWithConfirm · confirm cancelled", () => {
+  it("leaves the line untouched when cancelled", async () => {
+    seedStandalone();
+    const before = useProjectStore.getState().lines;
+
+    const done = removeBackgroundWithConfirm("L1");
+    useConfirmStore.getState().resolveAndClose(false, false);
+    await done;
+
+    expect(useProjectStore.getState().lines).toEqual(before);
+    expect(bgVoice(getLine("L1"))).not.toBeNull();
+  });
+});
+
+describe("removeBackgroundWithConfirm · confirm options", () => {
+  it("opens a destructive, recoverable confirm gated on confirmRemoveBackground", () => {
+    seedStandalone();
+
+    void removeBackgroundWithConfirm("L1");
+
+    const options = useConfirmStore.getState().options;
+    expect(options?.title).toBe("Remove background vocals?");
+    expect(options?.confirmLabel).toBe("Remove background");
+    expect(options?.variant).toBe("destructive");
+    expect(options?.settingsKey).toBe("confirmRemoveBackground");
+    expect(options?.recoverable).toBe(true);
+
+    useConfirmStore.getState().resolveAndClose(false, false);
+  });
+
+  it("uses the standalone description when the line has no linked siblings", () => {
+    seedStandalone();
+
+    void removeBackgroundWithConfirm("L1");
+
+    expect(descriptionText()).toBe("The background vocals on this line will be removed.");
+
+    useConfirmStore.getState().resolveAndClose(false, false);
+  });
+
+  it("uses the linked-instance description when the line has linked siblings", () => {
+    seedLinkedPair();
+
+    void removeBackgroundWithConfirm("a0");
+
+    expect(descriptionText()).toBe("The background vocals on this line and its linked instances will be removed.");
+
+    useConfirmStore.getState().resolveAndClose(false, false);
+  });
+});
+
+describe("removeBackgroundWithConfirm · setting gate", () => {
+  it("removes immediately without opening when the setting is off", async () => {
+    seedStandalone();
+    useSettingsStore.setState({ confirmRemoveBackground: false });
+
+    await removeBackgroundWithConfirm("L1");
+
+    expect(useConfirmStore.getState().isOpen).toBe(false);
+    expect(bgVoice(getLine("L1"))).toBeNull();
+  });
+});
+
+describe("removeBackgroundWithConfirm · no background", () => {
+  it("returns early without opening a confirm when the line has no bg", async () => {
+    useProjectStore.setState({
+      lines: [
+        reconcileLine({ id: "L1", text: "Real line", agentId: "v1", words: [{ text: "Real line", begin: 0, end: 2 }] }),
+      ],
+    });
+
+    await removeBackgroundWithConfirm("L1");
+
+    expect(useConfirmStore.getState().isOpen).toBe(false);
+    expect(useConfirmStore.getState().options).toBeNull();
+  });
+
+  it("returns early without opening a confirm for a missing line", async () => {
+    seedStandalone();
+
+    await removeBackgroundWithConfirm("nope");
+
+    expect(useConfirmStore.getState().isOpen).toBe(false);
+    expect(useConfirmStore.getState().options).toBeNull();
+  });
+});

--- a/src/views/timeline/remove-background-with-confirm.ts
+++ b/src/views/timeline/remove-background-with-confirm.ts
@@ -1,0 +1,32 @@
+import { getLinkScope, isLinkedSibling } from "@/domain/group/linking";
+import { bgVoice } from "@/domain/line/voices";
+import { useConfirmStore } from "@/stores/confirm-store";
+import { useProjectStore } from "@/stores/project";
+
+// -- Operation ----------------------------------------------------------------
+
+async function removeBackgroundWithConfirm(lineId: string): Promise<void> {
+  const lines = useProjectStore.getState().lines;
+  const line = lines.find((l) => l.id === lineId);
+  if (!line || bgVoice(line) === null) return;
+
+  const linkScope = getLinkScope(line);
+  const hasLinkedSiblings = linkScope ? lines.some((l) => l.id !== lineId && isLinkedSibling(l, linkScope)) : false;
+
+  const ok = await useConfirmStore.getState().open({
+    title: "Remove background vocals?",
+    description: hasLinkedSiblings
+      ? "The background vocals on this line and its linked instances will be removed."
+      : "The background vocals on this line will be removed.",
+    confirmLabel: "Remove background",
+    variant: "destructive",
+    settingsKey: "confirmRemoveBackground",
+    recoverable: true,
+  });
+  if (!ok) return;
+  useProjectStore.getState().removeLineBackground(lineId);
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { removeBackgroundWithConfirm };

--- a/src/views/timeline/repeating-sections.test.ts
+++ b/src/views/timeline/repeating-sections.test.ts
@@ -105,10 +105,10 @@ describe("findRepeatingStandaloneSections", () => {
 
   it("matches by structural equality including word splits", () => {
     const a: LyricLine[] = [
-      { id: "1", text: "I love", agentId: "v1", words: [{ text: "I love", begin: 0, end: 1 }] },
-      { id: "2", text: "you", agentId: "v1", words: [{ text: "you", begin: 1, end: 2 }] },
-      { id: "3", text: "I love", agentId: "v1", words: [{ text: "I love", begin: 10, end: 11 }] },
-      { id: "4", text: "you", agentId: "v1", words: [{ text: "you", begin: 11, end: 12 }] },
+      reconcileLine({ id: "1", text: "I love", agentId: "v1", words: [{ text: "I love", begin: 0, end: 1 }] }),
+      reconcileLine({ id: "2", text: "you", agentId: "v1", words: [{ text: "you", begin: 1, end: 2 }] }),
+      reconcileLine({ id: "3", text: "I love", agentId: "v1", words: [{ text: "I love", begin: 10, end: 11 }] }),
+      reconcileLine({ id: "4", text: "you", agentId: "v1", words: [{ text: "you", begin: 11, end: 12 }] }),
     ];
     const result = findRepeatingStandaloneSections(a);
     expect(result).toHaveLength(1);
@@ -117,7 +117,7 @@ describe("findRepeatingStandaloneSections", () => {
 
   it("rejects pseudo-repeats whose word splits differ", () => {
     const a: LyricLine[] = [
-      {
+      reconcileLine({
         id: "1",
         text: "I love",
         agentId: "v1",
@@ -125,10 +125,10 @@ describe("findRepeatingStandaloneSections", () => {
           { text: "I", begin: 0, end: 1 },
           { text: " love", begin: 1, end: 2 },
         ],
-      },
-      { id: "2", text: "you", agentId: "v1" },
-      { id: "3", text: "I love", agentId: "v1", words: [{ text: "I love", begin: 10, end: 11 }] },
-      { id: "4", text: "you", agentId: "v1" },
+      }),
+      reconcileLine({ id: "2", text: "you", agentId: "v1" }),
+      reconcileLine({ id: "3", text: "I love", agentId: "v1", words: [{ text: "I love", begin: 10, end: 11 }] }),
+      reconcileLine({ id: "4", text: "you", agentId: "v1" }),
     ];
     expect(findRepeatingStandaloneSections(a)).toEqual([]);
   });

--- a/src/views/timeline/repeating-sections.ts
+++ b/src/views/timeline/repeating-sections.ts
@@ -1,4 +1,5 @@
 import type { LyricLine } from "@/domain/line/model";
+import { bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { structurallyEqualLineSequences } from "@/views/timeline/structural-match";
 
 interface RepeatingSection {
@@ -45,8 +46,8 @@ function findRepeatingStandaloneSections(lines: LyricLine[]): RepeatingSection[]
         results.push({
           starts,
           length: k,
-          preview: lines[i].text,
-          previewLines: lines.slice(i, i + k).map((l) => l.text),
+          preview: lineText(lines[i]),
+          previewLines: lines.slice(i, i + k).map((l) => lineText(l)),
           fingerprint: fingerprintBlock(lines, i, k),
         });
         i = i + k - 1;
@@ -64,9 +65,9 @@ function fingerprintBlock(lines: LyricLine[], start: number, length: number): st
   const parts: string[] = [];
   for (let p = start; p < start + length; p++) {
     const l = lines[p];
-    const wordsKey = (l.words ?? []).map((w) => w.text).join(FS);
-    const bgKey = (l.backgroundWords ?? []).map((w) => w.text).join(FS);
-    parts.push([l.text, l.agentId, l.backgroundText ?? "", wordsKey, bgKey].join(RS));
+    const wordsKey = (mainWords(l) ?? []).map((w) => w.text).join(FS);
+    const bgKey = (bgWords(l) ?? []).map((w) => w.text).join(FS);
+    parts.push([lineText(l), l.agentId, bgText(l) ?? "", wordsKey, bgKey].join(RS));
   }
   return parts.join("\n");
 }

--- a/src/views/timeline/snap.test.ts
+++ b/src/views/timeline/snap.test.ts
@@ -1,14 +1,14 @@
 /**
  * @vitest-environment node
  */
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
 import { type SnapAnchor, collectSnapAnchors, findSnapShift, selfKey } from "./snap";
 
 // -- Fixtures ------------------------------------------------------------------
 
 function wordTimedLine(): LyricLine {
-  return {
+  return reconcileLine({
     id: "l1",
     text: "I love you",
     agentId: "v1",
@@ -22,17 +22,17 @@ function wordTimedLine(): LyricLine {
       { text: "oh ", begin: 0.4, end: 0.55 },
       { text: "yeah", begin: 0.55, end: 0.8 },
     ],
-  };
+  });
 }
 
 function lineSyncedLine(): LyricLine {
-  return {
+  return reconcileLine({
     id: "l2",
     text: "another line",
     agentId: "v1",
     begin: 2,
     end: 3,
-  };
+  });
 }
 
 // -- collectSnapAnchors --------------------------------------------------------
@@ -178,7 +178,7 @@ describe("collectSnapAnchors", () => {
   });
 
   it("contributes nothing for a line with neither words nor begin/end", () => {
-    const empty: LyricLine = { id: "lx", text: "no timing", agentId: "v1" };
+    const empty: LyricLine = reconcileLine({ id: "lx", text: "no timing", agentId: "v1" });
     const anchors = collectSnapAnchors([empty], new Set(), null);
     expect(anchors).toEqual([]);
   });

--- a/src/views/timeline/snap.ts
+++ b/src/views/timeline/snap.ts
@@ -1,5 +1,7 @@
+import { mainBounds } from "@/domain/line/bounds";
 import { isLineSynced } from "@/domain/line/predicates";
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords as bgWordsOf, lineText, mainWords } from "@/domain/line/voices";
 
 // -- Types ---------------------------------------------------------------------
 
@@ -56,7 +58,7 @@ function collectSnapAnchors(
 
   if (includeTimelineAnchors) {
     for (const line of lines) {
-      const words = line.words;
+      const words = mainWords(line);
       const wordCount = words?.length ?? 0;
       const wordTimed = wordCount > 0;
 
@@ -84,11 +86,11 @@ function collectSnapAnchors(
         }
       }
 
-      const bgWords = line.backgroundWords;
-      const bgCount = bgWords?.length ?? 0;
-      if (bgWords && bgCount > 0) {
+      const bgWordArr = bgWordsOf(line);
+      const bgCount = bgWordArr?.length ?? 0;
+      if (bgWordArr && bgCount > 0) {
         for (let i = 0; i < bgCount; i++) {
-          const word = bgWords[i];
+          const word = bgWordArr[i];
           if (!selfIds.has(selfKey(line.id, i, "bg"))) {
             anchors.push({
               t: word.begin,
@@ -110,9 +112,10 @@ function collectSnapAnchors(
         }
       }
 
-      if (!wordTimed && isLineSynced(line)) {
-        anchors.push({ t: line.begin, kind: "line-begin", label: line.text, lineId: line.id });
-        anchors.push({ t: line.end, kind: "line-end", label: line.text, lineId: line.id });
+      const mb = mainBounds(line);
+      if (!wordTimed && isLineSynced(line) && mb) {
+        anchors.push({ t: mb.begin, kind: "line-begin", label: lineText(line), lineId: line.id });
+        anchors.push({ t: mb.end, kind: "line-end", label: lineText(line), lineId: line.id });
       }
     }
 

--- a/src/views/timeline/split-lines-into-words.test.ts
+++ b/src/views/timeline/split-lines-into-words.test.ts
@@ -1,21 +1,23 @@
 /**
  * @vitest-environment node
  */
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
 import { getEffectiveLines } from "@/domain/line/effective-words";
+import { mainWords } from "@/domain/line/voices";
+import { isLineSynced } from "@/domain/line/predicates";
 import { useProjectStore } from "@/stores/project";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { beforeEach, describe, expect, it } from "vitest";
 import { computeSplitIntoWordsUpdates, computeSplitSelections, splitLinesIntoWords } from "./split-lines-into-words";
 
-const lineSynced: LyricLine = { id: "L1", text: "one two three", agentId: "v1", begin: 1, end: 4 };
-const wordSynced: LyricLine = {
+const lineSynced: LyricLine = reconcileLine({ id: "L1", text: "one two three", agentId: "v1", begin: 1, end: 4 });
+const wordSynced: LyricLine = reconcileLine({
   id: "L2",
   text: "already words",
   agentId: "v1",
   words: [{ text: "already words", begin: 5, end: 6 }],
-};
-const anotherSynced: LyricLine = { id: "L3", text: "four five", agentId: "v1", begin: 7, end: 9 };
+});
+const anotherSynced: LyricLine = reconcileLine({ id: "L3", text: "four five", agentId: "v1", begin: 7, end: 9 });
 
 describe("computeSplitIntoWordsUpdates", () => {
   it("converts a line-synced line into a word update with begin/end cleared", () => {
@@ -72,10 +74,9 @@ describe("splitLinesIntoWords (store-mutating)", () => {
     splitLinesIntoWords(["L1"], effective);
 
     const after = useProjectStore.getState().lines[0];
-    expect(after.words?.length).toBeGreaterThan(0);
-    expect(after.begin).toBeUndefined();
-    expect(after.end).toBeUndefined();
-    expect(useTimelineStore.getState().selectedWords.length).toBe(after.words?.length);
+    expect(mainWords(after)?.length).toBeGreaterThan(0);
+    expect(isLineSynced(after)).toBe(false);
+    expect(useTimelineStore.getState().selectedWords.length).toBe(mainWords(after)?.length);
   });
 
   it("converts multiple line-synced rows in one history step", () => {
@@ -85,8 +86,10 @@ describe("splitLinesIntoWords (store-mutating)", () => {
     splitLinesIntoWords(["L1", "L3"], effective);
 
     const after = useProjectStore.getState().lines;
-    expect(after.find((l) => l.id === "L1")?.words?.length).toBeGreaterThan(0);
-    expect(after.find((l) => l.id === "L3")?.words?.length).toBeGreaterThan(0);
+    const l1 = after.find((l) => l.id === "L1");
+    const l3 = after.find((l) => l.id === "L3");
+    expect(l1 && mainWords(l1)?.length).toBeGreaterThan(0);
+    expect(l3 && mainWords(l3)?.length).toBeGreaterThan(0);
   });
 
   it("leaves a word-synced row untouched and selects nothing", () => {
@@ -95,7 +98,7 @@ describe("splitLinesIntoWords (store-mutating)", () => {
 
     splitLinesIntoWords(["L2"], effective);
 
-    expect(useProjectStore.getState().lines[0].words).toEqual(wordSynced.words);
+    expect(mainWords(useProjectStore.getState().lines[0])).toEqual(mainWords(wordSynced));
     expect(useTimelineStore.getState().selectedWords).toHaveLength(0);
   });
 });

--- a/src/views/timeline/split-lines-into-words.test.ts
+++ b/src/views/timeline/split-lines-into-words.test.ts
@@ -6,12 +6,18 @@ import { bgBounds, mainBounds } from "@/domain/line/bounds";
 import { getEffectiveLines } from "@/domain/line/effective-words";
 import { reconcileLine, type LyricLine } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/line/predicates";
-import { bgVoice, bgWords, mainWords } from "@/domain/line/voices";
+import { bgVoice, bgWords, mainVoice, mainWords } from "@/domain/line/voices";
+import type { WordSelection } from "@/domain/selection/model";
 import { isLineSynced as isVoiceLineSynced, isWordSynced as isVoiceWordSynced } from "@/domain/voice/predicates";
 import { useProjectStore } from "@/stores/project";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { beforeEach, describe, expect, it } from "vitest";
-import { computeSplitIntoWordsUpdates, computeSplitSelections, splitVoiceIntoWords } from "./split-lines-into-words";
+import {
+  computeSplitIntoWordsUpdates,
+  computeSplitSelections,
+  splitTargetLineIds,
+  splitVoiceIntoWords,
+} from "./split-lines-into-words";
 
 const lineSynced: LyricLine = reconcileLine({ id: "L1", text: "one two three", agentId: "v1", begin: 1, end: 4 });
 const wordSynced: LyricLine = reconcileLine({
@@ -135,6 +141,39 @@ describe("computeSplitSelections", () => {
   });
 });
 
+describe("splitTargetLineIds", () => {
+  const sel = (lineId: string, type: WordSelection["type"], wordIndex = 0): WordSelection => ({
+    lineId,
+    lineIndex: 0,
+    wordIndex,
+    type,
+  });
+
+  it("falls back to just the target when it is absent from the selection", () => {
+    const selection = [sel("L1", "word"), sel("L2", "word")];
+    expect(splitTargetLineIds(selection, "word", "L9")).toEqual(["L9"]);
+  });
+
+  it("returns every same-type selected line id when the target is among them", () => {
+    const selection = [sel("L1", "word"), sel("L2", "word", 1), sel("L3", "word")];
+    expect(splitTargetLineIds(selection, "word", "L2")).toEqual(["L1", "L2", "L3"]);
+  });
+
+  it("excludes selections of the other voice type", () => {
+    const selection = [sel("B1", "bg"), sel("B2", "bg")];
+    expect(splitTargetLineIds(selection, "word", "L1")).toEqual(["L1"]);
+  });
+
+  it("dedupes repeated line ids from multi-word selections", () => {
+    const selection = [sel("L1", "word", 0), sel("L1", "word", 1), sel("L2", "word", 0)];
+    expect(splitTargetLineIds(selection, "word", "L1")).toEqual(["L1", "L2"]);
+  });
+
+  it("returns just the target for an empty selection", () => {
+    expect(splitTargetLineIds([], "word", "L1")).toEqual(["L1"]);
+  });
+});
+
 describe("splitVoiceIntoWords · main (store-mutating)", () => {
   beforeEach(() => {
     useProjectStore.getState().reset();
@@ -229,7 +268,7 @@ describe("splitVoiceIntoWords · bg (store-mutating)", () => {
     splitVoiceIntoWords(["M1"], effective, "bg");
 
     const after = useProjectStore.getState().lines[0];
-    expect(isVoiceLineSynced(after.main)).toBe(true);
+    expect(isVoiceLineSynced(mainVoice(after))).toBe(true);
     expect(useTimelineStore.getState().selectedWords).toHaveLength(0);
   });
 });

--- a/src/views/timeline/split-lines-into-words.test.ts
+++ b/src/views/timeline/split-lines-into-words.test.ts
@@ -1,14 +1,17 @@
 /**
  * @vitest-environment node
  */
-import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { setBackground } from "@/domain/line/background";
+import { bgBounds, mainBounds } from "@/domain/line/bounds";
 import { getEffectiveLines } from "@/domain/line/effective-words";
-import { mainWords } from "@/domain/line/voices";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/line/predicates";
+import { bgVoice, bgWords, mainWords } from "@/domain/line/voices";
+import { isLineSynced as isVoiceLineSynced, isWordSynced as isVoiceWordSynced } from "@/domain/voice/predicates";
 import { useProjectStore } from "@/stores/project";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { beforeEach, describe, expect, it } from "vitest";
-import { computeSplitIntoWordsUpdates, computeSplitSelections, splitLinesIntoWords } from "./split-lines-into-words";
+import { computeSplitIntoWordsUpdates, computeSplitSelections, splitVoiceIntoWords } from "./split-lines-into-words";
 
 const lineSynced: LyricLine = reconcileLine({ id: "L1", text: "one two three", agentId: "v1", begin: 1, end: 4 });
 const wordSynced: LyricLine = reconcileLine({
@@ -19,9 +22,20 @@ const wordSynced: LyricLine = reconcileLine({
 });
 const anotherSynced: LyricLine = reconcileLine({ id: "L3", text: "four five", agentId: "v1", begin: 7, end: 9 });
 
-describe("computeSplitIntoWordsUpdates", () => {
+// A line whose MAIN is word-synced and whose BACKGROUND is line-synced. setBackground
+// writes the nested background voice directly (the flat round-trip cannot express a
+// line-synced background), matching how the background lane is built in production.
+const bgLineSynced: LyricLine = setBackground(
+  reconcileLine({ id: "B1", text: "lead vox", agentId: "v1", words: [{ text: "lead vox", begin: 0, end: 2 }] }),
+  { text: "ooh ooh ooh", begin: 3, end: 6, source: "manual" },
+);
+
+// A line whose MAIN is line-synced and that has NO background at all.
+const mainLineSyncedNoBg: LyricLine = reconcileLine({ id: "M1", text: "verse here", agentId: "v1", begin: 1, end: 3 });
+
+describe("computeSplitIntoWordsUpdates (main voice)", () => {
   it("converts a line-synced line into a word update with begin/end cleared", () => {
-    const updates = computeSplitIntoWordsUpdates(["L1"], [lineSynced]);
+    const updates = computeSplitIntoWordsUpdates(["L1"], [lineSynced], "main");
     expect(updates).toHaveLength(1);
     expect(updates[0].id).toBe("L1");
     expect(updates[0].updates.begin).toBeUndefined();
@@ -29,38 +43,99 @@ describe("computeSplitIntoWordsUpdates", () => {
     expect(updates[0].updates.words?.length).toBeGreaterThan(0);
   });
 
+  it("distributes the line text across the line's own bounds", () => {
+    const updates = computeSplitIntoWordsUpdates(["L1"], [lineSynced], "main");
+    const words = updates[0].updates.words;
+    expect(words).toBeDefined();
+    expect(words?.length).toBe(3);
+    expect(words?.[0].begin).toBe(1);
+    expect(words?.[words.length - 1].end).toBe(4);
+  });
+
   it("skips lines that are already word-synced", () => {
-    const updates = computeSplitIntoWordsUpdates(["L2"], [wordSynced]);
+    const updates = computeSplitIntoWordsUpdates(["L2"], [wordSynced], "main");
     expect(updates).toHaveLength(0);
   });
 
   it("skips unknown ids", () => {
-    const updates = computeSplitIntoWordsUpdates(["missing"], [lineSynced]);
+    const updates = computeSplitIntoWordsUpdates(["missing"], [lineSynced], "main");
     expect(updates).toHaveLength(0);
   });
 
   it("handles a mix of target ids, converting only the line-synced ones", () => {
-    const updates = computeSplitIntoWordsUpdates(["L1", "L2", "L3"], [lineSynced, wordSynced, anotherSynced]);
+    const updates = computeSplitIntoWordsUpdates(["L1", "L2", "L3"], [lineSynced, wordSynced, anotherSynced], "main");
     expect(updates.map((u) => u.id).sort()).toEqual(["L1", "L3"]);
+  });
+
+  it("ignores the background when splitting the main voice", () => {
+    const updates = computeSplitIntoWordsUpdates(["B1"], [bgLineSynced], "main");
+    expect(updates).toHaveLength(0);
+  });
+});
+
+describe("computeSplitIntoWordsUpdates (bg voice)", () => {
+  it("distributes the bg text across the bg's OWN bounds, not the main's", () => {
+    const updates = computeSplitIntoWordsUpdates(["B1"], [bgLineSynced], "bg");
+    expect(updates).toHaveLength(1);
+    expect(updates[0].id).toBe("B1");
+    const words = updates[0].updates.backgroundWords;
+    expect(words).toBeDefined();
+    expect(words?.length).toBe(3);
+    expect(words?.[0].begin).toBe(3);
+    expect(words?.[words.length - 1].end).toBe(6);
+    expect(updates[0].updates.words).toBeUndefined();
+  });
+
+  it("skips a line whose bg is word-synced", () => {
+    const wordSyncedBg = setBackground(reconcileLine({ id: "WB", text: "main", agentId: "v1", begin: 0, end: 1 }), {
+      text: "(echo)",
+      words: [{ text: "(echo)", begin: 2, end: 3 }],
+      source: "manual",
+    });
+    const updates = computeSplitIntoWordsUpdates(["WB"], [wordSyncedBg], "bg");
+    expect(updates).toHaveLength(0);
+  });
+
+  it("skips a line whose bg is untimed", () => {
+    const untimedBg = reconcileLine({ id: "UB", text: "main", agentId: "v1", begin: 0, end: 1, backgroundText: "ooh" });
+    const updates = computeSplitIntoWordsUpdates(["UB"], [untimedBg], "bg");
+    expect(updates).toHaveLength(0);
+  });
+
+  it("skips a line with no background", () => {
+    const updates = computeSplitIntoWordsUpdates(["M1"], [mainLineSyncedNoBg], "bg");
+    expect(updates).toHaveLength(0);
+  });
+
+  it("ignores a line-synced main when the voice is bg (only the bg matters)", () => {
+    const updates = computeSplitIntoWordsUpdates(["M1"], [mainLineSyncedNoBg], "bg");
+    expect(updates).toHaveLength(0);
   });
 });
 
 describe("computeSplitSelections", () => {
-  it("produces a word selection per converted word, indexed against effective lines", () => {
-    const updates = computeSplitIntoWordsUpdates(["L1"], [lineSynced]);
-    const selections = computeSplitSelections(updates, [lineSynced]);
+  it("produces a word selection per converted word for the main voice", () => {
+    const updates = computeSplitIntoWordsUpdates(["L1"], [lineSynced], "main");
+    const selections = computeSplitSelections(updates, [lineSynced], "main");
     expect(selections.length).toBe(updates[0].updates.words?.length);
     expect(selections.every((s) => s.lineId === "L1" && s.lineIndex === 0 && s.type === "word")).toBe(true);
   });
 
+  it("produces a bg selection per converted word for the bg voice", () => {
+    const updates = computeSplitIntoWordsUpdates(["B1"], [bgLineSynced], "bg");
+    const selections = computeSplitSelections(updates, [bgLineSynced], "bg");
+    expect(selections.length).toBe(updates[0].updates.backgroundWords?.length);
+    expect(selections.every((s) => s.lineId === "B1" && s.lineIndex === 0 && s.type === "bg")).toBe(true);
+  });
+
   it("returns no selections when an update id is absent from the effective lines", () => {
-    const updates = computeSplitIntoWordsUpdates(["L1"], [lineSynced]);
-    const selections = computeSplitSelections(updates, [anotherSynced]);
+    const updates = computeSplitIntoWordsUpdates(["L1"], [lineSynced], "main");
+    const selections = computeSplitSelections(updates, [anotherSynced], "main");
     expect(selections).toHaveLength(0);
   });
 });
 
-describe("splitLinesIntoWords (store-mutating)", () => {
+describe("splitVoiceIntoWords · main (store-mutating)", () => {
   beforeEach(() => {
     useProjectStore.getState().reset();
     useProjectStore.getState().clearHistory();
@@ -71,34 +146,90 @@ describe("splitLinesIntoWords (store-mutating)", () => {
     useProjectStore.setState({ lines: [{ ...lineSynced }] });
     const effective = getEffectiveLines(useProjectStore.getState().lines);
 
-    splitLinesIntoWords(["L1"], effective);
+    splitVoiceIntoWords(["L1"], effective, "main");
 
     const after = useProjectStore.getState().lines[0];
     expect(mainWords(after)?.length).toBeGreaterThan(0);
     expect(isLineSynced(after)).toBe(false);
     expect(useTimelineStore.getState().selectedWords.length).toBe(mainWords(after)?.length);
+    expect(useTimelineStore.getState().selectedWords.every((s) => s.type === "word")).toBe(true);
   });
 
   it("converts multiple line-synced rows in one history step", () => {
     useProjectStore.setState({ lines: [{ ...lineSynced }, { ...anotherSynced }] });
     const effective = getEffectiveLines(useProjectStore.getState().lines);
 
-    splitLinesIntoWords(["L1", "L3"], effective);
+    splitVoiceIntoWords(["L1", "L3"], effective, "main");
 
     const after = useProjectStore.getState().lines;
     const l1 = after.find((l) => l.id === "L1");
     const l3 = after.find((l) => l.id === "L3");
     expect(l1 && mainWords(l1)?.length).toBeGreaterThan(0);
     expect(l3 && mainWords(l3)?.length).toBeGreaterThan(0);
+    const before = useProjectStore.getState().history.length;
+    useProjectStore.getState().undo();
+    const restored = useProjectStore.getState().lines;
+    expect(isLineSynced(restored.find((l) => l.id === "L1")!)).toBe(true);
+    expect(isLineSynced(restored.find((l) => l.id === "L3")!)).toBe(true);
+    expect(before).toBeGreaterThan(0);
   });
 
   it("leaves a word-synced row untouched and selects nothing", () => {
     useProjectStore.setState({ lines: [{ ...wordSynced }] });
     const effective = getEffectiveLines(useProjectStore.getState().lines);
 
-    splitLinesIntoWords(["L2"], effective);
+    splitVoiceIntoWords(["L2"], effective, "main");
 
     expect(mainWords(useProjectStore.getState().lines[0])).toEqual(mainWords(wordSynced));
+    expect(useTimelineStore.getState().selectedWords).toHaveLength(0);
+  });
+});
+
+describe("splitVoiceIntoWords · bg (store-mutating)", () => {
+  beforeEach(() => {
+    useProjectStore.getState().reset();
+    useProjectStore.getState().clearHistory();
+    useTimelineStore.getState().clearSelection();
+  });
+
+  it("makes a line-synced bg word-synced and leaves the main untouched", () => {
+    useProjectStore.setState({ lines: [{ ...bgLineSynced }] });
+    const effective = getEffectiveLines(useProjectStore.getState().lines);
+
+    splitVoiceIntoWords(["B1"], effective, "bg");
+
+    const after = useProjectStore.getState().lines[0];
+    const bg = bgVoice(after);
+    expect(bg).not.toBeNull();
+    expect(isVoiceWordSynced(bg!)).toBe(true);
+    expect(bgWords(after)?.length).toBeGreaterThan(0);
+    expect(bgBounds(after)).toEqual({ begin: 3, end: 6 });
+
+    // Main voice untouched.
+    expect(mainWords(after)).toEqual(mainWords(bgLineSynced));
+    expect(mainBounds(after)).toEqual(mainBounds(bgLineSynced));
+  });
+
+  it("selects the new bg words with type bg", () => {
+    useProjectStore.setState({ lines: [{ ...bgLineSynced }] });
+    const effective = getEffectiveLines(useProjectStore.getState().lines);
+
+    splitVoiceIntoWords(["B1"], effective, "bg");
+
+    const after = useProjectStore.getState().lines[0];
+    const selections = useTimelineStore.getState().selectedWords;
+    expect(selections.length).toBe(bgWords(after)?.length);
+    expect(selections.every((s) => s.lineId === "B1" && s.type === "bg")).toBe(true);
+  });
+
+  it("leaves a line-synced main with the same line untouched when voice is bg", () => {
+    useProjectStore.setState({ lines: [{ ...mainLineSyncedNoBg }] });
+    const effective = getEffectiveLines(useProjectStore.getState().lines);
+
+    splitVoiceIntoWords(["M1"], effective, "bg");
+
+    const after = useProjectStore.getState().lines[0];
+    expect(isVoiceLineSynced(after.main)).toBe(true);
     expect(useTimelineStore.getState().selectedWords).toHaveLength(0);
   });
 });

--- a/src/views/timeline/split-lines-into-words.ts
+++ b/src/views/timeline/split-lines-into-words.ts
@@ -21,6 +21,22 @@ interface LineWordsUpdate {
 
 // -- Pure computation ----------------------------------------------------------
 
+// Resolves which line ids a split operates on, given the current word selection,
+// the voice type of the context-menu target, and the target line id. The target
+// set is the line ids of same-type selected words; when that set already contains
+// the target (and is non-empty) it wins, otherwise the split is scoped to the
+// target line alone. Shared by the menu count site and the menu action site so the
+// displayed "Split N ..." count can never diverge from what actually splits.
+function splitTargetLineIds(
+  selectedWords: WordSelection[],
+  type: WordSelection["type"],
+  targetLineId: string,
+): string[] {
+  const sameVoiceLineIds = selectedWords.flatMap((w) => (w.type === type ? [w.lineId] : []));
+  const selectedLineIds = new Set(sameVoiceLineIds);
+  return selectedLineIds.has(targetLineId) && selectedLineIds.size > 0 ? [...selectedLineIds] : [targetLineId];
+}
+
 function mainUpdate(realLine: LyricLine): Partial<LooseLine> | null {
   if (!isLineSynced(realLine)) return null;
   const converted = convertLineToWord(toFlat(realLine));
@@ -109,5 +125,5 @@ function splitVoiceIntoWords(targetLineIds: Iterable<string>, effectiveLines: Ly
 
 // -- Exports -------------------------------------------------------------------
 
-export { computeSplitIntoWordsUpdates, computeSplitSelections, splitVoiceIntoWords };
+export { computeSplitIntoWordsUpdates, computeSplitSelections, splitTargetLineIds, splitVoiceIntoWords };
 export type { SplitVoice };

--- a/src/views/timeline/split-lines-into-words.ts
+++ b/src/views/timeline/split-lines-into-words.ts
@@ -1,11 +1,18 @@
+import { manualBackgroundWordEdit } from "@/domain/line/background";
+import { bgBounds } from "@/domain/line/bounds";
 import { toFlat, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/line/predicates";
+import { bgText, bgVoice } from "@/domain/line/voices";
 import type { WordSelection } from "@/domain/selection/model";
+import { isLineSynced as isVoiceLineSynced } from "@/domain/voice/predicates";
+import type { WordTiming } from "@/domain/word/timing";
 import { useProjectStore } from "@/stores/project";
 import { convertLineToWord } from "@/utils/sync-helpers";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 
 // -- Types --------------------------------------------------------------------
+
+type SplitVoice = "main" | "bg";
 
 interface LineWordsUpdate {
   id: string;
@@ -14,32 +21,69 @@ interface LineWordsUpdate {
 
 // -- Pure computation ----------------------------------------------------------
 
-function computeSplitIntoWordsUpdates(targetLineIds: Iterable<string>, rawLines: LyricLine[]): LineWordsUpdate[] {
+function mainUpdate(realLine: LyricLine): Partial<LooseLine> | null {
+  if (!isLineSynced(realLine)) return null;
+  const converted = convertLineToWord(toFlat(realLine));
+  if (!converted.words) return null;
+  return { words: converted.words, begin: undefined, end: undefined };
+}
+
+// Splits a line-synced background over its OWN bounds. toFlat drops a line-synced
+// background's begin/end, so the bounds and text are read from the nested voice
+// (bgBounds/bgText), then fed through the same distribution primitive the main
+// split uses. Writing the words via manualBackgroundWordEdit stamps "manual"
+// provenance and keeps backgroundText coherent, matching the timeline's other
+// bg-word write paths (retime, merge).
+function bgUpdate(realLine: LyricLine): Partial<LooseLine> | null {
+  const bg = bgVoice(realLine);
+  if (bg === null || !isVoiceLineSynced(bg)) return null;
+  const bounds = bgBounds(realLine);
+  const text = bgText(realLine);
+  if (bounds === null || text === undefined) return null;
+  const seed: { text: string; begin: number; end: number; words?: WordTiming[] } = {
+    text,
+    begin: bounds.begin,
+    end: bounds.end,
+  };
+  const converted = convertLineToWord(seed);
+  if (!converted.words) return null;
+  return manualBackgroundWordEdit(converted.words);
+}
+
+function computeSplitIntoWordsUpdates(
+  targetLineIds: Iterable<string>,
+  rawLines: LyricLine[],
+  voice: SplitVoice,
+): LineWordsUpdate[] {
   const rawLinesById = new Map<string, LyricLine>();
   for (const line of rawLines) rawLinesById.set(line.id, line);
 
   const updates: LineWordsUpdate[] = [];
   for (const id of targetLineIds) {
     const realLine = rawLinesById.get(id);
-    if (!realLine || !isLineSynced(realLine)) continue;
-    const converted = convertLineToWord(toFlat(realLine));
-    if (converted.words) {
-      updates.push({ id, updates: { words: converted.words, begin: undefined, end: undefined } });
-    }
+    if (!realLine) continue;
+    const update = voice === "main" ? mainUpdate(realLine) : bgUpdate(realLine);
+    if (update) updates.push({ id, updates: update });
   }
   return updates;
 }
 
-function computeSplitSelections(updates: LineWordsUpdate[], effectiveLines: LyricLine[]): WordSelection[] {
+function computeSplitSelections(
+  updates: LineWordsUpdate[],
+  effectiveLines: LyricLine[],
+  voice: SplitVoice,
+): WordSelection[] {
   const lineIndexById = new Map<string, number>();
   for (let i = 0; i < effectiveLines.length; i++) lineIndexById.set(effectiveLines[i].id, i);
 
+  const type = voice === "main" ? "word" : "bg";
   const selections: WordSelection[] = [];
   for (const update of updates) {
     const lineIndex = lineIndexById.get(update.id);
-    if (lineIndex === undefined || !update.updates.words) continue;
-    for (let wi = 0; wi < update.updates.words.length; wi++) {
-      selections.push({ lineId: update.id, lineIndex, wordIndex: wi, type: "word" });
+    const words = voice === "main" ? update.updates.words : update.updates.backgroundWords;
+    if (lineIndex === undefined || !words) continue;
+    for (let wi = 0; wi < words.length; wi++) {
+      selections.push({ lineId: update.id, lineIndex, wordIndex: wi, type });
     }
   }
   return selections;
@@ -47,9 +91,9 @@ function computeSplitSelections(updates: LineWordsUpdate[], effectiveLines: Lyri
 
 // -- Store-mutating operation --------------------------------------------------
 
-function splitLinesIntoWords(targetLineIds: Iterable<string>, effectiveLines: LyricLine[]): void {
+function splitVoiceIntoWords(targetLineIds: Iterable<string>, effectiveLines: LyricLine[], voice: SplitVoice): void {
   const projectState = useProjectStore.getState();
-  const updates = computeSplitIntoWordsUpdates(targetLineIds, projectState.lines);
+  const updates = computeSplitIntoWordsUpdates(targetLineIds, projectState.lines, voice);
 
   if (updates.length === 1) {
     projectState.updateLineWithHistory(updates[0].id, updates[0].updates);
@@ -57,7 +101,7 @@ function splitLinesIntoWords(targetLineIds: Iterable<string>, effectiveLines: Ly
     projectState.updateLinesWithHistory(updates);
   }
 
-  const newSelections = computeSplitSelections(updates, effectiveLines);
+  const newSelections = computeSplitSelections(updates, effectiveLines, voice);
   if (newSelections.length > 0) {
     useTimelineStore.getState().setSelectedWords(newSelections);
   }
@@ -65,4 +109,5 @@ function splitLinesIntoWords(targetLineIds: Iterable<string>, effectiveLines: Ly
 
 // -- Exports -------------------------------------------------------------------
 
-export { computeSplitIntoWordsUpdates, computeSplitSelections, splitLinesIntoWords };
+export { computeSplitIntoWordsUpdates, computeSplitSelections, splitVoiceIntoWords };
+export type { SplitVoice };

--- a/src/views/timeline/split-lines-into-words.ts
+++ b/src/views/timeline/split-lines-into-words.ts
@@ -1,4 +1,4 @@
-import type { LyricLine } from "@/domain/line/model";
+import { toFlat, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/line/predicates";
 import type { WordSelection } from "@/domain/selection/model";
 import { useProjectStore } from "@/stores/project";
@@ -9,7 +9,7 @@ import { useTimelineStore } from "@/views/timeline/timeline-store";
 
 interface LineWordsUpdate {
   id: string;
-  updates: Partial<LyricLine>;
+  updates: Partial<LooseLine>;
 }
 
 // -- Pure computation ----------------------------------------------------------
@@ -22,7 +22,7 @@ function computeSplitIntoWordsUpdates(targetLineIds: Iterable<string>, rawLines:
   for (const id of targetLineIds) {
     const realLine = rawLinesById.get(id);
     if (!realLine || !isLineSynced(realLine)) continue;
-    const converted = convertLineToWord(realLine);
+    const converted = convertLineToWord(toFlat(realLine));
     if (converted.words) {
       updates.push({ id, updates: { words: converted.words, begin: undefined, end: undefined } });
     }

--- a/src/views/timeline/structural-match.test.ts
+++ b/src/views/timeline/structural-match.test.ts
@@ -1,58 +1,58 @@
 /**
  * @vitest-environment node
  */
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
 import { findMatchingTemplate, linesStructurallyEqual, structurallyEqualLineSequences } from "./structural-match";
 
-const baseLine: LyricLine = { id: "x", text: "I love you", agentId: "v1" };
+const baseLine: LyricLine = reconcileLine({ id: "x", text: "I love you", agentId: "v1" });
 
 describe("linesStructurallyEqual", () => {
   it("equal when text/agentId/words/bg match", () => {
-    const a: LyricLine = {
+    const a: LyricLine = reconcileLine({
       ...baseLine,
       words: [
         { text: "I ", begin: 0, end: 1 },
         { text: "love", begin: 1, end: 2 },
       ],
-    };
-    const b: LyricLine = {
+    });
+    const b: LyricLine = reconcileLine({
       ...baseLine,
       id: "y",
       words: [
         { text: "I ", begin: 30, end: 31 },
         { text: "love", begin: 31, end: 32 },
       ],
-    };
+    });
     expect(linesStructurallyEqual(a, b)).toBe(true);
   });
 
   it("unequal when text differs", () => {
-    expect(linesStructurallyEqual(baseLine, { ...baseLine, text: "different" })).toBe(false);
+    expect(linesStructurallyEqual(baseLine, reconcileLine({ ...baseLine, text: "different" }))).toBe(false);
   });
 
   it("unequal when agent differs", () => {
-    expect(linesStructurallyEqual(baseLine, { ...baseLine, agentId: "v2" })).toBe(false);
+    expect(linesStructurallyEqual(baseLine, reconcileLine({ ...baseLine, agentId: "v2" }))).toBe(false);
   });
 
   it("unequal when word count differs", () => {
-    const a: LyricLine = {
+    const a: LyricLine = reconcileLine({
       ...baseLine,
       words: [
         { text: "I ", begin: 0, end: 1 },
         { text: "love", begin: 1, end: 2 },
       ],
-    };
-    const b: LyricLine = {
+    });
+    const b: LyricLine = reconcileLine({
       ...baseLine,
       words: [{ text: "I ", begin: 0, end: 1 }],
-    };
+    });
     expect(linesStructurallyEqual(a, b)).toBe(false);
   });
 
   it("unequal when background differs", () => {
-    const a: LyricLine = { ...baseLine, backgroundText: "yeah" };
-    const b: LyricLine = { ...baseLine, backgroundText: "yeah yeah" };
+    const a: LyricLine = reconcileLine({ ...baseLine, backgroundText: "yeah" });
+    const b: LyricLine = reconcileLine({ ...baseLine, backgroundText: "yeah yeah" });
     expect(linesStructurallyEqual(a, b)).toBe(false);
   });
 });
@@ -60,21 +60,21 @@ describe("linesStructurallyEqual", () => {
 describe("structurallyEqualLineSequences", () => {
   it("matches sequences with same structure but different timings", () => {
     const a: LyricLine[] = [
-      { id: "1", text: "I love", agentId: "v1", words: [{ text: "I", begin: 0, end: 1 }] },
-      { id: "2", text: "you", agentId: "v1", words: [{ text: "you", begin: 1, end: 2 }] },
+      reconcileLine({ id: "1", text: "I love", agentId: "v1", words: [{ text: "I", begin: 0, end: 1 }] }),
+      reconcileLine({ id: "2", text: "you", agentId: "v1", words: [{ text: "you", begin: 1, end: 2 }] }),
     ];
     const b: LyricLine[] = [
-      { id: "x", text: "I love", agentId: "v1", words: [{ text: "I", begin: 30, end: 31 }] },
-      { id: "y", text: "you", agentId: "v1", words: [{ text: "you", begin: 31, end: 32 }] },
+      reconcileLine({ id: "x", text: "I love", agentId: "v1", words: [{ text: "I", begin: 30, end: 31 }] }),
+      reconcileLine({ id: "y", text: "you", agentId: "v1", words: [{ text: "you", begin: 31, end: 32 }] }),
     ];
     expect(structurallyEqualLineSequences(a, b)).toBe(true);
   });
 
   it("rejects different line counts", () => {
-    const a: LyricLine[] = [{ id: "1", text: "I", agentId: "v1" }];
+    const a: LyricLine[] = [reconcileLine({ id: "1", text: "I", agentId: "v1" })];
     const b: LyricLine[] = [
-      { id: "1", text: "I", agentId: "v1" },
-      { id: "2", text: "you", agentId: "v1" },
+      reconcileLine({ id: "1", text: "I", agentId: "v1" }),
+      reconcileLine({ id: "2", text: "you", agentId: "v1" }),
     ];
     expect(structurallyEqualLineSequences(a, b)).toBe(false);
   });
@@ -83,7 +83,7 @@ describe("structurallyEqualLineSequences", () => {
 describe("findMatchingTemplate", () => {
   it("finds a matching instance template in the project", () => {
     const projectLines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "a",
         text: "I love",
         agentId: "v1",
@@ -91,8 +91,8 @@ describe("findMatchingTemplate", () => {
         instanceIdx: 0,
         templateLineIdx: 0,
         words: [{ text: "I love", begin: 0, end: 2 }],
-      },
-      {
+      }),
+      reconcileLine({
         id: "b",
         text: "you",
         agentId: "v1",
@@ -100,11 +100,11 @@ describe("findMatchingTemplate", () => {
         instanceIdx: 0,
         templateLineIdx: 1,
         words: [{ text: "you", begin: 2, end: 3 }],
-      },
+      }),
     ];
     const candidate: LyricLine[] = [
-      { id: "p", text: "I love", agentId: "v1", words: [{ text: "I love", begin: 30, end: 32 }] },
-      { id: "q", text: "you", agentId: "v1", words: [{ text: "you", begin: 32, end: 33 }] },
+      reconcileLine({ id: "p", text: "I love", agentId: "v1", words: [{ text: "I love", begin: 30, end: 32 }] }),
+      reconcileLine({ id: "q", text: "you", agentId: "v1", words: [{ text: "you", begin: 32, end: 33 }] }),
     ];
     const found = findMatchingTemplate(candidate, projectLines);
     expect(found).toEqual({ groupId: "g1", instanceIdx: 0 });
@@ -112,7 +112,7 @@ describe("findMatchingTemplate", () => {
 
   it("returns null when no match", () => {
     const projectLines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "a",
         text: "I love",
         agentId: "v1",
@@ -120,9 +120,9 @@ describe("findMatchingTemplate", () => {
         instanceIdx: 0,
         templateLineIdx: 0,
         words: [{ text: "I love", begin: 0, end: 2 }],
-      },
+      }),
     ];
-    const candidate: LyricLine[] = [{ id: "p", text: "different text", agentId: "v1" }];
+    const candidate: LyricLine[] = [reconcileLine({ id: "p", text: "different text", agentId: "v1" })];
     expect(findMatchingTemplate(candidate, projectLines)).toBeNull();
   });
 });

--- a/src/views/timeline/structural-match.test.ts
+++ b/src/views/timeline/structural-match.test.ts
@@ -1,23 +1,24 @@
 /**
  * @vitest-environment node
  */
-import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
 import { findMatchingTemplate, linesStructurallyEqual, structurallyEqualLineSequences } from "./structural-match";
 
-const baseLine: LyricLine = reconcileLine({ id: "x", text: "I love you", agentId: "v1" });
+const baseFields: LooseLine = { id: "x", text: "I love you", agentId: "v1" };
+const baseLine: LyricLine = reconcileLine(baseFields);
 
 describe("linesStructurallyEqual", () => {
   it("equal when text/agentId/words/bg match", () => {
     const a: LyricLine = reconcileLine({
-      ...baseLine,
+      ...baseFields,
       words: [
         { text: "I ", begin: 0, end: 1 },
         { text: "love", begin: 1, end: 2 },
       ],
     });
     const b: LyricLine = reconcileLine({
-      ...baseLine,
+      ...baseFields,
       id: "y",
       words: [
         { text: "I ", begin: 30, end: 31 },
@@ -28,31 +29,31 @@ describe("linesStructurallyEqual", () => {
   });
 
   it("unequal when text differs", () => {
-    expect(linesStructurallyEqual(baseLine, reconcileLine({ ...baseLine, text: "different" }))).toBe(false);
+    expect(linesStructurallyEqual(baseLine, reconcileLine({ ...baseFields, text: "different" }))).toBe(false);
   });
 
   it("unequal when agent differs", () => {
-    expect(linesStructurallyEqual(baseLine, reconcileLine({ ...baseLine, agentId: "v2" }))).toBe(false);
+    expect(linesStructurallyEqual(baseLine, reconcileLine({ ...baseFields, agentId: "v2" }))).toBe(false);
   });
 
   it("unequal when word count differs", () => {
     const a: LyricLine = reconcileLine({
-      ...baseLine,
+      ...baseFields,
       words: [
         { text: "I ", begin: 0, end: 1 },
         { text: "love", begin: 1, end: 2 },
       ],
     });
     const b: LyricLine = reconcileLine({
-      ...baseLine,
+      ...baseFields,
       words: [{ text: "I ", begin: 0, end: 1 }],
     });
     expect(linesStructurallyEqual(a, b)).toBe(false);
   });
 
   it("unequal when background differs", () => {
-    const a: LyricLine = reconcileLine({ ...baseLine, backgroundText: "yeah" });
-    const b: LyricLine = reconcileLine({ ...baseLine, backgroundText: "yeah yeah" });
+    const a: LyricLine = reconcileLine({ ...baseFields, backgroundText: "yeah" });
+    const b: LyricLine = reconcileLine({ ...baseFields, backgroundText: "yeah yeah" });
     expect(linesStructurallyEqual(a, b)).toBe(false);
   });
 });

--- a/src/views/timeline/structural-match.ts
+++ b/src/views/timeline/structural-match.ts
@@ -1,6 +1,7 @@
 import { linesOfInstance } from "@/domain/instance/enumerate";
 import { isLinked } from "@/domain/instance/predicates";
 import type { LyricLine } from "@/domain/line/model";
+import { bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 
 // -- Helpers -------------------------------------------------------------------
 
@@ -18,11 +19,11 @@ function wordTextsEqual(a: { text: string }[] | undefined, b: { text: string }[]
 // -- Public --------------------------------------------------------------------
 
 function linesStructurallyEqual(a: LyricLine, b: LyricLine): boolean {
-  if (a.text !== b.text) return false;
+  if (lineText(a) !== lineText(b)) return false;
   if (a.agentId !== b.agentId) return false;
-  if ((a.backgroundText ?? "") !== (b.backgroundText ?? "")) return false;
-  if (!wordTextsEqual(a.words, b.words)) return false;
-  if (!wordTextsEqual(a.backgroundWords, b.backgroundWords)) return false;
+  if ((bgText(a) ?? "") !== (bgText(b) ?? "")) return false;
+  if (!wordTextsEqual(mainWords(a), mainWords(b))) return false;
+  if (!wordTextsEqual(bgWords(a), bgWords(b))) return false;
   return true;
 }
 

--- a/src/views/timeline/timeline-context-menu-line-ops.test.ts
+++ b/src/views/timeline/timeline-context-menu-line-ops.test.ts
@@ -2,8 +2,11 @@
  * @vitest-environment node
  */
 import { beforeEach, describe, expect, it } from "vitest";
+import { reconcileLine } from "@/domain/line/model";
 import { useProjectStore } from "@/stores/project";
 import { getEffectiveLines } from "@/domain/line/effective-words";
+import { mainWords } from "@/domain/line/voices";
+import { mainBounds } from "@/domain/line/bounds";
 
 // These pin the Task 1.4 contract: gutter add/delete operations on a project
 // containing line-synced rows must NOT flip those rows to word-synced.
@@ -23,12 +26,12 @@ describe("gutter add/delete preserves line-sync granularity", () => {
 
   it("inserting a line above a line-synced row leaves the row line-synced", () => {
     useProjectStore.setState({
-      lines: [{ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 }],
+      lines: [reconcileLine({ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 })],
     });
     // Simulating what the FIXED handler does: read raw lines, splice, write.
     const raw = useProjectStore.getState().lines;
     const targetIdx = raw.findIndex((l) => l.id === "L1");
-    const newLine = { id: "X", text: "", agentId: "v1" };
+    const newLine = reconcileLine({ id: "X", text: "", agentId: "v1" });
     const newLines = [...raw];
     newLines.splice(targetIdx, 0, newLine);
     useProjectStore.getState().setLinesWithHistory(newLines);
@@ -36,37 +39,37 @@ describe("gutter add/delete preserves line-sync granularity", () => {
     const after = useProjectStore.getState().lines;
     expect(after).toHaveLength(2);
     const L1 = after.find((l) => l.id === "L1");
-    expect(L1?.words).toBeUndefined();
-    expect(L1?.begin).toBe(5);
-    expect(L1?.end).toBe(7);
+    expect(L1 && mainWords(L1)).toBeUndefined();
+    expect(L1 && mainBounds(L1)?.begin).toBe(5);
+    expect(L1 && mainBounds(L1)?.end).toBe(7);
   });
 
   it("regression: writing effective-line synthesised words DOES flip line-sync (proves the bug shape)", () => {
     // This is what the OLD handler effectively did. Documenting the bug shape
     // so a future caller reintroducing this pattern fails loudly.
     useProjectStore.setState({
-      lines: [{ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 }],
+      lines: [reconcileLine({ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 })],
     });
     const effective = getEffectiveLines(useProjectStore.getState().lines);
     // effective[0] now has a synthesised single-word array
-    expect(effective[0].words).toHaveLength(1);
+    expect(mainWords(effective[0])).toHaveLength(1);
     useProjectStore.getState().setLinesWithHistory([...effective]);
     const after = useProjectStore.getState().lines[0];
     // Without the fix, line is now word-synced (the corruption)
-    expect(after.words?.length).toBe(1);
+    expect(mainWords(after)?.length).toBe(1);
   });
 
   it("deleting a line by id (not effective index) does not perturb other rows", () => {
     useProjectStore.setState({
       lines: [
-        { id: "A", text: "synced", agentId: "v1", begin: 0, end: 2 },
-        {
+        reconcileLine({ id: "A", text: "synced", agentId: "v1", begin: 0, end: 2 }),
+        reconcileLine({
           id: "B",
           text: "with words",
           agentId: "v1",
           words: [{ text: "with words", begin: 2, end: 4 }],
-        },
-        { id: "C", text: "another synced", agentId: "v1", begin: 4, end: 6 },
+        }),
+        reconcileLine({ id: "C", text: "another synced", agentId: "v1", begin: 4, end: 6 }),
       ],
     });
     // Simulating the fixed delete: filter raw by id
@@ -78,16 +81,16 @@ describe("gutter add/delete preserves line-sync granularity", () => {
     const A = after.find((l) => l.id === "A");
     const C = after.find((l) => l.id === "C");
     // A and C remain line-synced
-    expect(A?.words).toBeUndefined();
-    expect(A?.begin).toBe(0);
-    expect(C?.words).toBeUndefined();
-    expect(C?.begin).toBe(4);
+    expect(A && mainWords(A)).toBeUndefined();
+    expect(A && mainBounds(A)?.begin).toBe(0);
+    expect(C && mainWords(C)).toBeUndefined();
+    expect(C && mainBounds(C)?.begin).toBe(4);
   });
 
   it("inserting between a grouped instance's lines does not detach the instance", () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "A",
           text: "x",
           agentId: "v1",
@@ -96,8 +99,8 @@ describe("gutter add/delete preserves line-sync granularity", () => {
           templateLineIdx: 0,
           begin: 0,
           end: 1,
-        },
-        {
+        }),
+        reconcileLine({
           id: "B",
           text: "y",
           agentId: "v1",
@@ -106,14 +109,14 @@ describe("gutter add/delete preserves line-sync granularity", () => {
           templateLineIdx: 1,
           begin: 1,
           end: 2,
-        },
+        }),
       ],
       groups: [{ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 }],
     });
     // The handler doesn't strip group attrs on adjacent rows
     const raw = useProjectStore.getState().lines;
     const newLines = [...raw];
-    newLines.splice(1, 0, { id: "X", text: "", agentId: "v1" });
+    newLines.splice(1, 0, reconcileLine({ id: "X", text: "", agentId: "v1" }));
     useProjectStore.getState().setLinesWithHistory(newLines);
 
     const after = useProjectStore.getState().lines;

--- a/src/views/timeline/timeline-context-menu.browser.test.tsx
+++ b/src/views/timeline/timeline-context-menu.browser.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { setBackground } from "@/domain/line/background";
 import { bgBounds, mainBounds } from "@/domain/line/bounds";
-import { bgSource, bgText, bgWords, mainWords } from "@/domain/line/voices";
+import { reconcileLine } from "@/domain/line/model";
+import { isLineSynced } from "@/domain/line/predicates";
+import { bgSource, bgText, bgVoice, bgWords, mainWords } from "@/domain/line/voices";
+import { isWordSynced as isVoiceWordSynced } from "@/domain/voice/predicates";
 import { TimelineContextMenu } from "@/views/timeline/timeline-context-menu";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { useAudioStore } from "@/stores/audio";
@@ -392,5 +396,73 @@ describe("TimelineContextMenu · Place background here (bg track only)", () => {
     expect(bgBounds(updated)).toEqual({ begin: 5, end: 5 + 2 * 0.3 });
     expect(mainBounds(updated)).toBeNull();
     expect(mainWords(updated)).toBeUndefined();
+  });
+});
+
+// -- Voice-aware split into words ---------------------------------------------
+
+function openWordTarget(lineId: string, type: "word" | "bg") {
+  useTimelineStore.setState({
+    contextMenu: { x: 100, y: 100, target: { kind: "word", lineId, lineIndex: 0, wordIndex: 0, type } },
+    selectedWords: [{ lineId, lineIndex: 0, wordIndex: 0, type }],
+  });
+}
+
+describe("TimelineContextMenu · Split into words (voice-aware)", () => {
+  it("labels the main voice action 'Split into words'", async () => {
+    useProjectStore.setState({
+      lines: [reconcileLine({ id: "l1", text: "one two", agentId: "v1", begin: 1, end: 3 })],
+    });
+    openWordTarget("l1", "word");
+    await render(<TimelineContextMenu />);
+    expect(findButton(/Split into words/)).toBeDefined();
+    expect(findButton(/Split background into words/)).toBeUndefined();
+  });
+
+  it("labels the bg voice action 'Split background into words'", async () => {
+    const main = reconcileLine({ id: "l1", text: "lead", agentId: "v1", words: [{ text: "lead", begin: 0, end: 2 }] });
+    const raw = setBackground(main, { text: "ooh ooh", begin: 3, end: 5, source: "manual" });
+    useProjectStore.setState({ lines: [raw] });
+    openWordTarget("l1", "bg");
+    await render(<TimelineContextMenu />);
+    expect(findButton(/Split background into words/)).toBeDefined();
+    expect(findButton(/Split into words/)).toBeUndefined();
+  });
+
+  it("splits the line-synced bg into words and leaves the main untouched when clicked", async () => {
+    const main = reconcileLine({
+      id: "l1",
+      text: "lead",
+      agentId: "v1",
+      words: [{ text: "lead", begin: 0, end: 2 }],
+    });
+    const raw = setBackground(main, { text: "ooh ooh ooh", begin: 3, end: 6, source: "manual" });
+    useProjectStore.setState({ lines: [raw] });
+    openWordTarget("l1", "bg");
+    await render(<TimelineContextMenu />);
+
+    findButton(/Split background into words/)?.click();
+
+    const updated = useProjectStore.getState().lines[0];
+    const bg = bgVoice(updated);
+    expect(bg).not.toBeNull();
+    expect(isVoiceWordSynced(bg!)).toBe(true);
+    expect(bgWords(updated)?.length).toBe(3);
+    expect(bgBounds(updated)).toEqual({ begin: 3, end: 6 });
+    expect(mainWords(updated)).toEqual([{ text: "lead", begin: 0, end: 2 }]);
+  });
+
+  it("splits the line-synced main into words when the main action is clicked", async () => {
+    useProjectStore.setState({
+      lines: [reconcileLine({ id: "l1", text: "one two three", agentId: "v1", begin: 1, end: 4 })],
+    });
+    openWordTarget("l1", "word");
+    await render(<TimelineContextMenu />);
+
+    findButton(/Split into words/)?.click();
+
+    const updated = useProjectStore.getState().lines[0];
+    expect(isLineSynced(updated)).toBe(false);
+    expect(mainWords(updated)?.length).toBe(3);
   });
 });

--- a/src/views/timeline/timeline-context-menu.browser.test.tsx
+++ b/src/views/timeline/timeline-context-menu.browser.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { bgSource, bgText, bgWords, mainWords } from "@/domain/line/voices";
 import { TimelineContextMenu } from "@/views/timeline/timeline-context-menu";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { useAudioStore } from "@/stores/audio";
@@ -61,7 +62,7 @@ describe("TimelineContextMenu", () => {
     );
     expect(explicitButton).toBeDefined();
     explicitButton?.click();
-    const updated = useProjectStore.getState().lines[0].words?.[0];
+    const updated = mainWords(useProjectStore.getState().lines[0])?.[0];
     expect(updated?.explicit).toBe(true);
   });
 
@@ -90,7 +91,7 @@ describe("TimelineContextMenu", () => {
     expect(mergeBtn).toBeDefined();
     mergeBtn?.click();
 
-    const words = useProjectStore.getState().lines[0].words ?? [];
+    const words = mainWords(useProjectStore.getState().lines[0]) ?? [];
     expect(words).toHaveLength(1);
     expect(words[0].text).toBe("every");
     expect(words[0].begin).toBe(0);
@@ -164,7 +165,7 @@ describe("TimelineContextMenu", () => {
     expect(snapBtn).toBeDefined();
     snapBtn?.click();
 
-    const words = useProjectStore.getState().lines[0].words ?? [];
+    const words = mainWords(useProjectStore.getState().lines[0]) ?? [];
     expect(words[0].end).toBe(words[1].begin);
     expect(words[1].end).toBe(words[2].begin);
     expect(words[0].begin).toBe(0);
@@ -202,8 +203,8 @@ describe("TimelineContextMenu background provenance", () => {
     findButton(/Delete word/i)?.click();
 
     const updated = useProjectStore.getState().lines[0];
-    expect(updated.backgroundWords?.map((w) => w.text)).toEqual(["aah"]);
-    expect(updated.backgroundTextSource).toBe("manual");
+    expect(bgWords(updated)?.map((w) => w.text)).toEqual(["aah"]);
+    expect(bgSource(updated)).toBe("manual");
   });
 
   it("clears all three background fields when the last bg word is deleted", async () => {
@@ -229,9 +230,9 @@ describe("TimelineContextMenu background provenance", () => {
     findButton(/Delete word/i)?.click();
 
     const updated = useProjectStore.getState().lines[0];
-    expect(updated.backgroundWords).toBeUndefined();
-    expect(updated.backgroundText).toBeUndefined();
-    expect(updated.backgroundTextSource).toBeUndefined();
+    expect(bgWords(updated)).toBeUndefined();
+    expect(bgText(updated)).toBeUndefined();
+    expect(bgSource(updated)).toBeUndefined();
   });
 
   it("stamps backgroundTextSource manual when a bg word is added via 'Add word here'", async () => {
@@ -249,8 +250,8 @@ describe("TimelineContextMenu background provenance", () => {
     findButton(/Add word here/i)?.click();
 
     const updated = useProjectStore.getState().lines[0];
-    expect(updated.backgroundWords?.length).toBe(3);
-    expect(updated.backgroundTextSource).toBe("manual");
+    expect(bgWords(updated)?.length).toBe(3);
+    expect(bgSource(updated)).toBe("manual");
   });
 
   it("stamps backgroundTextSource manual when bg words are merged", async () => {
@@ -271,8 +272,8 @@ describe("TimelineContextMenu background provenance", () => {
     findButton(/Merge words/i)?.click();
 
     const updated = useProjectStore.getState().lines[0];
-    expect(updated.backgroundWords).toHaveLength(1);
-    expect(updated.backgroundTextSource).toBe("manual");
+    expect(bgWords(updated)).toHaveLength(1);
+    expect(bgSource(updated)).toBe("manual");
   });
 
   it("leaves background provenance untouched when a main word is deleted", async () => {
@@ -297,6 +298,6 @@ describe("TimelineContextMenu background provenance", () => {
 
     findButton(/Delete word/i)?.click();
 
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("extraction");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("extraction");
   });
 });

--- a/src/views/timeline/timeline-context-menu.browser.test.tsx
+++ b/src/views/timeline/timeline-context-menu.browser.test.tsx
@@ -8,6 +8,7 @@ import { isWordSynced as isVoiceWordSynced } from "@/domain/voice/predicates";
 import { TimelineContextMenu } from "@/views/timeline/timeline-context-menu";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { useAudioStore } from "@/stores/audio";
+import { useConfirmStore } from "@/stores/confirm-store";
 import { useProjectStore } from "@/stores/project";
 import { createLine, createWord } from "@/test/factories";
 import { render } from "@/test/render";
@@ -505,5 +506,18 @@ describe("TimelineContextMenu · Remove background (gutter only)", () => {
     openWordContextMenu("l1");
     await render(<TimelineContextMenu />);
     expect(findButton(/Remove background/i)).toBeUndefined();
+  });
+
+  it("opens the confirm on click and clears the bg when accepted", async () => {
+    useProjectStore.setState({ lines: [createLine({ id: "l1", text: "verse", backgroundText: "ooh" })] });
+    openGutterContextMenu("l1");
+    await render(<TimelineContextMenu />);
+
+    findButton(/Remove background/i)?.click();
+    expect(useConfirmStore.getState().isOpen).toBe(true);
+
+    useConfirmStore.getState().resolveAndClose(true, false);
+
+    await expect.poll(() => bgVoice(useProjectStore.getState().lines[0])).toBeNull();
   });
 });

--- a/src/views/timeline/timeline-context-menu.browser.test.tsx
+++ b/src/views/timeline/timeline-context-menu.browser.test.tsx
@@ -466,3 +466,44 @@ describe("TimelineContextMenu · Split into words (voice-aware)", () => {
     expect(mainWords(updated)?.length).toBe(3);
   });
 });
+
+// -- Remove background (gutter only) ------------------------------------------
+
+function openGutterContextMenu(lineId: string) {
+  useTimelineStore.setState({
+    contextMenu: { x: 100, y: 100, target: { kind: "gutter", lineId, lineIndex: 0 } },
+    selectedWords: [],
+  });
+}
+
+describe("TimelineContextMenu · Remove background (gutter only)", () => {
+  it("shows 'Remove background' on the gutter for a line with a bg", async () => {
+    useProjectStore.setState({ lines: [createLine({ id: "l1", text: "verse", backgroundText: "ooh" })] });
+    openGutterContextMenu("l1");
+    await render(<TimelineContextMenu />);
+    expect(findButton(/Remove background/i)).toBeDefined();
+  });
+
+  it("hides 'Remove background' on the gutter for a line with no bg", async () => {
+    useProjectStore.setState({ lines: [createLine({ id: "l1", text: "verse" })] });
+    openGutterContextMenu("l1");
+    await render(<TimelineContextMenu />);
+    expect(findButton(/Remove background/i)).toBeUndefined();
+  });
+
+  it("hides 'Remove background' on a word target even when the line has a bg", async () => {
+    useProjectStore.setState({
+      lines: [
+        createLine({
+          id: "l1",
+          text: "verse",
+          words: [createWord({ text: "verse", begin: 0, end: 1 })],
+          backgroundText: "ooh",
+        }),
+      ],
+    });
+    openWordContextMenu("l1");
+    await render(<TimelineContextMenu />);
+    expect(findButton(/Remove background/i)).toBeUndefined();
+  });
+});

--- a/src/views/timeline/timeline-context-menu.browser.test.tsx
+++ b/src/views/timeline/timeline-context-menu.browser.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { bgBounds, mainBounds } from "@/domain/line/bounds";
 import { bgSource, bgText, bgWords, mainWords } from "@/domain/line/voices";
 import { TimelineContextMenu } from "@/views/timeline/timeline-context-menu";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
@@ -299,5 +300,97 @@ describe("TimelineContextMenu background provenance", () => {
     findButton(/Delete word/i)?.click();
 
     expect(bgSource(useProjectStore.getState().lines[0])).toBe("extraction");
+  });
+});
+
+// -- Voice-aware placement ----------------------------------------------------
+
+function openTrackContextMenu(lineId: string, type: "word" | "bg", time: number) {
+  useTimelineStore.setState({
+    contextMenu: { x: 100, y: 100, target: { kind: "track", lineId, lineIndex: 0, time, type } },
+    selectedWords: [],
+  });
+}
+
+describe("TimelineContextMenu · Place line here (main track only)", () => {
+  it("shows 'Place line here' on the main track for an untimed line", async () => {
+    useProjectStore.setState({ lines: [createLine({ id: "l1", text: "verse" })] });
+    openTrackContextMenu("l1", "word", 5);
+    await render(<TimelineContextMenu />);
+    expect(findButton(/Place line here/i)).toBeDefined();
+  });
+
+  it("hides 'Place line here' on the bg track even when the main is placeable", async () => {
+    useProjectStore.setState({ lines: [createLine({ id: "l1", text: "verse" })] });
+    openTrackContextMenu("l1", "bg", 5);
+    await render(<TimelineContextMenu />);
+    expect(findButton(/Place line here/i)).toBeUndefined();
+  });
+});
+
+describe("TimelineContextMenu · Place background here (bg track only)", () => {
+  it("shows 'Place background here' on the bg track for an untimed bg", async () => {
+    useProjectStore.setState({ lines: [createLine({ id: "l1", text: "verse", backgroundText: "ooh ooh" })] });
+    openTrackContextMenu("l1", "bg", 5);
+    await render(<TimelineContextMenu />);
+    expect(findButton(/Place background here/i)).toBeDefined();
+  });
+
+  it("hides 'Place background here' on the main track", async () => {
+    useProjectStore.setState({ lines: [createLine({ id: "l1", text: "verse", backgroundText: "ooh ooh" })] });
+    openTrackContextMenu("l1", "word", 5);
+    await render(<TimelineContextMenu />);
+    expect(findButton(/Place background here/i)).toBeUndefined();
+  });
+
+  it("hides 'Place background here' when the line has no bg text", async () => {
+    useProjectStore.setState({ lines: [createLine({ id: "l1", text: "verse" })] });
+    openTrackContextMenu("l1", "bg", 5);
+    await render(<TimelineContextMenu />);
+    expect(findButton(/Place background here/i)).toBeUndefined();
+  });
+
+  it("hides 'Place background here' when the bg is already word-synced", async () => {
+    useProjectStore.setState({
+      lines: [
+        createLine({
+          id: "l1",
+          text: "verse",
+          backgroundText: "ooh aah",
+          backgroundWords: [
+            createWord({ text: "ooh ", begin: 1, end: 1.5 }),
+            createWord({ text: "aah", begin: 1.5, end: 2 }),
+          ],
+          backgroundTextSource: "extraction",
+        }),
+      ],
+    });
+    openTrackContextMenu("l1", "bg", 5);
+    await render(<TimelineContextMenu />);
+    expect(findButton(/Place background here/i)).toBeUndefined();
+  });
+
+  it("hides 'Place background here' when the bg is already line-synced", async () => {
+    const line = createLine({ id: "l1", text: "verse", begin: 0, end: 4 });
+    useProjectStore.setState({ lines: [line] });
+    useProjectStore.getState().applyLineBackground("l1", { text: "ooh", source: "manual" });
+    expect(bgBounds(useProjectStore.getState().lines[0])).not.toBeNull();
+    openTrackContextMenu("l1", "bg", 5);
+    await render(<TimelineContextMenu />);
+    expect(findButton(/Place background here/i)).toBeUndefined();
+  });
+
+  it("line-syncs the bg at the clicked time and leaves the main untouched when clicked", async () => {
+    useProjectStore.setState({ lines: [createLine({ id: "l1", text: "verse line", backgroundText: "ooh ooh" })] });
+    openTrackContextMenu("l1", "bg", 5);
+    await render(<TimelineContextMenu />);
+
+    findButton(/Place background here/i)?.click();
+
+    const updated = useProjectStore.getState().lines[0];
+    expect(bgWords(updated)).toBeUndefined();
+    expect(bgBounds(updated)).toEqual({ begin: 5, end: 5 + 2 * 0.3 });
+    expect(mainBounds(updated)).toBeNull();
+    expect(mainWords(updated)).toBeUndefined();
   });
 });

--- a/src/views/timeline/timeline-context-menu.tsx
+++ b/src/views/timeline/timeline-context-menu.tsx
@@ -8,6 +8,7 @@ import { useContextMenuTargets } from "@/views/timeline/use-context-menu-targets
 import { useGroupMenuActions } from "@/views/timeline/use-group-menu-actions";
 import { useInstanceMenuActions } from "@/views/timeline/use-instance-menu-actions";
 import { useLineMenuActions } from "@/views/timeline/use-line-menu-actions";
+import type { SplitVoice } from "@/views/timeline/split-lines-into-words";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { useWordMenuActions } from "@/views/timeline/use-word-menu-actions";
 import { IconCommand } from "@tabler/icons-react";
@@ -47,6 +48,13 @@ function MenuItem({
 
 function MenuDivider() {
   return <div className="my-1 border-t border-composer-border" />;
+}
+
+function splitIntoWordsLabel(voice: SplitVoice, count: number): string {
+  if (voice === "bg") {
+    return count > 1 ? `Split ${count} backgrounds into words` : "Split background into words";
+  }
+  return count > 1 ? `Split ${count} lines into words` : "Split into words";
 }
 
 // -- Component ----------------------------------------------------------------
@@ -199,11 +207,7 @@ const TimelineContextMenu: React.FC = () => {
               <>
                 <MenuDivider />
                 <MenuItem
-                  label={
-                    splitIntoWordsInfo.count > 1
-                      ? `Split ${splitIntoWordsInfo.count} lines into words`
-                      : "Split into words"
-                  }
+                  label={splitIntoWordsLabel(splitIntoWordsInfo.voice, splitIntoWordsInfo.count)}
                   shortcut={getEffectiveKeysArray("timeline.splitIntoWords")}
                   onClick={handleSplitIntoWords}
                 />

--- a/src/views/timeline/timeline-context-menu.tsx
+++ b/src/views/timeline/timeline-context-menu.tsx
@@ -72,6 +72,7 @@ const TimelineContextMenu: React.FC = () => {
     groupedWordInfo,
     snapNeededInfo,
     placeLineHereInfo,
+    placeBackgroundHereInfo,
     splitIntoWordsInfo,
   } = targets;
 
@@ -89,6 +90,7 @@ const TimelineContextMenu: React.FC = () => {
 
   const {
     handlePlaceLineHere,
+    handlePlaceBackgroundHere,
     handleAddLine,
     handleDeleteLine,
     handleDetachLine,
@@ -253,6 +255,7 @@ const TimelineContextMenu: React.FC = () => {
           <>
             <MenuItem label="Add word here" shortcut={["Double Click"]} onClick={handleAddWordHere} />
             {placeLineHereInfo && <MenuItem label="Place line here" onClick={handlePlaceLineHere} />}
+            {placeBackgroundHereInfo && <MenuItem label="Place background here" onClick={handlePlaceBackgroundHere} />}
             {groupableSelection && (
               <>
                 <MenuDivider />

--- a/src/views/timeline/timeline-context-menu.tsx
+++ b/src/views/timeline/timeline-context-menu.tsx
@@ -75,6 +75,7 @@ const TimelineContextMenu: React.FC = () => {
     lines,
     explicitToggleContext,
     gutterLineGroupInfo,
+    gutterBackgroundInfo,
     groupableSelection,
     mergeInfo,
     groupedWordInfo,
@@ -101,6 +102,7 @@ const TimelineContextMenu: React.FC = () => {
     handlePlaceBackgroundHere,
     handleAddLine,
     handleDeleteLine,
+    handleRemoveBackground,
     handleDetachLine,
     handleAssignAgent,
     handleSplitIntoWords,
@@ -330,6 +332,7 @@ const TimelineContextMenu: React.FC = () => {
                 <MenuDivider />
               </>
             )}
+            {gutterBackgroundInfo && <MenuItem label="Remove background" onClick={handleRemoveBackground} danger />}
             <MenuItem label="Delete line" onClick={handleDeleteLine} danger />
           </>
         )}

--- a/src/views/timeline/timeline-header.tsx
+++ b/src/views/timeline/timeline-header.tsx
@@ -1,5 +1,6 @@
 import { isLinked } from "@/domain/instance/predicates";
 import { isLineSynced } from "@/domain/line/predicates";
+import { lineText, mainWords } from "@/domain/line/voices";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import type { WordTiming } from "@/domain/word/timing";
@@ -62,7 +63,10 @@ const TimelineHeader: React.FC<TimelineHeaderProps> = ({ onImportLyrics, scrollC
   const collapsedInstances = useTimelineStore((s) => s.collapsedInstances);
   const setInstanceCollapsed = useTimelineStore((s) => s.setInstanceCollapsed);
 
-  const hasUnexpandedLines = useMemo(() => lines.some((l) => !l.words?.length && l.text.trim().length > 0), [lines]);
+  const hasUnexpandedLines = useMemo(
+    () => lines.some((l) => !mainWords(l)?.length && lineText(l).trim().length > 0),
+    [lines],
+  );
 
   const instanceKeys = useMemo(() => {
     const keys = new Set<string>();
@@ -92,8 +96,8 @@ const TimelineHeader: React.FC<TimelineHeaderProps> = ({ onImportLyrics, scrollC
     const updates: Array<{ id: string; updates: { words?: WordTiming[]; begin?: undefined; end?: undefined } }> = [];
 
     for (const line of lines) {
-      if (line.words?.length) continue;
-      if (!line.text.trim()) continue;
+      if (mainWords(line)?.length) continue;
+      if (!lineText(line).trim()) continue;
 
       if (isLineSynced(line)) {
         const converted = convertLineToWord(line);
@@ -101,7 +105,7 @@ const TimelineHeader: React.FC<TimelineHeaderProps> = ({ onImportLyrics, scrollC
           updates.push({ id: line.id, updates: { words: converted.words, begin: undefined, end: undefined } });
         }
       } else {
-        const { parts, trailingSpace } = splitIntoWordsWithMeta(line.text);
+        const { parts, trailingSpace } = splitIntoWordsWithMeta(lineText(line));
         if (parts.length === 0) continue;
         const words: WordTiming[] = parts.map((part, i) => ({
           text: trailingSpace[i] ? `${part} ` : part,

--- a/src/views/timeline/timeline-header.tsx
+++ b/src/views/timeline/timeline-header.tsx
@@ -1,4 +1,5 @@
 import { isLinked } from "@/domain/instance/predicates";
+import { toFlat } from "@/domain/line/model";
 import { isLineSynced } from "@/domain/line/predicates";
 import { lineText, mainWords } from "@/domain/line/voices";
 import { useAudioStore } from "@/stores/audio";
@@ -100,7 +101,7 @@ const TimelineHeader: React.FC<TimelineHeaderProps> = ({ onImportLyrics, scrollC
       if (!lineText(line).trim()) continue;
 
       if (isLineSynced(line)) {
-        const converted = convertLineToWord(line);
+        const converted = convertLineToWord(toFlat(line));
         if (converted.words) {
           updates.push({ id: line.id, updates: { words: converted.words, begin: undefined, end: undefined } });
         }

--- a/src/views/timeline/timeline-info-panel.browser.test.tsx
+++ b/src/views/timeline/timeline-info-panel.browser.test.tsx
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { userEvent } from "vitest/browser";
+import { reconcileLine } from "@/domain/line/model";
+import { bgSource, bgText, bgWords, mainWords } from "@/domain/line/voices";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { createLine, createWord } from "@/test/factories";
@@ -54,8 +56,8 @@ describe("BackgroundTextEditor provenance", () => {
     await screen.getByPlaceholder("Background vocals").fill("ooh");
     await userEvent.keyboard("{Enter}");
 
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundText).toBe("ooh");
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
+    await expect.poll(() => bgText(useProjectStore.getState().lines[0])).toBe("ooh");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
   });
 
   it("flips an extraction-sourced background to manual when edited", async () => {
@@ -74,8 +76,8 @@ describe("BackgroundTextEditor provenance", () => {
     await screen.getByPlaceholder("Background vocals").fill("aah");
     await userEvent.keyboard("{Enter}");
 
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundText).toBe("aah");
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
+    await expect.poll(() => bgText(useProjectStore.getState().lines[0])).toBe("aah");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
   });
 
   it("clears all three background fields when the editor is emptied", async () => {
@@ -87,7 +89,7 @@ describe("BackgroundTextEditor provenance", () => {
       backgroundTextSource: "extraction",
     });
     useProjectStore.setState({
-      lines: [{ ...line, backgroundWords: [createWord({ text: "ooh", begin: 0, end: 1 })] }],
+      lines: [reconcileLine({ ...line, backgroundWords: [createWord({ text: "ooh", begin: 0, end: 1 })] })],
     });
     selectFirstWordOf("l1");
     const screen = await render(<TimelineInfoPanel />);
@@ -96,9 +98,9 @@ describe("BackgroundTextEditor provenance", () => {
     await screen.getByPlaceholder("Background vocals").fill("");
     await userEvent.keyboard("{Enter}");
 
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundText).toBeUndefined();
-    expect(useProjectStore.getState().lines[0].backgroundWords).toBeUndefined();
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBeUndefined();
+    await expect.poll(() => bgText(useProjectStore.getState().lines[0])).toBeUndefined();
+    expect(bgWords(useProjectStore.getState().lines[0])).toBeUndefined();
+    expect(bgSource(useProjectStore.getState().lines[0])).toBeUndefined();
   });
 });
 
@@ -122,8 +124,8 @@ describe("TimelineInfoPanel bg word retiming provenance", () => {
 
     await screen.getByRole("button", { name: /Set Begin/ }).click();
 
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundWords?.[0].begin).toBeCloseTo(1.3);
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
+    await expect.poll(() => bgWords(useProjectStore.getState().lines[0])?.[0].begin).toBeCloseTo(1.3);
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
   });
 
   it("stamps backgroundTextSource manual when a bg word's end is set to the cursor", async () => {
@@ -134,8 +136,8 @@ describe("TimelineInfoPanel bg word retiming provenance", () => {
 
     await screen.getByRole("button", { name: /Set End/ }).click();
 
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundWords?.[0].end).toBeCloseTo(1.7);
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
+    await expect.poll(() => bgWords(useProjectStore.getState().lines[0])?.[0].end).toBeCloseTo(1.7);
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
   });
 
   it("leaves background provenance untouched when a main word's begin is retimed", async () => {
@@ -146,7 +148,7 @@ describe("TimelineInfoPanel bg word retiming provenance", () => {
 
     await screen.getByRole("button", { name: /Set Begin/ }).click();
 
-    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0].begin).toBeCloseTo(0.4);
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("extraction");
+    await expect.poll(() => mainWords(useProjectStore.getState().lines[0])?.[0].begin).toBeCloseTo(0.4);
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("extraction");
   });
 });

--- a/src/views/timeline/timeline-info-panel.browser.test.tsx
+++ b/src/views/timeline/timeline-info-panel.browser.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { userEvent } from "vitest/browser";
+import { bgBounds } from "@/domain/line/bounds";
 import { bgSource, bgText, bgWords, mainWords } from "@/domain/line/voices";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
@@ -56,6 +57,27 @@ describe("BackgroundTextEditor provenance", () => {
     await userEvent.keyboard("{Enter}");
 
     await expect.poll(() => bgText(useProjectStore.getState().lines[0])).toBe("ooh");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
+  });
+
+  it("regression: line-synced line keeps line-synced background (#122)", async () => {
+    const line = createLine({
+      id: "l1",
+      text: "lead",
+      begin: 0,
+      end: 4,
+    });
+    useProjectStore.setState({ lines: [line] });
+    selectFirstWordOf("l1");
+    const screen = await render(<TimelineInfoPanel />);
+
+    await screen.getByRole("button", { name: "Add BG" }).click();
+    await screen.getByPlaceholder("Background vocals").fill("ooh");
+    await userEvent.keyboard("{Enter}");
+
+    await expect.poll(() => bgText(useProjectStore.getState().lines[0])).toBe("ooh");
+    expect(bgBounds(useProjectStore.getState().lines[0])).not.toBeNull();
+    expect(bgWords(useProjectStore.getState().lines[0])).toBeUndefined();
     expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
   });
 

--- a/src/views/timeline/timeline-info-panel.browser.test.tsx
+++ b/src/views/timeline/timeline-info-panel.browser.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { userEvent } from "vitest/browser";
-import { reconcileLine } from "@/domain/line/model";
 import { bgSource, bgText, bgWords, mainWords } from "@/domain/line/voices";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
@@ -86,11 +85,10 @@ describe("BackgroundTextEditor provenance", () => {
       text: "hello",
       words: [createWord({ text: "hello", begin: 0, end: 1 })],
       backgroundText: "ooh",
+      backgroundWords: [createWord({ text: "ooh", begin: 0, end: 1 })],
       backgroundTextSource: "extraction",
     });
-    useProjectStore.setState({
-      lines: [reconcileLine({ ...line, backgroundWords: [createWord({ text: "ooh", begin: 0, end: 1 })] })],
-    });
+    useProjectStore.setState({ lines: [line] });
     selectFirstWordOf("l1");
     const screen = await render(<TimelineInfoPanel />);
 

--- a/src/views/timeline/timeline-info-panel.tsx
+++ b/src/views/timeline/timeline-info-panel.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/ui/button";
 import { createBgWordsFromLine } from "@/utils/sync-helpers";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { isLineSynced } from "@/domain/line/predicates";
+import { bgText, bgWords, mainWords } from "@/domain/line/voices";
 import { getEffectiveLines } from "@/domain/line/effective-words";
 import { formatTime } from "@/views/timeline/utils";
 import { IconBracketsContainEnd, IconBracketsContainStart, IconLink } from "@tabler/icons-react";
@@ -25,8 +26,11 @@ const BackgroundTextEditor: React.FC<{ lineId: string; backgroundText?: string }
     const trimmed = value.trim() || undefined;
     if (trimmed) {
       const line = useProjectStore.getState().lines.find((l) => l.id === lineId);
-      const bgWords = line ? createBgWordsFromLine({ ...line, backgroundText: trimmed }) : null;
-      updateLineWithHistory(lineId, backgroundFields({ text: trimmed, words: bgWords ?? undefined, source: "manual" }));
+      const derivedBgWords = line ? createBgWordsFromLine({ ...line, backgroundText: trimmed }) : null;
+      updateLineWithHistory(
+        lineId,
+        backgroundFields({ text: trimmed, words: derivedBgWords ?? undefined, source: "manual" }),
+      );
     } else {
       updateLineWithHistory(lineId, CLEARED_BACKGROUND);
     }
@@ -126,7 +130,7 @@ const TimelineInfoPanel: React.FC = () => {
     const line = lines[selectedWord.lineIndex];
     if (!line) return null;
 
-    const wordsArray = selectedWord.type === "word" ? line.words : line.backgroundWords;
+    const wordsArray = selectedWord.type === "word" ? mainWords(line) : bgWords(line);
     if (!wordsArray) return null;
 
     const word = wordsArray[selectedWord.wordIndex];
@@ -145,7 +149,7 @@ const TimelineInfoPanel: React.FC = () => {
     for (const sel of selectedWords) {
       const line = lines[sel.lineIndex];
       if (!line) continue;
-      const wordsArray = sel.type === "word" ? line.words : line.backgroundWords;
+      const wordsArray = sel.type === "word" ? mainWords(line) : bgWords(line);
       const word = wordsArray?.[sel.wordIndex];
       if (!word) continue;
       minBegin = Math.min(minBegin, word.begin);
@@ -167,7 +171,7 @@ const TimelineInfoPanel: React.FC = () => {
     const line = lines[selectedWord.lineIndex];
     if (!line) return;
 
-    const wordsArray = selectedWord.type === "word" ? line.words : line.backgroundWords;
+    const wordsArray = selectedWord.type === "word" ? mainWords(line) : bgWords(line);
     if (!wordsArray) return;
 
     const audioEl = useAudioStore.getState().audioElement;
@@ -196,7 +200,7 @@ const TimelineInfoPanel: React.FC = () => {
     const line = lines[selectedWord.lineIndex];
     if (!line) return;
 
-    const wordsArray = selectedWord.type === "word" ? line.words : line.backgroundWords;
+    const wordsArray = selectedWord.type === "word" ? mainWords(line) : bgWords(line);
     if (!wordsArray) return;
 
     const audioEl = useAudioStore.getState().audioElement;
@@ -309,7 +313,7 @@ const TimelineInfoPanel: React.FC = () => {
         </div>
       </div>
 
-      <BackgroundTextEditor lineId={line.id} backgroundText={line.backgroundText} />
+      <BackgroundTextEditor lineId={line.id} backgroundText={bgText(line)} />
 
       <div className="flex items-center gap-2 ml-auto">
         <Button variant="secondary" size="sm" hasIcon onClick={handleSetBeginToCursor} title="Set begin to cursor ([)">

--- a/src/views/timeline/timeline-info-panel.tsx
+++ b/src/views/timeline/timeline-info-panel.tsx
@@ -1,10 +1,8 @@
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { getAgentColor } from "@/domain/agent/colors";
-import { backgroundFields, CLEARED_BACKGROUND, manualBackgroundWordEdit } from "@/domain/line/background";
-import { reconcileLine, toFlat } from "@/domain/line/model";
+import { manualBackgroundWordEdit } from "@/domain/line/background";
 import { Button } from "@/ui/button";
-import { createBgWordsFromLine } from "@/utils/sync-helpers";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { isLineSynced } from "@/domain/line/predicates";
 import { bgText, bgWords, mainWords } from "@/domain/line/voices";
@@ -21,24 +19,11 @@ const BackgroundTextEditor: React.FC<{ lineId: string; backgroundText?: string }
   const focusOnMount = useCallback((el: HTMLInputElement | null) => {
     el?.focus();
   }, []);
-  const updateLineWithHistory = useProjectStore((s) => s.updateLineWithHistory);
-
   const handleCommit = useCallback(() => {
-    const trimmed = value.trim() || undefined;
-    if (trimmed) {
-      const line = useProjectStore.getState().lines.find((l) => l.id === lineId);
-      const derivedBgWords = line
-        ? createBgWordsFromLine(reconcileLine({ ...toFlat(line), backgroundText: trimmed }))
-        : null;
-      updateLineWithHistory(
-        lineId,
-        backgroundFields({ text: trimmed, words: derivedBgWords ?? undefined, source: "manual" }),
-      );
-    } else {
-      updateLineWithHistory(lineId, CLEARED_BACKGROUND);
-    }
+    const trimmed = value.trim();
+    useProjectStore.getState().applyLineBackground(lineId, { text: trimmed, source: "manual" });
     setIsEditing(false);
-  }, [lineId, value, updateLineWithHistory]);
+  }, [lineId, value]);
 
   if (!isEditing) {
     return (

--- a/src/views/timeline/timeline-info-panel.tsx
+++ b/src/views/timeline/timeline-info-panel.tsx
@@ -2,6 +2,7 @@ import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { getAgentColor } from "@/domain/agent/colors";
 import { backgroundFields, CLEARED_BACKGROUND, manualBackgroundWordEdit } from "@/domain/line/background";
+import { reconcileLine, toFlat } from "@/domain/line/model";
 import { Button } from "@/ui/button";
 import { createBgWordsFromLine } from "@/utils/sync-helpers";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
@@ -26,7 +27,9 @@ const BackgroundTextEditor: React.FC<{ lineId: string; backgroundText?: string }
     const trimmed = value.trim() || undefined;
     if (trimmed) {
       const line = useProjectStore.getState().lines.find((l) => l.id === lineId);
-      const derivedBgWords = line ? createBgWordsFromLine({ ...line, backgroundText: trimmed }) : null;
+      const derivedBgWords = line
+        ? createBgWordsFromLine(reconcileLine({ ...toFlat(line), backgroundText: trimmed }))
+        : null;
       updateLineWithHistory(
         lineId,
         backgroundFields({ text: trimmed, words: derivedBgWords ?? undefined, source: "manual" }),

--- a/src/views/timeline/timeline-panel.tsx
+++ b/src/views/timeline/timeline-panel.tsx
@@ -39,6 +39,7 @@ import { useTimelinePan } from "@/views/timeline/use-timeline-pan";
 import { useTimelineWheel } from "@/views/timeline/use-timeline-wheel";
 import { mainBounds } from "@/domain/line/bounds";
 import { getEffectiveLines } from "@/domain/line/effective-words";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { computeRowLayout, distributeLinesTiming } from "@/views/timeline/utils";
 import { GROUP_HEADER_HEIGHT } from "@/views/timeline/group-header-row";
 import { IconMusic } from "@tabler/icons-react";
@@ -108,7 +109,7 @@ function makeDragOverlapCheck(
 ) {
   const line = lines.find((l) => l.id === data.lineId);
   if (!line) return () => true;
-  const wordsArr = data.trackType === "word" ? (line.words ?? []) : (line.backgroundWords ?? []);
+  const wordsArr = data.trackType === "word" ? (mainWords(line) ?? []) : (bgWords(line) ?? []);
   return (shift: number) => {
     const newBegin = data.begin + shift;
     const newEnd = data.end + shift;
@@ -198,7 +199,7 @@ const TimelinePanel: React.FC = () => {
     const valid = selectedWords.filter((sel) => {
       const line = effectiveLines[sel.lineIndex];
       if (!line || line.id !== sel.lineId) return false;
-      const words = sel.type === "word" ? line.words : line.backgroundWords;
+      const words = sel.type === "word" ? mainWords(line) : bgWords(line);
       return !!words?.[sel.wordIndex];
     });
     if (valid.length < selectedWords.length) {
@@ -266,7 +267,8 @@ const TimelinePanel: React.FC = () => {
       const pos = layout.lineTops.get(line.id);
       if (!pos) continue;
       const mainH = rowHeights[line.id] ?? defaultRowHeight;
-      const hasBg = line.backgroundWords && line.backgroundWords.length > 0;
+      const lineBgWords = bgWords(line);
+      const hasBg = lineBgWords && lineBgWords.length > 0;
       const bgH = hasBg ? mainH : BG_DROP_ZONE_HEIGHT;
       rowTops[line.id] = pos.top;
       rowMainHeights[line.id] = mainH;
@@ -297,7 +299,7 @@ const TimelinePanel: React.FC = () => {
     const seen = new Set<string>();
     for (const sel of baseSelections) {
       const line = lineById.get(sel.lineId);
-      const wordsArray = sel.type === "word" ? line?.words : line?.backgroundWords;
+      const wordsArray = line ? (sel.type === "word" ? mainWords(line) : bgWords(line)) : undefined;
       if (!line || !wordsArray) continue;
       const indices = expandSelectionToGroupmates(wordsArray, [sel.wordIndex]);
       for (const idx of indices) {
@@ -332,7 +334,7 @@ const TimelinePanel: React.FC = () => {
       let positions = positionsByLineTrack.get(key);
       if (!positions) {
         const line = lineById.get(lineId);
-        const wordsArray = type === "word" ? line?.words : line?.backgroundWords;
+        const wordsArray = line ? (type === "word" ? mainWords(line) : bgWords(line)) : undefined;
         positions = wordsArray ? getSyllablePositions(wordsArray) : [];
         positionsByLineTrack.set(key, positions);
       }
@@ -341,7 +343,7 @@ const TimelinePanel: React.FC = () => {
 
     const cells = wordsToShow.map((sel) => {
       const line = lineById.get(sel.lineId);
-      const wordsArray = sel.type === "word" ? line?.words : line?.backgroundWords;
+      const wordsArray = line ? (sel.type === "word" ? mainWords(line) : bgWords(line)) : undefined;
       const word = wordsArray?.[sel.wordIndex];
       if (!word || !line)
         return { text: "", left: 0, top: 0, width: 0, height: 0, syllablePosition: "none" as SyllablePosition };

--- a/src/views/timeline/timeline-panel.tsx
+++ b/src/views/timeline/timeline-panel.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/utils/cn";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { getAgentColor } from "@/domain/agent/colors";
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, toFlat, type LyricLine } from "@/domain/line/model";
 import { boundsOverlap } from "@/domain/word/overlap";
 import { selfKey } from "@/views/timeline/snap";
 import { useSnapBypass } from "@/views/timeline/use-snap-bypass";
@@ -187,7 +187,7 @@ const TimelinePanel: React.FC = () => {
     const hasAnyTiming = lines.some((l) => mainBounds(l) !== null);
 
     if (!hasAnyTiming) {
-      const distributed = distributeLinesTiming(lines, duration);
+      const distributed = distributeLinesTiming(lines.map(toFlat), duration).map(reconcileLine);
       setLines(distributed);
     }
     lastDistributedDurationRef.current = duration;

--- a/src/views/timeline/timeline-preview-sidebar.tsx
+++ b/src/views/timeline/timeline-preview-sidebar.tsx
@@ -2,6 +2,8 @@ import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { getAgentColor } from "@/domain/agent/colors";
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, lineText, mainWords } from "@/domain/line/voices";
+import type { WordTiming } from "@/domain/word/timing";
 import { Scroll } from "@/ui/scroll";
 import { stripSplitCharacter } from "@/utils/split-character";
 import { splitIntoWords } from "@/utils/sync-helpers";
@@ -42,7 +44,7 @@ const WordWithProgress: React.FC<{
 );
 
 const BgWordsRow: React.FC<{
-  backgroundWords: NonNullable<LyricLine["backgroundWords"]>;
+  backgroundWords: WordTiming[];
   lineIndex: number;
   alignmentClass: string;
 }> = ({ backgroundWords, lineIndex, alignmentClass }) => (
@@ -84,9 +86,10 @@ const MiniPreviewLine: React.FC<{
     />
   );
 
-  const words = line.words ?? [];
-  const bgWords = line.backgroundWords?.length ? (
-    <BgWordsRow backgroundWords={line.backgroundWords} lineIndex={lineIndex} alignmentClass={alignmentClass} />
+  const words = mainWords(line) ?? [];
+  const lineBgWords = bgWords(line);
+  const bgWordsRow = lineBgWords?.length ? (
+    <BgWordsRow backgroundWords={lineBgWords} lineIndex={lineIndex} alignmentClass={alignmentClass} />
   ) : null;
 
   if (granularity === "line") {
@@ -101,7 +104,7 @@ const MiniPreviewLine: React.FC<{
         <div className="flex items-center gap-2 text-sm font-medium">
           {alignment === "left" && AgentDotLeft}
           <span className="relative block truncate">
-            <span className="text-composer-text-muted">{stripSplitCharacter(line.text)}</span>
+            <span className="text-composer-text-muted">{stripSplitCharacter(lineText(line))}</span>
             <span
               className="absolute inset-0 text-composer-accent-text truncate"
               data-word-begin={timing?.begin ?? 0}
@@ -109,12 +112,12 @@ const MiniPreviewLine: React.FC<{
               data-line-idx={lineIndex}
               style={{ clipPath: "inset(0 100% 0 0)" }}
             >
-              {stripSplitCharacter(line.text)}
+              {stripSplitCharacter(lineText(line))}
             </span>
           </span>
           {alignment === "right" && AgentDotRight}
         </div>
-        {bgWords}
+        {bgWordsRow}
       </div>
     );
   }
@@ -139,14 +142,14 @@ const MiniPreviewLine: React.FC<{
                 lineIndex={lineIndex}
               />
             ))
-          : splitIntoWords(line.text).map((word, idx) => (
+          : splitIntoWords(lineText(line)).map((word, idx) => (
               <span key={`${idx}-${word}`} className="text-composer-text-muted">
                 {word}{" "}
               </span>
             ))}
         {alignment === "right" && AgentDotRight}
       </div>
-      {bgWords}
+      {bgWordsRow}
     </div>
   );
 };

--- a/src/views/timeline/timeline-rows.tsx
+++ b/src/views/timeline/timeline-rows.tsx
@@ -1,6 +1,7 @@
 import { useAudioStore } from "@/stores/audio";
 import { manualBackgroundWordEdit } from "@/domain/line/background";
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { useProjectStore } from "@/stores/project";
 import type { WordTiming } from "@/domain/word/timing";
 import { applyWordPatch } from "@/utils/word-patch";
@@ -94,9 +95,10 @@ const TimelineRows: React.FC<TimelineRowsProps> = ({ scrollContainerRef }) => {
         return;
       }
 
-      if (!realLine.words) return;
+      const realMainWords = mainWords(realLine);
+      if (!realMainWords) return;
       const updatedWords = applyWordPatch(
-        realLine.words,
+        realMainWords,
         wordIndex,
         updates,
         adjacentIndex !== undefined && adjacentUpdates ? { index: adjacentIndex, updates: adjacentUpdates } : undefined,
@@ -116,10 +118,11 @@ const TimelineRows: React.FC<TimelineRowsProps> = ({ scrollContainerRef }) => {
       adjacentUpdates?: Partial<WordTiming>,
     ) => {
       const line = lines.find((l) => l.id === lineId);
-      if (!line?.backgroundWords) return;
+      const lineBgWords = line ? bgWords(line) : undefined;
+      if (!lineBgWords) return;
 
       const updatedWords = applyWordPatch(
-        line.backgroundWords,
+        lineBgWords,
         wordIndex,
         updates,
         adjacentIndex !== undefined && adjacentUpdates ? { index: adjacentIndex, updates: adjacentUpdates } : undefined,
@@ -138,7 +141,8 @@ const TimelineRows: React.FC<TimelineRowsProps> = ({ scrollContainerRef }) => {
       if (!row) return DEFAULT_ROW_HEIGHT + BG_DROP_ZONE_HEIGHT;
       if (row.kind === "group-header") return GROUP_HEADER_HEIGHT;
       const mainHeight = rowHeights[row.line.id] ?? DEFAULT_ROW_HEIGHT;
-      const hasBgWords = row.line.backgroundWords && row.line.backgroundWords.length > 0;
+      const rowBgWords = bgWords(row.line);
+      const hasBgWords = rowBgWords && rowBgWords.length > 0;
       return mainHeight + (hasBgWords ? mainHeight : BG_DROP_ZONE_HEIGHT) + 1;
     },
     [visibleRows, rowHeights],

--- a/src/views/timeline/timeline-rows.tsx
+++ b/src/views/timeline/timeline-rows.tsx
@@ -1,6 +1,6 @@
 import { useAudioStore } from "@/stores/audio";
 import { manualBackgroundWordEdit } from "@/domain/line/background";
-import type { LyricLine } from "@/domain/line/model";
+import type { LooseLine } from "@/domain/line/model";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import { useProjectStore } from "@/stores/project";
 import type { WordTiming } from "@/domain/word/timing";
@@ -88,7 +88,7 @@ const TimelineRows: React.FC<TimelineRowsProps> = ({ scrollContainerRef }) => {
       if (!realLine) return;
 
       if (isLineSynced(realLine)) {
-        const lineUpdates: Partial<LyricLine> = {};
+        const lineUpdates: Partial<LooseLine> = {};
         if (updates.begin !== undefined) lineUpdates.begin = updates.begin;
         if (updates.end !== undefined) lineUpdates.end = updates.end;
         updateLineWithHistory(lineId, lineUpdates, { propagateToSiblings: false });

--- a/src/views/timeline/timeline-syllable-splitter-apply-to-all.browser.test.tsx
+++ b/src/views/timeline/timeline-syllable-splitter-apply-to-all.browser.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { mainWords } from "@/domain/line/voices";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
@@ -89,7 +90,7 @@ describe("TimelineSyllableSplitter apply-to-all wiring", () => {
     await screen.getByRole("button", { name: "Split all" }).click();
     await screen.getByRole("button", { name: "Split" }).click();
 
-    await expect.poll(() => useProjectStore.getState().lines[1].words?.length).toBe(2);
+    await expect.poll(() => mainWords(useProjectStore.getState().lines[1])?.length).toBe(2);
     await expect.poll(() => document.querySelector("dialog")).toBeNull();
   });
 
@@ -124,7 +125,7 @@ describe("TimelineSyllableSplitter apply-to-all wiring", () => {
     await screen.getByLabelText("Apply to all identical words").click();
     await screen.getByRole("button", { name: "Split all" }).click();
 
-    await expect.poll(() => useProjectStore.getState().lines[1].words?.length).toBe(2);
+    await expect.poll(() => mainWords(useProjectStore.getState().lines[1])?.length).toBe(2);
   });
 
   it("single-word path (apply-to-all off) writes via the divergence-aware flow", async () => {
@@ -138,8 +139,8 @@ describe("TimelineSyllableSplitter apply-to-all wiring", () => {
     await screen.getByRole("button", { name: "Split point 3" }).click();
     await screen.getByRole("button", { name: "Split Word" }).click();
 
-    await expect.poll(() => useProjectStore.getState().lines[0].words?.length).toBe(2);
-    expect(useProjectStore.getState().lines[1].words?.length).toBe(1);
+    await expect.poll(() => mainWords(useProjectStore.getState().lines[0])?.length).toBe(2);
+    expect(mainWords(useProjectStore.getState().lines[1])?.length).toBe(1);
   });
 
   it("persists checkbox state to syllableSplitDefaults after a successful split", async () => {
@@ -178,8 +179,8 @@ describe("TimelineSyllableSplitter apply-to-all wiring", () => {
     await screen.getByRole("button", { name: "Split point 3" }).click();
     await screen.getByRole("button", { name: "Split Word" }).click();
 
-    await expect.poll(() => useProjectStore.getState().lines[0].words?.length).toBe(2);
-    const wordsAfter = useProjectStore.getState().lines[0].words ?? [];
+    await expect.poll(() => mainWords(useProjectStore.getState().lines[0])?.length).toBe(2);
+    const wordsAfter = mainWords(useProjectStore.getState().lines[0]) ?? [];
     expect(wordsAfter[0].end).toBeCloseTo(0.42, 5);
     expect(wordsAfter[1].begin).toBeCloseTo(0.42, 5);
     expect(wordsAfter[0].syllableGroupId).toBeDefined();

--- a/src/views/timeline/timeline-syllable-splitter.browser.test.tsx
+++ b/src/views/timeline/timeline-syllable-splitter.browser.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { lineText, mainWords } from "@/domain/line/voices";
 import { TimelineSyllableSplitter } from "@/views/timeline/timeline-syllable-splitter";
 import { useProjectStore } from "@/stores/project";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
@@ -61,10 +62,10 @@ describe("TimelineSyllableSplitter", () => {
     await screen.getByRole("button", { name: "Split Word" }).click();
 
     await vi.waitFor(() => {
-      const words = useProjectStore.getState().lines[0].words ?? [];
+      const words = mainWords(useProjectStore.getState().lines[0]) ?? [];
       expect(words.map((w) => w.text)).toEqual(["ev", "er", "y"]);
     });
-    const wordsAfter = useProjectStore.getState().lines[0].words ?? [];
+    const wordsAfter = mainWords(useProjectStore.getState().lines[0]) ?? [];
     const ids = wordsAfter.map((w) => w.syllableGroupId);
     expect(ids[0]).toBeDefined();
     expect(ids[0]).toBe(ids[1]);
@@ -98,10 +99,10 @@ describe("TimelineSyllableSplitter", () => {
     await screen.getByRole("button", { name: "Split Word" }).click();
 
     await vi.waitFor(() => {
-      const words = useProjectStore.getState().lines[0].words ?? [];
+      const words = mainWords(useProjectStore.getState().lines[0]) ?? [];
       expect(words.length).toBe(4);
     });
-    const wordsAfter = useProjectStore.getState().lines[0].words ?? [];
+    const wordsAfter = mainWords(useProjectStore.getState().lines[0]) ?? [];
     expect(wordsAfter.every((w) => w.syllableGroupId === "g_source")).toBe(true);
   });
 
@@ -126,10 +127,10 @@ describe("TimelineSyllableSplitter", () => {
     await screen.getByRole("button", { name: "Split Word" }).click();
 
     await vi.waitFor(() => {
-      const words = useProjectStore.getState().lines[0].words ?? [];
+      const words = mainWords(useProjectStore.getState().lines[0]) ?? [];
       expect(words.length).toBe(2);
     });
-    const wordsAfter = useProjectStore.getState().lines[0].words ?? [];
+    const wordsAfter = mainWords(useProjectStore.getState().lines[0]) ?? [];
     expect(wordsAfter.map((w) => w.text)).toEqual(["hel ", "lo"]);
     expect(wordsAfter.every((w) => w.syllableGroupId === undefined)).toBe(true);
   });
@@ -182,12 +183,12 @@ describe("TimelineSyllableSplitter", () => {
     await screen.getByRole("button", { name: "Split Word" }).click();
 
     await vi.waitFor(() => {
-      const words = useProjectStore.getState().lines[0].words ?? [];
+      const words = mainWords(useProjectStore.getState().lines[0]) ?? [];
       expect(words.length).toBe(3);
     });
     const lineAfter = useProjectStore.getState().lines[0];
     // text is reconciled via reconstructLineText: the split char marks the
     // syllable joints so line.text tokenizes 1:1 back to line.words.
-    expect(lineAfter.text).toBe("ev|er|y");
+    expect(lineText(lineAfter)).toBe("ev|er|y");
   });
 });

--- a/src/views/timeline/timeline-syllable-splitter.tsx
+++ b/src/views/timeline/timeline-syllable-splitter.tsx
@@ -1,3 +1,4 @@
+import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { useProjectStore } from "@/stores/project";
 import { Modal } from "@/ui/modal";
@@ -30,7 +31,7 @@ const TimelineSyllableSplitter: React.FC = () => {
       const line = lines.find((l) => l.id === sel.lineId);
       if (!line) return;
 
-      const wordsArray = sel.type === "word" ? line.words : line.backgroundWords;
+      const wordsArray = sel.type === "word" ? mainWords(line) : bgWords(line);
       const word: WordTiming | undefined = wordsArray?.[sel.wordIndex];
       if (!word || word.text.trimEnd().length < 2) return;
 

--- a/src/views/timeline/use-context-menu-targets.browser.test.tsx
+++ b/src/views/timeline/use-context-menu-targets.browser.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { renderHook } from "vitest-browser-react";
+import { setBackground } from "@/domain/line/background";
+import { getEffectiveLines } from "@/domain/line/effective-words";
+import { reconcileLine } from "@/domain/line/model";
+import { useProjectStore } from "@/stores/project";
+import { useContextMenuTargets } from "@/views/timeline/use-context-menu-targets";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+
+// -- Helpers ------------------------------------------------------------------
+
+function lineSyncedMain(id: string) {
+  return reconcileLine({ id, text: "one two three", agentId: "v1", begin: 1, end: 4 });
+}
+
+function lineSyncedBg(id: string) {
+  const main = reconcileLine({ id, text: "lead", agentId: "v1", words: [{ text: "lead", begin: 0, end: 2 }] });
+  return setBackground(main, { text: "ooh ooh", begin: 3, end: 5, source: "manual" });
+}
+
+function wordSyncedMain(id: string) {
+  return reconcileLine({ id, text: "done", agentId: "v1", words: [{ text: "done", begin: 0, end: 1 }] });
+}
+
+function setLineAndTarget(rawLine: ReturnType<typeof reconcileLine>, type: "word" | "bg") {
+  useProjectStore.setState({ lines: [rawLine] });
+  const effective = getEffectiveLines([rawLine]);
+  const lineIndex = effective.findIndex((l) => l.id === rawLine.id);
+  useTimelineStore.setState({
+    contextMenu: { x: 0, y: 0, target: { kind: "word", lineId: rawLine.id, lineIndex, wordIndex: 0, type } },
+    selectedWords: [],
+  });
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("useContextMenuTargets · splitIntoWordsInfo voice", () => {
+  it("reports voice main for a line-synced main block target", async () => {
+    setLineAndTarget(lineSyncedMain("L1"), "word");
+    const { result } = await renderHook(() => useContextMenuTargets());
+    expect(result.current.splitIntoWordsInfo).toEqual({ count: 1, voice: "main" });
+  });
+
+  it("reports voice bg for a line-synced bg block target", async () => {
+    setLineAndTarget(lineSyncedBg("B1"), "bg");
+    const { result } = await renderHook(() => useContextMenuTargets());
+    expect(result.current.splitIntoWordsInfo).toEqual({ count: 1, voice: "bg" });
+  });
+
+  it("returns null for a word-synced main block target", async () => {
+    setLineAndTarget(wordSyncedMain("W1"), "word");
+    const { result } = await renderHook(() => useContextMenuTargets());
+    expect(result.current.splitIntoWordsInfo).toBeNull();
+  });
+
+  it("returns null for a word-synced bg block target", async () => {
+    const main = reconcileLine({ id: "WB", text: "lead", agentId: "v1", begin: 0, end: 1 });
+    const withWordBg = setBackground(main, {
+      text: "(echo)",
+      words: [{ text: "(echo)", begin: 2, end: 3 }],
+      source: "manual",
+    });
+    setLineAndTarget(withWordBg, "bg");
+    const { result } = await renderHook(() => useContextMenuTargets());
+    expect(result.current.splitIntoWordsInfo).toBeNull();
+  });
+
+  it("ignores a line-synced main when the target block is bg with no background", async () => {
+    setLineAndTarget(lineSyncedMain("L1"), "bg");
+    const { result } = await renderHook(() => useContextMenuTargets());
+    expect(result.current.splitIntoWordsInfo).toBeNull();
+  });
+
+  it("counts only same-type selected lines for a bg target", async () => {
+    const b1 = lineSyncedBg("B1");
+    const b2 = lineSyncedBg("B2");
+    useProjectStore.setState({ lines: [b1, b2] });
+    useTimelineStore.setState({
+      contextMenu: { x: 0, y: 0, target: { kind: "word", lineId: "B1", lineIndex: 0, wordIndex: 0, type: "bg" } },
+      // A main selection on B1 plus bg selections on B1 and B2: only the bg ones count.
+      selectedWords: [
+        { lineId: "B1", lineIndex: 0, wordIndex: 0, type: "word" },
+        { lineId: "B1", lineIndex: 0, wordIndex: 0, type: "bg" },
+        { lineId: "B2", lineIndex: 1, wordIndex: 0, type: "bg" },
+      ],
+    });
+    const { result } = await renderHook(() => useContextMenuTargets());
+    expect(result.current.splitIntoWordsInfo).toEqual({ count: 2, voice: "bg" });
+  });
+});

--- a/src/views/timeline/use-context-menu-targets.browser.test.tsx
+++ b/src/views/timeline/use-context-menu-targets.browser.test.tsx
@@ -32,6 +32,14 @@ function setLineAndTarget(rawLine: ReturnType<typeof reconcileLine>, type: "word
   });
 }
 
+function setGutterTarget(rawLine: ReturnType<typeof reconcileLine>) {
+  useProjectStore.setState({ lines: [rawLine] });
+  useTimelineStore.setState({
+    contextMenu: { x: 0, y: 0, target: { kind: "gutter", lineId: rawLine.id, lineIndex: 0 } },
+    selectedWords: [],
+  });
+}
+
 // -- Tests --------------------------------------------------------------------
 
 describe("useContextMenuTargets · splitIntoWordsInfo voice", () => {
@@ -86,5 +94,31 @@ describe("useContextMenuTargets · splitIntoWordsInfo voice", () => {
     });
     const { result } = await renderHook(() => useContextMenuTargets());
     expect(result.current.splitIntoWordsInfo).toEqual({ count: 2, voice: "bg" });
+  });
+});
+
+describe("useContextMenuTargets · gutterBackgroundInfo", () => {
+  it("is non-null for a gutter target on a line with an untimed bg", async () => {
+    setGutterTarget(reconcileLine({ id: "G1", text: "verse", agentId: "v1", backgroundText: "ooh" }));
+    const { result } = await renderHook(() => useContextMenuTargets());
+    expect(result.current.gutterBackgroundInfo).toEqual({ lineId: "G1" });
+  });
+
+  it("is non-null for a gutter target on a line with a line-synced bg", async () => {
+    setGutterTarget(lineSyncedBg("G2"));
+    const { result } = await renderHook(() => useContextMenuTargets());
+    expect(result.current.gutterBackgroundInfo).toEqual({ lineId: "G2" });
+  });
+
+  it("is null for a gutter target on a line with no bg", async () => {
+    setGutterTarget(reconcileLine({ id: "G3", text: "verse", agentId: "v1" }));
+    const { result } = await renderHook(() => useContextMenuTargets());
+    expect(result.current.gutterBackgroundInfo).toBeNull();
+  });
+
+  it("is null for a non-gutter (word) target even when the line has a bg", async () => {
+    setLineAndTarget(lineSyncedBg("G4"), "bg");
+    const { result } = await renderHook(() => useContextMenuTargets());
+    expect(result.current.gutterBackgroundInfo).toBeNull();
   });
 });

--- a/src/views/timeline/use-context-menu-targets.ts
+++ b/src/views/timeline/use-context-menu-targets.ts
@@ -9,7 +9,7 @@ import { hasIntraGroupGap } from "@/domain/word/syllable-groups";
 import { fieldWords } from "@/stores/project/lines-slice-helpers";
 import { useProjectStore } from "@/stores/project";
 import { createGroupFromSelection, fillSelectionGaps } from "@/views/timeline/group-ops";
-import type { SplitVoice } from "@/views/timeline/split-lines-into-words";
+import { splitTargetLineIds, type SplitVoice } from "@/views/timeline/split-lines-into-words";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { useMemo } from "react";
 
@@ -139,10 +139,7 @@ function useContextMenuTargets() {
     const target = contextMenu.target;
     const voice: SplitVoice = target.type === "word" ? "main" : "bg";
 
-    const sameVoiceLineIds = selectedWords.flatMap((w) => (w.type === target.type ? [w.lineId] : []));
-    const selectedLineIds = new Set(sameVoiceLineIds);
-    const targetIds =
-      selectedLineIds.has(target.lineId) && selectedLineIds.size > 0 ? [...selectedLineIds] : [target.lineId];
+    const targetIds = splitTargetLineIds(selectedWords, target.type, target.lineId);
 
     const rawLinesById = new Map(rawLines.map((l) => [l.id, l] as const));
     const lineSyncedIds = targetIds.filter((id) => {

--- a/src/views/timeline/use-context-menu-targets.ts
+++ b/src/views/timeline/use-context-menu-targets.ts
@@ -2,12 +2,14 @@ import { bgBounds, mainBounds } from "@/domain/line/bounds";
 import type { LyricLine } from "@/domain/line/model";
 import { getEffectiveLines } from "@/domain/line/effective-words";
 import { isLineSynced } from "@/domain/line/predicates";
-import { bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { bgText, bgVoice, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { contiguousSelectionRun } from "@/domain/selection/contiguous";
+import { isLineSynced as isVoiceLineSynced } from "@/domain/voice/predicates";
 import { hasIntraGroupGap } from "@/domain/word/syllable-groups";
 import { fieldWords } from "@/stores/project/lines-slice-helpers";
 import { useProjectStore } from "@/stores/project";
 import { createGroupFromSelection, fillSelectionGaps } from "@/views/timeline/group-ops";
+import type { SplitVoice } from "@/views/timeline/split-lines-into-words";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { useMemo } from "react";
 
@@ -135,19 +137,24 @@ function useContextMenuTargets() {
   const splitIntoWordsInfo = useMemo(() => {
     if (!contextMenu || contextMenu.target.kind !== "word") return null;
     const target = contextMenu.target;
+    const voice: SplitVoice = target.type === "word" ? "main" : "bg";
 
-    const selectedLineIds = new Set(selectedWords.map((w) => w.lineId));
+    const sameVoiceLineIds = selectedWords.flatMap((w) => (w.type === target.type ? [w.lineId] : []));
+    const selectedLineIds = new Set(sameVoiceLineIds);
     const targetIds =
       selectedLineIds.has(target.lineId) && selectedLineIds.size > 0 ? [...selectedLineIds] : [target.lineId];
 
     const rawLinesById = new Map(rawLines.map((l) => [l.id, l] as const));
     const lineSyncedIds = targetIds.filter((id) => {
       const realLine = rawLinesById.get(id);
-      return realLine && isLineSynced(realLine);
+      if (!realLine) return false;
+      if (voice === "main") return isLineSynced(realLine);
+      const bg = bgVoice(realLine);
+      return bg !== null && isVoiceLineSynced(bg);
     });
 
     if (lineSyncedIds.length === 0) return null;
-    return { count: lineSyncedIds.length };
+    return { count: lineSyncedIds.length, voice };
   }, [contextMenu, selectedWords, rawLines]);
 
   return {

--- a/src/views/timeline/use-context-menu-targets.ts
+++ b/src/views/timeline/use-context-menu-targets.ts
@@ -52,6 +52,14 @@ function useContextMenuTargets() {
     return { lineId, groupId: realLine.groupId };
   }, [contextMenu, rawLines]);
 
+  const gutterBackgroundInfo = useMemo(() => {
+    if (!contextMenu || contextMenu.target.kind !== "gutter") return null;
+    const { lineId } = contextMenu.target;
+    const realLine = rawLines.find((l) => l.id === lineId);
+    if (!realLine || bgVoice(realLine) === null) return null;
+    return { lineId };
+  }, [contextMenu, rawLines]);
+
   const groupableSelection = useMemo(() => {
     if (!contextMenu) return null;
     const target = contextMenu.target;
@@ -158,6 +166,7 @@ function useContextMenuTargets() {
     lines,
     explicitToggleContext,
     gutterLineGroupInfo,
+    gutterBackgroundInfo,
     groupableSelection,
     mergeInfo,
     groupedWordInfo,

--- a/src/views/timeline/use-context-menu-targets.ts
+++ b/src/views/timeline/use-context-menu-targets.ts
@@ -115,7 +115,8 @@ function useContextMenuTargets() {
     const trackTarget = contextMenu.target;
     const targetLine = rawLines.find((l) => l.id === trackTarget.lineId);
     if (!targetLine) return null;
-    const canPlace = lineText(targetLine).trim() !== "" && !mainWords(targetLine)?.length && mainBounds(targetLine) === null;
+    const canPlace =
+      lineText(targetLine).trim() !== "" && !mainWords(targetLine)?.length && mainBounds(targetLine) === null;
     return canPlace ? targetLine : null;
   }, [contextMenu, rawLines]);
 

--- a/src/views/timeline/use-context-menu-targets.ts
+++ b/src/views/timeline/use-context-menu-targets.ts
@@ -1,8 +1,8 @@
-import { mainBounds } from "@/domain/line/bounds";
+import { bgBounds, mainBounds } from "@/domain/line/bounds";
 import type { LyricLine } from "@/domain/line/model";
 import { getEffectiveLines } from "@/domain/line/effective-words";
 import { isLineSynced } from "@/domain/line/predicates";
-import { bgWords, lineText, mainWords } from "@/domain/line/voices";
+import { bgText, bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { contiguousSelectionRun } from "@/domain/selection/contiguous";
 import { hasIntraGroupGap } from "@/domain/word/syllable-groups";
 import { fieldWords } from "@/stores/project/lines-slice-helpers";
@@ -113,10 +113,22 @@ function useContextMenuTargets() {
   const placeLineHereInfo = useMemo(() => {
     if (!contextMenu || contextMenu.target.kind !== "track") return null;
     const trackTarget = contextMenu.target;
+    if (trackTarget.type !== "word") return null;
     const targetLine = rawLines.find((l) => l.id === trackTarget.lineId);
     if (!targetLine) return null;
     const canPlace =
       lineText(targetLine).trim() !== "" && !mainWords(targetLine)?.length && mainBounds(targetLine) === null;
+    return canPlace ? targetLine : null;
+  }, [contextMenu, rawLines]);
+
+  const placeBackgroundHereInfo = useMemo(() => {
+    if (!contextMenu || contextMenu.target.kind !== "track") return null;
+    const trackTarget = contextMenu.target;
+    if (trackTarget.type !== "bg") return null;
+    const targetLine = rawLines.find((l) => l.id === trackTarget.lineId);
+    if (!targetLine) return null;
+    const canPlace =
+      (bgText(targetLine)?.trim() ?? "") !== "" && !bgWords(targetLine)?.length && bgBounds(targetLine) === null;
     return canPlace ? targetLine : null;
   }, [contextMenu, rawLines]);
 
@@ -147,6 +159,7 @@ function useContextMenuTargets() {
     groupedWordInfo,
     snapNeededInfo,
     placeLineHereInfo,
+    placeBackgroundHereInfo,
     splitIntoWordsInfo,
   };
 }

--- a/src/views/timeline/use-context-menu-targets.ts
+++ b/src/views/timeline/use-context-menu-targets.ts
@@ -1,8 +1,11 @@
+import { mainBounds } from "@/domain/line/bounds";
 import type { LyricLine } from "@/domain/line/model";
 import { getEffectiveLines } from "@/domain/line/effective-words";
 import { isLineSynced } from "@/domain/line/predicates";
+import { bgWords, lineText, mainWords } from "@/domain/line/voices";
 import { contiguousSelectionRun } from "@/domain/selection/contiguous";
 import { hasIntraGroupGap } from "@/domain/word/syllable-groups";
+import { fieldWords } from "@/stores/project/lines-slice-helpers";
 import { useProjectStore } from "@/stores/project";
 import { createGroupFromSelection, fillSelectionGaps } from "@/views/timeline/group-ops";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
@@ -23,7 +26,7 @@ function useContextMenuTargets() {
     const line = rawLines.find((l) => l.id === lineId);
     if (!line) return null;
     const field: "words" | "backgroundWords" = type === "word" ? "words" : "backgroundWords";
-    const wordsArray = line[field];
+    const wordsArray = fieldWords(line, field);
     if (!wordsArray || wordsArray.length === 0) return null;
 
     const selectedWords = useTimelineStore.getState().selectedWords;
@@ -82,7 +85,7 @@ function useContextMenuTargets() {
 
     const line = lines.find((l) => l.id === run.lineId);
     if (!line) return null;
-    const wordsArray = run.type === "word" ? line.words : line.backgroundWords;
+    const wordsArray = run.type === "word" ? mainWords(line) : bgWords(line);
     if (!wordsArray) return null;
 
     return { indices: run.indices, lineId: run.lineId, type: run.type };
@@ -94,7 +97,7 @@ function useContextMenuTargets() {
     const line = rawLines.find((l) => l.id === lineId);
     if (!line) return null;
     const field: "words" | "backgroundWords" = type === "word" ? "words" : "backgroundWords";
-    const word = line[field]?.[wordIndex];
+    const word = fieldWords(line, field)?.[wordIndex];
     if (!word || word.syllableGroupId === undefined) return null;
     return { lineId, field, wordIndex };
   }, [contextMenu, rawLines]);
@@ -102,7 +105,7 @@ function useContextMenuTargets() {
   const snapNeededInfo = useMemo(() => {
     if (!groupedWordInfo) return null;
     const line = rawLines.find((l) => l.id === groupedWordInfo.lineId);
-    const words = line?.[groupedWordInfo.field];
+    const words = line ? fieldWords(line, groupedWordInfo.field) : undefined;
     if (!words) return null;
     return hasIntraGroupGap(words) ? groupedWordInfo : null;
   }, [groupedWordInfo, rawLines]);
@@ -112,7 +115,7 @@ function useContextMenuTargets() {
     const trackTarget = contextMenu.target;
     const targetLine = rawLines.find((l) => l.id === trackTarget.lineId);
     if (!targetLine) return null;
-    const canPlace = targetLine.text.trim() !== "" && !targetLine.words?.length && targetLine.begin === undefined;
+    const canPlace = lineText(targetLine).trim() !== "" && !mainWords(targetLine)?.length && mainBounds(targetLine) === null;
     return canPlace ? targetLine : null;
   }, [contextMenu, rawLines]);
 

--- a/src/views/timeline/use-instance-menu-actions.ts
+++ b/src/views/timeline/use-instance-menu-actions.ts
@@ -1,5 +1,6 @@
 import { instanceBounds } from "@/domain/instance/bounds";
 import { linesOfInstance } from "@/domain/instance/enumerate";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordSelection } from "@/domain/selection/model";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
@@ -106,10 +107,10 @@ function useInstanceMenuActions(clearContextMenu: () => void) {
       for (let li = 0; li < projectLines.length; li++) {
         const line = projectLines[li];
         if (line.groupId !== groupId || line.instanceIdx !== next) continue;
-        for (let wi = 0; wi < (line.words?.length ?? 0); wi++) {
+        for (let wi = 0; wi < (mainWords(line)?.length ?? 0); wi++) {
           wordsInNext.push({ lineId: line.id, lineIndex: li, wordIndex: wi, type: "word" });
         }
-        for (let wi = 0; wi < (line.backgroundWords?.length ?? 0); wi++) {
+        for (let wi = 0; wi < (bgWords(line)?.length ?? 0); wi++) {
           wordsInNext.push({ lineId: line.id, lineIndex: li, wordIndex: wi, type: "bg" });
         }
       }

--- a/src/views/timeline/use-line-menu-actions.ts
+++ b/src/views/timeline/use-line-menu-actions.ts
@@ -3,7 +3,7 @@ import { placeVoice } from "@/domain/line/place-voice";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import { showGroupActionToast } from "@/utils/group-toast";
-import { splitLinesIntoWords } from "@/views/timeline/split-lines-into-words";
+import { splitVoiceIntoWords } from "@/views/timeline/split-lines-into-words";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import type { useContextMenuTargets } from "@/views/timeline/use-context-menu-targets";
 import { useCallback } from "react";
@@ -15,7 +15,7 @@ type ContextMenuTargets = ReturnType<typeof useContextMenuTargets>;
 // -- Hook ---------------------------------------------------------------------
 
 function useLineMenuActions(targets: ContextMenuTargets, clearContextMenu: () => void) {
-  const { lines, gutterLineGroupInfo } = targets;
+  const { lines, gutterLineGroupInfo, splitIntoWordsInfo } = targets;
   const contextMenu = useTimelineStore((s) => s.contextMenu);
   const selectedWords = useTimelineStore((s) => s.selectedWords);
   const rawLines = useProjectStore((s) => s.lines);
@@ -95,15 +95,17 @@ function useLineMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
   );
 
   const handleSplitIntoWords = useCallback(() => {
-    if (!contextMenu || contextMenu.target.kind !== "word") return;
-    const { lineId } = contextMenu.target;
+    if (!contextMenu || contextMenu.target.kind !== "word" || !splitIntoWordsInfo) return;
+    const { lineId, type } = contextMenu.target;
+    const { voice } = splitIntoWordsInfo;
 
-    const selectedLineIds = new Set(selectedWords.map((w) => w.lineId));
+    const sameVoiceLineIds = selectedWords.flatMap((w) => (w.type === type ? [w.lineId] : []));
+    const selectedLineIds = new Set(sameVoiceLineIds);
     const targetIds = selectedLineIds.has(lineId) && selectedLineIds.size > 0 ? [...selectedLineIds] : [lineId];
 
-    splitLinesIntoWords(targetIds, lines);
+    splitVoiceIntoWords(targetIds, lines, voice);
     clearContextMenu();
-  }, [contextMenu, selectedWords, lines, clearContextMenu]);
+  }, [contextMenu, selectedWords, lines, splitIntoWordsInfo, clearContextMenu]);
 
   return {
     handlePlaceLineHere,

--- a/src/views/timeline/use-line-menu-actions.ts
+++ b/src/views/timeline/use-line-menu-actions.ts
@@ -1,9 +1,8 @@
 import { reconcileLine } from "@/domain/line/model";
-import { lineText } from "@/domain/line/voices";
+import { placeVoice } from "@/domain/line/place-voice";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import { showGroupActionToast } from "@/utils/group-toast";
-import { splitIntoWordsWithMeta } from "@/utils/sync-helpers";
 import { splitLinesIntoWords } from "@/views/timeline/split-lines-into-words";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import type { useContextMenuTargets } from "@/views/timeline/use-context-menu-targets";
@@ -22,6 +21,7 @@ function useLineMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
   const rawLines = useProjectStore((s) => s.lines);
   const agents = useProjectStore((s) => s.agents);
   const updateLineWithHistory = useProjectStore((s) => s.updateLineWithHistory);
+  const setLineWithHistory = useProjectStore((s) => s.setLineWithHistory);
   const setLinesWithHistory = useProjectStore((s) => s.setLinesWithHistory);
 
   const handlePlaceLineHere = useCallback(() => {
@@ -30,14 +30,9 @@ function useLineMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
     const line = rawLines.find((l) => l.id === lineId);
     if (!line) return;
     const wordDuration = useSettingsStore.getState().defaultWordDuration;
-    const wordCount = splitIntoWordsWithMeta(lineText(line)).parts.length;
-    const lineDuration = Math.max(wordCount, 1) * wordDuration;
-    updateLineWithHistory(lineId, {
-      begin: time,
-      end: time + lineDuration,
-    });
+    setLineWithHistory(lineId, placeVoice(line, "main", time, wordDuration));
     clearContextMenu();
-  }, [contextMenu, rawLines, updateLineWithHistory, clearContextMenu]);
+  }, [contextMenu, rawLines, setLineWithHistory, clearContextMenu]);
 
   const handleAddLine = useCallback(
     (position: "above" | "below") => {

--- a/src/views/timeline/use-line-menu-actions.ts
+++ b/src/views/timeline/use-line-menu-actions.ts
@@ -3,7 +3,7 @@ import { placeVoice } from "@/domain/line/place-voice";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import { showGroupActionToast } from "@/utils/group-toast";
-import { splitVoiceIntoWords } from "@/views/timeline/split-lines-into-words";
+import { splitTargetLineIds, splitVoiceIntoWords } from "@/views/timeline/split-lines-into-words";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import type { useContextMenuTargets } from "@/views/timeline/use-context-menu-targets";
 import { useCallback } from "react";
@@ -99,9 +99,7 @@ function useLineMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
     const { lineId, type } = contextMenu.target;
     const { voice } = splitIntoWordsInfo;
 
-    const sameVoiceLineIds = selectedWords.flatMap((w) => (w.type === type ? [w.lineId] : []));
-    const selectedLineIds = new Set(sameVoiceLineIds);
-    const targetIds = selectedLineIds.has(lineId) && selectedLineIds.size > 0 ? [...selectedLineIds] : [lineId];
+    const targetIds = splitTargetLineIds(selectedWords, type, lineId);
 
     splitVoiceIntoWords(targetIds, lines, voice);
     clearContextMenu();

--- a/src/views/timeline/use-line-menu-actions.ts
+++ b/src/views/timeline/use-line-menu-actions.ts
@@ -30,7 +30,7 @@ function useLineMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
     const line = rawLines.find((l) => l.id === lineId);
     if (!line) return;
     const wordDuration = useSettingsStore.getState().defaultWordDuration;
-    setLineWithHistory(lineId, placeVoice(line, "main", time, wordDuration));
+    setLineWithHistory(lineId, placeVoice(line, "main", time, wordDuration), { propagateToSiblings: false });
     clearContextMenu();
   }, [contextMenu, rawLines, setLineWithHistory, clearContextMenu]);
 

--- a/src/views/timeline/use-line-menu-actions.ts
+++ b/src/views/timeline/use-line-menu-actions.ts
@@ -30,6 +30,8 @@ function useLineMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
     const line = rawLines.find((l) => l.id === lineId);
     if (!line) return;
     const wordDuration = useSettingsStore.getState().defaultWordDuration;
+    // Placing one instance is a per-instance timing write; propagating would
+    // clear or re-resolve linked siblings' backgrounds (regression vs the old path).
     setLineWithHistory(lineId, placeVoice(line, "main", time, wordDuration), { propagateToSiblings: false });
     clearContextMenu();
   }, [contextMenu, rawLines, setLineWithHistory, clearContextMenu]);

--- a/src/views/timeline/use-line-menu-actions.ts
+++ b/src/views/timeline/use-line-menu-actions.ts
@@ -3,6 +3,7 @@ import { placeVoice } from "@/domain/line/place-voice";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import { showGroupActionToast } from "@/utils/group-toast";
+import { removeBackgroundWithConfirm } from "@/views/timeline/remove-background-with-confirm";
 import { splitTargetLineIds, splitVoiceIntoWords } from "@/views/timeline/split-lines-into-words";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import type { useContextMenuTargets } from "@/views/timeline/use-context-menu-targets";
@@ -77,6 +78,13 @@ function useLineMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
     clearContextMenu();
   }, [contextMenu, rawLines, setLinesWithHistory, clearContextMenu]);
 
+  const handleRemoveBackground = useCallback(() => {
+    if (!contextMenu || contextMenu.target.kind !== "gutter") return;
+    const { lineId } = contextMenu.target;
+    void removeBackgroundWithConfirm(lineId);
+    clearContextMenu();
+  }, [contextMenu, clearContextMenu]);
+
   const handleDetachLine = useCallback(() => {
     if (!gutterLineGroupInfo) return;
     useProjectStore.getState().detachLine(gutterLineGroupInfo.lineId);
@@ -110,6 +118,7 @@ function useLineMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
     handlePlaceBackgroundHere,
     handleAddLine,
     handleDeleteLine,
+    handleRemoveBackground,
     handleDetachLine,
     handleAssignAgent,
     handleSplitIntoWords,

--- a/src/views/timeline/use-line-menu-actions.ts
+++ b/src/views/timeline/use-line-menu-actions.ts
@@ -1,3 +1,4 @@
+import { reconcileLine } from "@/domain/line/model";
 import { lineText } from "@/domain/line/voices";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
@@ -49,7 +50,7 @@ function useLineMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
       const targetIndex = rawLines.findIndex((l) => l.id === lineId);
       if (targetIndex === -1) return;
       const defaultAgentId = agents?.[0]?.id ?? "v1";
-      const newLine = { id: crypto.randomUUID(), text: "", agentId: defaultAgentId };
+      const newLine = reconcileLine({ id: crypto.randomUUID(), text: "", agentId: defaultAgentId });
       const newLines = [...rawLines];
       const insertIndex = position === "above" ? targetIndex : targetIndex + 1;
       newLines.splice(insertIndex, 0, newLine);

--- a/src/views/timeline/use-line-menu-actions.ts
+++ b/src/views/timeline/use-line-menu-actions.ts
@@ -36,6 +36,18 @@ function useLineMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
     clearContextMenu();
   }, [contextMenu, rawLines, setLineWithHistory, clearContextMenu]);
 
+  const handlePlaceBackgroundHere = useCallback(() => {
+    if (!contextMenu || contextMenu.target.kind !== "track") return;
+    const { lineId, time } = contextMenu.target;
+    const line = rawLines.find((l) => l.id === lineId);
+    if (!line) return;
+    const wordDuration = useSettingsStore.getState().defaultWordDuration;
+    // Placing one instance is a per-instance timing write; propagating would
+    // clear or re-resolve linked siblings' backgrounds (regression vs the old path).
+    setLineWithHistory(lineId, placeVoice(line, "background", time, wordDuration), { propagateToSiblings: false });
+    clearContextMenu();
+  }, [contextMenu, rawLines, setLineWithHistory, clearContextMenu]);
+
   const handleAddLine = useCallback(
     (position: "above" | "below") => {
       if (!contextMenu || contextMenu.target.kind !== "gutter") return;
@@ -95,6 +107,7 @@ function useLineMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
 
   return {
     handlePlaceLineHere,
+    handlePlaceBackgroundHere,
     handleAddLine,
     handleDeleteLine,
     handleDetachLine,

--- a/src/views/timeline/use-line-menu-actions.ts
+++ b/src/views/timeline/use-line-menu-actions.ts
@@ -1,3 +1,4 @@
+import { lineText } from "@/domain/line/voices";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import { showGroupActionToast } from "@/utils/group-toast";
@@ -28,7 +29,7 @@ function useLineMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
     const line = rawLines.find((l) => l.id === lineId);
     if (!line) return;
     const wordDuration = useSettingsStore.getState().defaultWordDuration;
-    const wordCount = splitIntoWordsWithMeta(line.text).parts.length;
+    const wordCount = splitIntoWordsWithMeta(lineText(line)).parts.length;
     const lineDuration = Math.max(wordCount, 1) * wordDuration;
     updateLineWithHistory(lineId, {
       begin: time,

--- a/src/views/timeline/use-marquee.ts
+++ b/src/views/timeline/use-marquee.ts
@@ -3,6 +3,7 @@ import { GROUP_HEADER_HEIGHT } from "@/views/timeline/group-header-row";
 import type { WordSelection } from "@/domain/selection/model";
 import { GUTTER_WIDTH, useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
 import { getEffectiveLines } from "@/domain/line/effective-words";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { mergeWordSelections } from "@/domain/selection/set-ops";
 import { computeRowLayout } from "@/views/timeline/utils";
 import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
@@ -79,13 +80,15 @@ function useMarquee(scrollContainerRef: RefObject<HTMLDivElement | null>) {
       if (!pos) continue;
 
       const mainHeight = rowHeights[line.id] ?? defaultRowHeight;
-      const hasBg = line.backgroundWords && line.backgroundWords.length > 0;
+      const main = mainWords(line);
+      const bg = bgWords(line);
+      const hasBg = bg && bg.length > 0;
       const mainTop = pos.top;
       const mainBottom = mainTop + mainHeight;
 
-      if (mainTop < rectBottom && mainBottom > rect.y && line.words) {
-        for (let wordIndex = 0; wordIndex < line.words.length; wordIndex++) {
-          const word = line.words[wordIndex];
+      if (mainTop < rectBottom && mainBottom > rect.y && main) {
+        for (let wordIndex = 0; wordIndex < main.length; wordIndex++) {
+          const word = main[wordIndex];
           const wordLeft = GUTTER_WIDTH + word.begin * zoom;
           const wordRight = GUTTER_WIDTH + word.end * zoom;
           if (wordLeft < rectRight && wordRight > rect.x) {
@@ -94,13 +97,13 @@ function useMarquee(scrollContainerRef: RefObject<HTMLDivElement | null>) {
         }
       }
 
-      if (hasBg && line.backgroundWords) {
+      if (hasBg && bg) {
         const bgHeight = mainHeight;
         const bgTop = mainBottom;
         const bgBottom = bgTop + bgHeight;
         if (bgTop < rectBottom && bgBottom > rect.y) {
-          for (let wordIndex = 0; wordIndex < line.backgroundWords.length; wordIndex++) {
-            const word = line.backgroundWords[wordIndex];
+          for (let wordIndex = 0; wordIndex < bg.length; wordIndex++) {
+            const word = bg[wordIndex];
             const wordLeft = GUTTER_WIDTH + word.begin * zoom;
             const wordRight = GUTTER_WIDTH + word.end * zoom;
             if (wordLeft < rectRight && wordRight > rect.x) {

--- a/src/views/timeline/use-timeline-clipboard.ts
+++ b/src/views/timeline/use-timeline-clipboard.ts
@@ -1,5 +1,6 @@
 import { useProjectStore } from "@/stores/project";
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { applyWordDeletion } from "@/views/timeline/apply-word-deletion";
 import { buildCandidateLines } from "@/views/timeline/build-candidate-lines";
 import type { ClipboardData, ClipboardEntry } from "@/views/timeline/selection-types";
@@ -21,7 +22,7 @@ function useTimelineClipboard(lines: LyricLine[]) {
     for (const sel of selectedWords) {
       const line = lines[sel.lineIndex];
       if (!line) continue;
-      const wordsArray = sel.type === "word" ? line.words : line.backgroundWords;
+      const wordsArray = sel.type === "word" ? mainWords(line) : bgWords(line);
       const word = wordsArray?.[sel.wordIndex];
       if (!word) continue;
 

--- a/src/views/timeline/use-timeline-dnd.alt-duplicate.browser.test.tsx
+++ b/src/views/timeline/use-timeline-dnd.alt-duplicate.browser.test.tsx
@@ -1,3 +1,5 @@
+import { reconcileLine } from "@/domain/line/model";
+import { mainWords } from "@/domain/line/voices";
 import { computeSyllableGroups } from "@/domain/word/syllable-groups";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
@@ -13,7 +15,7 @@ describe("useTimelineDnd · alt-drag duplicate", () => {
     useTimelineStore.setState({ zoom: 100 });
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "l1",
           text: "Hello world",
           agentId: "v1",
@@ -21,7 +23,7 @@ describe("useTimelineDnd · alt-drag duplicate", () => {
             { text: "Hello ", begin: 0, end: 0.5 },
             { text: "world", begin: 2, end: 2.5 },
           ],
-        },
+        }),
       ],
     });
   });
@@ -32,7 +34,7 @@ describe("useTimelineDnd · alt-drag duplicate", () => {
 
     result.current.handleDragEnd(makeAltDuplicateEvent(1, -100));
 
-    const words = useProjectStore.getState().lines[0].words ?? [];
+    const words = mainWords(useProjectStore.getState().lines[0]) ?? [];
     expect(words.map((w) => w.text)).toEqual(["Hello ", "world ", "world"]);
     const groups = computeSyllableGroups(words);
     expect(groups.some((g) => g.startIndex <= 1 && g.endIndex >= 2)).toBe(false);

--- a/src/views/timeline/use-timeline-dnd.bg-provenance.browser.test.tsx
+++ b/src/views/timeline/use-timeline-dnd.bg-provenance.browser.test.tsx
@@ -1,3 +1,5 @@
+import { reconcileLine } from "@/domain/line/model";
+import { bgSource, bgWords } from "@/domain/line/voices";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useTimelineDnd } from "@/views/timeline/use-timeline-dnd";
@@ -18,7 +20,7 @@ describe("useTimelineDnd · background-word drag provenance", () => {
     useTimelineStore.setState({ zoom: 100, rowHeights: {}, defaultRowHeight: 44, collapsedInstances: {} });
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "l1",
           text: "main",
           agentId: "v1",
@@ -29,7 +31,7 @@ describe("useTimelineDnd · background-word drag provenance", () => {
             { text: "aah", begin: 1, end: 1.5 },
           ],
           backgroundTextSource: "extraction",
-        },
+        }),
       ],
     });
     scrollHost = installScrollHost();
@@ -48,8 +50,8 @@ describe("useTimelineDnd · background-word drag provenance", () => {
     result.current.handleDragEnd(makeBgReorderDragEndEvent(-80));
 
     const after = useProjectStore.getState().lines[0];
-    expect(after.backgroundTextSource).toBe("manual");
-    expect(after.backgroundWords?.length).toBe(2);
+    expect(bgSource(after)).toBe("manual");
+    expect(bgWords(after)?.length).toBe(2);
   });
 
   it("preserves the dragged background word texts and count", async () => {
@@ -60,7 +62,7 @@ describe("useTimelineDnd · background-word drag provenance", () => {
     window.dispatchEvent(new PointerEvent("pointermove", { clientX: 220, clientY: 140 }));
     result.current.handleDragEnd(makeBgReorderDragEndEvent(-80));
 
-    const bg = useProjectStore.getState().lines[0].backgroundWords ?? [];
+    const bg = bgWords(useProjectStore.getState().lines[0]) ?? [];
     expect(bg).toHaveLength(2);
     expect(bg.map((w) => w.text.trim()).toSorted()).toEqual(["aah", "ooh"]);
   });

--- a/src/views/timeline/use-timeline-dnd.cross-line.browser.test.tsx
+++ b/src/views/timeline/use-timeline-dnd.cross-line.browser.test.tsx
@@ -1,3 +1,5 @@
+import { reconcileLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useTimelineDnd } from "@/views/timeline/use-timeline-dnd";
@@ -47,7 +49,7 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
   it("drops a main word into the same line's empty bg zone reliably even when cursor x stays put", async () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "l1",
           text: "hello world",
           agentId: "v1",
@@ -55,7 +57,7 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
             { text: "hello ", begin: 0.1, end: 0.5 },
             { text: "world", begin: 0.5, end: 0.9 },
           ],
-        },
+        }),
       ],
     });
     const lines = useProjectStore.getState().lines;
@@ -76,15 +78,15 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
     });
 
     const after = useProjectStore.getState().lines[0];
-    expect(after.words?.length).toBe(1);
-    expect(after.backgroundWords?.length).toBe(1);
-    expect(after.backgroundWords?.[0].text.trim()).toBe("world");
+    expect(mainWords(after)?.length).toBe(1);
+    expect(bgWords(after)?.length).toBe(1);
+    expect(bgWords(after)?.[0].text.trim()).toBe("world");
   });
 
   it("drops a bg word back into the same line's main zone reliably", async () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "l1",
           text: "hello",
           agentId: "v1",
@@ -95,7 +97,7 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
             { text: "aah", begin: 1.5, end: 1.9 },
           ],
           backgroundTextSource: "manual",
-        },
+        }),
       ],
     });
     const lines = useProjectStore.getState().lines;
@@ -116,15 +118,15 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
     });
 
     const after = useProjectStore.getState().lines[0];
-    expect(after.words?.length).toBe(2);
-    expect(after.backgroundWords?.length).toBe(1);
-    expect(after.words?.some((w) => w.text.trim() === "aah")).toBe(true);
+    expect(mainWords(after)?.length).toBe(2);
+    expect(bgWords(after)?.length).toBe(1);
+    expect(mainWords(after)?.some((w) => w.text.trim() === "aah")).toBe(true);
   });
 
   it("drops a main word from line A into line B's main track", async () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "lA",
           text: "alpha beta",
           agentId: "v1",
@@ -132,13 +134,13 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
             { text: "alpha ", begin: 0.1, end: 0.4 },
             { text: "beta", begin: 0.4, end: 0.7 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "lB",
           text: "delta",
           agentId: "v1",
           words: [{ text: "delta", begin: 5.0, end: 5.4 }],
-        },
+        }),
       ],
     });
     const lines = useProjectStore.getState().lines;
@@ -161,14 +163,14 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
     const after = useProjectStore.getState().lines;
     const a = after.find((l) => l.id === "lA");
     const b = after.find((l) => l.id === "lB");
-    expect(a?.words?.length).toBe(1);
-    expect(b?.words?.some((w) => w.text.trim() === "alpha")).toBe(true);
+    expect(a && mainWords(a)?.length).toBe(1);
+    expect(b && mainWords(b)?.some((w) => w.text.trim() === "alpha")).toBe(true);
   });
 
   it("drops a main word from line A into line B's bg track", async () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "lA",
           text: "alpha beta",
           agentId: "v1",
@@ -176,13 +178,13 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
             { text: "alpha ", begin: 0.1, end: 0.4 },
             { text: "beta", begin: 0.4, end: 0.7 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "lB",
           text: "delta",
           agentId: "v1",
           words: [{ text: "delta", begin: 5.0, end: 5.4 }],
-        },
+        }),
       ],
     });
     const lines = useProjectStore.getState().lines;
@@ -205,14 +207,14 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
     const after = useProjectStore.getState().lines;
     const a = after.find((l) => l.id === "lA");
     const b = after.find((l) => l.id === "lB");
-    expect(a?.words?.length).toBe(1);
-    expect(b?.backgroundWords?.some((w) => w.text.trim() === "alpha")).toBe(true);
+    expect(a && mainWords(a)?.length).toBe(1);
+    expect(b && bgWords(b)?.some((w) => w.text.trim() === "alpha")).toBe(true);
   });
 
   it("rejects with a toast on cross-instance attempts and leaves both lines untouched", async () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "lA",
           text: "alpha beta",
           agentId: "v1",
@@ -222,19 +224,19 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
             { text: "alpha ", begin: 0.1, end: 0.4 },
             { text: "beta", begin: 0.4, end: 0.7 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "lB",
           text: "delta",
           agentId: "v1",
           groupId: "g1",
           instanceIdx: 1,
           words: [{ text: "delta", begin: 5.0, end: 5.4 }],
-        },
+        }),
       ],
     });
     const lines = useProjectStore.getState().lines;
-    const before = lines.map((l) => l.words?.map((w) => w.text).join("|"));
+    const before = lines.map((l) => mainWords(l)?.map((w) => w.text).join("|"));
     const baseline = toast.getHistory().length;
     const { result } = await renderHook(() => useTimelineDnd(lines));
 
@@ -252,7 +254,7 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
       deltaY: 0,
     });
 
-    const after = useProjectStore.getState().lines.map((l) => l.words?.map((w) => w.text).join("|"));
+    const after = useProjectStore.getState().lines.map((l) => mainWords(l)?.map((w) => w.text).join("|"));
     expect(after).toEqual(before);
     const fired = toast.getHistory().slice(baseline);
     expect(fired.some((t) => "title" in t && /Detach the line first/.test(String(t.title)))).toBe(true);
@@ -261,7 +263,7 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
   it("rejects with a toast when target line is line-synced and leaves data untouched", async () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "lA",
           text: "alpha beta",
           agentId: "v1",
@@ -269,14 +271,14 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
             { text: "alpha ", begin: 0.1, end: 0.4 },
             { text: "beta", begin: 0.4, end: 0.7 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "lB",
           text: "delta",
           agentId: "v1",
           begin: 5.0,
           end: 5.4,
-        },
+        }),
       ],
     });
     const lines = useProjectStore.getState().lines;
@@ -298,8 +300,10 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
     });
 
     const after = useProjectStore.getState().lines;
-    expect(after.find((l) => l.id === "lA")?.words?.length).toBe(2);
-    expect(after.find((l) => l.id === "lB")?.words).toBeUndefined();
+    const lineA = after.find((l) => l.id === "lA");
+    const lineB = after.find((l) => l.id === "lB");
+    expect(lineA && mainWords(lineA)?.length).toBe(2);
+    expect(lineB && mainWords(lineB)).toBeUndefined();
     const fired = toast.getHistory().slice(baseline);
     expect(fired.some((t) => "title" in t && /Sync this line into words first/.test(String(t.title)))).toBe(true);
   });
@@ -307,7 +311,7 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
   it("silently rejects an overlap and leaves both lines untouched", async () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "lA",
           text: "alpha beta",
           agentId: "v1",
@@ -315,13 +319,13 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
             { text: "alpha ", begin: 0.1, end: 0.4 },
             { text: "beta", begin: 0.4, end: 0.7 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "lB",
           text: "delta",
           agentId: "v1",
           words: [{ text: "delta", begin: 6.0, end: 6.6 }],
-        },
+        }),
       ],
     });
     const lines = useProjectStore.getState().lines;
@@ -351,7 +355,7 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
   it("no-ops when cursor falls outside any row on drop", async () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "l1",
           text: "hello world",
           agentId: "v1",
@@ -359,7 +363,7 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
             { text: "hello ", begin: 0.1, end: 0.5 },
             { text: "world", begin: 0.5, end: 0.9 },
           ],
-        },
+        }),
       ],
     });
     const lines = useProjectStore.getState().lines;
@@ -387,7 +391,7 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
   it("switches track when the cursor lands in the bg zone even with only a few pixels of delta.y", async () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "l1",
           text: "hello",
           agentId: "v1",
@@ -395,7 +399,7 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
           backgroundText: "ooh",
           backgroundWords: [{ text: "ooh", begin: 1.0, end: 1.4 }],
           backgroundTextSource: "manual",
-        },
+        }),
       ],
     });
     const lines = useProjectStore.getState().lines;
@@ -416,14 +420,14 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
     });
 
     const after = useProjectStore.getState().lines[0];
-    expect(after.words?.length ?? 0).toBe(0);
-    expect(after.backgroundWords?.length).toBe(2);
+    expect(mainWords(after)?.length ?? 0).toBe(0);
+    expect(bgWords(after)?.length).toBe(2);
   });
 
   it("uses live cursor position over container scrollTop, so auto-scroll during drag doesn't shift the drop target", async () => {
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "lA",
           text: "alpha beta",
           agentId: "v1",
@@ -431,13 +435,13 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
             { text: "alpha ", begin: 0.1, end: 0.4 },
             { text: "beta", begin: 0.4, end: 0.7 },
           ],
-        },
-        {
+        }),
+        reconcileLine({
           id: "lB",
           text: "delta",
           agentId: "v1",
           words: [{ text: "delta", begin: 5.0, end: 5.4 }],
-        },
+        }),
       ],
     });
     const lines = useProjectStore.getState().lines;
@@ -484,14 +488,14 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
 
     const after = useProjectStore.getState().lines;
     const b = after.find((l) => l.id === "lB");
-    expect(b?.words?.some((w) => w.text.trim() === "alpha")).toBe(true);
+    expect(b && mainWords(b)?.some((w) => w.text.trim() === "alpha")).toBe(true);
   });
 
   describe("sibling propagation parity for cross-track moves", () => {
     it("does not propagate to linked sibling when toggling main to bg same-line on a linked instance", async () => {
       useProjectStore.setState({
         lines: [
-          {
+          reconcileLine({
             id: "a0",
             text: "alpha beta",
             agentId: "v1",
@@ -501,8 +505,8 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
               { text: "alpha ", begin: 0.1, end: 0.4 },
               { text: "beta", begin: 0.4, end: 0.7 },
             ],
-          },
-          {
+          }),
+          reconcileLine({
             id: "a1",
             text: "alpha beta",
             agentId: "v1",
@@ -512,7 +516,7 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
               { text: "alpha ", begin: 5.1, end: 5.4 },
               { text: "beta", begin: 5.4, end: 5.7 },
             ],
-          },
+          }),
         ],
       });
       const lines = useProjectStore.getState().lines;
@@ -536,15 +540,15 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
       const after = useProjectStore.getState().lines;
       const source = after.find((l) => l.id === "a0");
       const sibling = after.find((l) => l.id === "a1");
-      expect(source?.words?.length).toBe(1);
-      expect(source?.backgroundWords?.length).toBe(1);
+      expect(source && mainWords(source)?.length).toBe(1);
+      expect(source && bgWords(source)?.length).toBe(1);
       expect(JSON.stringify(sibling)).toBe(siblingBefore);
     });
 
     it("does not propagate to linked sibling when moving across lines in a linked instance", async () => {
       useProjectStore.setState({
         lines: [
-          {
+          reconcileLine({
             id: "a0",
             text: "alpha beta",
             agentId: "v1",
@@ -554,8 +558,8 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
               { text: "alpha ", begin: 0.1, end: 0.4 },
               { text: "beta", begin: 0.4, end: 0.7 },
             ],
-          },
-          {
+          }),
+          reconcileLine({
             id: "a1",
             text: "gamma delta",
             agentId: "v1",
@@ -565,8 +569,8 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
               { text: "gamma ", begin: 1.0, end: 1.4 },
               { text: "delta", begin: 1.4, end: 1.7 },
             ],
-          },
-          {
+          }),
+          reconcileLine({
             id: "b0",
             text: "alpha beta",
             agentId: "v1",
@@ -576,8 +580,8 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
               { text: "alpha ", begin: 10.1, end: 10.4 },
               { text: "beta", begin: 10.4, end: 10.7 },
             ],
-          },
-          {
+          }),
+          reconcileLine({
             id: "b1",
             text: "gamma delta",
             agentId: "v1",
@@ -587,7 +591,7 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
               { text: "gamma ", begin: 11.0, end: 11.4 },
               { text: "delta", begin: 11.4, end: 11.7 },
             ],
-          },
+          }),
         ],
       });
       const lines = useProjectStore.getState().lines;
@@ -612,8 +616,8 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
       const after = useProjectStore.getState().lines;
       const a0After = after.find((l) => l.id === "a0");
       const a1After = after.find((l) => l.id === "a1");
-      expect(a0After?.words?.length).toBe(1);
-      expect(a1After?.words?.some((w) => w.text.trim() === "alpha")).toBe(true);
+      expect(a0After && mainWords(a0After)?.length).toBe(1);
+      expect(a1After && mainWords(a1After)?.some((w) => w.text.trim() === "alpha")).toBe(true);
 
       const b0After = JSON.stringify(after.find((l) => l.id === "b0"));
       const b1After = JSON.stringify(after.find((l) => l.id === "b1"));

--- a/src/views/timeline/use-timeline-dnd.cross-line.browser.test.tsx
+++ b/src/views/timeline/use-timeline-dnd.cross-line.browser.test.tsx
@@ -236,7 +236,11 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
       ],
     });
     const lines = useProjectStore.getState().lines;
-    const before = lines.map((l) => mainWords(l)?.map((w) => w.text).join("|"));
+    const before = lines.map((l) =>
+      mainWords(l)
+        ?.map((w) => w.text)
+        .join("|"),
+    );
     const baseline = toast.getHistory().length;
     const { result } = await renderHook(() => useTimelineDnd(lines));
 
@@ -254,7 +258,11 @@ describe("useTimelineDnd · cross-line and reliable track switch", () => {
       deltaY: 0,
     });
 
-    const after = useProjectStore.getState().lines.map((l) => mainWords(l)?.map((w) => w.text).join("|"));
+    const after = useProjectStore.getState().lines.map((l) =>
+      mainWords(l)
+        ?.map((w) => w.text)
+        .join("|"),
+    );
     expect(after).toEqual(before);
     const fired = toast.getHistory().slice(baseline);
     expect(fired.some((t) => "title" in t && /Detach the line first/.test(String(t.title)))).toBe(true);

--- a/src/views/timeline/use-timeline-dnd.live-shift.browser.test.tsx
+++ b/src/views/timeline/use-timeline-dnd.live-shift.browser.test.tsx
@@ -1,3 +1,5 @@
+import { reconcileLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useTimelineDnd } from "@/views/timeline/use-timeline-dnd";
@@ -20,7 +22,7 @@ describe("useTimelineDnd · live shift state", () => {
     useTimelineStore.setState({ rowHeights: {}, defaultRowHeight: 44, collapsedInstances: {} });
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "l1",
           text: "every",
           agentId: "v1",
@@ -29,7 +31,7 @@ describe("useTimelineDnd · live shift state", () => {
             { text: "er", begin: 0.3, end: 0.6, syllableGroupId: "g" },
             { text: "y ", begin: 0.6, end: 0.9, syllableGroupId: "g" },
           ],
-        },
+        }),
       ],
     });
     scrollHost = installScrollHost();
@@ -51,19 +53,19 @@ describe("useTimelineDnd · live shift state", () => {
     );
 
     const after = useProjectStore.getState().lines[0];
-    expect(after.words?.length ?? 0).toBe(0);
-    expect(after.backgroundWords?.length).toBe(3);
-    const sharedId = after.backgroundWords?.[0].syllableGroupId;
+    expect(mainWords(after)?.length ?? 0).toBe(0);
+    expect(bgWords(after)?.length).toBe(3);
+    const sharedId = bgWords(after)?.[0].syllableGroupId;
     expect(sharedId).toBeDefined();
-    expect(after.backgroundWords?.[1].syllableGroupId).toBe(sharedId);
-    expect(after.backgroundWords?.[2].syllableGroupId).toBe(sharedId);
+    expect(bgWords(after)?.[1].syllableGroupId).toBe(sharedId);
+    expect(bgWords(after)?.[2].syllableGroupId).toBe(sharedId);
   });
 
   it("shifts every groupmate by the same delta when a non-leading syllable is shift-dragged", async () => {
     useTimelineStore.setState({ zoom: 100 });
     const zoom = useTimelineStore.getState().zoom;
     const lines = useProjectStore.getState().lines;
-    const before = lines[0].words ?? [];
+    const before = mainWords(lines[0]) ?? [];
     const { result } = await renderHook(() => useTimelineDnd(lines));
 
     result.current.handleDragStart(makeDragStartEvent(true));
@@ -81,7 +83,7 @@ describe("useTimelineDnd · live shift state", () => {
     );
 
     const after = useProjectStore.getState().lines[0];
-    const words = after.words ?? [];
+    const words = mainWords(after) ?? [];
     expect(words.length).toBe(3);
 
     const expectedShift = deltaX / zoom;
@@ -111,11 +113,11 @@ describe("useTimelineDnd · live shift state", () => {
     );
 
     const after = useProjectStore.getState().lines[0];
-    expect(after.words?.length ?? 0).toBe(0);
-    expect(after.backgroundWords?.length).toBe(3);
-    const sharedId = after.backgroundWords?.[0].syllableGroupId;
+    expect(mainWords(after)?.length ?? 0).toBe(0);
+    expect(bgWords(after)?.length).toBe(3);
+    const sharedId = bgWords(after)?.[0].syllableGroupId;
     expect(sharedId).toBeDefined();
-    expect(after.backgroundWords?.[1].syllableGroupId).toBe(sharedId);
-    expect(after.backgroundWords?.[2].syllableGroupId).toBe(sharedId);
+    expect(bgWords(after)?.[1].syllableGroupId).toBe(sharedId);
+    expect(bgWords(after)?.[2].syllableGroupId).toBe(sharedId);
   });
 });

--- a/src/views/timeline/use-timeline-dnd.reorder-seam.browser.test.tsx
+++ b/src/views/timeline/use-timeline-dnd.reorder-seam.browser.test.tsx
@@ -1,3 +1,5 @@
+import { reconcileLine } from "@/domain/line/model";
+import { mainWords } from "@/domain/line/voices";
 import { computeSyllableGroups } from "@/domain/word/syllable-groups";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
@@ -20,7 +22,7 @@ describe("useTimelineDnd · within-track reorder seam", () => {
     useTimelineStore.setState({ zoom: 100, rowHeights: {}, defaultRowHeight: 44, collapsedInstances: {} });
     useProjectStore.setState({
       lines: [
-        {
+        reconcileLine({
           id: "l1",
           text: "word1 word2 word3",
           agentId: "v1",
@@ -29,7 +31,7 @@ describe("useTimelineDnd · within-track reorder seam", () => {
             { text: "word2 ", begin: 1, end: 1.5 },
             { text: "word3", begin: 2, end: 2.5 },
           ],
-        },
+        }),
       ],
     });
     scrollHost = installScrollHost();
@@ -47,7 +49,7 @@ describe("useTimelineDnd · within-track reorder seam", () => {
     window.dispatchEvent(new PointerEvent("pointermove", { clientX: 250, clientY: POINTER_Y_MAIN }));
     result.current.handleDragEnd(makeReorderDragEndEvent());
 
-    const words = useProjectStore.getState().lines[0].words ?? [];
+    const words = mainWords(useProjectStore.getState().lines[0]) ?? [];
     expect(words.length).toBe(3);
 
     expect(computeSyllableGroups(words)).toEqual([]);

--- a/src/views/timeline/use-timeline-keyboard.browser.test.tsx
+++ b/src/views/timeline/use-timeline-keyboard.browser.test.tsx
@@ -1,7 +1,12 @@
 import { createRef } from "react";
 import { describe, expect, it } from "vitest";
 import { renderHook } from "vitest-browser-react";
-import { bgSource, bgWords, mainWords } from "@/domain/line/voices";
+import { setBackground } from "@/domain/line/background";
+import { getEffectiveLines } from "@/domain/line/effective-words";
+import { reconcileLine } from "@/domain/line/model";
+import { isLineSynced } from "@/domain/line/predicates";
+import { bgSource, bgVoice, bgWords, mainWords } from "@/domain/line/voices";
+import { isWordSynced as isVoiceWordSynced } from "@/domain/voice/predicates";
 import { createLine, snapPoints } from "@/test/factories";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
@@ -429,5 +434,44 @@ describe("useTimelineKeyboard · background provenance", () => {
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "[", bubbles: true }));
 
     expect(bgSource(useProjectStore.getState().lines[0])).toBe("extraction");
+  });
+});
+
+describe("useTimelineKeyboard · split into words (w)", () => {
+  it("splits the main voice when a main word selection is active", async () => {
+    const raw = reconcileLine({ id: "L1", text: "one two three", agentId: "v1", begin: 1, end: 4 });
+    useProjectStore.setState({ activeTab: "timeline", lines: [raw] });
+    const effective = getEffectiveLines([raw]);
+    useTimelineStore.setState({ selectedWords: [{ lineId: "L1", lineIndex: 0, wordIndex: 0, type: "word" }] });
+    const scrollContainerRef = createRef<HTMLDivElement | null>();
+    await renderHook(() => useTimelineKeyboard(scrollContainerRef, effective, 10));
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "w", bubbles: true }));
+
+    const after = useProjectStore.getState().lines[0];
+    expect(isLineSynced(after)).toBe(false);
+    expect(mainWords(after)?.length).toBe(3);
+    expect(useTimelineStore.getState().selectedWords.every((s) => s.type === "word")).toBe(true);
+  });
+
+  it("splits the background voice when a bg word selection is active", async () => {
+    const main = reconcileLine({ id: "B1", text: "lead", agentId: "v1", words: [{ text: "lead", begin: 0, end: 2 }] });
+    const raw = setBackground(main, { text: "ooh ooh ooh", begin: 3, end: 6, source: "manual" });
+    useProjectStore.setState({ activeTab: "timeline", lines: [raw] });
+    const effective = getEffectiveLines([raw]);
+    useTimelineStore.setState({ selectedWords: [{ lineId: "B1", lineIndex: 0, wordIndex: 0, type: "bg" }] });
+    const scrollContainerRef = createRef<HTMLDivElement | null>();
+    await renderHook(() => useTimelineKeyboard(scrollContainerRef, effective, 10));
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "w", bubbles: true }));
+
+    const after = useProjectStore.getState().lines[0];
+    const bg = bgVoice(after);
+    expect(bg).not.toBeNull();
+    expect(isVoiceWordSynced(bg!)).toBe(true);
+    expect(bgWords(after)?.length).toBe(3);
+    // Main untouched.
+    expect(mainWords(after)).toEqual([{ text: "lead", begin: 0, end: 2 }]);
+    expect(useTimelineStore.getState().selectedWords.every((s) => s.type === "bg")).toBe(true);
   });
 });

--- a/src/views/timeline/use-timeline-keyboard.browser.test.tsx
+++ b/src/views/timeline/use-timeline-keyboard.browser.test.tsx
@@ -1,6 +1,7 @@
 import { createRef } from "react";
 import { describe, expect, it } from "vitest";
 import { renderHook } from "vitest-browser-react";
+import { bgSource, bgWords, mainWords } from "@/domain/line/voices";
 import { createLine, snapPoints } from "@/test/factories";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
@@ -119,7 +120,7 @@ describe("useTimelineKeyboard", () => {
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "m", bubbles: true }));
 
     const mergedLine = useProjectStore.getState().lines[0];
-    expect(mergedLine.words).toEqual([{ text: "everyday", begin: 1, end: 2 }]);
+    expect(mainWords(mergedLine)).toEqual([{ text: "everyday", begin: 1, end: 2 }]);
   });
 });
 
@@ -330,7 +331,7 @@ describe("useTimelineKeyboard · delete hovered snap point", () => {
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Delete", bubbles: true }));
 
     expect(useProjectStore.getState().customSnapPoints.map((p) => p.time)).toEqual([12]);
-    expect(useProjectStore.getState().lines[0].words).toHaveLength(2);
+    expect(mainWords(useProjectStore.getState().lines[0])).toHaveLength(2);
     expect(useTimelineStore.getState().selectedWords).toHaveLength(1);
   });
 
@@ -377,8 +378,8 @@ describe("useTimelineKeyboard · background provenance", () => {
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "[", bubbles: true }));
 
     const updated = useProjectStore.getState().lines[0];
-    expect(updated.backgroundTextSource).toBe("manual");
-    expect(updated.backgroundWords?.[0].begin).toBeCloseTo(1.2);
+    expect(bgSource(updated)).toBe("manual");
+    expect(bgWords(updated)?.[0].begin).toBeCloseTo(1.2);
   });
 
   it("stamps backgroundTextSource manual when bg words are merged", async () => {
@@ -405,8 +406,8 @@ describe("useTimelineKeyboard · background provenance", () => {
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "m", bubbles: true }));
 
     const updated = useProjectStore.getState().lines[0];
-    expect(updated.backgroundWords).toEqual([{ text: "oohaah", begin: 1, end: 2 }]);
-    expect(updated.backgroundTextSource).toBe("manual");
+    expect(bgWords(updated)).toEqual([{ text: "oohaah", begin: 1, end: 2 }]);
+    expect(bgSource(updated)).toBe("manual");
   });
 
   it("leaves background provenance untouched when a main word's timing is set", async () => {
@@ -427,6 +428,6 @@ describe("useTimelineKeyboard · background provenance", () => {
 
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "[", bubbles: true }));
 
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("extraction");
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("extraction");
   });
 });

--- a/src/views/timeline/use-timeline-keyboard.ts
+++ b/src/views/timeline/use-timeline-keyboard.ts
@@ -17,7 +17,7 @@ import { createGroupFromSelection, fillSelectionGaps, instanceToTemplate } from 
 import { scrollToInstanceHeader } from "@/views/timeline/scroll-helpers";
 import { adjacentSnapPoint } from "@/views/timeline/snap-marker-math";
 import { normalizeTimes, snapPointTimes } from "@/domain/snap-point/model";
-import { splitVoiceIntoWords } from "@/views/timeline/split-lines-into-words";
+import { splitTargetLineIds, splitVoiceIntoWords } from "@/views/timeline/split-lines-into-words";
 import { mergeWordText } from "@/utils/word-merge";
 import type { WordSelection } from "@/domain/selection/model";
 import { GUTTER_WIDTH, useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
@@ -460,7 +460,7 @@ function useTimelineKeyboard(
           if (wSel.length === 0) break;
           e.preventDefault();
           const splitVoice = wSel[0].type === "word" ? "main" : "bg";
-          const lineIds = new Set(wSel.flatMap((w) => (w.type === wSel[0].type ? [w.lineId] : [])));
+          const lineIds = splitTargetLineIds(wSel, wSel[0].type, wSel[0].lineId);
           splitVoiceIntoWords(lineIds, lines, splitVoice);
           break;
         }

--- a/src/views/timeline/use-timeline-keyboard.ts
+++ b/src/views/timeline/use-timeline-keyboard.ts
@@ -17,7 +17,7 @@ import { createGroupFromSelection, fillSelectionGaps, instanceToTemplate } from 
 import { scrollToInstanceHeader } from "@/views/timeline/scroll-helpers";
 import { adjacentSnapPoint } from "@/views/timeline/snap-marker-math";
 import { normalizeTimes, snapPointTimes } from "@/domain/snap-point/model";
-import { splitLinesIntoWords } from "@/views/timeline/split-lines-into-words";
+import { splitVoiceIntoWords } from "@/views/timeline/split-lines-into-words";
 import { mergeWordText } from "@/utils/word-merge";
 import type { WordSelection } from "@/domain/selection/model";
 import { GUTTER_WIDTH, useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
@@ -459,8 +459,9 @@ function useTimelineKeyboard(
           const { selectedWords: wSel } = useTimelineStore.getState();
           if (wSel.length === 0) break;
           e.preventDefault();
-          const lineIds = new Set(wSel.map((w) => w.lineId));
-          splitLinesIntoWords(lineIds, lines);
+          const splitVoice = wSel[0].type === "word" ? "main" : "bg";
+          const lineIds = new Set(wSel.flatMap((w) => (w.type === wSel[0].type ? [w.lineId] : [])));
+          splitVoiceIntoWords(lineIds, lines, splitVoice);
           break;
         }
         case "timeline.expandAll": {

--- a/src/views/timeline/use-timeline-keyboard.ts
+++ b/src/views/timeline/use-timeline-keyboard.ts
@@ -2,6 +2,7 @@ import { useAudioStore } from "@/stores/audio";
 import { isAnyModalOpen } from "@/stores/modal-stack";
 import { useProjectStore } from "@/stores/project";
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { useSettingsStore } from "@/stores/settings";
 import { showGroupActionToast } from "@/utils/group-toast";
 import { handleWordChangeWithDivergenceCheck } from "@/utils/word-divergence-flow";
@@ -100,7 +101,7 @@ function useTimelineKeyboard(
       const line = lines[targetWord.lineIndex];
       if (!line) return;
 
-      const wordsArray = targetWord.type === "word" ? line.words : line.backgroundWords;
+      const wordsArray = targetWord.type === "word" ? mainWords(line) : bgWords(line);
       if (!wordsArray) return;
 
       const wordIndex = targetWord.wordIndex;
@@ -224,9 +225,9 @@ function useTimelineKeyboard(
         const allSelections: WordSelection[] = [];
         for (let li = 0; li < lines.length; li++) {
           const line = lines[li];
-          for (let wi = 0; wi < (line.words?.length ?? 0); wi++)
+          for (let wi = 0; wi < (mainWords(line)?.length ?? 0); wi++)
             allSelections.push({ lineId: line.id, lineIndex: li, wordIndex: wi, type: "word" });
-          for (let wi = 0; wi < (line.backgroundWords?.length ?? 0); wi++)
+          for (let wi = 0; wi < (bgWords(line)?.length ?? 0); wi++)
             allSelections.push({ lineId: line.id, lineIndex: li, wordIndex: wi, type: "bg" });
         }
         useTimelineStore.getState().setSelectedWords(allSelections);
@@ -419,7 +420,7 @@ function useTimelineKeyboard(
           if (!run) break;
           const mLine = lines.find((l) => l.id === run.lineId);
           if (!mLine) break;
-          const mWords = run.type === "word" ? mLine.words : mLine.backgroundWords;
+          const mWords = run.type === "word" ? mainWords(mLine) : bgWords(mLine);
           if (!mWords) break;
           e.preventDefault();
           const firstIdx = run.indices[0];

--- a/src/views/timeline/use-timeline-keyboard.ts
+++ b/src/views/timeline/use-timeline-keyboard.ts
@@ -1,7 +1,7 @@
 import { useAudioStore } from "@/stores/audio";
 import { isAnyModalOpen } from "@/stores/modal-stack";
 import { useProjectStore } from "@/stores/project";
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import { useSettingsStore } from "@/stores/settings";
 import { showGroupActionToast } from "@/utils/group-toast";
@@ -379,7 +379,7 @@ function useTimelineKeyboard(
           const lineIndex = nSel[0].lineIndex;
           const agents = useProjectStore.getState().agents;
           const defaultAgentId = agents?.[0]?.id ?? "v1";
-          const newLine = { id: crypto.randomUUID(), text: "", agentId: defaultAgentId };
+          const newLine = reconcileLine({ id: crypto.randomUUID(), text: "", agentId: defaultAgentId });
           const newLines = [...lines];
           const insertIndex = matched === "timeline.insertLineAbove" ? lineIndex : lineIndex + 1;
           newLines.splice(insertIndex, 0, newLine);

--- a/src/views/timeline/use-timeline-snap.custom-points.browser.test.tsx
+++ b/src/views/timeline/use-timeline-snap.custom-points.browser.test.tsx
@@ -1,3 +1,4 @@
+import { reconcileLine } from "@/domain/line/model";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
@@ -97,7 +98,7 @@ describe("useTimelineSnap · custom snap points", () => {
 
   it("does not emit timeline grid anchors when timelineSnap is OFF but a custom point exists", async () => {
     useProjectStore.setState({
-      lines: [{ id: "g1", text: "grid", agentId: "v1", begin: 2, end: 3 }],
+      lines: [reconcileLine({ id: "g1", text: "grid", agentId: "v1", begin: 2, end: 3 })],
       customSnapPoints: snapPoints([1]),
     });
     const { result } = await renderHook(() => useTimelineSnap());

--- a/src/views/timeline/use-timeline-syllable-splitter-state.ts
+++ b/src/views/timeline/use-timeline-syllable-splitter-state.ts
@@ -1,4 +1,5 @@
 import { manualBackgroundWordEdit } from "@/domain/line/background";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { useAudioStore } from "@/stores/audio";
 import { useConfirm } from "@/stores/confirm-store";
@@ -111,7 +112,7 @@ function useTimelineSyllableSplitterState({
     const line = currentLines.find((l) => l.id === lineId);
     if (!line) return;
 
-    const wordsArray = type === "word" ? line.words : line.backgroundWords;
+    const wordsArray = type === "word" ? mainWords(line) : bgWords(line);
     if (!wordsArray) return;
 
     const updatedWords = [...wordsArray.slice(0, wordIndex), ...newWords, ...wordsArray.slice(wordIndex + 1)];

--- a/src/views/timeline/use-word-menu-actions.ts
+++ b/src/views/timeline/use-word-menu-actions.ts
@@ -1,4 +1,5 @@
 import { CLEARED_BACKGROUND, manualBackgroundWordEdit } from "@/domain/line/background";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
 import { absorbDeletedSyllablesIntoNeighbors } from "@/domain/word/syllable-groups";
 import type { WordTiming } from "@/domain/word/timing";
@@ -67,7 +68,7 @@ function useWordMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
     const line = lines.find((l) => l.id === lineId);
     if (!line) return;
 
-    const wordsArray = type === "word" ? line.words : line.backgroundWords;
+    const wordsArray = type === "word" ? mainWords(line) : bgWords(line);
     if (!wordsArray) return;
 
     const absorbed = absorbDeletedSyllablesIntoNeighbors(wordsArray, [wordIndex]);
@@ -87,7 +88,7 @@ function useWordMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
     if (!line) return;
 
     const wordDuration = useSettingsStore.getState().defaultWordDuration;
-    const existingWords = type === "word" ? line.words : line.backgroundWords;
+    const existingWords = type === "word" ? mainWords(line) : bgWords(line);
     const slot = findInsertionSlot(existingWords ?? [], time, wordDuration, duration);
     if (!slot) {
       clearContextMenu();
@@ -127,7 +128,7 @@ function useWordMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
     const line = lines.find((l) => l.id === lineId);
     if (!line) return;
 
-    const wordsArray = type === "word" ? line.words : line.backgroundWords;
+    const wordsArray = type === "word" ? mainWords(line) : bgWords(line);
     if (!wordsArray) return;
 
     const firstIdx = indices[0];

--- a/src/views/timeline/utils.hit-test.test.ts
+++ b/src/views/timeline/utils.hit-test.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
-import type { LyricLine } from "@/domain/line/model";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import type { WordTiming } from "@/domain/word/timing";
 import { computeRowLayout, getLineAndTrackAtY } from "@/views/timeline/utils";
 
-const line = (id: string, words?: LyricLine["words"]): LyricLine =>
-  ({ id, agentId: "a", text: id, words: words ?? [{ text: id, begin: 0, end: 1 }] }) as LyricLine;
+const line = (id: string, words?: WordTiming[]): LyricLine =>
+  reconcileLine({ id, agentId: "a", text: id, words: words ?? [{ text: id, begin: 0, end: 1 }] });
 
 describe("getLineAndTrackAtY", () => {
   const layout = computeRowLayout({

--- a/src/views/timeline/utils.test.ts
+++ b/src/views/timeline/utils.test.ts
@@ -447,7 +447,9 @@ describe("instanceBounds (legacy call site coverage)", () => {
     expect(instanceBounds(lines)).toEqual({ begin: 5, end: 7 });
   });
 
-  it("ignores stale line.begin/end when only bg words are present", () => {
+  // A line with begin/end and no main words is line-synced main, not stale
+  // timing, so its bounds count alongside the background (union of both voices).
+  it("counts line-synced main bounds alongside background words", () => {
     const lines: LyricLine[] = [
       {
         id: "a",
@@ -458,7 +460,7 @@ describe("instanceBounds (legacy call site coverage)", () => {
         backgroundWords: [{ text: "ah", begin: 5, end: 6 }],
       },
     ];
-    expect(instanceBounds(lines)).toEqual({ begin: 5, end: 6 });
+    expect(instanceBounds(lines)).toEqual({ begin: 5, end: 20 });
   });
 
   it("falls back to line.begin/end ONLY when the line is truly line-synced (no words and no bg words)", () => {

--- a/src/views/timeline/utils.test.ts
+++ b/src/views/timeline/utils.test.ts
@@ -112,7 +112,7 @@ describe("distributeLinesTiming", () => {
 
 describe("effectiveBounds (legacy call site coverage)", () => {
   it("returns timing from words when available", () => {
-    const line = {
+    const line = reconcileLine({
       id: "1",
       text: "Hello",
       agentId: "v1",
@@ -120,7 +120,7 @@ describe("effectiveBounds (legacy call site coverage)", () => {
         { text: "Hello", begin: 2, end: 5 },
         { text: "World", begin: 5, end: 8 },
       ],
-    };
+    });
 
     const timing = effectiveBounds(line);
 
@@ -128,13 +128,13 @@ describe("effectiveBounds (legacy call site coverage)", () => {
   });
 
   it("returns direct timing when no words", () => {
-    const line = {
+    const line = reconcileLine({
       id: "1",
       text: "Hello",
       agentId: "v1",
       begin: 3,
       end: 7,
-    };
+    });
 
     const timing = effectiveBounds(line);
 
@@ -142,13 +142,13 @@ describe("effectiveBounds (legacy call site coverage)", () => {
   });
 
   it("returns null when no timing available", () => {
-    const line = {
+    const line = reconcileLine({
       id: "1",
       text: "Hello",
       agentId: "v1",
       begin: undefined,
       end: undefined,
-    };
+    });
 
     const timing = effectiveBounds(line);
 
@@ -156,12 +156,12 @@ describe("effectiveBounds (legacy call site coverage)", () => {
   });
 
   it("prefers words timing over direct timing", () => {
-    const line = {
+    const line = reconcileLine({
       id: "1",
       text: "Hello",
       agentId: "v1",
       words: [{ text: "Hello", begin: 2, end: 5 }],
-    };
+    });
 
     const timing = effectiveBounds(line);
 
@@ -169,12 +169,12 @@ describe("effectiveBounds (legacy call site coverage)", () => {
   });
 
   it("returns null for a word-synced line with an empty words array", () => {
-    const line = {
+    const line = reconcileLine({
       id: "1",
       text: "Hello",
       agentId: "v1",
       words: [] as WordTiming[],
-    };
+    });
 
     const timing = effectiveBounds(line);
 
@@ -182,7 +182,7 @@ describe("effectiveBounds (legacy call site coverage)", () => {
   });
 
   it("extends end past main words when bg words end later", () => {
-    const line = {
+    const line = reconcileLine({
       id: "1",
       text: "Hello",
       agentId: "v1",
@@ -195,7 +195,7 @@ describe("effectiveBounds (legacy call site coverage)", () => {
         { text: "ech", begin: 6, end: 9 },
         { text: "o", begin: 9, end: 12 },
       ],
-    };
+    });
 
     const timing = effectiveBounds(line);
 
@@ -203,14 +203,14 @@ describe("effectiveBounds (legacy call site coverage)", () => {
   });
 
   it("pulls begin earlier when bg words begin before main words", () => {
-    const line = {
+    const line = reconcileLine({
       id: "1",
       text: "Hello",
       agentId: "v1",
       words: [{ text: "Hello", begin: 5, end: 8 }],
       backgroundText: "ooh",
       backgroundWords: [{ text: "ooh", begin: 3, end: 6 }],
-    };
+    });
 
     const timing = effectiveBounds(line);
 
@@ -218,7 +218,7 @@ describe("effectiveBounds (legacy call site coverage)", () => {
   });
 
   it("extends line-synced end when bg words extend past it", () => {
-    const line = {
+    const line = reconcileLine({
       id: "1",
       text: "Hello",
       agentId: "v1",
@@ -226,7 +226,7 @@ describe("effectiveBounds (legacy call site coverage)", () => {
       end: 7,
       backgroundText: "ahh",
       backgroundWords: [{ text: "ahh", begin: 6, end: 10 }],
-    };
+    });
 
     const timing = effectiveBounds(line);
 
@@ -234,14 +234,14 @@ describe("effectiveBounds (legacy call site coverage)", () => {
   });
 
   it("leaves timing unchanged when bg words sit fully inside main range", () => {
-    const line = {
+    const line = reconcileLine({
       id: "1",
       text: "Hello",
       agentId: "v1",
       words: [{ text: "Hello", begin: 2, end: 10 }],
       backgroundText: "yeah",
       backgroundWords: [{ text: "yeah", begin: 4, end: 7 }],
-    };
+    });
 
     const timing = effectiveBounds(line);
 
@@ -249,13 +249,13 @@ describe("effectiveBounds (legacy call site coverage)", () => {
   });
 
   it("ignores empty bg words array", () => {
-    const line = {
+    const line = reconcileLine({
       id: "1",
       text: "Hello",
       agentId: "v1",
       words: [{ text: "Hello", begin: 2, end: 5 }],
       backgroundWords: [],
-    };
+    });
 
     const timing = effectiveBounds(line);
 
@@ -263,13 +263,13 @@ describe("effectiveBounds (legacy call site coverage)", () => {
   });
 
   it("returns null when bg words exist but no main timing is set", () => {
-    const line = {
+    const line = reconcileLine({
       id: "1",
       text: "Hello",
       agentId: "v1",
       backgroundText: "ooh",
       backgroundWords: [{ text: "ooh", begin: 3, end: 6 }],
-    };
+    });
 
     const timing = effectiveBounds(line);
 
@@ -777,7 +777,9 @@ describe("nudgeSelectedWords as instance shift", () => {
   });
 
   it("clamps shift to song duration when selection touches the end", () => {
-    const lines: LyricLine[] = [reconcileLine({ id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 59.7, end: 60 }] })];
+    const lines: LyricLine[] = [
+      reconcileLine({ id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 59.7, end: 60 }] }),
+    ];
     const result = nudgeSelectedWords(lines, [{ lineId: "A", type: "word", wordIndex: 0 }], 0.5, 60);
     expect(result.appliedDelta).toBe(0);
   });
@@ -981,7 +983,9 @@ describe("shiftSelectionsTogether", () => {
   });
 
   it("works when only the word-synced partition has selections", () => {
-    const lines: LyricLine[] = [reconcileLine({ id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 5, end: 6 }] })];
+    const lines: LyricLine[] = [
+      reconcileLine({ id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 5, end: 6 }] }),
+    ];
     const partitioned = partitionNudgeSelections(lines, [{ lineId: "A", type: "word", wordIndex: 0 }]);
     const result = shiftSelectionsTogether(lines, partitioned, 0.1, 60);
     expect(result.appliedDelta).toBeCloseTo(0.1);
@@ -1010,7 +1014,9 @@ describe("shiftSelectionsTogether", () => {
   });
 
   it("preserves direction when clamping (negative requestedDelta yields negative applied)", () => {
-    const lines: LyricLine[] = [reconcileLine({ id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 0.05, end: 1 }] })];
+    const lines: LyricLine[] = [
+      reconcileLine({ id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 0.05, end: 1 }] }),
+    ];
     const partitioned = partitionNudgeSelections(lines, [{ lineId: "A", type: "word", wordIndex: 0 }]);
     const result = shiftSelectionsTogether(lines, partitioned, -0.5, 60);
     expect(result.appliedDelta).toBeLessThan(0);

--- a/src/views/timeline/utils.test.ts
+++ b/src/views/timeline/utils.test.ts
@@ -6,6 +6,7 @@ import type { WordTiming } from "@/domain/word/timing";
 import { describe, expect, it } from "vitest";
 import { instanceBounds } from "@/domain/instance/bounds";
 import { effectiveBounds } from "@/domain/line/bounds";
+import { mainWords } from "@/domain/line/voices";
 import {
   distributeLinesTiming,
   distributeWordsInLine,
@@ -418,7 +419,7 @@ describe("getEffectiveRows", () => {
 describe("instanceBounds (legacy call site coverage)", () => {
   it("uses min/max across word and bg word timings", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "a",
         text: "x",
         agentId: "v1",
@@ -427,14 +428,14 @@ describe("instanceBounds (legacy call site coverage)", () => {
           { text: "world", begin: 6, end: 7 },
         ],
         backgroundWords: [{ text: "yeah", begin: 4, end: 4.5 }],
-      },
+      }),
     ];
     expect(instanceBounds(lines)).toEqual({ begin: 4, end: 7 });
   });
 
   it("ignores stale line.begin/end when words are present", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "a",
         text: "x",
         agentId: "v1",
@@ -442,7 +443,7 @@ describe("instanceBounds (legacy call site coverage)", () => {
           { text: "hello", begin: 5, end: 6 },
           { text: "world", begin: 6, end: 7 },
         ],
-      },
+      }),
     ];
     expect(instanceBounds(lines)).toEqual({ begin: 5, end: 7 });
   });
@@ -451,32 +452,32 @@ describe("instanceBounds (legacy call site coverage)", () => {
   // timing, so its bounds count alongside the background (union of both voices).
   it("counts line-synced main bounds alongside background words", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "a",
         text: "x",
         agentId: "v1",
         begin: 10,
         end: 20,
         backgroundWords: [{ text: "ah", begin: 5, end: 6 }],
-      },
+      }),
     ];
     expect(instanceBounds(lines)).toEqual({ begin: 5, end: 20 });
   });
 
   it("falls back to line.begin/end ONLY when the line is truly line-synced (no words and no bg words)", () => {
-    const lines: LyricLine[] = [{ id: "a", text: "x", agentId: "v1", begin: 5, end: 7 }];
+    const lines: LyricLine[] = [reconcileLine({ id: "a", text: "x", agentId: "v1", begin: 5, end: 7 })];
     expect(instanceBounds(lines)).toEqual({ begin: 5, end: 7 });
   });
 
   it("mixes correctly across multiple lines: word-synced lines use words, line-synced uses begin/end", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "a",
         text: "x",
         agentId: "v1",
         words: [{ text: "hello", begin: 5, end: 6 }],
-      },
-      { id: "b", text: "y", agentId: "v1", begin: 10, end: 12 },
+      }),
+      reconcileLine({ id: "b", text: "y", agentId: "v1", begin: 10, end: 12 }),
     ];
     expect(instanceBounds(lines)).toEqual({ begin: 5, end: 12 });
   });
@@ -485,7 +486,7 @@ describe("instanceBounds (legacy call site coverage)", () => {
 describe("getWordsInInstance", () => {
   it("collects all words and bg words across all lines of an instance", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "a",
         text: "x",
         agentId: "v1",
@@ -497,8 +498,8 @@ describe("getWordsInInstance", () => {
           { text: "love", begin: 1, end: 2 },
         ],
         backgroundWords: [{ text: "yeah", begin: 0.5, end: 1.5 }],
-      },
-      {
+      }),
+      reconcileLine({
         id: "b",
         text: "x",
         agentId: "v1",
@@ -506,9 +507,9 @@ describe("getWordsInInstance", () => {
         instanceIdx: 0,
         templateLineIdx: 1,
         words: [{ text: "you", begin: 2, end: 3 }],
-      },
+      }),
       // Other instance
-      {
+      reconcileLine({
         id: "c",
         text: "x",
         agentId: "v1",
@@ -516,7 +517,7 @@ describe("getWordsInInstance", () => {
         instanceIdx: 1,
         templateLineIdx: 0,
         words: [{ text: "I", begin: 30, end: 31 }],
-      },
+      }),
     ];
 
     const sels = getWordsInInstance(lines, "g1", 0);
@@ -534,7 +535,7 @@ describe("getWordsInInstance", () => {
 // -- nudgeSelectedWords --------------------------------------------------------
 
 function makeLine(id: string, words: { text: string; begin: number; end: number }[]): LyricLine {
-  return { id, text: words.map((w) => w.text).join(""), agentId: "v1", words };
+  return reconcileLine({ id, text: words.map((w) => w.text).join(""), agentId: "v1", words });
 }
 
 describe("nudgeSelectedWords", () => {
@@ -552,8 +553,8 @@ describe("nudgeSelectedWords", () => {
     const updatedWords = result.updates[0].updates.words!;
     expect(updatedWords[1].begin).toBeCloseTo(1.05);
     expect(updatedWords[1].end).toBeCloseTo(2.05);
-    expect(updatedWords[0]).toEqual(lines[0].words![0]);
-    expect(updatedWords[2]).toEqual(lines[0].words![2]);
+    expect(updatedWords[0]).toEqual(mainWords(lines[0])![0]);
+    expect(updatedWords[2]).toEqual(mainWords(lines[0])![2]);
   });
 
   it("shifts a single word left preserving duration", () => {
@@ -641,12 +642,12 @@ describe("nudgeSelectedWords", () => {
     );
     expect(result.appliedDelta).toBeCloseTo(0.05);
     const updated = result.updates[0].updates.words!;
-    expect(updated[0]).toEqual(lines[0].words![0]);
+    expect(updated[0]).toEqual(mainWords(lines[0])![0]);
     expect(updated[1].begin).toBeCloseTo(1.05);
     expect(updated[1].end).toBeCloseTo(2.05);
     expect(updated[2].begin).toBeCloseTo(2.05);
     expect(updated[2].end).toBeCloseTo(3.05);
-    expect(updated[3]).toEqual(lines[0].words![3]);
+    expect(updated[3]).toEqual(mainWords(lines[0])![3]);
   });
 
   it("clamps a block to the most-restrictive non-selected neighbor", () => {
@@ -674,7 +675,7 @@ describe("nudgeSelectedWords", () => {
 
   it("nudges background words via backgroundWords", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L",
         text: "a",
         agentId: "v1",
@@ -684,7 +685,7 @@ describe("nudgeSelectedWords", () => {
           { text: "ooh", begin: 2, end: 3 },
           { text: "ah", begin: 5, end: 6 },
         ],
-      },
+      }),
     ];
     const result = nudgeSelectedWords(lines, [{ lineId: "L", type: "bg", wordIndex: 0 }], 0.1, 10);
     expect(result.appliedDelta).toBeCloseTo(0.1);
@@ -731,7 +732,7 @@ describe("nudgeSelectedWords", () => {
 describe("nudgeSelectedWords as instance shift", () => {
   it("shifts every word in an instance by the same delta when all words are selected", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "A",
         text: "I love",
         agentId: "v1",
@@ -742,8 +743,8 @@ describe("nudgeSelectedWords as instance shift", () => {
           { text: "I ", begin: 10, end: 10.3 },
           { text: "love", begin: 10.3, end: 10.8 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "B",
         text: "all night",
         agentId: "v1",
@@ -754,9 +755,9 @@ describe("nudgeSelectedWords as instance shift", () => {
           { text: "all ", begin: 11, end: 11.4 },
           { text: "night", begin: 11.4, end: 12 },
         ],
-      },
+      }),
       // Standalone line OUTSIDE the instance, must NOT be touched
-      { id: "C", text: "outside", agentId: "v1", words: [{ text: "outside", begin: 30, end: 31 }] },
+      reconcileLine({ id: "C", text: "outside", agentId: "v1", words: [{ text: "outside", begin: 30, end: 31 }] }),
     ];
     const allInstanceSelections = [
       { lineId: "A", type: "word" as const, wordIndex: 0 },
@@ -776,7 +777,7 @@ describe("nudgeSelectedWords as instance shift", () => {
   });
 
   it("clamps shift to song duration when selection touches the end", () => {
-    const lines: LyricLine[] = [{ id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 59.7, end: 60 }] }];
+    const lines: LyricLine[] = [reconcileLine({ id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 59.7, end: 60 }] })];
     const result = nudgeSelectedWords(lines, [{ lineId: "A", type: "word", wordIndex: 0 }], 0.5, 60);
     expect(result.appliedDelta).toBe(0);
   });
@@ -787,7 +788,7 @@ describe("nudgeSelectedWords as instance shift", () => {
 describe("partitionNudgeSelections", () => {
   it("classifies word-synced lines as wordSynced", () => {
     const lines: LyricLine[] = [
-      { id: "L1", text: "hello", agentId: "v1", words: [{ text: "hello", begin: 0, end: 1 }] },
+      reconcileLine({ id: "L1", text: "hello", agentId: "v1", words: [{ text: "hello", begin: 0, end: 1 }] }),
     ];
     const sels = [{ lineId: "L1", type: "word" as const, wordIndex: 0 }];
     const result = partitionNudgeSelections(lines, sels);
@@ -796,7 +797,7 @@ describe("partitionNudgeSelections", () => {
   });
 
   it("classifies line-synced lines as lineSynced", () => {
-    const lines: LyricLine[] = [{ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 }];
+    const lines: LyricLine[] = [reconcileLine({ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 })];
     const sels = [{ lineId: "L1", type: "word" as const, wordIndex: 0 }];
     const result = partitionNudgeSelections(lines, sels);
     expect(result.lineSynced).toEqual(sels);
@@ -807,7 +808,7 @@ describe("partitionNudgeSelections", () => {
     // Effective lines synthesize a single 'word' for line-synced rows. If a user marquee-selected
     // a line-synced row from a viewport that briefly produced multiple synthetic indices,
     // we should still only shift the line once.
-    const lines: LyricLine[] = [{ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 }];
+    const lines: LyricLine[] = [reconcileLine({ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 })];
     const sels = [
       { lineId: "L1", type: "word" as const, wordIndex: 0 },
       { lineId: "L1", type: "word" as const, wordIndex: 0 },
@@ -819,14 +820,14 @@ describe("partitionNudgeSelections", () => {
   it("treats backgroundWords selections as wordSynced regardless of line-sync state", () => {
     // BG words always have explicit timing even on otherwise line-synced rows
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "main",
         agentId: "v1",
         begin: 5,
         end: 7,
         backgroundWords: [{ text: "ah", begin: 5.2, end: 5.6 }],
-      },
+      }),
     ];
     const sels = [{ lineId: "L1", type: "bg" as const, wordIndex: 0 }];
     const result = partitionNudgeSelections(lines, sels);
@@ -836,8 +837,8 @@ describe("partitionNudgeSelections", () => {
 
   it("handles mixed selections across line-synced and word-synced rows", () => {
     const lines: LyricLine[] = [
-      { id: "A", text: "synced", agentId: "v1", begin: 0, end: 1 },
-      { id: "B", text: "with words", agentId: "v1", words: [{ text: "with words", begin: 1, end: 2 }] },
+      reconcileLine({ id: "A", text: "synced", agentId: "v1", begin: 0, end: 1 }),
+      reconcileLine({ id: "B", text: "with words", agentId: "v1", words: [{ text: "with words", begin: 1, end: 2 }] }),
     ];
     const sels = [
       { lineId: "A", type: "word" as const, wordIndex: 0 },
@@ -855,7 +856,7 @@ describe("partitionNudgeSelections", () => {
   });
 
   it("treats lines with no words and no begin/end as neither (skipped)", () => {
-    const lines: LyricLine[] = [{ id: "empty", text: "", agentId: "v1" }];
+    const lines: LyricLine[] = [reconcileLine({ id: "empty", text: "", agentId: "v1" })];
     const result = partitionNudgeSelections(lines, [{ lineId: "empty", type: "word", wordIndex: 0 }]);
     expect(result.wordSynced).toEqual([]);
     expect(result.lineSynced).toEqual([]);
@@ -863,7 +864,7 @@ describe("partitionNudgeSelections", () => {
 
   it("expands a syllable-group selection to all groupmates in the wordSynced bucket", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "every",
         agentId: "v1",
@@ -872,7 +873,7 @@ describe("partitionNudgeSelections", () => {
           { text: "er", begin: 0.3, end: 0.6, syllableGroupId: "g_every" },
           { text: "y", begin: 0.6, end: 1, syllableGroupId: "g_every" },
         ],
-      },
+      }),
     ];
     const sels = [{ lineId: "L1", type: "word" as const, wordIndex: 1 }];
     const result = partitionNudgeSelections(lines, sels);
@@ -884,7 +885,7 @@ describe("partitionNudgeSelections", () => {
 
 describe("shiftLineSyncedRows", () => {
   it("shifts begin and end by the requested delta and preserves line-sync (no words written)", () => {
-    const lines: LyricLine[] = [{ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 }];
+    const lines: LyricLine[] = [reconcileLine({ id: "L1", text: "verse", agentId: "v1", begin: 5, end: 7 })];
     const result = shiftLineSyncedRows(lines, [{ lineId: "L1", type: "word", wordIndex: 0 }], 0.5, 60);
     expect(result.appliedDelta).toBe(0.5);
     expect(result.updates).toHaveLength(1);
@@ -896,8 +897,8 @@ describe("shiftLineSyncedRows", () => {
 
   it("shifts multiple line-synced rows together by the smallest allowed delta", () => {
     const lines: LyricLine[] = [
-      { id: "A", text: "a", agentId: "v1", begin: 0.1, end: 1 },
-      { id: "B", text: "b", agentId: "v1", begin: 5, end: 6 },
+      reconcileLine({ id: "A", text: "a", agentId: "v1", begin: 0.1, end: 1 }),
+      reconcileLine({ id: "B", text: "b", agentId: "v1", begin: 5, end: 6 }),
     ];
     // Request -0.5s shift; A only has 0.1s headroom on the left, so applied delta is -0.1
     const result = shiftLineSyncedRows(
@@ -915,16 +916,16 @@ describe("shiftLineSyncedRows", () => {
   });
 
   it("returns no-op when shift would push past 0 or duration", () => {
-    const lines: LyricLine[] = [{ id: "L1", text: "x", agentId: "v1", begin: 0, end: 1 }];
+    const lines: LyricLine[] = [reconcileLine({ id: "L1", text: "x", agentId: "v1", begin: 0, end: 1 })];
     const r1 = shiftLineSyncedRows(lines, [{ lineId: "L1", type: "word", wordIndex: 0 }], -0.5, 60);
     expect(r1.appliedDelta).toBe(0);
-    const lines2: LyricLine[] = [{ id: "L1", text: "x", agentId: "v1", begin: 59, end: 60 }];
+    const lines2: LyricLine[] = [reconcileLine({ id: "L1", text: "x", agentId: "v1", begin: 59, end: 60 })];
     const r2 = shiftLineSyncedRows(lines2, [{ lineId: "L1", type: "word", wordIndex: 0 }], 0.5, 60);
     expect(r2.appliedDelta).toBe(0);
   });
 
   it("returns no-op for zero delta", () => {
-    const lines: LyricLine[] = [{ id: "L1", text: "x", agentId: "v1", begin: 5, end: 6 }];
+    const lines: LyricLine[] = [reconcileLine({ id: "L1", text: "x", agentId: "v1", begin: 5, end: 6 })];
     const result = shiftLineSyncedRows(lines, [{ lineId: "L1", type: "word", wordIndex: 0 }], 0, 60);
     expect(result.appliedDelta).toBe(0);
     expect(result.updates).toEqual([]);
@@ -937,7 +938,7 @@ describe("shiftLineSyncedRows", () => {
   });
 
   it("skips selections where line is missing or has no begin/end", () => {
-    const lines: LyricLine[] = [{ id: "L1", text: "x", agentId: "v1" }];
+    const lines: LyricLine[] = [reconcileLine({ id: "L1", text: "x", agentId: "v1" })];
     const result = shiftLineSyncedRows(lines, [{ lineId: "L1", type: "word", wordIndex: 0 }], 0.5, 60);
     expect(result.appliedDelta).toBe(0);
     expect(result.updates).toEqual([]);
@@ -953,9 +954,9 @@ describe("shiftSelectionsTogether", () => {
     // If they apply different deltas, the group banner stretches asymmetrically.
     const lines: LyricLine[] = [
       // Word-synced row whose first word starts at 0.05 → max left shift = 0.05
-      { id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 0.05, end: 1 }] },
+      reconcileLine({ id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 0.05, end: 1 }] }),
       // Line-synced row with much more left headroom (begin=10)
-      { id: "B", text: "y", agentId: "v1", begin: 10, end: 11 },
+      reconcileLine({ id: "B", text: "y", agentId: "v1", begin: 10, end: 11 }),
     ];
     const partitioned = partitionNudgeSelections(lines, [
       { lineId: "A", type: "word", wordIndex: 0 },
@@ -972,7 +973,7 @@ describe("shiftSelectionsTogether", () => {
   });
 
   it("works when only the line-synced partition has selections", () => {
-    const lines: LyricLine[] = [{ id: "A", text: "x", agentId: "v1", begin: 5, end: 6 }];
+    const lines: LyricLine[] = [reconcileLine({ id: "A", text: "x", agentId: "v1", begin: 5, end: 6 })];
     const partitioned = partitionNudgeSelections(lines, [{ lineId: "A", type: "word", wordIndex: 0 }]);
     const result = shiftSelectionsTogether(lines, partitioned, 0.1, 60);
     expect(result.appliedDelta).toBeCloseTo(0.1);
@@ -980,7 +981,7 @@ describe("shiftSelectionsTogether", () => {
   });
 
   it("works when only the word-synced partition has selections", () => {
-    const lines: LyricLine[] = [{ id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 5, end: 6 }] }];
+    const lines: LyricLine[] = [reconcileLine({ id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 5, end: 6 }] })];
     const partitioned = partitionNudgeSelections(lines, [{ lineId: "A", type: "word", wordIndex: 0 }]);
     const result = shiftSelectionsTogether(lines, partitioned, 0.1, 60);
     expect(result.appliedDelta).toBeCloseTo(0.1);
@@ -996,9 +997,9 @@ describe("shiftSelectionsTogether", () => {
   it("clamps to the smaller of word-synced and line-synced headroom (line-synced wins)", () => {
     const lines: LyricLine[] = [
       // Word-synced row with tons of headroom on both sides
-      { id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 30, end: 31 }] },
+      reconcileLine({ id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 30, end: 31 }] }),
       // Line-synced row with only 0.01s headroom on the right (close to duration=60)
-      { id: "B", text: "y", agentId: "v1", begin: 58.99, end: 59.99 },
+      reconcileLine({ id: "B", text: "y", agentId: "v1", begin: 58.99, end: 59.99 }),
     ];
     const partitioned = partitionNudgeSelections(lines, [
       { lineId: "A", type: "word", wordIndex: 0 },
@@ -1009,7 +1010,7 @@ describe("shiftSelectionsTogether", () => {
   });
 
   it("preserves direction when clamping (negative requestedDelta yields negative applied)", () => {
-    const lines: LyricLine[] = [{ id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 0.05, end: 1 }] }];
+    const lines: LyricLine[] = [reconcileLine({ id: "A", text: "x", agentId: "v1", words: [{ text: "x", begin: 0.05, end: 1 }] })];
     const partitioned = partitionNudgeSelections(lines, [{ lineId: "A", type: "word", wordIndex: 0 }]);
     const result = shiftSelectionsTogether(lines, partitioned, -0.5, 60);
     expect(result.appliedDelta).toBeLessThan(0);
@@ -1020,7 +1021,7 @@ describe("shiftSelectionsTogether", () => {
     // The user-reported bug: instance with all members selected, nudge left,
     // header right edge stays affixed while left edge moves. Unified clamp prevents.
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "L1",
         text: "I love",
         agentId: "v1",
@@ -1031,8 +1032,8 @@ describe("shiftSelectionsTogether", () => {
           { text: "I ", begin: 10, end: 10.3 },
           { text: "love", begin: 10.3, end: 10.8 },
         ],
-      },
-      {
+      }),
+      reconcileLine({
         id: "L2",
         text: "all night",
         agentId: "v1",
@@ -1043,7 +1044,7 @@ describe("shiftSelectionsTogether", () => {
           { text: "all ", begin: 11, end: 11.4 },
           { text: "night", begin: 11.4, end: 12 },
         ],
-      },
+      }),
     ];
     const partitioned = partitionNudgeSelections(lines, [
       { lineId: "L1", type: "word", wordIndex: 0 },
@@ -1073,7 +1074,7 @@ describe("shiftSelectionsTogether", () => {
 describe("shiftSelectionsTogether · background provenance", () => {
   it("stamps backgroundTextSource manual when nudging background words", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "A",
         text: "main",
         agentId: "v1",
@@ -1081,7 +1082,7 @@ describe("shiftSelectionsTogether · background provenance", () => {
         backgroundText: "ooh",
         backgroundWords: [{ text: "ooh", begin: 2, end: 3 }],
         backgroundTextSource: "extraction",
-      },
+      }),
     ];
     const partitioned = partitionNudgeSelections(lines, [{ lineId: "A", type: "bg", wordIndex: 0 }]);
     const result = shiftSelectionsTogether(lines, partitioned, 0.1, 60);
@@ -1092,7 +1093,7 @@ describe("shiftSelectionsTogether · background provenance", () => {
 
   it("leaves the nudged background word data unchanged apart from timing", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "A",
         text: "main",
         agentId: "v1",
@@ -1103,7 +1104,7 @@ describe("shiftSelectionsTogether · background provenance", () => {
           { text: "aah", begin: 2.5, end: 3 },
         ],
         backgroundTextSource: "extraction",
-      },
+      }),
     ];
     const partitioned = partitionNudgeSelections(lines, [
       { lineId: "A", type: "bg", wordIndex: 0 },
@@ -1121,7 +1122,7 @@ describe("shiftSelectionsTogether · background provenance", () => {
 
   it("does not touch background provenance when nudging only main words", () => {
     const lines: LyricLine[] = [
-      {
+      reconcileLine({
         id: "A",
         text: "main",
         agentId: "v1",
@@ -1129,7 +1130,7 @@ describe("shiftSelectionsTogether · background provenance", () => {
         backgroundText: "ooh",
         backgroundWords: [{ text: "ooh", begin: 2, end: 3 }],
         backgroundTextSource: "extraction",
-      },
+      }),
     ];
     const partitioned = partitionNudgeSelections(lines, [{ lineId: "A", type: "word", wordIndex: 0 }]);
     const result = shiftSelectionsTogether(lines, partitioned, 0.1, 60);

--- a/src/views/timeline/utils.ts
+++ b/src/views/timeline/utils.ts
@@ -1,9 +1,11 @@
 import { instanceBounds } from "@/domain/instance/bounds";
 import { isLinked } from "@/domain/instance/predicates";
 import { manualBackgroundWordEdit } from "@/domain/line/background";
+import { mainBounds } from "@/domain/line/bounds";
 import { getEffectiveLines } from "@/domain/line/effective-words";
 import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordSelection } from "@/domain/selection/model";
 import type { WordTiming } from "@/domain/word/timing";
 import { formatTime as formatTimeBase } from "@/utils/format-time";
@@ -113,13 +115,15 @@ function getWordsInInstance(lines: LyricLine[], groupId: string, instanceIdx: nu
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
     const line = lines[lineIndex];
     if (line.groupId !== groupId || line.instanceIdx !== instanceIdx) continue;
-    if (line.words?.length) {
-      for (let wordIndex = 0; wordIndex < line.words.length; wordIndex++) {
+    const main = mainWords(line);
+    if (main?.length) {
+      for (let wordIndex = 0; wordIndex < main.length; wordIndex++) {
         out.push({ lineId: line.id, lineIndex, wordIndex, type: "word" });
       }
     }
-    if (line.backgroundWords?.length) {
-      for (let wordIndex = 0; wordIndex < line.backgroundWords.length; wordIndex++) {
+    const bg = bgWords(line);
+    if (bg?.length) {
+      for (let wordIndex = 0; wordIndex < bg.length; wordIndex++) {
         out.push({ lineId: line.id, lineIndex, wordIndex, type: "bg" });
       }
     }
@@ -178,7 +182,8 @@ function computeRowLayout({
     if (isCollapsed) continue;
 
     const mainHeight = rowHeights[line.id] ?? defaultRowHeight;
-    const hasBg = line.backgroundWords && line.backgroundWords.length > 0;
+    const bg = bgWords(line);
+    const hasBg = bg && bg.length > 0;
     const rowHeight = mainHeight + (hasBg ? mainHeight : bgDropZoneHeight) + 1;
     lineTops.set(line.id, { top: rowTop, height: rowHeight, mainBottom: rowTop + mainHeight });
     rowTop += rowHeight;
@@ -222,7 +227,7 @@ function partitionNudgeSelections(
   const seenLineSyncedIds = new Set<string>();
 
   const pushWordSynced = (sel: NudgeSelection, line: LyricLine) => {
-    const wordsArray = sel.type === "bg" ? line.backgroundWords : line.words;
+    const wordsArray = sel.type === "bg" ? bgWords(line) : mainWords(line);
     if (!wordsArray) return;
     const expanded = expandSelectionToGroupmates(wordsArray, [sel.wordIndex]);
     for (const idx of expanded) {
@@ -300,22 +305,24 @@ function shiftLineSyncedRows(
   }
   const direction = requestedDelta < 0 ? -1 : 1;
   let allowedMagnitude = Math.abs(requestedDelta);
-  const targets: LyricLine[] = [];
+  const targets: { id: string; begin: number; end: number }[] = [];
   const linesById = new Map<string, LyricLine>();
   for (const l of rawLines) linesById.set(l.id, l);
   for (const sel of selections) {
     const line = linesById.get(sel.lineId);
-    if (!line || line.begin === undefined || line.end === undefined) continue;
-    targets.push(line);
-    const headroom = direction < 0 ? line.begin : duration - line.end;
+    if (!line) continue;
+    const mb = mainBounds(line);
+    if (!isLineSynced(line) || !mb) continue;
+    targets.push({ id: line.id, begin: mb.begin, end: mb.end });
+    const headroom = direction < 0 ? mb.begin : duration - mb.end;
     if (headroom < allowedMagnitude) allowedMagnitude = headroom;
     if (allowedMagnitude <= 0) return { appliedDelta: 0, updates: [] };
   }
   if (targets.length === 0) return { appliedDelta: 0, updates: [] };
   const appliedDelta = direction * allowedMagnitude;
-  const updates: NudgeUpdate[] = targets.map((line) => ({
-    id: line.id,
-    updates: { begin: (line.begin as number) + appliedDelta, end: (line.end as number) + appliedDelta },
+  const updates: NudgeUpdate[] = targets.map((target) => ({
+    id: target.id,
+    updates: { begin: target.begin + appliedDelta, end: target.end + appliedDelta },
   }));
   return { appliedDelta, updates };
 }
@@ -337,7 +344,7 @@ function nudgeSelectedWords(
   for (const sel of selections) {
     const line = linesById.get(sel.lineId);
     if (!line) continue;
-    const wordsArray = sel.type === "word" ? line.words : line.backgroundWords;
+    const wordsArray = sel.type === "word" ? mainWords(line) : bgWords(line);
     if (!wordsArray || wordsArray[sel.wordIndex] === undefined) continue;
     const key = `${sel.lineId}:${sel.type}`;
     let group = groups.get(key);
@@ -354,7 +361,7 @@ function nudgeSelectedWords(
   let allowedMagnitude = Math.abs(requestedDelta);
 
   for (const group of groups.values()) {
-    const wordsArray = (group.type === "word" ? group.line.words : group.line.backgroundWords) as WordTiming[];
+    const wordsArray = (group.type === "word" ? mainWords(group.line) : bgWords(group.line)) as WordTiming[];
     for (const idx of group.indices) {
       const word = wordsArray[idx];
       let headroom: number;
@@ -385,7 +392,7 @@ function nudgeSelectedWords(
   const appliedDelta = direction * allowedMagnitude;
   const updates: NudgeUpdate[] = [];
   for (const group of groups.values()) {
-    const wordsArray = (group.type === "word" ? group.line.words : group.line.backgroundWords) as WordTiming[];
+    const wordsArray = (group.type === "word" ? mainWords(group.line) : bgWords(group.line)) as WordTiming[];
     const updatedWords = wordsArray.map((w, i) =>
       group.indices.has(i) ? { ...w, begin: w.begin + appliedDelta, end: w.end + appliedDelta } : w,
     );

--- a/src/views/timeline/utils.ts
+++ b/src/views/timeline/utils.ts
@@ -4,7 +4,7 @@ import { manualBackgroundWordEdit } from "@/domain/line/background";
 import { mainBounds } from "@/domain/line/bounds";
 import { getEffectiveLines } from "@/domain/line/effective-words";
 import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
-import type { LyricLine } from "@/domain/line/model";
+import type { LooseLine, LyricLine } from "@/domain/line/model";
 import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordSelection } from "@/domain/selection/model";
 import type { WordTiming } from "@/domain/word/timing";
@@ -202,7 +202,7 @@ interface NudgeSelection {
 
 interface NudgeUpdate {
   id: string;
-  updates: Partial<LyricLine>;
+  updates: Partial<LooseLine>;
 }
 
 interface NudgeResult {

--- a/src/views/timeline/word-at-playhead.ts
+++ b/src/views/timeline/word-at-playhead.ts
@@ -1,4 +1,5 @@
 import type { LyricLine } from "@/domain/line/model";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import type { WordSelection } from "@/domain/selection/model";
 import { sameWordSelection } from "@/domain/selection/identity";
 
@@ -8,17 +9,19 @@ function findWordsAtTime(lines: LyricLine[], time: number): WordSelection[] {
   const matches: WordSelection[] = [];
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
     const line = lines[lineIndex];
-    if (line.words) {
-      for (let wordIndex = 0; wordIndex < line.words.length; wordIndex++) {
-        const word = line.words[wordIndex];
+    const main = mainWords(line);
+    if (main) {
+      for (let wordIndex = 0; wordIndex < main.length; wordIndex++) {
+        const word = main[wordIndex];
         if (time >= word.begin && time < word.end) {
           matches.push({ lineId: line.id, lineIndex, wordIndex, type: "word" });
         }
       }
     }
-    if (line.backgroundWords) {
-      for (let wordIndex = 0; wordIndex < line.backgroundWords.length; wordIndex++) {
-        const word = line.backgroundWords[wordIndex];
+    const bg = bgWords(line);
+    if (bg) {
+      for (let wordIndex = 0; wordIndex < bg.length; wordIndex++) {
+        const word = bg[wordIndex];
         if (time >= word.begin && time < word.end) {
           matches.push({ lineId: line.id, lineIndex, wordIndex, type: "bg" });
         }

--- a/src/views/timeline/word-edit-overlay.tsx
+++ b/src/views/timeline/word-edit-overlay.tsx
@@ -2,6 +2,7 @@ import { useProjectStore } from "@/stores/project";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { manualBackgroundWordEdit } from "@/domain/line/background";
 import { getEffectiveLines } from "@/domain/line/effective-words";
+import { bgWords, mainWords } from "@/domain/line/voices";
 import { FloatingPortal } from "@floating-ui/react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
@@ -24,7 +25,7 @@ const WordEditOverlay: React.FC<WordEditOverlayProps> = ({ lineId, wordIndex, ty
 
   const effectiveLines = useMemo(() => getEffectiveLines(rawLines), [rawLines]);
   const line = effectiveLines.find((l) => l.id === lineId);
-  const wordsArray = type === "word" ? line?.words : line?.backgroundWords;
+  const wordsArray = line ? (type === "word" ? mainWords(line) : bgWords(line)) : undefined;
   const word = wordsArray?.[wordIndex];
 
   const [pos, setPos] = useState<{ top: number; left: number; width: number } | null>(null);

--- a/src/views/timeline/word-track.background.browser.test.tsx
+++ b/src/views/timeline/word-track.background.browser.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { WordTrack } from "@/views/timeline/word-track";
+import { bgSource, bgWords } from "@/domain/line/voices";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
@@ -15,7 +16,7 @@ async function renderBgTrack(lineId: string) {
     <WordTrack
       lineId={lineId}
       lineIndex={0}
-      words={useProjectStore.getState().lines[0].backgroundWords ?? []}
+      words={bgWords(useProjectStore.getState().lines[0]) ?? []}
       color="#a3c9ff"
       trackType="bg"
       duration={3}
@@ -46,8 +47,8 @@ describe("WordTrack background provenance", () => {
       new MouseEvent("dblclick", { bubbles: true, clientX: rect.left + 250, clientY: rect.top + 10 }),
     );
 
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundWords?.length).toBe(2);
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
+    await expect.poll(() => bgWords(useProjectStore.getState().lines[0])?.length).toBe(2);
+    expect(bgSource(useProjectStore.getState().lines[0])).toBe("manual");
   });
 
   it("keeps the existing background words intact apart from the added one", async () => {
@@ -69,8 +70,8 @@ describe("WordTrack background provenance", () => {
       new MouseEvent("dblclick", { bubbles: true, clientX: rect.left + 250, clientY: rect.top + 10 }),
     );
 
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundWords?.length).toBe(2);
-    const bg = useProjectStore.getState().lines[0].backgroundWords;
+    await expect.poll(() => bgWords(useProjectStore.getState().lines[0])?.length).toBe(2);
+    const bg = bgWords(useProjectStore.getState().lines[0]);
     expect(bg?.some((w) => w.text.trim() === "ooh")).toBe(true);
   });
 });

--- a/src/views/timeline/word-track.browser.test.tsx
+++ b/src/views/timeline/word-track.browser.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { WordTrack } from "@/views/timeline/word-track";
+import { mainWords } from "@/domain/line/voices";
 import type { WordTiming } from "@/domain/word/timing";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
@@ -332,7 +333,7 @@ describe("WordTrack", () => {
       new MouseEvent("dblclick", { bubbles: true, clientX: rect.left + 250, clientY: rect.top + 10 }),
     );
 
-    await expect.poll(() => useProjectStore.getState().lines[0].words?.length).toBe(3);
-    expect(useProjectStore.getState().lines[0].words?.map((w) => w.text)).toEqual(["hello ", "world ", "..."]);
+    await expect.poll(() => mainWords(useProjectStore.getState().lines[0])?.length).toBe(3);
+    expect(mainWords(useProjectStore.getState().lines[0])?.map((w) => w.text)).toEqual(["hello ", "world ", "..."]);
   });
 });


### PR DESCRIPTION
## Summary

Background vocals are now a first-class voice with the same three-state timing model as the main vocal: untimed, line-synced, or word-synced. Previously a background on a line-synced line was automatically broken up into words. Now it stays a single line-synced block, matching how the main line behaves.

Closes #122.

## What changed

- **Data model:** `LyricLine` nests its timing into voices, `{ main: Voice; background?: BackgroundVoice }`, where `Voice` is a structural union (untimed `{text}`, line-synced `{text,begin,end}`, word-synced `{text,words}`). A single seam (`domain/line/voices.ts`) is the only reader of the nested fields, and a fitness test bans inline access elsewhere.
- **Granularity resolver + one funnel:** every background write goes through a single resolver-aware chokepoint. An untimed background resolves against the main voice (line-synced over a line-synced main, distributed over a word-synced main). The old sync-panel effect that force-split backgrounds into words is gone.
- **Legacy migration:** projects saved in the old flat shape migrate to the voice model at load and import boundaries.
- **TTML parser:** preserves authored background granularity. One timed `x-bg` span imports as a line-synced background, two or more import as word-synced, and untimed text resolves against the main.
- **TTML export:** emits from the voice model. A line-synced background is one `x-bg` span with its own bounds, and `composer:timing` is derived from whether any voice is word-synced.
- **Timeline:** a background lane covering all three states, "Place background here", voice-aware "Split into words", and "Remove background" (with undo and a confirmation). A line-synced background renders identically to a line-synced main.

## Testing

- Unit 2565, component 1268, typecheck clean, lint clean, duplication under threshold.
- Covered end to end on a real line-synced TTML carrying a parenthetical background: it stays one line-synced block on import and survives a parse, export, and re-parse with no granularity change. The exporter output validates against the standalone TTML validator with no errors.
