### PR TITLE
chore: point composer links at betterlyrics.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://composer.boidu.dev"><img src="https://img.shields.io/badge/Open-composer.boidu.dev-F50032?style=flat-square" alt="Open Composer" /></a>
+  <a href="https://composer.betterlyrics.org"><img src="https://img.shields.io/badge/Open-composer.betterlyrics.org-F50032?style=flat-square" alt="Open Composer" /></a>
   <a href="https://www.w3.org/TR/2018/REC-ttml1-20181108/"><img src="https://img.shields.io/badge/TTML%201-W3C%20Compliant-4caf50?style=flat-square" alt="TTML 1 W3C Compliant" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL%203.0-2196f3?style=flat-square" alt="AGPL 3.0 License" /></a>
   <a href="https://betterlyrics.org"><img src="https://img.shields.io/badge/Built%20for-Better%20Lyrics-F50032?style=flat-square" alt="Built for Better Lyrics" /></a>
@@ -121,10 +121,10 @@ Two scripts in `scripts/` do the work:
 ### One-time R2 setup
 
 1. Create a public R2 bucket (e.g. `composer-vocal-models`).
-2. Bind a custom domain to the bucket (e.g. `models.composer.boidu.dev`). **Avoid `r2.dev`** — it's rate-limited and intended for development.
+2. Bind a custom domain to the bucket (e.g. `models.composer.betterlyrics.org`). **Avoid `r2.dev`** — it's rate-limited and intended for development.
 3. Add a Cloudflare page rule `Cache Everything` for that hostname so binary files are edge-cached.
 4. Add a CORS rule allowing your site origin(s).
-5. Set `VITE_VOCAL_MODEL_BASE_URL=https://models.composer.boidu.dev` at build time.
+5. Set `VITE_VOCAL_MODEL_BASE_URL=https://models.composer.betterlyrics.org` at build time.
 
 Cost: free egress; ~$0.0015/month storage for the fp16 model.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.32.1",
