### PR TITLE
fix: export edit textarea collapses to one line

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.32.3",
+  "version": "1.32.4",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/hooks/useProjectFileActions.ts
+++ b/src/hooks/useProjectFileActions.ts
@@ -1,0 +1,103 @@
+import { clearCurrentProject, exportProjectToFile, importProjectFromFile } from "@/lib/persistence";
+import { cancelPendingSave } from "@/lib/persistence-debounce";
+import { useAudioStore } from "@/stores/audio";
+import { useConfirm } from "@/stores/confirm-store";
+import { useProjectStore } from "@/stores/project";
+import { DEFAULT_SYLLABLE_SPLIT_DEFAULTS } from "@/stores/project/types";
+import { useCallback } from "react";
+
+// -- Hook ---------------------------------------------------------------------
+
+function useProjectFileActions(fileInputRef: React.RefObject<HTMLInputElement | null>) {
+  const metadata = useProjectStore((s) => s.metadata);
+  const agents = useProjectStore((s) => s.agents);
+  const lines = useProjectStore((s) => s.lines);
+  const groups = useProjectStore((s) => s.groups);
+  const granularity = useProjectStore((s) => s.granularity);
+  const setMetadata = useProjectStore((s) => s.setMetadata);
+  const setLines = useProjectStore((s) => s.setLines);
+  const setGranularity = useProjectStore((s) => s.setGranularity);
+  const setAgents = useProjectStore((s) => s.setAgents);
+  const reset = useProjectStore((s) => s.reset);
+  const markClean = useProjectStore((s) => s.markClean);
+  const confirm = useConfirm();
+
+  const handleExportProject = useCallback(() => {
+    const audioSource = useAudioStore.getState().source;
+    const audioFileName = audioSource?.type === "file" ? audioSource.file.name : undefined;
+    const { dismissedSuggestions, dismissedExplicitSuggestions, syllableSplitDefaults, customSnapPoints } =
+      useProjectStore.getState();
+    exportProjectToFile(
+      metadata,
+      agents,
+      lines,
+      groups,
+      granularity,
+      syllableSplitDefaults,
+      dismissedSuggestions,
+      dismissedExplicitSuggestions,
+      customSnapPoints,
+      audioFileName,
+    );
+  }, [metadata, agents, lines, groups, granularity]);
+
+  const handleImportProject = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      const existingLineCount = useProjectStore.getState().lines.length;
+      if (existingLineCount > 0) {
+        const ok = await confirm({
+          title: "Replace current project?",
+          description: `Loading this project file will replace your ${existingLineCount} existing line${existingLineCount === 1 ? "" : "s"} and metadata. This cannot be undone.`,
+          confirmLabel: "Replace",
+          variant: "destructive",
+          settingsKey: "confirmReplaceLyrics",
+        });
+        if (!ok) {
+          if (fileInputRef.current) fileInputRef.current.value = "";
+          return;
+        }
+      }
+
+      const project = await importProjectFromFile(file);
+      const store = useProjectStore.getState();
+      setMetadata(project.metadata);
+      setLines(project.lines);
+      store.setGroups(project.groups ?? []);
+      store.setDismissedSuggestions(project.dismissedSuggestions ?? []);
+      store.setDismissedExplicitSuggestions(project.dismissedExplicitSuggestions ?? []);
+      setGranularity(project.granularity);
+      store.setSyllableSplitDefaults(project.syllableSplitDefaults ?? DEFAULT_SYLLABLE_SPLIT_DEFAULTS);
+      setAgents(project.agents);
+      store.setCustomSnapPoints(project.customSnapPoints ?? []);
+      markClean();
+
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    },
+    [setMetadata, setLines, setGranularity, setAgents, markClean, confirm, fileInputRef],
+  );
+
+  const handleClearProject = useCallback(async () => {
+    const ok = await confirm({
+      title: "Clear all project data?",
+      description: "Remove every line, all metadata, and the audio file from this project. This cannot be undone.",
+      confirmLabel: "Clear",
+      variant: "destructive",
+      settingsKey: "confirmClearProject",
+    });
+    if (!ok) return;
+    cancelPendingSave();
+    reset();
+    await clearCurrentProject();
+  }, [reset, confirm]);
+
+  return { handleExportProject, handleImportProject, handleClearProject };
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { useProjectFileActions };

--- a/src/ui/select.browser.test.tsx
+++ b/src/ui/select.browser.test.tsx
@@ -62,4 +62,39 @@ describe("Select", () => {
     await expect.element(screen.getByRole("listbox")).not.toBeInTheDocument();
     expect(changes).toBe(0);
   });
