### PR TITLE
fix: sync skips empty lines instead of stalling on them

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.32.0",
+  "version": "1.32.1",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/hooks/useSyncHandlers.browser.test.tsx
+++ b/src/hooks/useSyncHandlers.browser.test.tsx
@@ -115,6 +115,35 @@ describe("useSyncHandlers.handleTap (word granularity)", () => {
     expect(useProjectStore.getState().lines[0].words?.length).toBe(2);
   });
 
+  it("regression: skips an empty line and still patches the word before it (issue #114)", async () => {
+    useProjectStore
+      .getState()
+      .setLines([
+        createLine({ id: "l0", text: "Hello world" }),
+        createLine({ id: "lblank", text: "" }),
+        createLine({ id: "l2", text: "Foo bar" }),
+      ]);
+
+    const { result, rerender, act, getSyncState } = await mountSyncHandlers();
+
+    await act(() => result.current.handleTap());
+    await rerender({ syncState: getSyncState(), currentTime: 0.5 });
+    await act(() => result.current.handleTap());
+
+    expect(getSyncState().position.lineIndex).toBe(2);
+
+    await rerender({ syncState: getSyncState(), currentTime: 1.25 });
+    await act(() => result.current.handleTap());
+
+    const lines = useProjectStore.getState().lines;
+    expect(lines[0].words).toHaveLength(2);
+    expect(lines[0].words?.[1].end).toBe(1.25);
+    expect(lines[1].text).toBe("");
+    expect(lines[1].words).toBeUndefined();
+    expect(lines[2].text).toBe("Foo bar");
+    expect(lines[2].words).toHaveLength(1);
+  });
+
   it("preserves prev-line text when patching a partially synced previous line on cross-line tap", async () => {
     useProjectStore.getState().setLines([
       createLine({

--- a/src/hooks/useSyncHandlers.helpers.test.ts
+++ b/src/hooks/useSyncHandlers.helpers.test.ts
@@ -1,7 +1,9 @@
 import {
   advanceSyncPosition,
   buildInitialWordUpdates,
+  nextSyncableLineIndex,
   prepareSyncWord,
+  prevSyncableLine,
   withBgSeedIfNeeded,
 } from "@/hooks/useSyncHandlers.helpers";
 import type { LyricLine } from "@/domain/line/model";
@@ -98,21 +100,93 @@ describe("advanceSyncPosition", () => {
     return { setSyncState, getState: () => state };
   }
 
+  const twoLines = [createLine({ text: "Hello world" }), createLine({ text: "Second line" })];
+
   it("advances within the same line when not at the last word", () => {
     const { setSyncState, getState } = makeSetter();
-    advanceSyncPosition(setSyncState, 0, 1, 5);
+    advanceSyncPosition(setSyncState, twoLines, 0, 1, 5);
     expect(getState().position).toEqual({ lineIndex: 0, wordIndex: 2 });
   });
 
   it("advances to the next line when crossing the last word", () => {
     const { setSyncState, getState } = makeSetter();
-    advanceSyncPosition(setSyncState, 0, 4, 5);
+    advanceSyncPosition(setSyncState, twoLines, 0, 4, 5);
     expect(getState().position).toEqual({ lineIndex: 1, wordIndex: 0 });
   });
 
   it("preserves the isActive flag", () => {
     const { setSyncState, getState } = makeSetter();
-    advanceSyncPosition(setSyncState, 0, 0, 3);
+    advanceSyncPosition(setSyncState, twoLines, 0, 0, 3);
     expect(getState().isActive).toBe(true);
+  });
+
+  it("skips an empty line when crossing to the next line", () => {
+    const lines = [createLine({ text: "Hello" }), createLine({ text: "" }), createLine({ text: "World" })];
+    const { setSyncState, getState } = makeSetter();
+    advanceSyncPosition(setSyncState, lines, 0, 0, 1);
+    expect(getState().position).toEqual({ lineIndex: 2, wordIndex: 0 });
+  });
+
+  it("skips multiple consecutive empty lines", () => {
+    const lines = [
+      createLine({ text: "Hello" }),
+      createLine({ text: "" }),
+      createLine({ text: "  " }),
+      createLine({ text: "World" }),
+    ];
+    const { setSyncState, getState } = makeSetter();
+    advanceSyncPosition(setSyncState, lines, 0, 0, 1);
+    expect(getState().position).toEqual({ lineIndex: 3, wordIndex: 0 });
+  });
+
+  it("lands on lines.length (complete) when only empty lines follow", () => {
+    const lines = [createLine({ text: "Hello" }), createLine({ text: "" })];
+    const { setSyncState, getState } = makeSetter();
+    advanceSyncPosition(setSyncState, lines, 0, 0, 1);
+    expect(getState().position.lineIndex).toBe(lines.length);
+  });
+});
+
+describe("nextSyncableLineIndex", () => {
+  it("returns the immediate next line when it has words", () => {
+    const lines = [createLine({ text: "a" }), createLine({ text: "b" })];
+    expect(nextSyncableLineIndex(lines, 0)).toBe(1);
+  });
+
+  it("skips empty and whitespace-only lines", () => {
+    const lines = [
+      createLine({ text: "a" }),
+      createLine({ text: "" }),
+      createLine({ text: "  " }),
+      createLine({ text: "b" }),
+    ];
+    expect(nextSyncableLineIndex(lines, 0)).toBe(3);
+  });
+
+  it("returns lines.length when no syncable line follows", () => {
+    const lines = [createLine({ text: "a" }), createLine({ text: "" })];
+    expect(nextSyncableLineIndex(lines, 0)).toBe(2);
+  });
+
+  it("finds the first syncable line from before the start (fromIndex -1)", () => {
+    const lines = [createLine({ text: "" }), createLine({ text: "a" })];
+    expect(nextSyncableLineIndex(lines, -1)).toBe(1);
+  });
+});
+
+describe("prevSyncableLine", () => {
+  it("returns the immediate previous line when it has words", () => {
+    const lines = [createLine({ text: "a" }), createLine({ text: "b" })];
+    expect(prevSyncableLine(lines, 1)?.text).toBe("a");
+  });
+
+  it("skips empty lines and returns the nearest syncable predecessor", () => {
+    const lines = [createLine({ text: "a" }), createLine({ text: "" }), createLine({ text: "b" })];
+    expect(prevSyncableLine(lines, 2)?.text).toBe("a");
+  });
+
+  it("returns undefined when no syncable line precedes", () => {
+    const lines = [createLine({ text: "" }), createLine({ text: "b" })];
+    expect(prevSyncableLine(lines, 1)).toBeUndefined();
   });
 });

--- a/src/hooks/useSyncHandlers.helpers.ts
+++ b/src/hooks/useSyncHandlers.helpers.ts
@@ -1,5 +1,5 @@
 import type { LyricLine } from "@/domain/line/model";
-import { createInitialBgWords, splitIntoWordsWithMeta, type SyncState } from "@/utils/sync-helpers";
+import { createInitialBgWords, splitIntoWords, splitIntoWordsWithMeta, type SyncState } from "@/utils/sync-helpers";
 
 // -- Types --------------------------------------------------------------------
 
@@ -46,15 +46,35 @@ function buildInitialWordUpdates(
   return withBgSeedIfNeeded({ words: [{ text: textWithSpace, begin, end }] }, line, begin);
 }
 
+function isSyncableLine(line: LyricLine | undefined): boolean {
+  return !!line && splitIntoWords(line.text).length > 0;
+}
+
+function nextSyncableLineIndex(lines: LyricLine[], fromIndex: number): number {
+  for (let i = fromIndex + 1; i < lines.length; i++) {
+    if (isSyncableLine(lines[i])) return i;
+  }
+  return lines.length;
+}
+
+function prevSyncableLine(lines: LyricLine[], fromIndex: number): LyricLine | undefined {
+  for (let i = fromIndex - 1; i >= 0; i--) {
+    if (isSyncableLine(lines[i])) return lines[i];
+  }
+  return undefined;
+}
+
 function advanceSyncPosition(
   setSyncState: SetSyncState,
+  lines: LyricLine[],
   lineIndex: number,
   wordIndex: number,
   totalWords: number,
 ): void {
   const nextWordIndex = wordIndex + 1;
   if (nextWordIndex >= totalWords) {
-    setSyncState((prev) => ({ ...prev, position: { lineIndex: lineIndex + 1, wordIndex: 0 } }));
+    const nextLineIndex = nextSyncableLineIndex(lines, lineIndex);
+    setSyncState((prev) => ({ ...prev, position: { lineIndex: nextLineIndex, wordIndex: 0 } }));
   } else {
     setSyncState((prev) => ({ ...prev, position: { ...prev.position, wordIndex: nextWordIndex } }));
   }
@@ -67,5 +87,13 @@ function triggerPulse(setShowPulse: (show: boolean) => void): void {
 
 // -- Exports ------------------------------------------------------------------
 
-export { prepareSyncWord, withBgSeedIfNeeded, buildInitialWordUpdates, advanceSyncPosition, triggerPulse };
+export {
+  prepareSyncWord,
+  withBgSeedIfNeeded,
+  buildInitialWordUpdates,
+  advanceSyncPosition,
+  nextSyncableLineIndex,
+  prevSyncableLine,
+  triggerPulse,
+};
 export type { PreparedSyncWord, SetSyncState };

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -15,7 +15,9 @@ import {
 import {
   advanceSyncPosition,
   buildInitialWordUpdates,
+  nextSyncableLineIndex,
   prepareSyncWord,
+  prevSyncableLine,
   triggerPulse,
   withBgSeedIfNeeded,
 } from "@/hooks/useSyncHandlers.helpers";
@@ -56,7 +58,7 @@ function useSyncHandlers({
 
   const { lineIndex, wordIndex } = syncState.position;
   const currentLine = lines[lineIndex];
-  const prevLine = lines[lineIndex - 1];
+  const prevLine = prevSyncableLine(lines, lineIndex);
   const isComplete = lineIndex >= lines.length && lines.length > 0;
 
   const handleTapWord = useCallback(() => {
@@ -85,7 +87,7 @@ function useSyncHandlers({
     }
 
     triggerPulse(setShowPulse);
-    advanceSyncPosition(setSyncState, lineIndex, wordIndex, lineWords.length);
+    advanceSyncPosition(setSyncState, lines, lineIndex, wordIndex, lineWords.length);
   }, [
     lines,
     lineIndex,
@@ -115,7 +117,7 @@ function useSyncHandlers({
     triggerPulse(setShowPulse);
     setSyncState((prev) => ({
       ...prev,
-      position: { lineIndex: lineIndex + 1, wordIndex: 0 },
+      position: { lineIndex: nextSyncableLineIndex(lines, lineIndex), wordIndex: 0 },
     }));
   }, [
     lines,
@@ -168,7 +170,7 @@ function useSyncHandlers({
     updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false, propagateToSiblings: false });
 
     triggerPulse(setShowPulse);
-    advanceSyncPosition(setSyncState, lineIndex, wordIndex, lineWords.length);
+    advanceSyncPosition(setSyncState, lines, lineIndex, wordIndex, lineWords.length);
   }, [lines, lineIndex, wordIndex, currentTime, updateLineWithHistory, isComplete, setShowPulse, setSyncState]);
 
   const handleHoldTap = useCallback(() => {
@@ -189,7 +191,8 @@ function useSyncHandlers({
     if (advancesToNextLine) {
       updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false, propagateToSiblings: false });
 
-      const nextLine = lines[lineIndex + 1];
+      const nextLineIndex = nextSyncableLineIndex(lines, lineIndex);
+      const nextLine = lines[nextLineIndex];
       if (nextLine) {
         const { parts: nextLineWords, trailingSpace: nextTrailingSpace } = splitIntoWordsWithMeta(nextLine.text);
         const nextWordText = nextLineWords[0];
@@ -202,7 +205,7 @@ function useSyncHandlers({
 
       setSyncState((prev) => ({
         ...prev,
-        position: { lineIndex: lineIndex + 1, wordIndex: 0 },
+        position: { lineIndex: nextLineIndex, wordIndex: 0 },
       }));
     } else {
       const nextWordText = lineWords[nextWordIndex];
@@ -254,9 +257,9 @@ function useSyncHandlers({
   }, [lines, setSyncState, confirm]);
 
   const handleStartSync = useCallback(() => {
-    setSyncState({ position: { lineIndex: 0, wordIndex: 0 }, isActive: true });
+    setSyncState({ position: { lineIndex: nextSyncableLineIndex(lines, -1), wordIndex: 0 }, isActive: true });
     setIsPlaying(true);
-  }, [setIsPlaying, setSyncState]);
+  }, [lines, setIsPlaying, setSyncState]);
 
   const handleJumpToLine = useCallback(
     (index: number) => {


### PR DESCRIPTION
Closes #114.

In sync mode the cursor moved to the literal next line when you finished a word. An empty line has no words, so the cursor landed there with nothing to tap and got stuck: you couldn't sync the line after a blank, and the word right before a blank never got its end time set.

Sync now skips lines with no text when advancing (and when starting), and looks past blanks to find the previous word to close off. Blank lines stay untouched.