### PR TITLE
feat: New setting: Rolling edit mode affects syllable conjoining

### DIFF
--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -37,7 +37,7 @@ interface SettingsState {
   defaultRowHeight: number;
   followPlayhead: boolean;
   defaultRollingEdit: boolean;
-  rollingAffectsSyllableConjoining: boolean;
+  rollingAffectsSyllables: boolean;
   defaultPreviewSidebar: boolean;
   timelineSnap: boolean;
   timelineSnapThreshold: number;
@@ -104,7 +104,7 @@ const DEFAULTS: SettingsState = {
   defaultRowHeight: 44,
   followPlayhead: true,
   defaultRollingEdit: false,
-  rollingAffectsSyllableConjoining: false,
+  rollingAffectsSyllables: false,
   defaultPreviewSidebar: false,
   timelineSnap: true,
   timelineSnapThreshold: 12,

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -37,6 +37,7 @@ interface SettingsState {
   defaultRowHeight: number;
   followPlayhead: boolean;
   defaultRollingEdit: boolean;
+  rollingAffectsSyllableConjoining: boolean;
   defaultPreviewSidebar: boolean;
   timelineSnap: boolean;
   timelineSnapThreshold: number;
@@ -103,6 +104,7 @@ const DEFAULTS: SettingsState = {
   defaultRowHeight: 44,
   followPlayhead: true,
   defaultRollingEdit: false,
+  rollingAffectsSyllableConjoining: false,
   defaultPreviewSidebar: false,
   timelineSnap: true,
   timelineSnapThreshold: 12,

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -37,12 +37,12 @@ interface SettingsState {
   defaultRowHeight: number;
   followPlayhead: boolean;
   defaultRollingEdit: boolean;
-  rollingAffectsSyllables: boolean;
   defaultPreviewSidebar: boolean;
   timelineSnap: boolean;
   timelineSnapThreshold: number;
   vocalOnsetSnap: boolean;
   snapPlayheadToPoints: boolean;
+  rollingAffectsSyllables: boolean;
   timelineHorizontalScroll: boolean;
 
   nudgeAmount: number;
@@ -104,12 +104,12 @@ const DEFAULTS: SettingsState = {
   defaultRowHeight: 44,
   followPlayhead: true,
   defaultRollingEdit: false,
-  rollingAffectsSyllables: false,
   defaultPreviewSidebar: false,
   timelineSnap: true,
   timelineSnapThreshold: 12,
   vocalOnsetSnap: true,
   snapPlayheadToPoints: true,
+  rollingAffectsSyllables: false,
   timelineHorizontalScroll: false,
 
   nudgeAmount: 0.05,

--- a/src/test/stores.ts
+++ b/src/test/stores.ts
@@ -60,6 +60,8 @@ async function resetAllStores(): Promise<void> {
     contextMenu: null,
     editingWord: null,
     rollingEditMode: false,
+    markerMode: false,
+    hoveredSnapPointId: null,
     collapsedInstances: {},
     pingingGroupId: null,
     renamingGroupId: null,

--- a/src/ui/settings/timeline-section.browser.test.tsx
+++ b/src/ui/settings/timeline-section.browser.test.tsx
@@ -8,7 +8,7 @@ describe("TimelineSection", () => {
   it("renders sliders and toggles for the timeline settings", async () => {
     const screen = await render(<TimelineSection />);
     expect(screen.container.querySelectorAll('input[type="range"]').length).toBe(3);
-    expect(screen.container.querySelectorAll('[role="switch"]').length).toBe(7);
+    expect(screen.container.querySelectorAll('[role="switch"]').length).toBe(8);
   });
 
   it("flips the default rolling edit setting when its toggle is clicked", async () => {

--- a/src/ui/settings/timeline-section.tsx
+++ b/src/ui/settings/timeline-section.tsx
@@ -1,6 +1,6 @@
 import { useSettingsStore } from "@/stores/settings";
 import { SliderSetting, ToggleSetting } from "@/ui/settings/setting-controls";
-import { MOD_KEY, ALT_KEY } from "@/utils/platform";
+import { MOD_KEY } from "@/utils/platform";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 
 // -- Timeline Section ---------------------------------------------------------
@@ -72,7 +72,7 @@ const TimelineSection: React.FC = () => {
       />
       <ToggleSetting
         label="Rolling edit mode affects syllable conjoining"
-        description={`Adjusting syllable timings will respect whether or not rolling edit mode is enabled. Hold ${ALT_KEY} to invert.`}
+        description="Adjusting syllable timings will respect whether or not rolling edit mode is enabled."
         settingKey="rollingAffectsSyllables"
       />
       <ToggleSetting

--- a/src/ui/settings/timeline-section.tsx
+++ b/src/ui/settings/timeline-section.tsx
@@ -73,7 +73,7 @@ const TimelineSection: React.FC = () => {
       <ToggleSetting
         label="Rolling edit mode affects syllable conjoining"
         description={`Adjusting syllable timings will respect whether or not rolling edit mode is enabled. Hold ${ALT_KEY} to invert.`}
-        settingKey="rollingAffectsSyllableConjoining"
+        settingKey="rollingAffectsSyllables"
       />
       <ToggleSetting
         label="Default preview sidebar"

--- a/src/ui/settings/timeline-section.tsx
+++ b/src/ui/settings/timeline-section.tsx
@@ -71,6 +71,11 @@ const TimelineSection: React.FC = () => {
         settingKey="defaultRollingEdit"
       />
       <ToggleSetting
+        label="Rolling edit mode affects syllable conjoining"
+        description="Adjusting syllable timings will respect whether or not rolling edit mode is enabled. Hold Alt to invert."
+        settingKey="rollingAffectsSyllableConjoining"
+      />
+      <ToggleSetting
         label="Default preview sidebar"
         description="Open the preview sidebar by default."
         settingKey="defaultPreviewSidebar"

--- a/src/ui/settings/timeline-section.tsx
+++ b/src/ui/settings/timeline-section.tsx
@@ -1,6 +1,6 @@
 import { useSettingsStore } from "@/stores/settings";
 import { SliderSetting, ToggleSetting } from "@/ui/settings/setting-controls";
-import { MOD_KEY } from "@/utils/platform";
+import { MOD_KEY, ALT_KEY } from "@/utils/platform";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 
 // -- Timeline Section ---------------------------------------------------------
@@ -72,7 +72,7 @@ const TimelineSection: React.FC = () => {
       />
       <ToggleSetting
         label="Rolling edit mode affects syllable conjoining"
-        description="Adjusting syllable timings will respect whether or not rolling edit mode is enabled. Hold Alt to invert."
+        description={`Adjusting syllable timings will respect whether or not rolling edit mode is enabled. Hold ${ALT_KEY} to invert.`}
         settingKey="rollingAffectsSyllableConjoining"
       />
       <ToggleSetting

--- a/src/views/timeline/word-track.browser.test.tsx
+++ b/src/views/timeline/word-track.browser.test.tsx
@@ -258,8 +258,7 @@ describe("WordTrack", () => {
     useSettingsStore.setState({ rollingAffectsSyllables: true });
     useTimelineStore.setState({ rollingEditMode: false });
 
-    const calls: Array<{ index: number, adjacentIndex?: number }> = [];
-
+    const calls: Array<{ index: number; adjacentIndex?: number }> = [];
     const words = [
       createWord({ text: "ev", begin: 0.5, end: 1.5, syllableGroupId: "l" }),
       createWord({ text: "er", begin: 1.5, end: 2.5, syllableGroupId: "l" }),
@@ -278,8 +277,7 @@ describe("WordTrack", () => {
     useSettingsStore.setState({ rollingAffectsSyllables: true });
     useTimelineStore.setState({ rollingEditMode: true });
 
-    const calls: Array<{ index: number, adjacentIndex?: number }> = [];
-
+    const calls: Array<{ index: number; adjacentIndex?: number }> = [];
     const words = [
       createWord({ text: "ev", begin: 0.5, end: 1.5, syllableGroupId: "l" }),
       createWord({ text: "er", begin: 1.5, end: 2.5, syllableGroupId: "l" }),
@@ -287,7 +285,6 @@ describe("WordTrack", () => {
 
     const screen = await renderTrack(words, (index, _u, adjacentIndex) => calls.push({ index, adjacentIndex }));
     const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
-
 
     // goal: drag boundary and they stay together
     dragRightEdge(blocks[0]);

--- a/src/views/timeline/word-track.browser.test.tsx
+++ b/src/views/timeline/word-track.browser.test.tsx
@@ -258,18 +258,18 @@ describe("WordTrack", () => {
     useSettingsStore.setState({ rollingAffectsSyllables: true });
     useTimelineStore.setState({ rollingEditMode: false });
 
-    const calls: Array<{index: number, adjacentIndex?: number}> = [];
+    const calls: Array<{ index: number, adjacentIndex?: number }> = [];
 
     const words = [
-      createWord({ text: "ev", begin: 0.5, end: 1.5, syllableGroupId: "l"}),
-      createWord({ text: "er", begin: 1.5, end: 2.5, syllableGroupId: "l"}),
+      createWord({ text: "ev", begin: 0.5, end: 1.5, syllableGroupId: "l" }),
+      createWord({ text: "er", begin: 1.5, end: 2.5, syllableGroupId: "l" }),
     ];
 
     const screen = await renderTrack(words, (index, _u, adjacentIndex) => calls.push({ index, adjacentIndex }));
     const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
 
     // goal: drag boundary to left and make sure they separate
-    dragRightEdgeBy(blocks[0], -20); // viable?
+    dragRightEdgeBy(blocks[0], -20);
     expect(calls).toHaveLength(1);
     expect(calls[0].adjacentIndex).toBe(undefined);
   });
@@ -278,11 +278,11 @@ describe("WordTrack", () => {
     useSettingsStore.setState({ rollingAffectsSyllables: true });
     useTimelineStore.setState({ rollingEditMode: true });
 
-    const calls: Array<{index: number, adjacentIndex?: number}> = [];
+    const calls: Array<{ index: number, adjacentIndex?: number }> = [];
 
     const words = [
-      createWord({ text: "ev", begin: 0.5, end: 1.5, syllableGroupId: "l"}),
-      createWord({ text: "er", begin: 1.5, end: 2.5, syllableGroupId: "l"}),
+      createWord({ text: "ev", begin: 0.5, end: 1.5, syllableGroupId: "l" }),
+      createWord({ text: "er", begin: 1.5, end: 2.5, syllableGroupId: "l" }),
     ];
 
     const screen = await renderTrack(words, (index, _u, adjacentIndex) => calls.push({ index, adjacentIndex }));

--- a/src/views/timeline/word-track.browser.test.tsx
+++ b/src/views/timeline/word-track.browser.test.tsx
@@ -254,6 +254,47 @@ describe("WordTrack", () => {
     expect(calls[0].updates.end).toBeGreaterThan(1.2);
   });
 
+  it("drags a flush syllable boundary independently when rollingAffectsSyllables is on and rolling edit is off", async () => {
+    useSettingsStore.setState({ rollingAffectsSyllables: true });
+    useTimelineStore.setState({ rollingEditMode: false });
+
+    const calls: Array<{index: number, adjacentIndex?: number}> = [];
+
+    const words = [
+      createWord({ text: "ev", begin: 0.5, end: 1.5, syllableGroupId: "l"}),
+      createWord({ text: "er", begin: 1.5, end: 2.5, syllableGroupId: "l"}),
+    ];
+
+    const screen = await renderTrack(words, (index, _u, adjacentIndex) => calls.push({ index, adjacentIndex }));
+    const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
+
+    // goal: drag boundary to left and make sure they separate
+    dragRightEdgeBy(blocks[0], -20); // viable?
+    expect(calls).toHaveLength(1);
+    expect(calls[0].adjacentIndex).toBe(undefined);
+  });
+
+  it("conjoins a flush syllable boundary when rollingAffectsSyllables is on and rolling edit is on", async () => {
+    useSettingsStore.setState({ rollingAffectsSyllables: true });
+    useTimelineStore.setState({ rollingEditMode: true });
+
+    const calls: Array<{index: number, adjacentIndex?: number}> = [];
+
+    const words = [
+      createWord({ text: "ev", begin: 0.5, end: 1.5, syllableGroupId: "l"}),
+      createWord({ text: "er", begin: 1.5, end: 2.5, syllableGroupId: "l"}),
+    ];
+
+    const screen = await renderTrack(words, (index, _u, adjacentIndex) => calls.push({ index, adjacentIndex }));
+    const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
+
+
+    // goal: drag boundary and they stay together
+    dragRightEdge(blocks[0]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].adjacentIndex).not.toBe(undefined);
+  });
+
   it("conjoins a touching word boundary when rolling edit mode is on", async () => {
     useTimelineStore.setState({ rollingEditMode: true, zoom: 100 });
     const calls: Array<{

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -151,10 +151,9 @@ const WordTrack: React.FC<WordTrackProps> = ({
         const altHeld = e.altKey;
 
         const conjoinedByDefault =
-          !boundaryHasGap(wordIndex, edge) && (
-            (!rollingAffectsSyllables && (rollingEdit || isSyllableBoundary(wordIndex, edge))) ||
-            (rollingAffectsSyllables && rollingEdit)
-          );
+          !boundaryHasGap(wordIndex, edge) &&
+          ((!rollingAffectsSyllables && (rollingEdit || isSyllableBoundary(wordIndex, edge))) ||
+            (rollingAffectsSyllables && rollingEdit));
 
         const conjoined = altHeld ? !conjoinedByDefault : conjoinedByDefault;
 
@@ -272,10 +271,9 @@ const WordTrack: React.FC<WordTrackProps> = ({
     const isSyllable = pos === "first" || pos === "middle";
     const hasGap = words[boundaryIndex].end < words[boundaryIndex + 1].begin;
 
-    const conjoinedByDefault = !hasGap && (
-      (!rollingAffectsSyllables && (rollingEditMode || isSyllable)) ||
-      (rollingAffectsSyllables && rollingEditMode)
-    );
+    const conjoinedByDefault =
+      !hasGap &&
+      ((!rollingAffectsSyllables && (rollingEditMode || isSyllable)) || (rollingAffectsSyllables && rollingEditMode));
 
     return altPressed ? !conjoinedByDefault : conjoinedByDefault;
   };

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -279,7 +279,7 @@ const WordTrack: React.FC<WordTrackProps> = ({
     const conjoinedByDefault = !hasGap && (
       (!rollingAffectsSyllableConjoining && (rollingEditMode || isSyllable)) ||
       (rollingAffectsSyllableConjoining && rollingEditMode)
-    )
+    );
 
     return altPressed ? !conjoinedByDefault : conjoinedByDefault;
   };

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -66,9 +66,7 @@ const WordTrack: React.FC<WordTrackProps> = ({
   const toggleSelection = useTimelineStore((s) => s.toggleSelection);
   const rollingEditMode = useTimelineStore((s) => s.rollingEditMode);
 
-  // LAYNE: temporary: make it actually part of the timeline store
   const rollingAffectsSyllables = useSettingsStore((s) => s.rollingAffectsSyllables);
-
   const showSyllableIndicators = useSettingsStore((s) => s.showSyllableIndicators);
   const syllablePositions = useMemo(() => getSyllablePositions(words), [words]);
 
@@ -152,12 +150,10 @@ const WordTrack: React.FC<WordTrackProps> = ({
         const rawDeltaPx = e.clientX - startX;
         const altHeld = e.altKey;
 
-        // LAYNE: logic here
-        const conjoinedByDefault = !boundaryHasGap(wordIndex, edge) &&
-          (
-            // expanded for readability
-            (rollingAffectsSyllables === false && (rollingEdit || isSyllableBoundary(wordIndex, edge))) ||
-            (rollingAffectsSyllables === true && rollingEdit === true)
+        const conjoinedByDefault =
+          !boundaryHasGap(wordIndex, edge) && (
+            (!rollingAffectsSyllables && (rollingEdit || isSyllableBoundary(wordIndex, edge))) ||
+            (rollingAffectsSyllables && rollingEdit)
           );
 
         const conjoined = altHeld ? !conjoinedByDefault : conjoinedByDefault;
@@ -270,12 +266,12 @@ const WordTrack: React.FC<WordTrackProps> = ({
     [words, zoom, duration, onUpdateWord, syllablePositions, snap, lineId, trackType],
   );
 
-  // LAYNE: this function exists solely for visual state
   const isBoundaryConjoined = (boundaryIndex: number): boolean => {
     if (boundaryIndex < 0 || boundaryIndex >= words.length - 1) return false;
     const pos = syllablePositions[boundaryIndex];
     const isSyllable = pos === "first" || pos === "middle";
     const hasGap = words[boundaryIndex].end < words[boundaryIndex + 1].begin;
+
     const conjoinedByDefault = !hasGap && (
       (!rollingAffectsSyllables && (rollingEditMode || isSyllable)) ||
       (rollingAffectsSyllables && rollingEditMode)

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -263,7 +263,7 @@ const WordTrack: React.FC<WordTrackProps> = ({
       document.addEventListener("pointermove", handleMouseMove);
       document.addEventListener("pointerup", handleMouseUp);
     },
-    [words, zoom, duration, onUpdateWord, syllablePositions, snap, lineId, trackType],
+    [words, zoom, duration, onUpdateWord, syllablePositions, snap, lineId, trackType, rollingAffectsSyllables],
   );
 
   const isBoundaryConjoined = (boundaryIndex: number): boolean => {

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -66,6 +66,9 @@ const WordTrack: React.FC<WordTrackProps> = ({
   const toggleSelection = useTimelineStore((s) => s.toggleSelection);
   const rollingEditMode = useTimelineStore((s) => s.rollingEditMode);
 
+  // LAYNE: temporary: make it actually part of the timeline store
+  const rollingAffectsSyllableConjoining = useSettingsStore((s) => s.rollingAffectsSyllableConjoining);
+
   const showSyllableIndicators = useSettingsStore((s) => s.showSyllableIndicators);
   const syllablePositions = useMemo(() => getSyllablePositions(words), [words]);
 
@@ -148,8 +151,14 @@ const WordTrack: React.FC<WordTrackProps> = ({
         const originalWord = words[wordIndex];
         const rawDeltaPx = e.clientX - startX;
         const altHeld = e.altKey;
-        const conjoinedByDefault =
-          (rollingEdit || isSyllableBoundary(wordIndex, edge)) && !boundaryHasGap(wordIndex, edge);
+
+        // LAYNE: logic here
+        const conjoinedByDefault = !boundaryHasGap(wordIndex, edge) &&
+          (
+            (rollingAffectsSyllableConjoining === false && (rollingEdit === true || isSyllableBoundary(wordIndex, edge))) ||
+            (rollingAffectsSyllableConjoining === true && rollingEdit === true)
+          );
+
         const conjoined = altHeld ? !conjoinedByDefault : conjoinedByDefault;
 
         const adjacentWordIndex =
@@ -260,6 +269,7 @@ const WordTrack: React.FC<WordTrackProps> = ({
     [words, zoom, duration, onUpdateWord, syllablePositions, snap, lineId, trackType],
   );
 
+  // LAYNE: this function exists solely for visual state
   const isBoundaryConjoined = (boundaryIndex: number): boolean => {
     if (boundaryIndex < 0 || boundaryIndex >= words.length - 1) return false;
     const pos = syllablePositions[boundaryIndex];

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -67,7 +67,7 @@ const WordTrack: React.FC<WordTrackProps> = ({
   const rollingEditMode = useTimelineStore((s) => s.rollingEditMode);
 
   // LAYNE: temporary: make it actually part of the timeline store
-  const rollingAffectsSyllableConjoining = useSettingsStore((s) => s.rollingAffectsSyllableConjoining);
+  const rollingAffectsSyllables = useSettingsStore((s) => s.rollingAffectsSyllables);
 
   const showSyllableIndicators = useSettingsStore((s) => s.showSyllableIndicators);
   const syllablePositions = useMemo(() => getSyllablePositions(words), [words]);
@@ -156,8 +156,8 @@ const WordTrack: React.FC<WordTrackProps> = ({
         const conjoinedByDefault = !boundaryHasGap(wordIndex, edge) &&
           (
             // expanded for readability
-            (rollingAffectsSyllableConjoining === false && (rollingEdit || isSyllableBoundary(wordIndex, edge))) ||
-            (rollingAffectsSyllableConjoining === true && rollingEdit === true)
+            (rollingAffectsSyllables === false && (rollingEdit || isSyllableBoundary(wordIndex, edge))) ||
+            (rollingAffectsSyllables === true && rollingEdit === true)
           );
 
         const conjoined = altHeld ? !conjoinedByDefault : conjoinedByDefault;
@@ -277,8 +277,8 @@ const WordTrack: React.FC<WordTrackProps> = ({
     const isSyllable = pos === "first" || pos === "middle";
     const hasGap = words[boundaryIndex].end < words[boundaryIndex + 1].begin;
     const conjoinedByDefault = !hasGap && (
-      (!rollingAffectsSyllableConjoining && (rollingEditMode || isSyllable)) ||
-      (rollingAffectsSyllableConjoining && rollingEditMode)
+      (!rollingAffectsSyllables && (rollingEditMode || isSyllable)) ||
+      (rollingAffectsSyllables && rollingEditMode)
     );
 
     return altPressed ? !conjoinedByDefault : conjoinedByDefault;

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -155,7 +155,8 @@ const WordTrack: React.FC<WordTrackProps> = ({
         // LAYNE: logic here
         const conjoinedByDefault = !boundaryHasGap(wordIndex, edge) &&
           (
-            (rollingAffectsSyllableConjoining === false && (rollingEdit === true || isSyllableBoundary(wordIndex, edge))) ||
+            // expanded for readability
+            (rollingAffectsSyllableConjoining === false && (rollingEdit || isSyllableBoundary(wordIndex, edge))) ||
             (rollingAffectsSyllableConjoining === true && rollingEdit === true)
           );
 
@@ -275,7 +276,11 @@ const WordTrack: React.FC<WordTrackProps> = ({
     const pos = syllablePositions[boundaryIndex];
     const isSyllable = pos === "first" || pos === "middle";
     const hasGap = words[boundaryIndex].end < words[boundaryIndex + 1].begin;
-    const conjoinedByDefault = (rollingEditMode || isSyllable) && !hasGap;
+    const conjoinedByDefault = !hasGap && (
+      (!rollingAffectsSyllableConjoining && (rollingEditMode || isSyllable)) ||
+      (rollingAffectsSyllableConjoining && rollingEditMode)
+    )
+
     return altPressed ? !conjoinedByDefault : conjoinedByDefault;
   };
 


### PR DESCRIPTION
In the timeline view, the rolling edit mode causes two adjacent words with no gap between them to act as if conjoined: pulling the end of one word forward in time will cause its sibling's start to move forward in time, such that there is never a gap between the words. When rolling edit mode is disabled, adjusting word boundaries solely affects that word.

However, when editing syllables, they always act as if rolling edit mode is enabled. This behavior can be manually overridden by pressing `Alt` to separate the syllable boundaries.

This PR introduces a toggle setting that allows syllables to also respect rolling edit mode, like words do. Namely: if the setting is enabled and rolling mode is disabled, syllables can be adjusted independently.

> *A note: This setting also respects alt-key inversion. While alt-key inversion is effectively useless in this context—since the user should be toggling rolling edit mode instead—I chose to leave it in order to mimic existing behavior and reduce logic changes :-)*

https://github.com/user-attachments/assets/050f8d1c-a7ef-4747-9dc0-ae289992ca15

*see [conversation in discord](https://canary.discord.com/channels/1268184963266908220/1516303276532957346/1519158874266009761)*