+
+  it("shows the placeholder on the trigger when the value matches no option", async () => {
+    const screen = await render(
+      <Select aria-label="Letter" value="" placeholder="Pick one" onChange={() => {}} options={OPTIONS} />,
+    );
+    await expect.element(screen.getByRole("button", { name: "Letter" })).toHaveTextContent("Pick one");
+  });
+
+  it("still selects an option when a placeholder is set", async () => {
+    let selected = "";
+    const screen = await render(
+      <Select
+        aria-label="Letter"
+        value=""
+        placeholder="Pick one"
+        onChange={(v) => {
+          selected = v;
+        }}
+        options={OPTIONS}
+      />,
+    );
+    await screen.getByRole("button", { name: "Letter" }).click();
+    await screen.getByRole("option", { name: "Beta" }).click();
+    expect(selected).toBe("b");
+  });
+
+  it("renders a leading color dot on the trigger when leadingColor is set", async () => {
+    const screen = await render(
+      <Select aria-label="Letter" value="a" leadingColor="rgb(255, 0, 0)" onChange={() => {}} options={OPTIONS} />,
+    );
+    const trigger = screen.getByRole("button", { name: "Letter" }).element() as HTMLElement;
+    const dot = trigger.querySelector("span[style]") as HTMLElement | null;
+    expect(dot).not.toBeNull();
+    expect(dot?.style.backgroundColor).toBe("rgb(255, 0, 0)");
+  });
 });

