### PR TITLE
refactor: drop unused internal exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.32.0",
+  "version": "1.32.1",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/audio/lame-priming.ts
+++ b/src/audio/lame-priming.ts
@@ -114,4 +114,3 @@ function cropAudioBufferHead(audio: AudioBuffer, startSample: number, ctx: BaseA
 // -- Exports -------------------------------------------------------------------
 
 export { cropAudioBufferHead, findFirstMp3FrameOffset, parseLamePriming, stripLeading };
-export type { LamePriming };

--- a/src/audio/scrub-preview.ts
+++ b/src/audio/scrub-preview.ts
@@ -118,4 +118,3 @@ function getActiveSnippet(): ActiveSnippet | null {
 const scrubPreview = { decode, useBuffer, play, stop, getActiveSnippet };
 
 export { scrubPreview };
-export type { ActiveSnippet };

--- a/src/audio/scrub-velocity.ts
+++ b/src/audio/scrub-velocity.ts
@@ -27,4 +27,4 @@ const DEFAULT_SCRUB_OPTS: ComputeScrubVelocityOpts = {
 };
 
 export { computeScrubVelocity, DEFAULT_SCRUB_OPTS };
-export type { ScrubSample, ComputeScrubVelocityOpts };
+export type { ScrubSample };

--- a/src/audio/separation/audio-codec.ts
+++ b/src/audio/separation/audio-codec.ts
@@ -127,5 +127,4 @@ async function hashFile(file: File | Blob): Promise<string> {
   return sha256Hex(buf);
 }
 
-export { TARGET_SAMPLE_RATE, TARGET_CHANNELS, decodeFileToFloat32, floatChannelsToWavBlob, sha256Hex, hashFile };
-export type { DecodedAudio };
+export { TARGET_SAMPLE_RATE, decodeFileToFloat32, floatChannelsToWavBlob, hashFile };

--- a/src/audio/separation/chunker.ts
+++ b/src/audio/separation/chunker.ts
@@ -86,5 +86,5 @@ function stitchChunks(chunks: Chunk[], totalFrames: number, numChannels: number)
   return output;
 }
 
-export { SEGMENT_SECONDS, SEGMENT_SAMPLES, OVERLAP_SAMPLES, STRIDE_SAMPLES, iterateChunks, chunkCount, stitchChunks };
+export { SEGMENT_SAMPLES, STRIDE_SAMPLES, iterateChunks, chunkCount, stitchChunks };
 export type { Chunk };

--- a/src/audio/separation/model-cache.ts
+++ b/src/audio/separation/model-cache.ts
@@ -75,4 +75,3 @@ async function fetchAndCacheModel(
 }
 
 export { hasCachedModel, readCachedModel, fetchAndCacheModel };
-export type { DownloadProgress };

--- a/src/audio/separation/stem-store.ts
+++ b/src/audio/separation/stem-store.ts
@@ -105,4 +105,4 @@ async function evictIfOverCapacity(): Promise<void> {
   });
 }
 
-export { getStem, hasStems, putStem, makeKey, makeJobKey };
+export { getStem, hasStems, putStem };

--- a/src/audio/separation/stft.ts
+++ b/src/audio/separation/stft.ts
@@ -175,5 +175,5 @@ function istft(spec: Spectrogram, outputLength: number, opts: IstftOptions = {})
   return result;
 }
 
-export { N_FFT, HOP_LENGTH, WIN_LENGTH, hannWindow, fftRadix2, ifftRadix2, reflectPad, stft, istft };
-export type { Spectrogram, StftOptions, IstftOptions };
+export { N_FFT, HOP_LENGTH, reflectPad, stft, istft };
+export type { Spectrogram };

--- a/src/audio/separation/worker-host.ts
+++ b/src/audio/separation/worker-host.ts
@@ -124,4 +124,3 @@ class SeparationWorker {
 }
 
 export { SeparationWorker };
-export type { ProcessResult };

