### PR TITLE
dev: Fix pnpm 11 building

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,23 +49,6 @@
     "wavesurfer.js": "^7.12.1",
     "zustand": "^5.0.0"
   },
-  "pnpm": {
-    "ignoredBuiltDependencies": [
-      "@biomejs/biome",
-      "esbuild",
-      "protobufjs",
-      "sharp"
-    ],
-    "overrides": {
-      "@braccato/parsers": "^0.1.2"
-    },
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "react-helmet-async>react": "19",
-        "react-helmet-async>react-dom": "19"
-      }
-    }
-  },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
     "@tailwindcss/vite": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@braccato/parsers': ^0.1.2
-
 importers:
 
   .:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@braccato/parsers': ^0.1.2
+
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,11 @@ packages:
   - "."
 minimumReleaseAge: 10080
 trustPolicy: no-downgrade
+trustPolicyExclude:
+  - semver@6.3.1
 blockExoticSubdeps: true
+allowBuilds:
+  '@biomejs/biome': true
+  esbuild: true
+  protobufjs: true
+  sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,9 +6,6 @@ trustPolicyExclude:
   - "semver@6.3.1"
 blockExoticSubdeps: true
 
-overrides:
-  "@braccato/parsers": "^0.1.2"
-
 peerDependencyRules:
   allowedVersions:
     "react-helmet-async>react": "19"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,10 +3,19 @@ packages:
 minimumReleaseAge: 10080
 trustPolicy: no-downgrade
 trustPolicyExclude:
-  - semver@6.3.1
+  - "semver@6.3.1"
 blockExoticSubdeps: true
+
+overrides:
+  "@braccato/parsers": "^0.1.2"
+
+peerDependencyRules:
+  allowedVersions:
+    "react-helmet-async>react": "19"
+    "react-helmet-async>react-dom": "19"
+
 allowBuilds:
-  '@biomejs/biome': true
-  esbuild: true
-  protobufjs: true
-  sharp: true
+  "@biomejs/biome": false
+  esbuild: false
+  protobufjs: false
+  sharp: false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
 
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
In pnpm 11, the `pnpm` field of `package.json` is no longer read, and should be instead moved into `pnpm-workspace.yaml`. Additionally,  `pnpm`'s supply-chain security heuristic mistakenly believes that `semver@6.3.1` is compromised or otherwise untrustworthy, and refuses to finish installing or building. As far as I've found, there are no vulnerabilities in that version of the package. Thus, I've also added a trust policy exclusion for the package so that the code builds normally. Finally, TypeScript 7.0 will deprecate the `baseUrl` key, which currently does not affect the project, so it has been safely removed. (I figured while I was messing with the dev environment, I would check that box off as well.)

Note that the 'ignored built dependencies' array is now a `<string, boolean>` map dictating which packages may build or not. 