--- a/src/ui/select.browser.test.tsx
+++ b/src/ui/select.browser.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { Select } from "@/ui/select";
+import { render } from "@/test/render";
+
+// -- Fixtures -----------------------------------------------------------------
+
+const OPTIONS = [
+  { value: "a", label: "Alpha" },
+  { value: "b", label: "Beta" },
+  { value: "c", label: "Gamma" },
+];
+
+// -- Tests --------------------------------------------------------------------
+
+describe("Select", () => {
+  it("shows the selected option's label on the trigger", async () => {
+    const screen = await render(<Select aria-label="Letter" value="b" onChange={() => {}} options={OPTIONS} />);
+    await expect.element(screen.getByRole("button", { name: "Letter" })).toHaveTextContent("Beta");
+  });
+
+  it("opens the listbox, and selecting an option calls onChange and closes", async () => {
+    let selected = "a";
+    const screen = await render(
+      <Select
+        aria-label="Letter"
+        value="a"
+        onChange={(value) => {
+          selected = value;
+        }}
+        options={OPTIONS}
+      />,
+    );
+    await screen.getByRole("button", { name: "Letter" }).click();
+    await expect.element(screen.getByRole("option", { name: "Gamma" })).toBeInTheDocument();
+    await screen.getByRole("option", { name: "Gamma" }).click();
+    expect(selected).toBe("c");
+    await expect.element(screen.getByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("marks the option matching the current value as selected", async () => {
+    const screen = await render(<Select aria-label="Letter" value="b" onChange={() => {}} options={OPTIONS} />);
+    await screen.getByRole("button", { name: "Letter" }).click();
+    await expect.element(screen.getByRole("option", { name: "Beta" })).toHaveAttribute("aria-selected", "true");
+    await expect.element(screen.getByRole("option", { name: "Alpha" })).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("closes on Escape without selecting", async () => {
+    let changes = 0;
+    const screen = await render(
+      <Select
+        aria-label="Letter"
+        value="a"
+        onChange={() => {
+          changes++;
+        }}
+        options={OPTIONS}
+      />,
+    );
+    await screen.getByRole("button", { name: "Letter" }).click();
+    await expect.element(screen.getByRole("listbox")).toBeInTheDocument();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await expect.element(screen.getByRole("listbox")).not.toBeInTheDocument();
+    expect(changes).toBe(0);
+  });
+});

--- a/src/ui/select.tsx
+++ b/src/ui/select.tsx
@@ -15,6 +15,8 @@ interface SelectProps {
   onChange: (value: string) => void;
   options: SelectOption[];
   "aria-label"?: string;
+  placeholder?: string;
+  leadingColor?: string;
   placement?: Placement;
   className?: string;
 }
@@ -26,10 +28,14 @@ const Select: React.FC<SelectProps> = ({
   onChange,
   options,
   "aria-label": ariaLabel,
+  placeholder,
+  leadingColor,
   placement = "bottom-end",
   className,
 }) => {
   const selected = options.find((option) => option.value === value);
+  const showPlaceholder = !selected && placeholder !== undefined;
+  const triggerLabel = selected?.label ?? placeholder ?? value;
 
   return (
     <Popover
@@ -44,7 +50,12 @@ const Select: React.FC<SelectProps> = ({
             className,
           )}
         >
-          <span className="truncate">{selected?.label ?? value}</span>
+          <span className="flex items-center gap-1.5 truncate">
+            {leadingColor && (
+              <span className="size-2 rounded-full shrink-0" style={{ backgroundColor: leadingColor }} />
+            )}
+            <span className={cn("truncate", showPlaceholder && "text-composer-text-muted")}>{triggerLabel}</span>
+          </span>
           <IconChevronDown className="size-4 text-composer-text opacity-50 shrink-0" />
         </button>
       }

--- a/src/ui/select.tsx
+++ b/src/ui/select.tsx
@@ -61,6 +61,7 @@ const Select: React.FC<SelectProps> = ({
       }
     >
       {(close) => (
+        // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- styled single-select popover; datalist is input autocomplete, not a listbox, and would reintroduce native chrome
         <div role="listbox" aria-label={ariaLabel} className="flex flex-col gap-0.5 p-1 w-max min-w-36">
           {options.map((option) => {
             const isSelected = option.value === value;
@@ -75,7 +76,7 @@ const Select: React.FC<SelectProps> = ({
                   close();
                 }}
                 className={cn(
-                  "flex items-center gap-2.5 w-full px-2 py-1.5 rounded-md text-sm text-left text-composer-text transition-colors",
+                  "flex items-center gap-2.5 w-full px-2 py-1.5 rounded-lg text-sm text-left text-composer-text transition-colors",
                   isSelected ? "bg-composer-button font-medium" : "cursor-pointer hover:bg-composer-button",
                 )}
               >

--- a/src/ui/select.tsx
+++ b/src/ui/select.tsx
@@ -1,0 +1,88 @@
+import type { Placement } from "@floating-ui/react";
+import { Popover } from "@/ui/popover";
+import { cn } from "@/utils/cn";
+import { IconCheck, IconChevronDown } from "@tabler/icons-react";
+
+// -- Interfaces ---------------------------------------------------------------
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: SelectOption[];
+  "aria-label"?: string;
+  placement?: Placement;
+  className?: string;
+}
+
+// -- Component ----------------------------------------------------------------
+
+const Select: React.FC<SelectProps> = ({
+  value,
+  onChange,
+  options,
+  "aria-label": ariaLabel,
+  placement = "bottom-end",
+  className,
+}) => {
+  const selected = options.find((option) => option.value === value);
+
+  return (
+    <Popover
+      placement={placement}
+      trigger={
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          aria-haspopup="listbox"
+          className={cn(
+            "inline-flex items-center justify-between gap-1.5 h-7 pl-3 pr-2 text-sm rounded-lg cursor-pointer transition-colors bg-composer-input text-composer-text border border-composer-border hover:border-composer-accent focus:outline-none focus:border-composer-accent",
+            className,
+          )}
+        >
+          <span className="truncate">{selected?.label ?? value}</span>
+          <IconChevronDown className="size-4 text-composer-text opacity-50 shrink-0" />
+        </button>
+      }
+    >
+      {(close) => (
+        <div role="listbox" aria-label={ariaLabel} className="flex flex-col gap-0.5 p-1 w-max min-w-36">
+          {options.map((option) => {
+            const isSelected = option.value === value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                role="option"
+                aria-selected={isSelected}
+                onClick={() => {
+                  onChange(option.value);
+                  close();
+                }}
+                className={cn(
+                  "flex items-center gap-2.5 w-full px-2 py-1.5 rounded-md text-sm text-left text-composer-text transition-colors",
+                  isSelected ? "bg-composer-button font-medium" : "cursor-pointer hover:bg-composer-button",
+                )}
+              >
+                <span className="flex-1">{option.label}</span>
+                <IconCheck
+                  aria-hidden={!isSelected}
+                  className={cn("size-3.5 text-composer-accent shrink-0", !isSelected && "invisible")}
+                />
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </Popover>
+  );
+};
+
+// -- Exports ------------------------------------------------------------------
+
+export { Select };
+export type { SelectOption };

--- a/src/ui/settings/advanced-section.browser.test.tsx
+++ b/src/ui/settings/advanced-section.browser.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { userEvent } from "vitest/browser";
 import { useSettingsStore } from "@/stores/settings";
 import { render } from "@/test/render";
 import { AdvancedSection } from "@/ui/settings/advanced-section";
@@ -7,14 +6,15 @@ import { AdvancedSection } from "@/ui/settings/advanced-section";
 describe("AdvancedSection", () => {
   it("renders the preview renderer select and the built-in Cobalt instance", async () => {
     const screen = await render(<AdvancedSection />);
-    await expect.element(screen.getByRole("combobox")).toBeInTheDocument();
+    await expect.element(screen.getByRole("button", { name: "Preview renderer" })).toBeInTheDocument();
     await expect.element(screen.getByText("Composer", { exact: true })).toBeInTheDocument();
   });
 
   it("updates the preview renderer setting from the select", async () => {
     useSettingsStore.setState({ previewRenderer: "braccato" });
     const screen = await render(<AdvancedSection />);
-    await userEvent.selectOptions(screen.getByRole("combobox").element(), "am-lyrics");
+    await screen.getByRole("button", { name: "Preview renderer" }).click();
+    await screen.getByRole("option", { name: "am-lyrics" }).click();
     await expect.poll(() => useSettingsStore.getState().previewRenderer).toBe("am-lyrics");
   });
 

--- a/src/ui/settings/setting-controls.browser.test.tsx
+++ b/src/ui/settings/setting-controls.browser.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { userEvent } from "vitest/browser";
 import { useSettingsStore } from "@/stores/settings";
 import { render } from "@/test/render";
 import { SelectSetting, SliderSetting, ToggleSetting } from "@/ui/settings/setting-controls";
@@ -115,7 +114,7 @@ describe("SelectSetting", () => {
         options={granularityOptions}
       />,
     );
-    await expect.element(screen.getByRole("combobox")).toHaveValue("line");
+    await expect.element(screen.getByRole("button", { name: "Granularity" })).toHaveTextContent("Line");
   });
 
   it("writes the chosen option to the store", async () => {
@@ -128,7 +127,8 @@ describe("SelectSetting", () => {
         options={granularityOptions}
       />,
     );
-    await userEvent.selectOptions(screen.getByRole("combobox").element(), "line");
+    await screen.getByRole("button", { name: "Granularity" }).click();
+    await screen.getByRole("option", { name: "Line" }).click();
     await expect.poll(() => useSettingsStore.getState().defaultGranularity).toBe("line");
   });
 });

--- a/src/ui/settings/setting-controls.tsx
+++ b/src/ui/settings/setting-controls.tsx
@@ -1,5 +1,6 @@
 import { useSettingsStore } from "@/stores/settings";
 import type { SettingsState } from "@/stores/settings";
+import { Select } from "@/ui/select";
 import { cn } from "@/utils/cn";
 
 // -- Setting Controls ---------------------------------------------------------
@@ -108,17 +109,12 @@ const SelectSetting: React.FC<{
         <span className="text-sm font-medium text-composer-text">{label}</span>
         <span className="text-xs text-composer-text-muted">{description}</span>
       </div>
-      <select
+      <Select
+        aria-label={label}
         value={value}
-        onChange={(e) => set(settingKey, e.target.value as SettingsState[typeof settingKey])}
-        className="h-7 px-2 text-sm rounded-lg bg-composer-input text-composer-text border border-composer-border focus:outline-none focus:border-composer-accent cursor-pointer"
-      >
-        {options.map((opt) => (
-          <option key={opt.value} value={opt.value}>
-            {opt.label}
-          </option>
-        ))}
-      </select>
+        onChange={(next) => set(settingKey, next as SettingsState[typeof settingKey])}
+        options={options}
+      />
     </div>
   );
 };

--- a/src/ui/settings/sync-section.browser.test.tsx
+++ b/src/ui/settings/sync-section.browser.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { userEvent } from "vitest/browser";
 import { useSettingsStore } from "@/stores/settings";
 import { render } from "@/test/render";
 import { SyncSection } from "@/ui/settings/sync-section";
@@ -8,14 +7,15 @@ describe("SyncSection", () => {
   it("renders the split character control, sliders, and granularity select", async () => {
     const screen = await render(<SyncSection />);
     await expect.element(screen.getByText("Split character")).toBeInTheDocument();
-    await expect.element(screen.getByRole("combobox")).toBeInTheDocument();
+    await expect.element(screen.getByRole("button", { name: "Default granularity" })).toBeInTheDocument();
     expect(screen.container.querySelectorAll('input[type="range"]').length).toBe(3);
   });
 
   it("updates the default granularity from the select", async () => {
     useSettingsStore.setState({ defaultGranularity: "word" });
     const screen = await render(<SyncSection />);
-    await userEvent.selectOptions(screen.getByRole("combobox").element(), "line");
+    await screen.getByRole("button", { name: "Default granularity" }).click();
+    await screen.getByRole("option", { name: "Line" }).click();
     await expect.poll(() => useSettingsStore.getState().defaultGranularity).toBe("line");
   });
 });

--- a/src/views/edit.browser.test.tsx
+++ b/src/views/edit.browser.test.tsx
@@ -228,6 +228,40 @@ describe("manual background vocal editing", () => {
   });
 });
 
+describe("agent assignment", () => {
+  const TWO_AGENTS = [
+    { id: "v1", name: "Lead", type: "person" as const },
+    { id: "v2", name: "Harmony", type: "person" as const },
+  ];
+
+  it("changes a line's agent through the per-line agent select", async () => {
+    useProjectStore.setState({
+      agents: TWO_AGENTS,
+      lines: [createLine({ text: "Hello world", agentId: "v1" })],
+    });
+    const screen = await render(<EditPanel />);
+
+    await screen.getByRole("button", { name: "Line agent", exact: true }).click();
+    await screen.getByRole("option", { name: "Harmony" }).click();
+
+    await expect.poll(() => useProjectStore.getState().lines[0].agentId).toBe("v2");
+  });
+
+  it("bulk-assigns an agent to the selected lines via the Assign agent select", async () => {
+    useProjectStore.setState({
+      agents: TWO_AGENTS,
+      lines: [createLine({ text: "alpha", agentId: "v1" }), createLine({ text: "bravo", agentId: "v1" })],
+    });
+    const screen = await render(<EditPanel />);
+
+    await screen.getByRole("button", { name: "1", exact: true }).click();
+    await screen.getByRole("button", { name: "Assign agent" }).click();
+    await screen.getByRole("option", { name: "Harmony" }).click();
+
+    await expect.poll(() => useProjectStore.getState().lines[0].agentId).toBe("v2");
+  });
+});
+
 describe("bulk line selection", () => {
   it("shift-clicking a second gutter selects the inclusive range from the prior click", async () => {
     useProjectStore.setState({

--- a/src/views/edit.tsx
+++ b/src/views/edit.tsx
@@ -14,6 +14,7 @@ import type { WordTiming } from "@/domain/word/timing";
 import { Button } from "@/ui/button";
 import { Popover } from "@/ui/popover";
 import { Scroll } from "@/ui/scroll";
+import { Select } from "@/ui/select";
 import { classifyLine, extractBackgroundVocals, extractInlineFromLine } from "@/utils/background-vocal-extraction";
 import { type ParseResult, parseLyricsFile } from "@/utils/lyrics-parsers";
 import { remapWordTextsPreservingTiming } from "@/domain/word/remap-text";
@@ -208,25 +209,20 @@ const LinePreview: React.FC<{
 
       <div className="flex items-center gap-1.5 ml-auto transition-opacity opacity-0 group-hover:opacity-100">
         {agents.length > 1 && line.lineId && (
-          <select
+          <Select
+            aria-label="Line agent"
             value={line.agentId}
-            onChange={(e) => {
+            onChange={(next) => {
               if (isSelected && hasMultipleSelected) {
-                onBulkAgentChange(e.target.value);
+                onBulkAgentChange(next);
               } else {
-                onAgentChange(line.lineId, e.target.value);
+                onAgentChange(line.lineId, next);
               }
             }}
-            onMouseDown={(e) => e.stopPropagation()}
-            className="h-5 px-1 text-xs border rounded cursor-pointer bg-composer-input border-composer-border focus:outline-none focus:border-composer-accent"
-            style={{ borderLeftColor: agentColor, borderLeftWidth: "2px" }}
-          >
-            {agents.map((agent) => (
-              <option key={agent.id} value={agent.id}>
-                {agent.name || agent.id}
-              </option>
-            ))}
-          </select>
+            options={agents.map((agent) => ({ value: agent.id, label: agent.name || agent.id }))}
+            leadingColor={agentColor}
+            className="h-5 pl-2 pr-1 text-xs"
+          />
         )}
 
         {line.lineId && (
@@ -730,20 +726,14 @@ Or drag and drop a lyrics file (.txt, .lrc, .srt, .ttml)"
                 {selectedLines.size} line{selectedLines.size !== 1 ? "s" : ""} selected
               </span>
               {agents.length > 1 && (
-                <select
-                  onChange={(e) => handleBulkAgentChange(e.target.value)}
+                <Select
+                  aria-label="Assign agent"
+                  placeholder="Assign agent"
                   value=""
-                  className="h-6 px-1.5 text-xs border rounded cursor-pointer bg-composer-input border-composer-border focus:outline-none focus:border-composer-accent"
-                >
-                  <option value="" disabled>
-                    Assign agent
-                  </option>
-                  {agents.map((agent) => (
-                    <option key={agent.id} value={agent.id}>
-                      {agent.name || agent.id}
-                    </option>
-                  ))}
-                </select>
+                  onChange={handleBulkAgentChange}
+                  options={agents.map((agent) => ({ value: agent.id, label: agent.name || agent.id }))}
+                  className="h-6 text-xs"
+                />
               )}
               <button
                 type="button"

--- a/src/views/edit/agent-manager.browser.test.tsx
+++ b/src/views/edit/agent-manager.browser.test.tsx
@@ -32,4 +32,25 @@ describe("AgentManager", () => {
     await screen.getByRole("button", { name: /Add/ }).click();
     await expect.element(screen.getByRole("textbox", { name: "Custom agent name" })).toBeInTheDocument();
   });
+
+  it("changes an agent's type via the type select and persists on save", async () => {
+    useProjectStore.setState({ agents: [{ id: "v1", name: "Lead", type: "person" }] });
+    const screen = await render(<AgentManager />);
+    await screen.getByRole("button", { name: /v1/ }).click();
+    await screen.getByRole("button", { name: "Agent type" }).click();
+    await screen.getByRole("option", { name: "Group" }).click();
+    await screen.getByRole("button", { name: "Save" }).click();
+    await expect.poll(() => useProjectStore.getState().agents.find((a) => a.id === "v1")?.type).toBe("group");
+  });
+
+  it("creates a custom agent with the chosen type", async () => {
+    useProjectStore.setState({ agents: [{ id: "v1", name: "Lead", type: "person" }] });
+    const screen = await render(<AgentManager />);
+    await screen.getByRole("button", { name: /Add/ }).click();
+    await screen.getByRole("textbox", { name: "Custom agent name" }).fill("Choir");
+    await screen.getByRole("button", { name: "Custom agent type" }).click();
+    await screen.getByRole("option", { name: "Group" }).click();
+    await screen.getByRole("button", { name: "Add Custom Agent" }).click();
+    await expect.poll(() => useProjectStore.getState().agents.find((a) => a.name === "Choir")?.type).toBe("group");
+  });
 });

--- a/src/views/edit/agent-manager.tsx
+++ b/src/views/edit/agent-manager.tsx
@@ -3,8 +3,19 @@ import { AGENT_PRESETS, getAgentColor } from "@/domain/agent/colors";
 import type { Agent, AgentType } from "@/domain/agent/model";
 import { Button } from "@/ui/button";
 import { Popover } from "@/ui/popover";
+import { Select } from "@/ui/select";
 import { IconPlus, IconTrash } from "@tabler/icons-react";
 import { useCallback, useState } from "react";
+
+// -- Constants ----------------------------------------------------------------
+
+const AGENT_TYPE_OPTIONS = [
+  { value: "person", label: "Person" },
+  { value: "group", label: "Group" },
+  { value: "character", label: "Character" },
+  { value: "organization", label: "Organization" },
+  { value: "other", label: "Other" },
+];
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -82,17 +93,14 @@ const EditAgentPopover: React.FC<{
               placeholder="Agent name"
               className="px-2 py-1.5 text-sm rounded-md bg-composer-input border border-composer-border focus:outline-none focus:border-composer-accent"
             />
-            <select
+            <Select
+              aria-label="Agent type"
               value={type}
-              onChange={(e) => setType(e.target.value as AgentType)}
-              className="px-2 py-1.5 text-sm rounded-md bg-composer-input border border-composer-border focus:outline-none focus:border-composer-accent cursor-pointer"
-            >
-              <option value="person">Person</option>
-              <option value="group">Group</option>
-              <option value="character">Character</option>
-              <option value="organization">Organization</option>
-              <option value="other">Other</option>
-            </select>
+              onChange={(next) => setType(next as AgentType)}
+              options={AGENT_TYPE_OPTIONS}
+              placement="bottom-start"
+              className="w-full"
+            />
             <div className="flex gap-2">
               <Button size="sm" variant="primary" onClick={() => handleSave(close)} className="flex-1">
                 Save
@@ -190,17 +198,14 @@ const AddAgentPopover: React.FC = () => {
               placeholder="Agent name"
               className="px-2 py-1.5 text-sm rounded-md bg-composer-input border border-composer-border focus:outline-none focus:border-composer-accent"
             />
-            <select
+            <Select
+              aria-label="Custom agent type"
               value={customType}
-              onChange={(e) => setCustomType(e.target.value as AgentType)}
-              className="px-2 py-1.5 text-sm rounded-md bg-composer-input border border-composer-border focus:outline-none focus:border-composer-accent cursor-pointer"
-            >
-              <option value="person">Person</option>
-              <option value="group">Group</option>
-              <option value="character">Character</option>
-              <option value="organization">Organization</option>
-              <option value="other">Other</option>
-            </select>
+              onChange={(next) => setCustomType(next as AgentType)}
+              options={AGENT_TYPE_OPTIONS}
+              placement="bottom-start"
+              className="w-full"
+            />
             <Button size="sm" variant="primary" onClick={() => handleAddCustom(close)} disabled={!customName.trim()}>
               Add Custom Agent
             </Button>

--- a/src/views/export.browser.test.tsx
+++ b/src/views/export.browser.test.tsx
@@ -45,6 +45,17 @@ describe("ExportPanel", () => {
     await screen.getByRole("button", { name: /Edit$/ }).click();
     await expect.element(screen.getByRole("textbox", { name: "Edit TTML content" })).toBeInTheDocument();
   });
+
+  it("renders the edit textarea outside the overflow-auto scroll container so it can fill the panel height", async () => {
+    useProjectStore.setState({
+      lines: [createLine({ text: "Hi", words: [createWord({ text: "Hi", begin: 0, end: 1 })] })],
+    });
+    const screen = await render(<ExportPanel />);
+    await screen.getByRole("button", { name: /Edit$/ }).click();
+    const textarea = screen.getByRole("textbox", { name: "Edit TTML content" });
+    await expect.element(textarea).toBeInTheDocument();
+    expect((textarea.element() as HTMLTextAreaElement).closest(".overflow-auto")).toBeNull();
+  });
 });
 
 describe("ExportPanel · project file customSnapPoints", () => {

--- a/src/views/export.browser.test.tsx
+++ b/src/views/export.browser.test.tsx
@@ -56,6 +56,19 @@ describe("ExportPanel", () => {
     await expect.element(textarea).toBeInTheDocument();
     expect((textarea.element() as HTMLTextAreaElement).closest(".overflow-auto")).toBeNull();
   });
+
+  it("keeps textarea edits after clicking Done", async () => {
+    useProjectStore.setState({
+      lines: [createLine({ text: "Hi", words: [createWord({ text: "Hi", begin: 0, end: 1 })] })],
+    });
+    const screen = await render(<ExportPanel />);
+    await screen.getByRole("button", { name: /Edit$/ }).click();
+    await screen.getByRole("textbox", { name: "Edit TTML content" }).fill("CUSTOM EDITED CONTENT");
+    await screen.getByRole("button", { name: "Done" }).click();
+    await expect
+      .poll(() => screen.container.querySelector("pre")?.textContent ?? "")
+      .toContain("CUSTOM EDITED CONTENT");
+  });
 });
 
 describe("ExportPanel · project file customSnapPoints", () => {

--- a/src/views/export.tsx
+++ b/src/views/export.tsx
@@ -41,6 +41,7 @@ const ExportPanel: React.FC = () => {
 
   const [copied, setCopied] = useState(false);
   const [editState, setEditState] = useState<{ source: string; content: string } | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const syncedLineCount = useMemo(() => lines.filter((line) => effectiveBounds(line) !== null).length, [lines]);
@@ -57,7 +58,6 @@ const ExportPanel: React.FC = () => {
   }, [metadata, agents, lines, groups, granularity, duration, hasSyncedContent]);
 
   const editedContent = editState && editState.source === generatedTtml ? editState.content : null;
-  const isEditing = editedContent !== null;
   const displayContent = editedContent ?? generatedTtml;
   const exportContent = editedContent ?? minifiedTtml;
 
@@ -86,11 +86,12 @@ const ExportPanel: React.FC = () => {
   }, [exportContent]);
 
   const handleEdit = useCallback(() => {
-    setEditState((prev) => (prev ? null : { source: generatedTtml, content: displayContent }));
-  }, [generatedTtml, displayContent]);
+    setIsEditing((prev) => !prev);
+  }, []);
 
   const handleRegenerate = useCallback(() => {
     setEditState(null);
+    setIsEditing(false);
   }, []);
 
   const handleExportProject = useCallback(() => {
@@ -259,7 +260,7 @@ const ExportPanel: React.FC = () => {
       {isEditing ? (
         <div className="flex flex-col flex-1 min-h-0 p-6">
           <textarea
-            value={editedContent ?? ""}
+            value={displayContent}
             aria-label="Edit TTML content"
             onChange={(e) => setEditState({ source: generatedTtml, content: e.target.value })}
             className="w-full flex-1 p-4 rounded-lg font-mono text-xs bg-composer-bg-elevated text-composer-text resize-none focus:outline-none focus:ring-1 focus:ring-composer-accent"

--- a/src/views/export.tsx
+++ b/src/views/export.tsx
@@ -256,16 +256,18 @@ const ExportPanel: React.FC = () => {
       </div>
 
       {/* Preview / Editor */}
-      <Scroll className="flex-1 p-6">
-        {isEditing ? (
+      {isEditing ? (
+        <div className="flex flex-col flex-1 min-h-0 p-6">
           <textarea
             value={editedContent ?? ""}
             aria-label="Edit TTML content"
             onChange={(e) => setEditState({ source: generatedTtml, content: e.target.value })}
-            className="w-full h-full p-4 rounded-lg font-mono text-xs bg-composer-bg-elevated text-composer-text resize-none focus:outline-none focus:ring-1 focus:ring-composer-accent"
+            className="w-full flex-1 p-4 rounded-lg font-mono text-xs bg-composer-bg-elevated text-composer-text resize-none focus:outline-none focus:ring-1 focus:ring-composer-accent"
             spellCheck={false}
           />
-        ) : (
+        </div>
+      ) : (
+        <Scroll className="flex-1 p-6">
           <Highlight theme={themes.nightOwl} code={displayContent} language="xml">
             {({ style, tokens, getLineProps, getTokenProps }) => (
               <pre
@@ -287,8 +289,8 @@ const ExportPanel: React.FC = () => {
               </pre>
             )}
           </Highlight>
-        )}
-      </Scroll>
+        </Scroll>
+      )}
     </div>
   );
 };

--- a/src/views/export.tsx
+++ b/src/views/export.tsx
@@ -1,9 +1,6 @@
-import { exportProjectToFile, importProjectFromFile, clearCurrentProject } from "@/lib/persistence";
-import { cancelPendingSave } from "@/lib/persistence-debounce";
+import { useProjectFileActions } from "@/hooks/useProjectFileActions";
 import { useAudioStore } from "@/stores/audio";
-import { useConfirm } from "@/stores/confirm-store";
 import { useProjectStore } from "@/stores/project";
-import { DEFAULT_SYLLABLE_SPLIT_DEFAULTS } from "@/stores/project/types";
 import { Button } from "@/ui/button";
 import { EmptyState } from "@/ui/empty-state";
 import { Scroll } from "@/ui/scroll";
@@ -31,18 +28,12 @@ const ExportPanel: React.FC = () => {
   const groups = useProjectStore((s) => s.groups);
   const granularity = useProjectStore((s) => s.granularity);
   const duration = useAudioStore((s) => s.duration);
-  const setMetadata = useProjectStore((s) => s.setMetadata);
-  const setLines = useProjectStore((s) => s.setLines);
-  const setGranularity = useProjectStore((s) => s.setGranularity);
-  const setAgents = useProjectStore((s) => s.setAgents);
-  const reset = useProjectStore((s) => s.reset);
-  const markClean = useProjectStore((s) => s.markClean);
-  const confirm = useConfirm();
 
   const [copied, setCopied] = useState(false);
   const [editState, setEditState] = useState<{ source: string; content: string } | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { handleExportProject, handleImportProject, handleClearProject } = useProjectFileActions(fileInputRef);
 
   const syncedLineCount = useMemo(() => lines.filter((line) => effectiveBounds(line) !== null).length, [lines]);
   const hasSyncedContent = syncedLineCount > 0;
@@ -93,79 +84,6 @@ const ExportPanel: React.FC = () => {
     setEditState(null);
     setIsEditing(false);
   }, []);
-
-  const handleExportProject = useCallback(() => {
-    const audioSource = useAudioStore.getState().source;
-    const audioFileName = audioSource?.type === "file" ? audioSource.file.name : undefined;
-    const { dismissedSuggestions, dismissedExplicitSuggestions, syllableSplitDefaults, customSnapPoints } =
-      useProjectStore.getState();
-    exportProjectToFile(
-      metadata,
-      agents,
-      lines,
-      groups,
-      granularity,
-      syllableSplitDefaults,
-      dismissedSuggestions,
-      dismissedExplicitSuggestions,
-      customSnapPoints,
-      audioFileName,
-    );
-  }, [metadata, agents, lines, groups, granularity]);
-
-  const handleImportProject = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (!file) return;
-
-      const existingLineCount = useProjectStore.getState().lines.length;
-      if (existingLineCount > 0) {
-        const ok = await confirm({
-          title: "Replace current project?",
-          description: `Loading this project file will replace your ${existingLineCount} existing line${existingLineCount === 1 ? "" : "s"} and metadata. This cannot be undone.`,
-          confirmLabel: "Replace",
-          variant: "destructive",
-          settingsKey: "confirmReplaceLyrics",
-        });
-        if (!ok) {
-          if (fileInputRef.current) fileInputRef.current.value = "";
-          return;
-        }
-      }
-
-      const project = await importProjectFromFile(file);
-      const store = useProjectStore.getState();
-      setMetadata(project.metadata);
-      setLines(project.lines);
-      store.setGroups(project.groups ?? []);
-      store.setDismissedSuggestions(project.dismissedSuggestions ?? []);
-      store.setDismissedExplicitSuggestions(project.dismissedExplicitSuggestions ?? []);
-      setGranularity(project.granularity);
-      store.setSyllableSplitDefaults(project.syllableSplitDefaults ?? DEFAULT_SYLLABLE_SPLIT_DEFAULTS);
-      setAgents(project.agents);
-      store.setCustomSnapPoints(project.customSnapPoints ?? []);
-      markClean();
-
-      if (fileInputRef.current) {
-        fileInputRef.current.value = "";
-      }
-    },
-    [setMetadata, setLines, setGranularity, setAgents, markClean, confirm],
-  );
-
-  const handleClearProject = useCallback(async () => {
-    const ok = await confirm({
-      title: "Clear all project data?",
-      description: "Remove every line, all metadata, and the audio file from this project. This cannot be undone.",
-      confirmLabel: "Clear",
-      variant: "destructive",
-      settingsKey: "confirmClearProject",
-    });
-    if (!ok) return;
-    cancelPendingSave();
-    reset();
-    await clearCurrentProject();
-  }, [reset, confirm]);
 
   const projectFileInput = (
     <input


### PR DESCRIPTION
## Overview

The Edit textarea on the export screen sat inside the overlay-scrollbars container, so it collapsed to a single line and you couldn't really type. Pulled it into a plain flex-height box, and edits now stick when you click Done instead of reverting. Also swapped the remaining native dropdowns (settings and the agent pickers) for the themed one, since that lands cleaner here than on the sync branch.