+  "version": "1.32.2",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://composer.boidu.dev/sitemap.xml
+Sitemap: https://composer.betterlyrics.org/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://composer.boidu.dev/</loc>
+    <loc>https://composer.betterlyrics.org/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/scripts/upload-htdemucs.sh
+++ b/scripts/upload-htdemucs.sh
@@ -43,6 +43,7 @@ cat > "${CORS_FILE}" <<'JSON'
       "allowed": {
         "origins": [
           "https://composer.betterlyrics.org",
+          "https://composer.boidu.dev",
           "http://localhost:5173",
           "http://127.0.0.1:5173",
           "http://localhost:4173",

--- a/scripts/upload-htdemucs.sh
+++ b/scripts/upload-htdemucs.sh
@@ -42,7 +42,7 @@ cat > "${CORS_FILE}" <<'JSON'
     {
       "allowed": {
         "origins": [
-          "https://composer.boidu.dev",
+          "https://composer.betterlyrics.org",
           "http://localhost:5173",
           "http://127.0.0.1:5173",
           "http://localhost:4173",
@@ -75,4 +75,4 @@ done
 
 echo ""
 echo "Done. Verify the files are reachable via your bound custom domain, e.g.:"
-echo "  curl -I https://models.composer.boidu.dev/htdemucs_fp16.onnx"
+echo "  curl -I https://models.composer.betterlyrics.org/htdemucs_fp16.onnx"

--- a/src/seo/schemas.ts
+++ b/src/seo/schemas.ts
@@ -1,4 +1,4 @@
-const SITE_ORIGIN = "https://composer.boidu.dev";
+const SITE_ORIGIN = "https://composer.betterlyrics.org";
 const SITE_NAME = "Composer";
 const ORG_NAME = "Better Lyrics";
 const ORG_URL = "https://better-lyrics.boidu.dev";

--- a/src/ui/help-sections/ttml-standards.tsx
+++ b/src/ui/help-sections/ttml-standards.tsx
@@ -45,7 +45,7 @@ const TtmlStandardsSection: React.FC = () => (
       vocabulary. That's the W3C-sanctioned way to add application-specific data while keeping the document conformant.
     </p>
     <p className={PROSE}>
-      Composer's namespace URI is <span className={INLINE_CODE}>https://composer.boidu.dev/ttml</span>. Custom
+      Composer's namespace URI is <span className={INLINE_CODE}>https://composer.betterlyrics.org/ttml</span>. Custom
       attributes show up as <span className={INLINE_CODE}>composer:groupId</span>,{" "}
       <span className={INLINE_CODE}>composer:instanceIdx</span>, and so on, on the root{" "}
       <span className={INLINE_CODE}>&lt;tt&gt;</span> element and on <span className={INLINE_CODE}>&lt;p&gt;</span>{" "}

--- a/src/utils/lyrics-parsers.ttml.test.ts
+++ b/src/utils/lyrics-parsers.ttml.test.ts
@@ -60,7 +60,7 @@ describe("parseLyricsFile - TTML word explicit attribute", () => {
   });
 
   it('recognizes composer:explicit="true" on a word span', () => {
-    const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:composer="https://composer.boidu.dev/ttml"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:02.000" ttm:agent="v1"><span begin="00:01.000" end="00:01.500">clean</span> <span begin="00:01.500" end="00:02.000" composer:explicit="true">dirty</span></p></div></body></tt>`;
+    const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:composer="https://composer.betterlyrics.org/ttml"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:02.000" ttm:agent="v1"><span begin="00:01.000" end="00:01.500">clean</span> <span begin="00:01.500" end="00:02.000" composer:explicit="true">dirty</span></p></div></body></tt>`;
     const result = parseLyricsFile("song.ttml", content);
     const words = result.lines[0].words!;
     expect(words[0].explicit).toBeUndefined();
@@ -74,7 +74,7 @@ describe("parseLyricsFile - TTML word explicit attribute", () => {
   });
 
   it('treats explicit="false" / "0" as not explicit', () => {
-    const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:composer="https://composer.boidu.dev/ttml"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:02.000" ttm:agent="v1"><span begin="00:01.000" end="00:01.500" composer:explicit="false">clean</span> <span begin="00:01.500" end="00:02.000" composer:explicit="0">also</span></p></div></body></tt>`;
+    const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:composer="https://composer.betterlyrics.org/ttml"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:02.000" ttm:agent="v1"><span begin="00:01.000" end="00:01.500" composer:explicit="false">clean</span> <span begin="00:01.500" end="00:02.000" composer:explicit="0">also</span></p></div></body></tt>`;
     const result = parseLyricsFile("song.ttml", content);
     const words = result.lines[0].words!;
     expect(words[0].explicit).toBeUndefined();
@@ -82,7 +82,7 @@ describe("parseLyricsFile - TTML word explicit attribute", () => {
   });
 
   it("recognizes explicit on a word inside x-bg, landing on backgroundWords", () => {
-    const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:composer="https://composer.boidu.dev/ttml"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:02.500" ttm:agent="v1"><span begin="00:01.000" end="00:02.000">main</span><span ttm:role="x-bg"><span begin="00:02.000" end="00:02.250">oh</span> <span begin="00:02.250" end="00:02.500" composer:explicit="true">shit</span></span></p></div></body></tt>`;
+    const content = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:composer="https://composer.betterlyrics.org/ttml"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:02.500" ttm:agent="v1"><span begin="00:01.000" end="00:02.000">main</span><span ttm:role="x-bg"><span begin="00:02.000" end="00:02.250">oh</span> <span begin="00:02.250" end="00:02.500" composer:explicit="true">shit</span></span></p></div></body></tt>`;
     const result = parseLyricsFile("song.ttml", content);
     const line = result.lines[0];
     expect(line.words![0].explicit).toBeUndefined();

--- a/src/utils/lyrics-parsers/composer-namespace.ts
+++ b/src/utils/lyrics-parsers/composer-namespace.ts
@@ -1,0 +1,11 @@
+// -- Constants ----------------------------------------------------------------
+
+const COMPOSER_NS = "https://composer.betterlyrics.org/ttml";
+
+const LEGACY_COMPOSER_NAMESPACES = ["https://composer.boidu.dev/ttml"];
+
+const COMPOSER_NAMESPACES = [COMPOSER_NS, ...LEGACY_COMPOSER_NAMESPACES];
+
+// -- Exports -------------------------------------------------------------------
+
+export { COMPOSER_NS, COMPOSER_NAMESPACES };

--- a/src/utils/lyrics-parsers/ttml.ts
+++ b/src/utils/lyrics-parsers/ttml.ts
@@ -8,10 +8,19 @@ import type { WordTiming } from "@/domain/word/timing";
 import { getSplitCharacter } from "@/utils/split-character";
 import { declareMissingNamespaces, extractTimedWords, parseTtmlTimestamp } from "@/utils/lyrics-parsers/ttml-helpers";
 import { generateLineId, type ParseResult } from "@/utils/lyrics-parsers/shared";
+import { COMPOSER_NAMESPACES } from "@/utils/lyrics-parsers/composer-namespace";
 
-// -- Constants ----------------------------------------------------------------
+// -- Helpers ------------------------------------------------------------------
 
-const COMPOSER_NS = "https://composer.boidu.dev/ttml";
+function getComposerAttribute(el: Element, name: string): string | null {
+  const prefixed = el.getAttribute(`composer:${name}`);
+  if (prefixed !== null) return prefixed;
+  for (const ns of COMPOSER_NAMESPACES) {
+    const value = el.getAttributeNS(ns, name);
+    if (value !== null) return value;
+  }
+  return null;
+}
 
 // -- TTML Parser --------------------------------------------------------------
 
@@ -60,7 +69,7 @@ function parseTtml(content: string, _fallbackDuration?: number): ParseResult {
   // Parse composer:groups registry
   const groups: LinkGroup[] = [];
   const groupEls = Array.from(doc.getElementsByTagName("composer:group")).concat(
-    Array.from(doc.getElementsByTagNameNS(COMPOSER_NS, "group")),
+    COMPOSER_NAMESPACES.flatMap((ns) => Array.from(doc.getElementsByTagNameNS(ns, "group"))),
   );
   const seenGroupIds = new Set<string>();
   for (const el of groupEls) {
@@ -82,17 +91,14 @@ function parseTtml(content: string, _fallbackDuration?: number): ParseResult {
     const end = parseTtmlTimestamp(p.getAttribute("end") ?? "");
     const agentId = p.getAttribute("ttm:agent")?.replace("#", "") ?? "v1";
 
-    // Extract composer: group attrs (try plain attribute first, then namespaced lookup)
-    const rawGroupId = p.getAttribute("composer:groupId") ?? p.getAttributeNS(COMPOSER_NS, "groupId") ?? null;
+    const rawGroupId = getComposerAttribute(p, "groupId");
     const knownGroupId = rawGroupId && seenGroupIds.has(rawGroupId) ? rawGroupId : null;
     if (rawGroupId && !knownGroupId) {
       console.warn(`[Composer] TTML <p> references unknown groupId="${rawGroupId}"; treating line as standalone.`);
     }
-    const instanceIdxStr =
-      p.getAttribute("composer:instanceIdx") ?? p.getAttributeNS(COMPOSER_NS, "instanceIdx") ?? null;
-    const templateLineIdxStr =
-      p.getAttribute("composer:templateLineIdx") ?? p.getAttributeNS(COMPOSER_NS, "templateLineIdx") ?? null;
-    const detachedStr = p.getAttribute("composer:detached") ?? p.getAttributeNS(COMPOSER_NS, "detached") ?? null;
+    const instanceIdxStr = getComposerAttribute(p, "instanceIdx");
+    const templateLineIdxStr = getComposerAttribute(p, "templateLineIdx");
+    const detachedStr = getComposerAttribute(p, "detached");
 
     const groupFields = knownGroupId
       ? {

--- a/src/utils/lyrics-search/providers/binimum.ts
+++ b/src/utils/lyrics-search/providers/binimum.ts
@@ -6,7 +6,7 @@ import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } 
 
 const BINIMUM_BASE_URL = "https://lyrics-api.binimum.org/";
 const ID_PREFIX = "binimum-";
-const USER_AGENT = "Better Lyrics Composer (https://composer.boidu.dev)";
+const USER_AGENT = "Better Lyrics Composer (https://composer.betterlyrics.org)";
 const ISRC_REGEX = /^[A-Z]{2}[A-Z0-9]{3}\d{7}$/;
 const VALID_TIMING_TYPES: ReadonlySet<SyncType> = new Set<SyncType>(["syllable", "word", "line"]);
 

--- a/src/utils/lyrics-search/providers/boidu-lyrics.ts
+++ b/src/utils/lyrics-search/providers/boidu-lyrics.ts
@@ -6,7 +6,7 @@ import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } 
 
 const BOIDU_BASE_URL = "https://lyrics-api.boidu.dev/getLyrics";
 const ID_PREFIX = "boidu-lyrics-";
-const USER_AGENT = "Better Lyrics Composer (https://composer.boidu.dev)";
+const USER_AGENT = "Better Lyrics Composer (https://composer.betterlyrics.org)";
 
 // -- Types --------------------------------------------------------------------
 

--- a/src/utils/lyrics-search/providers/lrclib.ts
+++ b/src/utils/lyrics-search/providers/lrclib.ts
@@ -8,7 +8,7 @@ const LRCLIB_BASE_URL = "https://lrclib.net";
 const SEARCH_PATH = "/api/search";
 const GET_PATH = "/api/get";
 const ID_PREFIX = "lrclib-";
-const USER_AGENT = "Better Lyrics Composer (https://composer.boidu.dev)";
+const USER_AGENT = "Better Lyrics Composer (https://composer.betterlyrics.org)";
 
 // -- Types --------------------------------------------------------------------
 

--- a/src/utils/ttml.groups.test.ts
+++ b/src/utils/ttml.groups.test.ts
@@ -243,6 +243,40 @@ describe("ttml import · per-line group attrs", () => {
   });
 });
 
+describe("ttml namespace · betterlyrics rebrand + legacy compat", () => {
+  const NEW_NS = "https://composer.betterlyrics.org/ttml";
+  const OLD_NS = "https://composer.boidu.dev/ttml";
+  const groups: LinkGroup[] = [{ id: "g1", label: "Chorus", color: "#f472b6", templateVersion: 1 }];
+
+  it("declares the new betterlyrics.org namespace on export, never the old one", () => {
+    const ttml = generateTTML({ metadata: baseMetadata, agents: baseAgents, lines: [], groups, granularity: "word" });
+    expect(ttml).toContain(`xmlns:composer="${NEW_NS}"`);
+    expect(ttml).not.toContain(OLD_NS);
+  });
+
+  it("parses a legacy file that declares the old namespace on the composer prefix", () => {
+    const legacy = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:composer="${OLD_NS}"><head><metadata><ttm:agent type="person" xml:id="v1"/><composer:groups><composer:group id="g1" label="Chorus" color="#f472b6" templateVersion="2"/></composer:groups></metadata></head><body><div><p begin="00:01.000" end="00:02.000" ttm:agent="v1" composer:groupId="g1" composer:instanceIdx="1" composer:templateLineIdx="0">hi</p></div></body></tt>`;
+    const result = parseLyricsFile("legacy.ttml", legacy);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups?.[0].label).toBe("Chorus");
+    expect(result.groups?.[0].templateVersion).toBe(2);
+    expect(result.lines[0].groupId).toBe("g1");
+    expect(result.lines[0].instanceIdx).toBe(1);
+  });
+
+  it("parses a legacy file that binds the old namespace to a non-composer prefix", () => {
+    const legacy = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:c="${OLD_NS}"><head><metadata><ttm:agent type="person" xml:id="v1"/><c:groups><c:group id="g1" label="Chorus" color="#f472b6" templateVersion="3"/></c:groups></metadata></head><body><div><p begin="00:01.000" end="00:02.000" ttm:agent="v1" c:groupId="g1" c:instanceIdx="2" c:templateLineIdx="0" c:detached="true">hi</p></div></body></tt>`;
+    const result = parseLyricsFile("legacy-prefix.ttml", legacy);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups?.[0].templateVersion).toBe(3);
+    expect(result.lines[0].groupId).toBe("g1");
+    expect(result.lines[0].instanceIdx).toBe(2);
+    expect(result.lines[0].detached).toBe(true);
+  });
+});
+
 describe("ttml export · explicit word attribute", () => {
   it('emits composer:explicit="true" only on flagged words', () => {
     const ttml = generateTTML({

--- a/src/utils/ttml.ts
+++ b/src/utils/ttml.ts
@@ -4,6 +4,7 @@ import type { LyricLine } from "@/domain/line/model";
 import type { ProjectMetadata } from "@/domain/project/metadata";
 import { formatTime } from "@/utils/format-time";
 import { stripSplitCharacter } from "@/utils/split-character";
+import { COMPOSER_NS } from "@/utils/lyrics-parsers/composer-namespace";
 import { effectiveBounds } from "@/domain/line/bounds";
 
 // -- Helpers ------------------------------------------------------------------
@@ -39,7 +40,7 @@ function generateTTML({ metadata, agents, lines, groups, granularity, minify = f
 
   // Root element with namespaces
   parts.push(
-    `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:composer="https://composer.boidu.dev/ttml" ttp:timeBase="media" xml:lang="${escapeXml(metadata.language || "en")}" composer:timing="${effectiveGranularity === "word" ? "Word" : "Line"}">`,
+    `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:composer="${COMPOSER_NS}" ttp:timeBase="media" xml:lang="${escapeXml(metadata.language || "en")}" composer:timing="${effectiveGranularity === "word" ? "Word" : "Line"}">`,
   );
 
   // Head section

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ import "vite-react-ssg";
 import { writeSeoAssets } from "./scripts/build-seo-assets";
 import pkg from "./package.json";
 
-const SITE_ORIGIN = "https://composer.boidu.dev";
+const SITE_ORIGIN = "https://composer.betterlyrics.org";
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],


### PR DESCRIPTION
## Overview

Moved Composer's domain from composer.boidu.dev to composer.betterlyrics.org wherever it appears: the site origin, search-provider user agents, robots.txt and sitemap, the R2 upload script, and the README. The TTML namespace URI moved with it, but the parser reads both the new and old URIs so lyrics files exported by older versions still import fine. The models bucket keeps both origins in its CORS allowlist so vocal separation works on either domain during the move. Left the license email and the lyrics API host alone since neither points at Composer.