--- a/src/domain/line/main-words.ts
+++ b/src/domain/line/main-words.ts
@@ -27,4 +27,3 @@ function applyMainWordEdit(line: LyricLine, words: WordTiming[]): LyricLine {
 // -- Exports ------------------------------------------------------------------
 
 export { applyMainWordEdit, mainWordEditFields };
-export type { MainWordFields };

--- a/src/domain/line/reconstruct-text.ts
+++ b/src/domain/line/reconstruct-text.ts
@@ -59,4 +59,3 @@ function withDerivedText(line: LyricLine, splitChar: string): LyricLine {
 // -- Exports ------------------------------------------------------------------
 
 export { reconstructLineText, withDerivedText, wordContentSpans };
-export type { WordContentSpan };

--- a/src/domain/theme/model.ts
+++ b/src/domain/theme/model.ts
@@ -275,5 +275,5 @@ const TOKEN_VAR: Record<TokenKey, string> = Object.fromEntries(TOKENS.map((t) =>
   string
 >;
 
-export type { Scheme, TokenKey, ThemeId, Theme, ResolvedTheme, TokenType, TokenMeta };
+export type { Scheme, TokenKey, ThemeId, Theme, ResolvedTheme, TokenMeta };
 export { TOKENS, SEED_TOKENS, QUICK_TOKENS, TOKEN_VAR };

--- a/src/domain/word/move-across-lines.ts
+++ b/src/domain/word/move-across-lines.ts
@@ -160,4 +160,4 @@ function applyWordMoveAcrossLines(lines: LyricLine[], moves: WordMove[], duratio
 // -- Exports ------------------------------------------------------------------
 
 export { applyWordMoveAcrossLines };
-export type { MoveRejectReason, MoveResult, WordMove, WordTrackKind };
+export type { WordMove };

--- a/src/hooks/useDualClickImport.tsx
+++ b/src/hooks/useDualClickImport.tsx
@@ -92,4 +92,3 @@ function useDualClickImport(openModal: () => void): DualClickImportHandlers {
 // -- Exports ------------------------------------------------------------------
 
 export { useDualClickImport };
-export type { DualClickImportHandlers };

--- a/src/hooks/useLyricsSearch.ts
+++ b/src/hooks/useLyricsSearch.ts
@@ -124,5 +124,5 @@ function useLyricsSearch(query: LyricsSearchQuery, options?: UseLyricsSearchOpti
 
 // -- Exports ------------------------------------------------------------------
 
-export { DEFAULT_DEBOUNCE_MS, useLyricsSearch };
+export { useLyricsSearch };
 export type { UseLyricsSearchOptions, UseLyricsSearchResult };

--- a/src/hooks/useSyncHandlers.helpers.ts
+++ b/src/hooks/useSyncHandlers.helpers.ts
@@ -68,4 +68,3 @@ function triggerPulse(setShowPulse: (show: boolean) => void): void {
 // -- Exports ------------------------------------------------------------------
 
 export { prepareSyncWord, withBgSeedIfNeeded, buildInitialWordUpdates, advanceSyncPosition, triggerPulse };
-export type { PreparedSyncWord, SetSyncState };

--- a/src/stores/import-modal-store.ts
+++ b/src/stores/import-modal-store.ts
@@ -110,4 +110,4 @@ function useLastImportResult(): LastImportResult | null {
 // -- Exports ------------------------------------------------------------------
 
 export { INITIAL_STATE, useImportModal, useImportModalState, useImportModalStore, useLastImportResult };
-export type { ImportModalSection, ImportModalState, LastImportResult, OpenArgs };
+export type { ImportModalSection };

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -98,4 +98,3 @@ function initTheme(): void {
 // -- Exports ------------------------------------------------------------------
 
 export { useThemeStore, initTheme, INITIAL_STATE };
-export type { ThemeState };

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -29,4 +29,3 @@ const useUIStore = create<UIState & UIActions>((set) => ({
 // -- Exports ------------------------------------------------------------------
 
 export { useUIStore };
-export type { SettingsHighlight };

--- a/src/ui/settings/bridge-install-guide.tsx
+++ b/src/ui/settings/bridge-install-guide.tsx
@@ -104,4 +104,3 @@ const BridgeInstallGuide: React.FC<BridgeInstallGuideProps> = ({ onCheckNow }) =
 // -- Exports ------------------------------------------------------------------
 
 export { BridgeInstallGuide };
-export type { BridgeInstallGuideProps };

--- a/src/utils/background-vocal-extraction.ts
+++ b/src/utils/background-vocal-extraction.ts
@@ -275,4 +275,3 @@ function lineHasInlineParens(line: LyricLine): boolean {
 // -- Exports ------------------------------------------------------------------
 
 export { classifyLine, extractBackgroundVocals, extractInlineFromLine, lineHasInlineParens, scanParenGroups };
-export type { ExtractOptions, LineClassification, LineClassKind, ParenGroup, ParenScan, ParenScanStatus };

--- a/src/utils/composer-bridge-api.ts
+++ b/src/utils/composer-bridge-api.ts
@@ -179,4 +179,4 @@ export {
   extensionForBridgeMime,
   buildBridgeAudioFile,
 };
-export type { BridgeHealth, BridgeAudio };
+export type { BridgeHealth };

--- a/src/utils/identical-word-matcher.ts
+++ b/src/utils/identical-word-matcher.ts
@@ -82,4 +82,4 @@ function findIdenticalWords(lines: LyricLine[], source: IdenticalMatchSource, op
 
 export { findIdenticalWords };
 
-export type { IdenticalMatch, IdenticalMatchSource, MatchOptions };
+export type { IdenticalMatchSource };

--- a/src/utils/single-word-syllable-split.ts
+++ b/src/utils/single-word-syllable-split.ts
@@ -29,4 +29,3 @@ function splitWordIntoSyllables({ word, splitPoints, reuseGroupId = false }: Spl
 // -- Exports ------------------------------------------------------------------
 
 export { splitWordIntoSyllables };
-export type { SplitOneWordParams };

--- a/src/views/lyrics-import-modal/paste-section.tsx
+++ b/src/views/lyrics-import-modal/paste-section.tsx
@@ -83,4 +83,3 @@ const PasteSection: React.FC<PasteSectionProps> = ({ value, onChange, onSwitchTo
 // -- Exports ------------------------------------------------------------------
 
 export { PasteSection };
-export type { PasteSectionProps };

--- a/src/views/lyrics-import-modal/result-row.tsx
+++ b/src/views/lyrics-import-modal/result-row.tsx
@@ -145,4 +145,3 @@ const ResultRow: React.FC<ResultRowProps> = ({
 // -- Exports ------------------------------------------------------------------
 
 export { ResultRow };
-export type { ResultRowProps };

--- a/src/views/lyrics-import-modal/search-field.tsx
+++ b/src/views/lyrics-import-modal/search-field.tsx
@@ -63,4 +63,3 @@ const SearchField: React.FC<SearchFieldProps> = ({
 // -- Exports ------------------------------------------------------------------
 
 export { SearchField };
-export type { SearchFieldProps };

--- a/src/views/lyrics-import-modal/search-results.tsx
+++ b/src/views/lyrics-import-modal/search-results.tsx
@@ -120,4 +120,3 @@ const SearchResults: React.FC<SearchResultsProps> = ({
 // -- Exports ------------------------------------------------------------------
 
 export { SearchResults };
-export type { SearchResultsProps };

--- a/src/views/lyrics-import-modal/search-section.tsx
+++ b/src/views/lyrics-import-modal/search-section.tsx
@@ -278,4 +278,3 @@ const SearchSection: React.FC<SearchSectionProps> = ({
 // -- Exports ------------------------------------------------------------------
 
 export { SearchSection };
-export type { SearchSectionProps };

--- a/src/views/lyrics-import-modal/sync-type-badge.tsx
+++ b/src/views/lyrics-import-modal/sync-type-badge.tsx
@@ -98,4 +98,3 @@ const SyncTypeBadge: React.FC<SyncTypeBadgeProps> = ({ syncType, sourceLabel }) 
 // -- Exports ------------------------------------------------------------------
 
 export { SyncTypeBadge };
-export type { SyncTypeBadgeProps };

--- a/src/views/lyrics-import-modal/upload-section.tsx
+++ b/src/views/lyrics-import-modal/upload-section.tsx
@@ -128,4 +128,3 @@ const UploadSection: React.FC<UploadSectionProps> = ({ onFile, onSwitchToSearch,
 // -- Exports ------------------------------------------------------------------
 
 export { ACCEPTED_EXTENSIONS, UNSUPPORTED_TYPE_MESSAGE, UploadSection };
-export type { UploadSectionProps };

--- a/src/views/lyrics-import-modal/use-import-modal-actions.ts
+++ b/src/views/lyrics-import-modal/use-import-modal-actions.ts
@@ -89,4 +89,4 @@ async function importParsedLyrics(parsed: ParseResult, ctx: ImportParsedLyricsCo
 // -- Exports ------------------------------------------------------------------
 
 export { importParsedLyrics };
-export type { ConfirmFn, ImportParsedLyricsContext, ImportSourceInfo };
+export type { ImportParsedLyricsContext, ImportSourceInfo };

--- a/src/views/sync/split-mode-content.tsx
+++ b/src/views/sync/split-mode-content.tsx
@@ -144,4 +144,3 @@ const SplitModeContent: React.FC<SplitModeContentProps> = ({
 // -- Exports ------------------------------------------------------------------
 
 export { SplitModeContent };
-export type { SplitModeContentProps };

--- a/src/views/timeline/apply-paste-to-lines.ts
+++ b/src/views/timeline/apply-paste-to-lines.ts
@@ -70,4 +70,3 @@ function applyPasteToLines({
 // -- Exports ------------------------------------------------------------------
 
 export { applyPasteToLines };
-export type { LineUpdate, PasteInput };

--- a/src/views/timeline/drag-end-resolution.ts
+++ b/src/views/timeline/drag-end-resolution.ts
@@ -60,4 +60,3 @@ function resolveDropTarget({ clientX, clientY, lines }: ResolveDropTargetInput):
 // -- Exports -------------------------------------------------------------------
 
 export { resolveDropTarget };
-export type { DropTarget };

--- a/src/views/timeline/playhead-drag.ts
+++ b/src/views/timeline/playhead-drag.ts
@@ -131,4 +131,4 @@ function createPlayheadDrag(config: PlayheadDragConfig): PlayheadDrag {
 // -- Exports -------------------------------------------------------------------
 
 export { createPlayheadDrag };
-export type { PlayheadDragConfig, PlayheadDrag };
+export type { PlayheadDragConfig };

--- a/src/views/timeline/snap-marker-pin.tsx
+++ b/src/views/timeline/snap-marker-pin.tsx
@@ -174,4 +174,3 @@ const SnapMarkerPin = memo(function SnapMarkerPin({
 // -- Exports -------------------------------------------------------------------
 
 export { SnapMarkerPin };
-export type { SnapMarkerPinProps };

--- a/src/views/timeline/timeline-wheel.ts
+++ b/src/views/timeline/timeline-wheel.ts
@@ -47,4 +47,3 @@ function normalizeWheelDelta(delta: number, deltaMode: number): number {
 // -- Exports -------------------------------------------------------------------
 
 export { decideWheelAction, computeScrubTime, normalizeWheelDelta };
-export type { WheelAction };

--- a/src/views/timeline/use-snap-marker-drag.ts
+++ b/src/views/timeline/use-snap-marker-drag.ts
@@ -91,4 +91,3 @@ function useSnapMarkerDrag({ scrollContainerRef }: SnapMarkerDragConfig): SnapMa
 // -- Exports -------------------------------------------------------------------
 
 export { useSnapMarkerDrag };
-export type { SnapMarkerDrag };

--- a/src/views/timeline/use-timeline-dnd.test-helpers.ts
+++ b/src/views/timeline/use-timeline-dnd.test-helpers.ts
@@ -224,4 +224,3 @@ export {
   makeReorderDragEndEvent,
   makeReorderDragStartEvent,
 };
-export type { CursorTargetingOptions, CursorTargetingStartOptions, DragEndOptions };


### PR DESCRIPTION
knip flagged 63 internal-only symbols (11 values, 52 types) as exported but imported nowhere outside their own file. I dropped the `export` on each so they stay file-local. No behavior change, just a smaller surface, and knip now passes clean.

One thing I left alone: `@lit/react` in package.json. It's genuinely unused, but removing it needs a lockfile regen that currently trips an unrelated pnpm trust check, which would drift the frozen install in CI. Worth pruning next time the lockfile gets regenerated anyway.