### PR TITLE
dev: Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# ensure that all code pushed has LF line-endings,
+# so that maintainers with `autocrlf` enabled don't create mixed line-endings in remote
+* text=auto
+
+# git probably will never mangle some binary files as text on accident,
+# but just in case, we can protect the logo and any future model files
+# (were they to be moved/added into the git repo)
+*.png binary
+*.onnx binary
+*.wasm binary


### PR DESCRIPTION
The repository currently lacks a `.gitattributes`; thus, line-ending normalization is determined by a given contributor's local Git config, not by the repository. If one's `core.autocrlf` is disabled or unset, then it's possible to accidentally push CRLF line-endings to remote. (And nobody wants mixed line-endings.)

This PR touches acts solely as a future-proofing mechanism and should touch no other files (see `git add --renormalize .`). The desired behavior is that maintainers can checkout and commit to the repo with their preferred line-endings, but files on remote will always be LF.

Note that—while it is theoretically possible that Git could [mistakenly detect binary files as text](https://stackoverflow.com/a/57121031) and then mangle them—since this repo contains only a single image, this doesn't happen here; and is extraordinarily unlikely, anyway. However, I've gone ahead and added safeguards for `.onnx` model files and `.wasm` binary files just in case they were ever to be added to the repo and misidentified. I would also recommend adding font file extensions to `.gitattributes` if you plan on ever committing them, as well.