### PR TITLE
feat: sync redo refinements and custom dropdowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.33.0",
+  "version": "1.34.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",
@@ -32,10 +32,12 @@
     "@uimaxbai/am-lyrics": "^1.5.4",
     "@wavesurfer/react": "^1.0.12",
     "clsx": "^2.1.1",
+    "diff": "^9.0.0",
     "driver.js": "^1.4.0",
     "lit": "^3.3.2",
     "motion": "^12.24.12",
     "nanoid": "^5.1.11",
+    "node-diff3": "^3.2.1",
     "obscenity": "^0.4.6",
     "onnxruntime-web": "^1.26.0",
     "overlayscrollbars": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.34.0",
+  "version": "1.35.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",
@@ -36,6 +36,7 @@
     "driver.js": "^1.4.0",
     "lit": "^3.3.2",
     "motion": "^12.24.12",
+    "music-metadata": "^11.13.0",
     "nanoid": "^5.1.11",
     "node-diff3": "^3.2.1",
     "obscenity": "^0.4.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.32.3",
+  "version": "1.33.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.35.0",
+  "version": "1.35.1",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.35.1",
+  "version": "1.36.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.36.0",
+  "version": "1.36.1",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.36.2",
+  "version": "1.36.3",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.36.1",
+  "version": "1.36.2",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.36.3",
+  "version": "1.37.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.37.0",
+  "version": "1.35.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       motion:
         specifier: ^12.24.12
         version: 12.24.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      music-metadata:
+        specifier: ^11.13.0
+        version: 11.13.0
       nanoid:
         specifier: ^5.1.11
         version: 5.1.11
@@ -338,6 +341,9 @@ packages:
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
   '@braccato/core@0.1.7':
     resolution: {integrity: sha512-z9TXJXiIToCu8uEDDxoLjpQjs7YseQE8De+cDN/iPgYqRJwrFx+xP+2c3se6g91lLqfh3Hyku7FKJtCjGPaXGA==}
@@ -1385,6 +1391,13 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -1656,6 +1669,10 @@ packages:
   constantinople@4.0.1:
     resolution: {integrity: sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==}
 
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -1821,6 +1838,10 @@ packages:
   fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
 
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -1954,6 +1975,9 @@ packages:
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -2199,6 +2223,10 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@2.0.0:
+    resolution: {integrity: sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q==}
+    engines: {node: '>=18'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -2251,6 +2279,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  music-metadata@11.13.0:
+    resolution: {integrity: sha512-uXRaov9dfjSpQufXIU7sMxVZnh+FilCQv2mXn+K5EJ/decP3dTWrgvPYa5r6MtRbieNSCE708Da4J0u1UGfQIw==}
+    engines: {node: '>=18'}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -2627,6 +2659,10 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2687,6 +2723,10 @@ packages:
   token-stream@1.0.0:
     resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
 
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -2714,6 +2754,10 @@ packages:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   unbash@3.0.0:
     resolution: {integrity: sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==}
@@ -2924,6 +2968,9 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  win-guid@0.2.1:
+    resolution: {integrity: sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==}
 
   with@7.0.2:
     resolution: {integrity: sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==}
@@ -3200,6 +3247,8 @@ snapshots:
     optional: true
 
   '@blazediff/core@1.9.1': {}
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@braccato/core@0.1.7':
     dependencies:
@@ -3909,6 +3958,15 @@ snapshots:
       '@tanstack/query-core': 5.100.10
       react: 19.2.3
 
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -4230,6 +4288,8 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
@@ -4407,6 +4467,15 @@ snapshots:
 
   fflate@0.7.4: {}
 
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -4537,6 +4606,8 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
 
   invariant@2.2.4:
     dependencies:
@@ -4814,6 +4885,8 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@2.0.0: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -4850,6 +4923,21 @@ snapshots:
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
+
+  music-metadata@11.13.0:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      content-type: 2.0.0
+      debug: 4.4.3
+      file-type: 21.3.4
+      media-typer: 2.0.0
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+      win-guid: 0.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   nanoid@3.3.12: {}
 
@@ -5325,6 +5413,10 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -5371,6 +5463,12 @@ snapshots:
 
   token-stream@1.0.0: {}
 
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
   totalist@3.0.1: {}
 
   tough-cookie@4.1.4:
@@ -5395,6 +5493,8 @@ snapshots:
   tslib@2.8.1: {}
 
   typescript@5.7.3: {}
+
+  uint8array-extras@1.5.0: {}
 
   unbash@3.0.0: {}
 
@@ -5539,6 +5639,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  win-guid@0.2.1: {}
 
   with@7.0.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      diff:
+        specifier: ^9.0.0
+        version: 9.0.0
       driver.js:
         specifier: ^1.4.0
         version: 1.4.0
@@ -56,6 +59,9 @@ importers:
       nanoid:
         specifier: ^5.1.11
         version: 5.1.11
+      node-diff3:
+        specifier: ^3.2.1
+        version: 3.2.1
       obscenity:
         specifier: ^0.4.6
         version: 0.4.6
@@ -1713,6 +1719,10 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+    engines: {node: '>=0.3.1'}
+
   doctypes@1.1.0:
     resolution: {integrity: sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==}
 
@@ -2251,6 +2261,10 @@ packages:
     resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
     engines: {node: ^18 || >=20}
     hasBin: true
+
+  node-diff3@3.2.1:
+    resolution: {integrity: sha512-eKZcJ8RtMQ3cIaA15EgmtwG927fYnRlhtdA4Q9HAcCpAZPQhhU2XptnTH9GeAkMiX2bAXxlJSAFa9shFbztPgw==}
+    engines: {bun: '>=1.3.10'}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -4272,6 +4286,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  diff@9.0.0: {}
+
   doctypes@1.1.0: {}
 
   driver.js@1.4.0: {}
@@ -4838,6 +4854,8 @@ snapshots:
   nanoid@3.3.12: {}
 
   nanoid@5.1.11: {}
+
+  node-diff3@3.2.1: {}
 
   node-releases@2.0.27: {}
 

--- a/src/domain/project/metadata-ttml.test.ts
+++ b/src/domain/project/metadata-ttml.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectMetadata } from "@/domain/project/metadata";
+import { fromComposerMeta, toComposerMeta } from "@/domain/project/metadata-ttml";
+
+const base: ProjectMetadata = {
+  title: "Song",
+  artists: ["Tyler, The Creator", "Kali Uchis"],
+  album: "Flower Boy",
+  duration: 0,
+  isrc: "USQX91700001",
+  songwriters: ["Tyler Okonma"],
+  extra: { spotifyId: "abc", mood: "chill" },
+};
+
+describe("toComposerMeta", () => {
+  it("emits one pair per artist, plus album/isrc/songwriter/extra, never the title", () => {
+    expect(toComposerMeta(base)).toEqual([
+      { key: "artists", value: "Tyler, The Creator" },
+      { key: "artists", value: "Kali Uchis" },
+      { key: "album", value: "Flower Boy" },
+      { key: "isrc", value: "USQX91700001" },
+      { key: "songwriter", value: "Tyler Okonma" },
+      { key: "mood", value: "chill" },
+      { key: "spotifyId", value: "abc" },
+    ]);
+  });
+  describe("edge cases", () => {
+    it("omits empty fields", () => {
+      expect(toComposerMeta({ title: "x", artists: [], album: "", duration: 0 })).toEqual([]);
+    });
+    it("sorts extra keys deterministically", () => {
+      const pairs = toComposerMeta({ title: "", artists: [], album: "", duration: 0, extra: { z: "1", a: "2" } });
+      expect(pairs.map((p) => p.key)).toEqual(["a", "z"]);
+    });
+    it("skips empty artist and songwriter entries", () => {
+      const pairs = toComposerMeta({ title: "", artists: ["", "A"], album: "", duration: 0, songwriters: ["", "W"] });
+      expect(pairs).toEqual([
+        { key: "artists", value: "A" },
+        { key: "songwriter", value: "W" },
+      ]);
+    });
+  });
+});
+
+describe("fromComposerMeta", () => {
+  it("collects known keys into typed fields and unknown keys into extra", () => {
+    const out = fromComposerMeta([
+      { key: "artists", value: "A" },
+      { key: "artists", value: "B" },
+      { key: "album", value: "Al" },
+      { key: "isrc", value: "USQX91700001" },
+      { key: "songwriter", value: "W1" },
+      { key: "songwriters", value: "W2" },
+      { key: "musicName", value: "T" },
+      { key: "weird", value: "w" },
+    ]);
+    expect(out).toEqual({
+      title: "T",
+      artists: ["A", "B"],
+      album: "Al",
+      isrc: "USQX91700001",
+      songwriters: ["W1", "W2"],
+      extra: { weird: "w" },
+    });
+  });
+  describe("edge cases", () => {
+    it("returns an empty object for no pairs", () => expect(fromComposerMeta([])).toEqual({}));
+    it("ignores pairs with an empty key", () => expect(fromComposerMeta([{ key: "", value: "x" }])).toEqual({}));
+    it("ignores pairs with an empty value", () => {
+      expect(
+        fromComposerMeta([
+          { key: "album", value: "" },
+          { key: "spotifyId", value: "" },
+        ]),
+      ).toEqual({});
+    });
+  });
+});
+
+describe("round-trip", () => {
+  it("fromComposerMeta(toComposerMeta(m)) recovers the non-title fields", () => {
+    const out = fromComposerMeta(toComposerMeta(base));
+    expect(out).toEqual({
+      artists: ["Tyler, The Creator", "Kali Uchis"],
+      album: "Flower Boy",
+      isrc: "USQX91700001",
+      songwriters: ["Tyler Okonma"],
+      extra: { mood: "chill", spotifyId: "abc" },
+    });
+  });
+});

--- a/src/domain/project/metadata-ttml.test.ts
+++ b/src/domain/project/metadata-ttml.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ProjectMetadata } from "@/domain/project/metadata";
-import { fromComposerMeta, toComposerMeta } from "@/domain/project/metadata-ttml";
+import { RESERVED_META_KEYS, fromComposerMeta, toComposerMeta } from "@/domain/project/metadata-ttml";
 
 const base: ProjectMetadata = {
   title: "Song",
@@ -87,5 +87,26 @@ describe("round-trip", () => {
       songwriters: ["Tyler Okonma"],
       extra: { mood: "chill", spotifyId: "abc" },
     });
+  });
+});
+
+// -- Reserved keys ------------------------------------------------------------
+
+describe("RESERVED_META_KEYS", () => {
+  it("covers every key fromComposerMeta routes away from extra", () => {
+    for (const key of ["artists", "album", "isrc", "musicName", "songwriter", "songwriters"]) {
+      expect(RESERVED_META_KEYS.has(key)).toBe(true);
+    }
+  });
+
+  it("does not claim an ordinary extra key", () => {
+    expect(RESERVED_META_KEYS.has("spotifyId")).toBe(false);
+  });
+
+  it("every reserved key is swallowed by the switch rather than landing in extra", () => {
+    for (const key of RESERVED_META_KEYS) {
+      const parsed = fromComposerMeta([{ key, value: "v" }]);
+      expect(parsed.extra?.[key]).toBeUndefined();
+    }
   });
 });

--- a/src/domain/project/metadata-ttml.ts
+++ b/src/domain/project/metadata-ttml.ts
@@ -1,0 +1,62 @@
+import type { ProjectMetadata } from "@/domain/project/metadata";
+
+// -- Types --------------------------------------------------------------------
+
+interface MetaPair {
+  key: string;
+  value: string;
+}
+
+// -- Mapping ------------------------------------------------------------------
+
+function toComposerMeta(metadata: ProjectMetadata): MetaPair[] {
+  const pairs: MetaPair[] = [];
+  for (const artist of metadata.artists) if (artist) pairs.push({ key: "artists", value: artist });
+  if (metadata.album) pairs.push({ key: "album", value: metadata.album });
+  if (metadata.isrc) pairs.push({ key: "isrc", value: metadata.isrc });
+  for (const writer of metadata.songwriters ?? []) if (writer) pairs.push({ key: "songwriter", value: writer });
+  for (const key of Object.keys(metadata.extra ?? {}).toSorted()) {
+    const value = metadata.extra?.[key];
+    if (value) pairs.push({ key, value });
+  }
+  return pairs;
+}
+
+function fromComposerMeta(pairs: MetaPair[]): Partial<ProjectMetadata> {
+  const out: Partial<ProjectMetadata> = {};
+  const artists: string[] = [];
+  const songwriters: string[] = [];
+  const extra: Record<string, string> = {};
+  for (const { key, value } of pairs) {
+    if (!key || !value) continue;
+    switch (key) {
+      case "artists":
+        artists.push(value);
+        break;
+      case "album":
+        out.album = value;
+        break;
+      case "isrc":
+        out.isrc = value;
+        break;
+      case "musicName":
+        if (out.title == null) out.title = value;
+        break;
+      case "songwriter":
+      case "songwriters":
+        songwriters.push(value);
+        break;
+      default:
+        extra[key] = value;
+    }
+  }
+  if (artists.length) out.artists = artists;
+  if (songwriters.length) out.songwriters = songwriters;
+  if (Object.keys(extra).length) out.extra = extra;
+  return out;
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { fromComposerMeta, toComposerMeta };
+export type { MetaPair };

--- a/src/domain/project/metadata-ttml.ts
+++ b/src/domain/project/metadata-ttml.ts
@@ -7,6 +7,17 @@ interface MetaPair {
   value: string;
 }
 
+// -- Reserved keys ------------------------------------------------------------
+
+const RESERVED_META_KEYS: ReadonlySet<string> = new Set([
+  "artists",
+  "album",
+  "isrc",
+  "musicName",
+  "songwriter",
+  "songwriters",
+]);
+
 // -- Mapping ------------------------------------------------------------------
 
 function toComposerMeta(metadata: ProjectMetadata): MetaPair[] {
@@ -58,5 +69,4 @@ function fromComposerMeta(pairs: MetaPair[]): Partial<ProjectMetadata> {
 
 // -- Exports ------------------------------------------------------------------
 
-export { fromComposerMeta, toComposerMeta };
-export type { MetaPair };
+export { RESERVED_META_KEYS, fromComposerMeta, toComposerMeta };

--- a/src/domain/project/metadata.test.ts
+++ b/src/domain/project/metadata.test.ts
@@ -5,7 +5,7 @@ describe("ProjectMetadata", () => {
   it("preserves thumbnailForVideoId when set alongside thumbnailDataUrl", () => {
     const m: ProjectMetadata = {
       title: "T",
-      artist: "A",
+      artists: ["A"],
       album: "AL",
       duration: 0,
       thumbnailDataUrl: "data:image/png;base64,xyz",
@@ -16,7 +16,7 @@ describe("ProjectMetadata", () => {
   });
 
   it("omits thumbnailForVideoId by default", () => {
-    const m: ProjectMetadata = { title: "", artist: "", album: "", duration: 0 };
+    const m: ProjectMetadata = { title: "", artists: [], album: "", duration: 0 };
     expect(m.thumbnailForVideoId).toBeUndefined();
     expect(m.thumbnailDataUrl).toBeUndefined();
   });
@@ -26,7 +26,7 @@ describe("ProjectMetadata: persistence invariants", () => {
   it("round-trips both thumbnail fields through JSON (the persistence path uses JSON via IndexedDB)", () => {
     const original: ProjectMetadata = {
       title: "Never Gonna Give You Up",
-      artist: "Rick Astley",
+      artists: ["Rick Astley"],
       album: "Whenever You Need Somebody",
       duration: 213,
       thumbnailDataUrl: "data:image/png;base64,ABCD",
@@ -41,14 +41,14 @@ describe("ProjectMetadata: persistence invariants", () => {
   it("distinguishes the legacy persisted state (thumbnailDataUrl only) from the post-refactor state (both set)", () => {
     const legacy: ProjectMetadata = {
       title: "",
-      artist: "",
+      artists: [],
       album: "",
       duration: 0,
       thumbnailDataUrl: "data:image/png;base64,LEGACY",
     };
     const tagged: ProjectMetadata = {
       title: "",
-      artist: "",
+      artists: [],
       album: "",
       duration: 0,
       thumbnailDataUrl: "data:image/png;base64,LEGACY",

--- a/src/domain/project/metadata.ts
+++ b/src/domain/project/metadata.ts
@@ -2,9 +2,12 @@
 
 interface ProjectMetadata {
   title: string;
-  artist: string;
+  artists: string[];
   album: string;
   duration: number;
+  isrc?: string;
+  songwriters?: string[];
+  extra?: Record<string, string>;
   language?: string;
   thumbnailDataUrl?: string;
   thumbnailForVideoId?: string;

--- a/src/domain/project/normalize-metadata.test.ts
+++ b/src/domain/project/normalize-metadata.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLoadedMetadata } from "@/domain/project/normalize-metadata";
+
+describe("normalizeLoadedMetadata", () => {
+  it("upgrades legacy single artist string to an array", () => {
+    const out = normalizeLoadedMetadata({ title: "T", artist: "Tyler, The Creator", album: "A", duration: 10 });
+    expect(out.artists).toEqual(["Tyler, The Creator"]);
+    expect("artist" in out).toBe(false);
+  });
+  it("passes through an already-migrated artists array", () => {
+    const out = normalizeLoadedMetadata({ title: "T", artists: ["A", "B"], album: "", duration: 0 });
+    expect(out.artists).toEqual(["A", "B"]);
+  });
+  describe("edge cases", () => {
+    it("fills defaults for a sparse object", () => {
+      const out = normalizeLoadedMetadata({});
+      expect(out).toMatchObject({ title: "", artists: [], album: "", duration: 0 });
+    });
+    it("drops an empty legacy artist string to an empty array", () => {
+      expect(normalizeLoadedMetadata({ artist: "" }).artists).toEqual([]);
+    });
+    it("is idempotent", () => {
+      const once = normalizeLoadedMetadata({ artist: "X" });
+      expect(normalizeLoadedMetadata(once)).toEqual(once);
+    });
+    it("preserves new optional fields", () => {
+      const out = normalizeLoadedMetadata({
+        artists: ["X"],
+        isrc: "USQX91700001",
+        songwriters: ["W"],
+        extra: { spotifyId: "z" },
+      });
+      expect(out).toMatchObject({ isrc: "USQX91700001", songwriters: ["W"], extra: { spotifyId: "z" } });
+    });
+    it("drops a whitespace-only legacy artist to an empty array", () => {
+      expect(normalizeLoadedMetadata({ artist: "   " }).artists).toEqual([]);
+    });
+  });
+  describe("invariants", () => {
+    it("prefers artists over a stale legacy artist when both are present", () => {
+      const out = normalizeLoadedMetadata({ artist: "Legacy", artists: ["New"] });
+      expect(out.artists).toEqual(["New"]);
+      expect("artist" in out).toBe(false);
+    });
+    it("never lets a default clobber a present field", () => {
+      const out = normalizeLoadedMetadata({ title: "Keep", artist: "X" });
+      expect(out.title).toBe("Keep");
+      expect(out.artists).toEqual(["X"]);
+    });
+    it("survives a real IndexedDB-style JSON round-trip of a legacy record", () => {
+      const legacy = { title: "T", artist: "Tyler, The Creator", album: "A", duration: 12 };
+      const out = normalizeLoadedMetadata(JSON.parse(JSON.stringify(legacy)));
+      expect(out.artists).toEqual(["Tyler, The Creator"]);
+      expect("artist" in out).toBe(false);
+    });
+  });
+});

--- a/src/domain/project/normalize-metadata.test.ts
+++ b/src/domain/project/normalize-metadata.test.ts
@@ -35,8 +35,28 @@ describe("normalizeLoadedMetadata", () => {
     it("drops a whitespace-only legacy artist to an empty array", () => {
       expect(normalizeLoadedMetadata({ artist: "   " }).artists).toEqual([]);
     });
+    it("regression: does not throw on a record with no metadata", () => {
+      expect(normalizeLoadedMetadata(undefined)).toMatchObject({ title: "", artists: [], album: "", duration: 0 });
+      expect(normalizeLoadedMetadata(null)).toMatchObject({ title: "", artists: [], album: "", duration: 0 });
+    });
   });
   describe("invariants", () => {
+    it("spells out every optional key so a spread clears stale values", () => {
+      const stale = normalizeLoadedMetadata({
+        artists: ["Old"],
+        isrc: "USQX91700001",
+        songwriters: ["W"],
+        extra: { mood: "sad" },
+        language: "ja",
+      });
+      const loaded = normalizeLoadedMetadata({ title: "New", artists: ["New"], album: "", duration: 0 });
+      const merged = { ...stale, ...loaded };
+      expect(merged.isrc).toBeUndefined();
+      expect(merged.songwriters).toBeUndefined();
+      expect(merged.extra).toBeUndefined();
+      expect(merged.language).toBeUndefined();
+      expect(merged.artists).toEqual(["New"]);
+    });
     it("prefers artists over a stale legacy artist when both are present", () => {
       const out = normalizeLoadedMetadata({ artist: "Legacy", artists: ["New"] });
       expect(out.artists).toEqual(["New"]);

--- a/src/domain/project/normalize-metadata.ts
+++ b/src/domain/project/normalize-metadata.ts
@@ -1,0 +1,27 @@
+import type { ProjectMetadata } from "@/domain/project/metadata";
+
+// -- Types --------------------------------------------------------------------
+
+interface StoredMetadata extends Partial<Omit<ProjectMetadata, "artists">> {
+  artist?: string;
+  artists?: string[];
+}
+
+// -- Normalizer ---------------------------------------------------------------
+
+function normalizeLoadedMetadata(raw: StoredMetadata): ProjectMetadata {
+  const artists = raw.artists ?? (raw.artist?.trim() ? [raw.artist] : []);
+  const { artist: _legacy, ...rest } = raw;
+  return {
+    title: raw.title ?? "",
+    album: raw.album ?? "",
+    duration: raw.duration ?? 0,
+    ...rest,
+    artists,
+  };
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { normalizeLoadedMetadata };
+export type { StoredMetadata };

--- a/src/domain/project/normalize-metadata.ts
+++ b/src/domain/project/normalize-metadata.ts
@@ -9,14 +9,25 @@ interface StoredMetadata extends Partial<Omit<ProjectMetadata, "artists">> {
 
 // -- Normalizer ---------------------------------------------------------------
 
-function normalizeLoadedMetadata(raw: StoredMetadata): ProjectMetadata {
-  const artists = raw.artists ?? (raw.artist?.trim() ? [raw.artist] : []);
-  const { artist: _legacy, ...rest } = raw;
+// Every optional key is spelled out so that spreading the result over existing
+// metadata clears the fields the loaded record omits. Returning a partial object
+// would let the previous project's ISRC, songwriters or extra fields survive an
+// import and end up in the newly exported TTML.
+function normalizeLoadedMetadata(raw: StoredMetadata | null | undefined): ProjectMetadata {
+  const source = raw ?? {};
+  const artists = source.artists ?? (source.artist?.trim() ? [source.artist] : []);
+  const { artist: _legacy, ...rest } = source;
   return {
-    title: raw.title ?? "",
-    album: raw.album ?? "",
-    duration: raw.duration ?? 0,
+    isrc: undefined,
+    songwriters: undefined,
+    extra: undefined,
+    language: undefined,
+    thumbnailDataUrl: undefined,
+    thumbnailForVideoId: undefined,
     ...rest,
+    title: source.title ?? "",
+    album: source.album ?? "",
+    duration: source.duration ?? 0,
     artists,
   };
 }

--- a/src/domain/project/normalize-metadata.ts
+++ b/src/domain/project/normalize-metadata.ts
@@ -24,4 +24,3 @@ function normalizeLoadedMetadata(raw: StoredMetadata): ProjectMetadata {
 // -- Exports ------------------------------------------------------------------
 
 export { normalizeLoadedMetadata };
-export type { StoredMetadata };

--- a/src/domain/word/order.test.ts
+++ b/src/domain/word/order.test.ts
@@ -1,0 +1,155 @@
+import { enforceOrderAround } from "@/domain/word/order";
+import type { WordTiming } from "@/domain/word/timing";
+import { describe, expect, it } from "vitest";
+
+// -- Helpers ------------------------------------------------------------------
+
+function isOrdered(words: WordTiming[]): boolean {
+  for (let i = 0; i < words.length; i++) {
+    if (words[i].end < words[i].begin) return false;
+    if (i > 0 && words[i].begin < words[i - 1].end) return false;
+  }
+  return true;
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("enforceOrderAround", () => {
+  it("leaves an already ordered tail untouched", () => {
+    const words: WordTiming[] = [
+      { text: "one ", begin: 0, end: 1 },
+      { text: "two ", begin: 1, end: 2 },
+      { text: "three", begin: 2, end: 3 },
+    ];
+    expect(enforceOrderAround(words, 0)).toBe(words);
+  });
+
+  it("squeezes a single overlapping successor forward", () => {
+    const words: WordTiming[] = [
+      { text: "one ", begin: 0.5, end: 0.8 },
+      { text: "two ", begin: 0.4, end: 0.8 },
+      { text: "three", begin: 0.8, end: 1.2 },
+    ];
+    expect(enforceOrderAround(words, 0)).toEqual([
+      { text: "one ", begin: 0.5, end: 0.8 },
+      { text: "two ", begin: 0.8, end: 0.8 },
+      { text: "three", begin: 0.8, end: 1.2 },
+    ]);
+  });
+
+  it("cascades when the anchor lands past the whole tail", () => {
+    const words: WordTiming[] = [
+      { text: "one ", begin: 30, end: 30.3 },
+      { text: "two ", begin: 1, end: 2 },
+      { text: "three", begin: 2, end: 3 },
+    ];
+    expect(enforceOrderAround(words, 0)).toEqual([
+      { text: "one ", begin: 30, end: 30.3 },
+      { text: "two ", begin: 30.3, end: 30.3 },
+      { text: "three", begin: 30.3, end: 30.3 },
+    ]);
+  });
+
+  it("stops as soon as the tail is already clear of the anchor", () => {
+    const words: WordTiming[] = [
+      { text: "one ", begin: 0, end: 1.5 },
+      { text: "two ", begin: 1, end: 2 },
+      { text: "three", begin: 5, end: 6 },
+    ];
+    const result = enforceOrderAround(words, 0);
+    expect(result[1]).toEqual({ text: "two ", begin: 1.5, end: 2 });
+    expect(result[2]).toBe(words[2]);
+  });
+
+  describe("edge cases", () => {
+    it("returns an empty array unchanged", () => {
+      expect(enforceOrderAround([], 0)).toEqual([]);
+    });
+
+    it("returns the input when the anchor index is out of range", () => {
+      const words: WordTiming[] = [{ text: "one", begin: 0, end: 1 }];
+      expect(enforceOrderAround(words, 5)).toBe(words);
+    });
+
+    it("is a no-op when the anchor is the last word", () => {
+      const words: WordTiming[] = [
+        { text: "one ", begin: 0, end: 1 },
+        { text: "two", begin: 1, end: 2 },
+      ];
+      expect(enforceOrderAround(words, 1)).toBe(words);
+    });
+
+    it("handles a zero-duration anchor", () => {
+      const words: WordTiming[] = [
+        { text: "one ", begin: 5, end: 5 },
+        { text: "two", begin: 1, end: 2 },
+      ];
+      expect(enforceOrderAround(words, 0)).toEqual([
+        { text: "one ", begin: 5, end: 5 },
+        { text: "two", begin: 5, end: 5 },
+      ]);
+    });
+  });
+
+  describe("invariants", () => {
+    it("never changes the array length", () => {
+      const words: WordTiming[] = [
+        { text: "one ", begin: 30, end: 31 },
+        { text: "two ", begin: 1, end: 2 },
+        { text: "three", begin: 2, end: 3 },
+      ];
+      expect(enforceOrderAround(words, 0)).toHaveLength(3);
+    });
+
+    it("does not mutate the input array or its entries", () => {
+      const entry: WordTiming = { text: "two ", begin: 1, end: 2, explicit: true };
+      const words: WordTiming[] = [{ text: "one ", begin: 30, end: 31 }, entry];
+      const snapshot = structuredClone(words);
+      enforceOrderAround(words, 0);
+      expect(words).toEqual(snapshot);
+      expect(entry).toEqual({ text: "two ", begin: 1, end: 2, explicit: true });
+    });
+
+    it("preserves per-word metadata on squeezed words", () => {
+      const words: WordTiming[] = [
+        { text: "one ", begin: 30, end: 31 },
+        { text: "two", begin: 1, end: 2, explicit: true, syllableGroupId: "g1" },
+      ];
+      const result = enforceOrderAround(words, 0);
+      expect(result[1].explicit).toBe(true);
+      expect(result[1].syllableGroupId).toBe("g1");
+    });
+
+    it("always produces a chronologically ordered array", () => {
+      const cases: WordTiming[][] = [
+        [
+          { text: "a ", begin: 9, end: 9 },
+          { text: "b ", begin: 0, end: 1 },
+          { text: "c", begin: 0.5, end: 0.6 },
+        ],
+        [
+          { text: "a ", begin: 2, end: 4 },
+          { text: "b ", begin: 3, end: 3.5 },
+          { text: "c", begin: 3.2, end: 8 },
+        ],
+        [
+          { text: "a ", begin: 0, end: 0 },
+          { text: "b", begin: 0, end: 0 },
+        ],
+      ];
+      for (const words of cases) {
+        expect(isOrdered(enforceOrderAround(words, 0))).toBe(true);
+      }
+    });
+
+    it("is idempotent", () => {
+      const words: WordTiming[] = [
+        { text: "one ", begin: 30, end: 31 },
+        { text: "two ", begin: 1, end: 2 },
+        { text: "three", begin: 2, end: 3 },
+      ];
+      const once = enforceOrderAround(words, 0);
+      expect(enforceOrderAround(once, 0)).toEqual(once);
+    });
+  });
+});

--- a/src/domain/word/order.ts
+++ b/src/domain/word/order.ts
@@ -1,0 +1,48 @@
+import type { WordTiming } from "@/domain/word/timing";
+
+// -- Functions ----------------------------------------------------------------
+
+// Word timings are chronological: each word begins at or after the previous one
+// ends, and no word ends before it begins. Re-recording a word in place can push
+// it past its neighbours in either direction, so the words around the edited one
+// are squeezed to the nearest times that restore the order. Squeezed words
+// collapse to zero duration, which the sync view already flags as needing a
+// re-record, rather than being dropped and leaving `words` shorter than the
+// line's text.
+function enforceOrderAround(words: WordTiming[], index: number): WordTiming[] {
+  const anchor = words[index];
+  if (!anchor) return words;
+
+  let result = words;
+  const copyOnWrite = () => {
+    if (result === words) result = [...words];
+  };
+
+  let nextBegin = anchor.begin;
+  for (let i = index - 1; i >= 0; i--) {
+    const word = result[i];
+    if (word.end <= nextBegin && word.begin <= word.end) break;
+    const end = Math.min(word.end, nextBegin);
+    const begin = Math.min(word.begin, end);
+    copyOnWrite();
+    result[i] = { ...word, begin, end };
+    nextBegin = begin;
+  }
+
+  let previousEnd = anchor.end;
+  for (let i = index + 1; i < words.length; i++) {
+    const word = result[i];
+    if (word.begin >= previousEnd && word.end >= word.begin) break;
+    const begin = Math.max(word.begin, previousEnd);
+    const end = Math.max(word.end, begin);
+    copyOnWrite();
+    result[i] = { ...word, begin, end };
+    previousEnd = end;
+  }
+
+  return result;
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { enforceOrderAround };

--- a/src/hooks/useImportFromHash.persistence.browser.test.tsx
+++ b/src/hooks/useImportFromHash.persistence.browser.test.tsx
@@ -51,7 +51,7 @@ async function waitForBootSettled(): Promise<void> {
 
 function importedPayload() {
   return {
-    metadata: { title: IMPORTED_TITLE, artist: "", album: "", duration: 0 },
+    metadata: { title: IMPORTED_TITLE, artists: [], album: "", duration: 0 },
     agents: [IMPORTED_AGENT],
     lines: [IMPORTED_LINE],
     granularity: "word" as const,
@@ -62,7 +62,7 @@ function savedSnapshot(audioSource?: { kind: "youtube"; videoId: string } | { ki
   return {
     version: 1,
     savedAt: Date.now(),
-    metadata: { title: SAVED_TITLE, artist: "", album: "", duration: 0 },
+    metadata: { title: SAVED_TITLE, artists: [], album: "", duration: 0 },
     lines: [SAVED_LINE],
     agents: [SAVED_AGENT],
     granularity: "word" as const,
@@ -72,7 +72,7 @@ function savedSnapshot(audioSource?: { kind: "youtube"; videoId: string } | { ki
 
 // -- Tests --------------------------------------------------------------------
 
-describe("usePersistence + useImportFromHash — hash overrides persistence", () => {
+describe("usePersistence + useImportFromHash: hash overrides persistence", () => {
   beforeEach(() => {
     setQuery("");
     setHash("");

--- a/src/hooks/useImportFromHash.persistence.browser.test.tsx
+++ b/src/hooks/useImportFromHash.persistence.browser.test.tsx
@@ -157,4 +157,17 @@ describe("usePersistence + useImportFromHash: hash overrides persistence", () =>
 
     expect(useProjectStore.getState().granularity).toBe("word");
   });
+
+  it("regression: a payload with null metadata is rejected and the saved project survives", async () => {
+    allowConsole(/Invalid import payload structure/);
+    await seedProject(savedSnapshot());
+    autoAcceptHashConfirm();
+    setHash(encodeHashPayload({ ...importedPayload(), metadata: null }));
+
+    await render(<HookHost />);
+    await waitForBootSettled();
+
+    expect(useProjectStore.getState().metadata.title).toBe(SAVED_TITLE);
+    expect(useProjectStore.getState().lines.map((line) => line.text)).toEqual([SAVED_LINE.text]);
+  });
 });

--- a/src/hooks/useImportFromHash.ts
+++ b/src/hooks/useImportFromHash.ts
@@ -5,6 +5,7 @@ import { useProjectStore } from "@/stores/project";
 import type { Agent } from "@/domain/agent/model";
 import type { LyricLine } from "@/domain/line/model";
 import type { ProjectMetadata } from "@/domain/project/metadata";
+import { normalizeLoadedMetadata } from "@/domain/project/normalize-metadata";
 import { useEffect } from "react";
 import { toast } from "sonner";
 
@@ -31,13 +32,14 @@ function isValidPayload(value: unknown): value is ImportPayload {
 async function isProjectNonEmpty(): Promise<boolean> {
   const state = useProjectStore.getState();
   if (state.lines.length > 0) return true;
-  const { title, artist, album } = state.metadata;
-  if (title || artist || album) return true;
+  const { title, artists, album } = state.metadata;
+  if (title || artists.length || album) return true;
 
   const saved = await loadCurrentProject();
   if (!saved) return false;
   if (saved.lines.length > 0) return true;
-  return Boolean(saved.metadata.title || saved.metadata.artist || saved.metadata.album);
+  const savedMetadata = normalizeLoadedMetadata(saved.metadata);
+  return Boolean(savedMetadata.title || savedMetadata.artists.length || savedMetadata.album);
 }
 
 function useImportFromHash(): void {
@@ -86,7 +88,7 @@ function useImportFromHash(): void {
 
         const state = useProjectStore.getState();
         state.reset();
-        state.setMetadata(payload.metadata);
+        state.setMetadata(normalizeLoadedMetadata(payload.metadata));
         state.setLines(payload.lines);
         state.setGranularity(payload.granularity);
         for (const agent of payload.agents) {

--- a/src/hooks/useImportFromHash.ts
+++ b/src/hooks/useImportFromHash.ts
@@ -1,5 +1,5 @@
-import { loadCurrentProject } from "@/lib/persistence";
 import { getPersistenceSettled, markHashImportSettled } from "@/lib/persistence-settled";
+import { isProjectNonEmpty } from "@/lib/project-non-empty";
 import { useConfirm } from "@/stores/confirm-store";
 import { useProjectStore } from "@/stores/project";
 import type { Agent } from "@/domain/agent/model";
@@ -27,19 +27,6 @@ function isValidPayload(value: unknown): value is ImportPayload {
     Array.isArray(payload.lines) &&
     (payload.granularity === "line" || payload.granularity === "word")
   );
-}
-
-async function isProjectNonEmpty(): Promise<boolean> {
-  const state = useProjectStore.getState();
-  if (state.lines.length > 0) return true;
-  const { title, artists, album } = state.metadata;
-  if (title || artists.length || album) return true;
-
-  const saved = await loadCurrentProject();
-  if (!saved) return false;
-  if (saved.lines.length > 0) return true;
-  const savedMetadata = normalizeLoadedMetadata(saved.metadata);
-  return Boolean(savedMetadata.title || savedMetadata.artists.length || savedMetadata.album);
 }
 
 function useImportFromHash(): void {

--- a/src/hooks/useImportFromHash.ts
+++ b/src/hooks/useImportFromHash.ts
@@ -22,6 +22,7 @@ function isValidPayload(value: unknown): value is ImportPayload {
   if (!value || typeof value !== "object") return false;
   const payload = value as Record<string, unknown>;
   return (
+    payload.metadata !== null &&
     typeof payload.metadata === "object" &&
     Array.isArray(payload.agents) &&
     Array.isArray(payload.lines) &&
@@ -73,9 +74,13 @@ function useImportFromHash(): void {
           }
         }
 
+        // Everything the import needs is built before the project is cleared, so
+        // a malformed payload can never leave the user with an emptied project.
+        const metadata = normalizeLoadedMetadata(payload.metadata);
+
         const state = useProjectStore.getState();
         state.reset();
-        state.setMetadata(normalizeLoadedMetadata(payload.metadata));
+        state.setMetadata(metadata);
         state.setLines(payload.lines);
         state.setGranularity(payload.granularity);
         for (const agent of payload.agents) {

--- a/src/hooks/useImportFromQuery.persistence.browser.test.tsx
+++ b/src/hooks/useImportFromQuery.persistence.browser.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useImportFromQuery } from "@/hooks/useImportFromQuery";
+import { usePersistence } from "@/hooks/usePersistence";
+import { getPersistenceSettled } from "@/lib/persistence-settled";
+import { useConfirmStore } from "@/stores/confirm-store";
+import { useProjectStore } from "@/stores/project";
+import { seedProject } from "@/test/idb";
+import { render } from "@/test/render";
+
+// -- Constants ----------------------------------------------------------------
+
+const SAVED_TITLE = "Midnight City";
+const SAVED_ARTIST = "M83";
+const LINK_QUERY = "?title=Blinding%20Lights&artist=The%20Weeknd&album=After%20Hours";
+
+const SAVED_LINE = { id: "saved-line", text: "saved line", agentId: "v1" };
+const SAVED_AGENT = { id: "v1", type: "person" as const, name: "Saved Lead" };
+
+// -- Helpers ------------------------------------------------------------------
+
+const HookHost: React.FC = () => {
+  usePersistence();
+  useImportFromQuery();
+  return null;
+};
+
+function setQuery(search: string): void {
+  window.history.replaceState(null, "", `/${search}`);
+}
+
+function savedSnapshot() {
+  return {
+    version: 1,
+    savedAt: Date.now(),
+    metadata: { title: SAVED_TITLE, artists: [SAVED_ARTIST], album: "", duration: 0 },
+    lines: [SAVED_LINE],
+    agents: [SAVED_AGENT],
+    granularity: "word" as const,
+  };
+}
+
+async function waitForConfirm(): Promise<void> {
+  await expect.poll(() => useConfirmStore.getState().isOpen).toBe(true);
+}
+
+function answerConfirm(value: boolean): void {
+  useConfirmStore.getState().resolveAndClose(value, false);
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("useImportFromQuery guards a restored project", () => {
+  beforeEach(() => {
+    setQuery("");
+  });
+
+  afterEach(() => {
+    setQuery("");
+  });
+
+  it("asks before replacing the metadata of a restored project", async () => {
+    await seedProject(savedSnapshot());
+    setQuery(LINK_QUERY);
+
+    await render(<HookHost />);
+    await getPersistenceSettled();
+    await waitForConfirm();
+
+    expect(useConfirmStore.getState().options?.variant).toBe("destructive");
+  });
+
+  it("leaves the restored metadata untouched when the prompt is declined", async () => {
+    await seedProject(savedSnapshot());
+    setQuery(LINK_QUERY);
+
+    await render(<HookHost />);
+    await getPersistenceSettled();
+    await waitForConfirm();
+    answerConfirm(false);
+
+    await expect.poll(() => useProjectStore.getState().metadata.title).toBe(SAVED_TITLE);
+    expect(useProjectStore.getState().metadata.artists).toEqual([SAVED_ARTIST]);
+  });
+
+  it("applies the link metadata when the prompt is accepted", async () => {
+    await seedProject(savedSnapshot());
+    setQuery(LINK_QUERY);
+
+    await render(<HookHost />);
+    await getPersistenceSettled();
+    await waitForConfirm();
+    answerConfirm(true);
+
+    await expect.poll(() => useProjectStore.getState().metadata.title).toBe("Blinding Lights");
+    expect(useProjectStore.getState().metadata.artists).toEqual(["The Weeknd"]);
+  });
+
+  it("writes without prompting when there is no project to overwrite", async () => {
+    setQuery(LINK_QUERY);
+
+    await render(<HookHost />);
+    await getPersistenceSettled();
+
+    await expect.poll(() => useProjectStore.getState().metadata.title).toBe("Blinding Lights");
+    expect(useConfirmStore.getState().isOpen).toBe(false);
+  });
+
+  it("offers no 'don't ask again' escape hatch, since metadata is not undoable", async () => {
+    await seedProject(savedSnapshot());
+    setQuery(LINK_QUERY);
+
+    await render(<HookHost />);
+    await getPersistenceSettled();
+    await waitForConfirm();
+
+    expect(useConfirmStore.getState().options?.settingsKey).toBeUndefined();
+  });
+});

--- a/src/hooks/useImportFromQuery.test.ts
+++ b/src/hooks/useImportFromQuery.test.ts
@@ -1,9 +1,11 @@
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { useImportFromQuery } from "@/hooks/useImportFromQuery";
+import { buildMetadataFromUrl, useImportFromQuery } from "@/hooks/useImportFromQuery";
 import { useImportFromYouTube } from "@/hooks/useImportFromYouTube";
+import { getPersistenceSettled, markPersistenceSettled } from "@/lib/persistence-settled";
 import { INITIAL_STATE, useImportModalStore } from "@/stores/import-modal-store";
+import { useProjectStore } from "@/stores/project";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -56,6 +58,7 @@ function currentSearch(): string {
 function resetStore(): void {
   useImportModalStore.setState({ ...INITIAL_STATE });
   window.localStorage.removeItem("composer-import-modal");
+  useProjectStore.getState().reset();
 }
 
 // -- Tests --------------------------------------------------------------------
@@ -233,6 +236,174 @@ describe("useImportFromQuery", () => {
     expect(useImportModalStore.getState().defaultPrefill).toEqual({ track: "Hello" });
     useImportModalStore.getState().clearDefaultPrefill();
     expect(useImportModalStore.getState().defaultPrefill).toBeNull();
+  });
+});
+
+describe("buildMetadataFromUrl", () => {
+  it("persists title/artists/album/isrc/duration from the enriched link", () => {
+    const out = buildMetadataFromUrl(new URLSearchParams("title=T&artist=A&album=Al&isrc=usqx91700001&duration=200"));
+    expect(out).toEqual({ title: "T", artists: ["A"], album: "Al", isrc: "USQX91700001", duration: 200 });
+  });
+  it("returns null when no fields present", () => {
+    expect(buildMetadataFromUrl(new URLSearchParams(""))).toBeNull();
+  });
+  it("drops an invalid isrc but keeps the rest", () => {
+    expect(buildMetadataFromUrl(new URLSearchParams("title=T&isrc=bad"))).toEqual({ title: "T" });
+  });
+  it("omits absent fields (no empty strings or zero duration)", () => {
+    expect(buildMetadataFromUrl(new URLSearchParams("artist=A"))).toEqual({ artists: ["A"] });
+  });
+});
+
+async function flushSettled(): Promise<void> {
+  markPersistenceSettled();
+  await act(async () => {
+    await getPersistenceSettled();
+  });
+}
+
+describe("useImportFromQuery persists enriched-link metadata", () => {
+  let handle: MountHandle | null = null;
+
+  beforeEach(() => {
+    resetStore();
+    setUrl("");
+  });
+
+  afterEach(() => {
+    if (handle) {
+      handle.unmount();
+      handle = null;
+    }
+    setUrl("");
+  });
+
+  it("writes title/artists/album/isrc/duration into the project store once persistence settles", async () => {
+    setUrl("?title=Hello&artist=Adele&album=25&isrc=gbum71029604&duration=355");
+
+    handle = mountHook();
+    await flushSettled();
+
+    expect(useProjectStore.getState().metadata).toMatchObject({
+      title: "Hello",
+      artists: ["Adele"],
+      album: "25",
+      isrc: "GBUM71029604",
+      duration: 355,
+    });
+  });
+
+  it("leaves project metadata untouched when no import params are present", async () => {
+    setUrl("?foo=bar");
+
+    handle = mountHook();
+    await flushSettled();
+
+    expect(useProjectStore.getState().metadata).toEqual({
+      title: "",
+      artists: [],
+      album: "",
+      duration: 0,
+    });
+  });
+
+  it("does not write a metadata patch when only videoId is present", async () => {
+    setUrl("?videoId=fJ9rUzIMcZQ");
+
+    handle = mountHook();
+    await flushSettled();
+
+    expect(useProjectStore.getState().metadata).toEqual({
+      title: "",
+      artists: [],
+      album: "",
+      duration: 0,
+    });
+  });
+});
+
+// -- Boot race: gate the project write behind persistence settling ------------
+
+describe("useImportFromQuery gates the metadata write behind persistence", () => {
+  let handle: MountHandle | null = null;
+
+  beforeEach(() => {
+    resetStore();
+    setUrl("");
+  });
+
+  afterEach(() => {
+    if (handle) {
+      handle.unmount();
+      handle = null;
+    }
+    setUrl("");
+  });
+
+  it("does not write enriched-link metadata until persistence has settled", () => {
+    setUrl("?title=Hello&artist=Adele&album=25&isrc=gbum71029604&duration=355");
+
+    handle = mountHook();
+
+    expect(useProjectStore.getState().metadata).toEqual({
+      title: "",
+      artists: [],
+      album: "",
+      duration: 0,
+    });
+  });
+
+  it("applies the enriched-link metadata after persistence settles", async () => {
+    setUrl("?title=Hello&artist=Adele&album=25&isrc=gbum71029604&duration=355");
+
+    handle = mountHook();
+    await flushSettled();
+
+    expect(useProjectStore.getState().metadata).toMatchObject({
+      title: "Hello",
+      artists: ["Adele"],
+      album: "25",
+      isrc: "GBUM71029604",
+      duration: 355,
+    });
+  });
+
+  it("does not clobber a persistence-restored project when the URL has no import params", async () => {
+    setUrl("?foo=bar");
+    useProjectStore.getState().setMetadata({
+      title: "Restored Title",
+      artists: ["Restored Artist"],
+      album: "Restored Album",
+      isrc: "USQX91700001",
+      duration: 200,
+    });
+
+    handle = mountHook();
+    await flushSettled();
+
+    expect(useProjectStore.getState().metadata).toMatchObject({
+      title: "Restored Title",
+      artists: ["Restored Artist"],
+      album: "Restored Album",
+      isrc: "USQX91700001",
+      duration: 200,
+    });
+  });
+
+  it("does not write after unmount even once persistence settles", async () => {
+    setUrl("?title=Hello&artist=Adele");
+
+    handle = mountHook();
+    handle.unmount();
+    handle = null;
+    await flushSettled();
+
+    expect(useProjectStore.getState().metadata).toEqual({
+      title: "",
+      artists: [],
+      album: "",
+      duration: 0,
+    });
   });
 });
 

--- a/src/hooks/useImportFromQuery.ts
+++ b/src/hooks/useImportFromQuery.ts
@@ -1,12 +1,15 @@
 import { useEffect } from "react";
+import type { ProjectMetadata } from "@/domain/project/metadata";
+import { getPersistenceSettled } from "@/lib/persistence-settled";
 import { useImportModalStore } from "@/stores/import-modal-store";
+import { useProjectStore } from "@/stores/project";
+import { normalizeIsrc } from "@/utils/isrc";
 import { stripQueryParams } from "@/utils/url-params";
 import type { LyricsSearchQuery } from "@/utils/lyrics-search/types";
 
 // -- Constants ----------------------------------------------------------------
 
 const IMPORT_PARAM_NAMES = ["title", "artist", "album", "duration", "isrc"] as const;
-const ISRC_PATTERN = /^[A-Z]{2}[A-Z0-9]{3}\d{7}$/;
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -24,18 +27,13 @@ function parseDurationSec(raw: string | null): number | undefined {
   return value;
 }
 
-function parseIsrc(raw: string | null): string | undefined {
-  if (raw === null) return undefined;
-  const normalized = raw.toUpperCase();
-  return ISRC_PATTERN.test(normalized) ? normalized : undefined;
-}
-
 function buildPrefillFromUrl(params: URLSearchParams): LyricsSearchQuery | null {
   const track = readTrimmed(params, "title");
   const artist = readTrimmed(params, "artist");
   const album = readTrimmed(params, "album");
   const durationSec = parseDurationSec(readTrimmed(params, "duration"));
-  const isrc = parseIsrc(readTrimmed(params, "isrc"));
+  const isrcRaw = readTrimmed(params, "isrc");
+  const isrc = isrcRaw ? normalizeIsrc(isrcRaw) : undefined;
   const videoId = readTrimmed(params, "videoId");
 
   const prefill: LyricsSearchQuery = {};
@@ -49,17 +47,48 @@ function buildPrefillFromUrl(params: URLSearchParams): LyricsSearchQuery | null 
   return Object.keys(prefill).length === 0 ? null : prefill;
 }
 
+function buildMetadataFromUrl(params: URLSearchParams): Partial<ProjectMetadata> | null {
+  const patch: Partial<ProjectMetadata> = {};
+  const title = readTrimmed(params, "title");
+  const artist = readTrimmed(params, "artist");
+  const album = readTrimmed(params, "album");
+  const duration = parseDurationSec(readTrimmed(params, "duration"));
+  const isrcRaw = readTrimmed(params, "isrc");
+  const isrc = isrcRaw ? normalizeIsrc(isrcRaw) : undefined;
+
+  if (title) patch.title = title;
+  if (artist) patch.artists = [artist];
+  if (album) patch.album = album;
+  if (duration !== undefined) patch.duration = duration;
+  if (isrc !== undefined) patch.isrc = isrc;
+
+  return Object.keys(patch).length === 0 ? null : patch;
+}
+
 function useImportFromQuery(): void {
   useEffect(() => {
     if (typeof window === "undefined") return;
     const params = new URLSearchParams(window.location.search);
     const prefill = buildPrefillFromUrl(params);
-    if (prefill === null) return;
+    const metaPatch = buildMetadataFromUrl(params);
+    if (prefill === null && metaPatch === null) return;
     stripQueryParams(IMPORT_PARAM_NAMES);
-    useImportModalStore.getState().setDefaultPrefill(prefill);
+    if (prefill !== null) useImportModalStore.getState().setDefaultPrefill(prefill);
+
+    if (metaPatch === null) return;
+
+    let cancelled = false;
+    getPersistenceSettled().then(() => {
+      if (cancelled) return;
+      useProjectStore.getState().setMetadata(metaPatch);
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 }
 
 // -- Exports ------------------------------------------------------------------
 
-export { useImportFromQuery };
+export { buildMetadataFromUrl, useImportFromQuery };

--- a/src/hooks/useImportFromQuery.ts
+++ b/src/hooks/useImportFromQuery.ts
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import type { ProjectMetadata } from "@/domain/project/metadata";
 import { getPersistenceSettled } from "@/lib/persistence-settled";
+import { isProjectNonEmpty } from "@/lib/project-non-empty";
+import { useConfirmStore } from "@/stores/confirm-store";
 import { useImportModalStore } from "@/stores/import-modal-store";
 import { useProjectStore } from "@/stores/project";
 import { normalizeIsrc } from "@/utils/isrc";
@@ -78,10 +80,22 @@ function useImportFromQuery(): void {
     if (metaPatch === null) return;
 
     let cancelled = false;
-    getPersistenceSettled().then(() => {
+    void (async () => {
+      await getPersistenceSettled();
+      if (cancelled) return;
+
+      if (await isProjectNonEmpty()) {
+        const accepted = await useConfirmStore.getState().open({
+          title: "Replace song metadata?",
+          description: "This link carries song details that will overwrite the metadata on your current project.",
+          confirmLabel: "Replace metadata",
+          variant: "destructive",
+        });
+        if (!accepted) return;
+      }
       if (cancelled) return;
       useProjectStore.getState().setMetadata(metaPatch);
-    });
+    })();
 
     return () => {
       cancelled = true;

--- a/src/hooks/useImportFromQuery.ts
+++ b/src/hooks/useImportFromQuery.ts
@@ -11,6 +11,7 @@ import type { LyricsSearchQuery } from "@/utils/lyrics-search/types";
 
 // -- Constants ----------------------------------------------------------------
 
+const LOG_PREFIX = "[Composer]";
 const IMPORT_PARAM_NAMES = ["title", "artist", "album", "duration", "isrc"] as const;
 
 // -- Helpers ------------------------------------------------------------------
@@ -84,7 +85,14 @@ function useImportFromQuery(): void {
       await getPersistenceSettled();
       if (cancelled) return;
 
-      if (await isProjectNonEmpty()) {
+      // Only the metadata fields are at stake here, so an unreadable saved
+      // project is treated as nothing to overwrite rather than blocking the link.
+      const hasProjectToOverwrite = await isProjectNonEmpty().catch((error) => {
+        console.warn(`${LOG_PREFIX} could not read the saved project`, error);
+        return false;
+      });
+
+      if (hasProjectToOverwrite) {
         const accepted = await useConfirmStore.getState().open({
           title: "Replace song metadata?",
           description: "This link carries song details that will overwrite the metadata on your current project.",

--- a/src/hooks/useImportFromYouTube.persistence.browser.test.tsx
+++ b/src/hooks/useImportFromYouTube.persistence.browser.test.tsx
@@ -71,7 +71,7 @@ function baseSavedProject(audioSource: { kind: "youtube"; videoId: string } | { 
   return {
     version: 1,
     savedAt: Date.now(),
-    metadata: { title: SAVED_TITLE, artist: "Saved Artist", album: "Saved Album", duration: 0 },
+    metadata: { title: SAVED_TITLE, artists: ["Saved Artist"], album: "Saved Album", duration: 0 },
     lines: [],
     agents: [{ id: "v1", type: "person", name: "Lead" }],
     granularity: "word" as const,
@@ -81,7 +81,7 @@ function baseSavedProject(audioSource: { kind: "youtube"; videoId: string } | { 
 
 // -- URL overrides persistence ------------------------------------------------
 
-describe("usePersistence + useImportFromYouTube — URL overrides persistence", () => {
+describe("usePersistence + useImportFromYouTube: URL overrides persistence", () => {
   beforeEach(() => setQuery(""));
   afterEach(() => setQuery(""));
 
@@ -165,7 +165,7 @@ describe("usePersistence + useImportFromYouTube — URL overrides persistence", 
 
 // -- Cold start ---------------------------------------------------------------
 
-describe("usePersistence + useImportFromYouTube — cold start", () => {
+describe("usePersistence + useImportFromYouTube: cold start", () => {
   beforeEach(() => setQuery(""));
   afterEach(() => setQuery(""));
 
@@ -197,7 +197,7 @@ describe("usePersistence + useImportFromYouTube — cold start", () => {
 
 // -- Edge cases ---------------------------------------------------------------
 
-describe("usePersistence + useImportFromYouTube — edge cases", () => {
+describe("usePersistence + useImportFromYouTube: edge cases", () => {
   beforeEach(() => setQuery(""));
   afterEach(() => setQuery(""));
 

--- a/src/hooks/usePersistence.priming-migration.browser.test.tsx
+++ b/src/hooks/usePersistence.priming-migration.browser.test.tsx
@@ -14,7 +14,7 @@ import { createMp3File } from "@/test/audio-fixtures";
 
 function seedSavedProject(opts: { primingStripped: boolean }): Promise<void> {
   return saveCurrentProject(
-    { title: "t", artist: "", album: "", duration: 0 },
+    { title: "t", artists: [], album: "", duration: 0 },
     DEFAULT_AGENTS,
     [
       {
@@ -133,7 +133,7 @@ describe("usePersistence priming-stripped flag survives the post-load debounced 
     expect(parseLamePriming(await mp3.arrayBuffer()).samples).toBeGreaterThan(0);
     await saveAudioFile(mp3);
     await saveCurrentProject(
-      { title: "race", artist: "", album: "", duration: 0 },
+      { title: "race", artists: [], album: "", duration: 0 },
       DEFAULT_AGENTS,
       [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
       [],
@@ -159,7 +159,7 @@ describe("usePersistence priming-stripped flag survives the post-load debounced 
     const noPrimingMp3 = new File([new Uint8Array([0, 1, 2, 3])], "not-mp3.bin", { type: "audio/mpeg" });
     await saveAudioFile(noPrimingMp3);
     await saveCurrentProject(
-      { title: "race-zero", artist: "", album: "", duration: 0 },
+      { title: "race-zero", artists: [], album: "", duration: 0 },
       DEFAULT_AGENTS,
       [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
       [],

--- a/src/hooks/usePersistence.snap-points.browser.test.tsx
+++ b/src/hooks/usePersistence.snap-points.browser.test.tsx
@@ -53,7 +53,7 @@ describe("usePersistence · customSnapPoints hydration", () => {
   it("regression: usePersistence hydrates saved customSnapPoints into the project store", async () => {
     await saveAudioFile(createMp3File());
     await saveCurrentProject(
-      { title: "with-markers", artist: "", album: "", duration: 0 },
+      { title: "with-markers", artists: [], album: "", duration: 0 },
       DEFAULT_AGENTS,
       [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
       [],
@@ -80,7 +80,7 @@ describe("usePersistence · customSnapPoints hydration", () => {
     const legacyRecord: SavedProject = {
       version: 1,
       savedAt: Date.now(),
-      metadata: { title: "legacy", artist: "", album: "", duration: 0 },
+      metadata: { title: "legacy", artists: [], album: "", duration: 0 },
       agents: DEFAULT_AGENTS,
       lines: [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
       groups: [],
@@ -106,7 +106,7 @@ describe("usePersistence · customSnapPoints hydration", () => {
   it("regression: a saved project's markers survive the audio-source clear fired during load", async () => {
     await saveAudioFile(createMp3File());
     await saveCurrentProject(
-      { title: "survives-load", artist: "", album: "", duration: 0 },
+      { title: "survives-load", artists: [], album: "", duration: 0 },
       DEFAULT_AGENTS,
       [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
       [],

--- a/src/hooks/usePersistence.stem.browser.test.tsx
+++ b/src/hooks/usePersistence.stem.browser.test.tsx
@@ -25,7 +25,7 @@ function seedSavedProject(currentStem?: "original" | "vocals" | "instrumental"):
   return seedProject({
     version: 1,
     savedAt: Date.now(),
-    metadata: { title: "Seeded Song", artist: "", album: "", duration: 0 },
+    metadata: { title: "Seeded Song", artists: [], album: "", duration: 0 },
     lines: [],
     agents: [{ id: "v1", type: "person", name: "Lead" }],
     granularity: "word",

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -12,6 +12,7 @@ import { type AudioSource, useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { DEFAULT_SYLLABLE_SPLIT_DEFAULTS } from "@/stores/project/types";
 import { DEFAULT_AGENTS } from "@/domain/agent/colors";
+import { normalizeLoadedMetadata } from "@/domain/project/normalize-metadata";
 import { useSeparationStore } from "@/stores/separation";
 import { useSettingsStore } from "@/stores/settings";
 import { useEffect } from "react";
@@ -115,7 +116,7 @@ function usePersistence(): void {
           }
 
           const state = useProjectStore.getState();
-          state.setMetadata(project.metadata);
+          state.setMetadata(normalizeLoadedMetadata(project.metadata));
           state.setLines(safeLines);
           state.setGroups(project.groups ?? []);
           state.setGranularity(safeGranularity);

--- a/src/hooks/useProjectFileActions.ts
+++ b/src/hooks/useProjectFileActions.ts
@@ -4,6 +4,7 @@ import { useAudioStore } from "@/stores/audio";
 import { useConfirm } from "@/stores/confirm-store";
 import { useProjectStore } from "@/stores/project";
 import { DEFAULT_SYLLABLE_SPLIT_DEFAULTS } from "@/stores/project/types";
+import { normalizeLoadedMetadata } from "@/domain/project/normalize-metadata";
 import { useCallback } from "react";
 
 // -- Hook ---------------------------------------------------------------------
@@ -63,7 +64,7 @@ function useProjectFileActions(fileInputRef: React.RefObject<HTMLInputElement | 
 
       const project = await importProjectFromFile(file);
       const store = useProjectStore.getState();
-      setMetadata(project.metadata);
+      setMetadata(normalizeLoadedMetadata(project.metadata));
       setLines(project.lines);
       store.setGroups(project.groups ?? []);
       store.setDismissedSuggestions(project.dismissedSuggestions ?? []);

--- a/src/hooks/useReconciledBuffer.ts
+++ b/src/hooks/useReconciledBuffer.ts
@@ -1,0 +1,52 @@
+import { useRef, useState } from "react";
+
+// -- Interfaces ---------------------------------------------------------------
+
+interface ReconciledBufferOps<Row, External> {
+  seed: (external: External) => Row[];
+  reconcile: (previous: Row[], external: External) => Row[];
+  equal: (a: External, b: External) => boolean;
+  emit: (rows: Row[]) => External;
+}
+
+interface ReconciledBuffer<Row> {
+  rows: Row[];
+  commit: (next: Row[]) => void;
+}
+
+// -- Hook ---------------------------------------------------------------------
+
+/**
+ * Keeps a local editing buffer (rows carrying stable ids) in sync with an
+ * external store value. The buffer resets only when the external value changes
+ * from outside (a project load, import, or other foreign write), never when it
+ * echoes back a change this buffer just emitted. Edits stay in the buffer with
+ * stable row identity, so inputs never lose focus.
+ */
+function useReconciledBuffer<Row, External>(
+  external: External,
+  onChange: (next: External) => void,
+  ops: ReconciledBufferOps<Row, External>,
+): ReconciledBuffer<Row> {
+  const [rows, setRows] = useState<Row[]>(() => ops.seed(external));
+  const lastExternal = useRef(external);
+
+  if (lastExternal.current !== external && !ops.equal(lastExternal.current, external)) {
+    lastExternal.current = external;
+    setRows((previous) => ops.reconcile(previous, external));
+  }
+
+  const commit = (next: Row[]) => {
+    const emitted = ops.emit(next);
+    lastExternal.current = emitted;
+    setRows(next);
+    onChange(emitted);
+  };
+
+  return { rows, commit };
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { useReconciledBuffer };
+export type { ReconciledBufferOps };

--- a/src/hooks/useReconciledBuffer.ts
+++ b/src/hooks/useReconciledBuffer.ts
@@ -16,13 +16,7 @@ interface ReconciledBuffer<Row> {
 
 // -- Hook ---------------------------------------------------------------------
 
-/**
- * Keeps a local editing buffer (rows carrying stable ids) in sync with an
- * external store value. The buffer resets only when the external value changes
- * from outside (a project load, import, or other foreign write), never when it
- * echoes back a change this buffer just emitted. Edits stay in the buffer with
- * stable row identity, so inputs never lose focus.
- */
+// Reseeds on foreign writes only, never on the store echoing back our own commit.
 function useReconciledBuffer<Row, External>(
   external: External,
   onChange: (next: External) => void,
@@ -49,4 +43,3 @@ function useReconciledBuffer<Row, External>(
 // -- Exports ------------------------------------------------------------------
 
 export { useReconciledBuffer };
-export type { ReconciledBufferOps };

--- a/src/hooks/useReconciledBuffer.ts
+++ b/src/hooks/useReconciledBuffer.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 // -- Interfaces ---------------------------------------------------------------
 
@@ -29,16 +29,16 @@ function useReconciledBuffer<Row, External>(
   ops: ReconciledBufferOps<Row, External>,
 ): ReconciledBuffer<Row> {
   const [rows, setRows] = useState<Row[]>(() => ops.seed(external));
-  const lastExternal = useRef(external);
+  const [lastExternal, setLastExternal] = useState(external);
 
-  if (lastExternal.current !== external && !ops.equal(lastExternal.current, external)) {
-    lastExternal.current = external;
+  if (lastExternal !== external && !ops.equal(lastExternal, external)) {
+    setLastExternal(external);
     setRows((previous) => ops.reconcile(previous, external));
   }
 
   const commit = (next: Row[]) => {
     const emitted = ops.emit(next);
-    lastExternal.current = emitted;
+    setLastExternal(emitted);
     setRows(next);
     onChange(emitted);
   };

--- a/src/hooks/useResolveYouTubeTunnel.browser.test.tsx
+++ b/src/hooks/useResolveYouTubeTunnel.browser.test.tsx
@@ -39,6 +39,7 @@ interface BridgeAudioResponse {
   titlePercentEncoded?: string;
   artistPercentEncoded?: string;
   albumPercentEncoded?: string;
+  isrcPercentEncoded?: string;
 }
 
 type ThumbBehavior =
@@ -89,6 +90,7 @@ beforeEach(() => {
       if (entry.titlePercentEncoded) headers.set("x-track-title", entry.titlePercentEncoded);
       if (entry.artistPercentEncoded) headers.set("x-track-artist", entry.artistPercentEncoded);
       if (entry.albumPercentEncoded) headers.set("x-track-album", entry.albumPercentEncoded);
+      if (entry.isrcPercentEncoded) headers.set("x-track-isrc", entry.isrcPercentEncoded);
       return new Response(entry.buffer, { headers });
     }
 
@@ -147,7 +149,7 @@ async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void
 
 // -- Bridge happy path --------------------------------------------------------
 
-describe("useResolveYouTubeTunnel — bridge happy path", () => {
+describe("useResolveYouTubeTunnel: bridge happy path", () => {
   it("writes the file from the bridge audio response into the audio store", async () => {
     bridge.audio.set("dQw4w9WgXcQ", {
       buffer: asBytes("opus-bytes"),
@@ -170,23 +172,69 @@ describe("useResolveYouTubeTunnel — bridge happy path", () => {
     expect(file.type).toBe("audio/opus");
   });
 
-  it("sets project metadata title/artist/album from the bridge response", async () => {
+  it("sets project metadata title/artist/album/isrc from the bridge response", async () => {
     bridge.audio.set("dQw4w9WgXcQ", {
       buffer: asBytes("opus"),
       mimeType: "audio/opus",
       titlePercentEncoded: encodeURIComponent("Never Gonna Give You Up"),
       artistPercentEncoded: encodeURIComponent("Rick Astley"),
       albumPercentEncoded: encodeURIComponent("Whenever You Need Somebody"),
+      isrcPercentEncoded: encodeURIComponent("GBARL9300135"),
     });
 
     enableBridgeAndSelectVideo("dQw4w9WgXcQ");
     await render(withQueryClient(<HookHost />));
 
-    await waitFor(() => useProjectStore.getState().metadata.artist === "Rick Astley");
+    await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Rick Astley");
     const md = useProjectStore.getState().metadata;
     expect(md.title).toBe("Rick Astley - Never Gonna Give You Up");
-    expect(md.artist).toBe("Rick Astley");
+    expect(md.artists).toEqual(["Rick Astley"]);
     expect(md.album).toBe("Whenever You Need Somebody");
+    expect(md.isrc).toBe("GBARL9300135");
+  });
+
+  it("leaves isrc unset when the bridge omits the x-track-isrc header", async () => {
+    bridge.audio.set("dQw4w9WgXcQ", {
+      buffer: asBytes("opus"),
+      mimeType: "audio/opus",
+      artistPercentEncoded: encodeURIComponent("Rick Astley"),
+    });
+
+    enableBridgeAndSelectVideo("dQw4w9WgXcQ");
+    await render(withQueryClient(<HookHost />));
+
+    await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Rick Astley");
+    expect(useProjectStore.getState().metadata.isrc).toBeUndefined();
+  });
+
+  it("rejects a malformed bridge isrc instead of writing it to the store", async () => {
+    bridge.audio.set("dQw4w9WgXcQ", {
+      buffer: asBytes("opus"),
+      mimeType: "audio/opus",
+      artistPercentEncoded: encodeURIComponent("Rick Astley"),
+      isrcPercentEncoded: encodeURIComponent("N/A"),
+    });
+
+    enableBridgeAndSelectVideo("dQw4w9WgXcQ");
+    await render(withQueryClient(<HookHost />));
+
+    await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Rick Astley");
+    expect(useProjectStore.getState().metadata.isrc).toBeUndefined();
+  });
+
+  it("uppercases a lowercase-but-otherwise-valid bridge isrc", async () => {
+    bridge.audio.set("dQw4w9WgXcQ", {
+      buffer: asBytes("opus"),
+      mimeType: "audio/opus",
+      artistPercentEncoded: encodeURIComponent("Rick Astley"),
+      isrcPercentEncoded: encodeURIComponent("gbarl9300135"),
+    });
+
+    enableBridgeAndSelectVideo("dQw4w9WgXcQ");
+    await render(withQueryClient(<HookHost />));
+
+    await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Rick Astley");
+    expect(useProjectStore.getState().metadata.isrc).toBe("GBARL9300135");
   });
 
   it("decodes percent-encoded UTF-8 metadata headers (the fullwidth-comma regression)", async () => {
@@ -200,14 +248,15 @@ describe("useResolveYouTubeTunnel — bridge happy path", () => {
     enableBridgeAndSelectVideo("dQw4w9WgXcQ");
     await render(withQueryClient(<HookHost />));
 
-    await waitFor(() => useProjectStore.getState().metadata.artist === "Tyler, The Creator");
+    await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Tyler, The Creator");
+    expect(useProjectStore.getState().metadata.artists).toEqual(["Tyler, The Creator"]);
     expect(useProjectStore.getState().metadata.title).toContain("RUNNING OUT OF TIME");
   });
 });
 
 // -- Fallback paths -----------------------------------------------------------
 
-describe("useResolveYouTubeTunnel — title fallback", () => {
+describe("useResolveYouTubeTunnel: title fallback", () => {
   it("falls back to videoId as the title when the bridge returns no metadata at all", async () => {
     bridge.audio.set("dQw4w9WgXcQ", { buffer: asBytes("opus"), mimeType: "audio/opus" });
 
@@ -240,7 +289,7 @@ describe("useResolveYouTubeTunnel — title fallback", () => {
 
 // -- mimeType / file format ---------------------------------------------------
 
-describe("useResolveYouTubeTunnel — file format", () => {
+describe("useResolveYouTubeTunnel: file format", () => {
   it("labels the File with the actual bridge mime (regression for the .m4a-hardcode)", async () => {
     bridge.audio.set("dQw4w9WgXcQ", { buffer: asBytes("opus"), mimeType: "audio/opus" });
     enableBridgeAndSelectVideo("dQw4w9WgXcQ");
@@ -289,7 +338,7 @@ describe("useResolveYouTubeTunnel: reload race", () => {
     await seedProject({
       version: 1,
       savedAt: Date.now(),
-      metadata: { title: "Never Gonna Give You Up", artist: "Rick Astley", album: "", duration: 0 },
+      metadata: { title: "Never Gonna Give You Up", artists: ["Rick Astley"], album: "", duration: 0 },
       lines: [],
       agents: [{ id: "v1", type: "person", name: "Lead" }],
       granularity: "word",
@@ -314,7 +363,7 @@ describe("useResolveYouTubeTunnel: reload race", () => {
       await new Promise((r) => setTimeout(r, 50));
 
       expect(useProjectStore.getState().metadata.title).toBe("Never Gonna Give You Up");
-      expect(useProjectStore.getState().metadata.artist).toBe("Rick Astley");
+      expect(useProjectStore.getState().metadata.artists).toEqual(["Rick Astley"]);
       expect(seenTitles).not.toContain("dQw4w9WgXcQ");
     } finally {
       unsubscribe();

--- a/src/hooks/useResolveYouTubeTunnel.browser.test.tsx
+++ b/src/hooks/useResolveYouTubeTunnel.browser.test.tsx
@@ -187,7 +187,7 @@ describe("useResolveYouTubeTunnel: bridge happy path", () => {
 
     await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Rick Astley");
     const md = useProjectStore.getState().metadata;
-    expect(md.title).toBe("Rick Astley - Never Gonna Give You Up");
+    expect(md.title).toBe("Never Gonna Give You Up");
     expect(md.artists).toEqual(["Rick Astley"]);
     expect(md.album).toBe("Whenever You Need Somebody");
     expect(md.isrc).toBe("GBARL9300135");
@@ -250,7 +250,59 @@ describe("useResolveYouTubeTunnel: bridge happy path", () => {
 
     await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Tyler, The Creator");
     expect(useProjectStore.getState().metadata.artists).toEqual(["Tyler, The Creator"]);
-    expect(useProjectStore.getState().metadata.title).toContain("RUNNING OUT OF TIME");
+    expect(useProjectStore.getState().metadata.title).toBe("RUNNING OUT OF TIME");
+  });
+});
+
+// -- Artist-prefixed titles (#146) --------------------------------------------
+
+describe("useResolveYouTubeTunnel: bridge title is never artist-prefixed", () => {
+  it("regression: writes the bridge title verbatim rather than joining artist and title", async () => {
+    bridge.audio.set("dQw4w9WgXcQ", {
+      buffer: asBytes("opus"),
+      mimeType: "audio/opus",
+      titlePercentEncoded: encodeURIComponent("Bezos I"),
+      artistPercentEncoded: encodeURIComponent("Bo Burnham"),
+    });
+
+    enableBridgeAndSelectVideo("dQw4w9WgXcQ");
+    await render(withQueryClient(<HookHost />));
+
+    await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Bo Burnham");
+    const md = useProjectStore.getState().metadata;
+    expect(md.title).toBe("Bezos I");
+    expect(md.title).not.toContain("Bo Burnham");
+    expect(md.artists).toEqual(["Bo Burnham"]);
+  });
+
+  it("preserves a separator that genuinely belongs to the title", async () => {
+    bridge.audio.set("dQw4w9WgXcQ", {
+      buffer: asBytes("opus"),
+      mimeType: "audio/opus",
+      titlePercentEncoded: encodeURIComponent("Wildfires - Live at Glastonbury"),
+      artistPercentEncoded: encodeURIComponent("Sault"),
+    });
+
+    enableBridgeAndSelectVideo("dQw4w9WgXcQ");
+    await render(withQueryClient(<HookHost />));
+
+    await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Sault");
+    expect(useProjectStore.getState().metadata.title).toBe("Wildfires - Live at Glastonbury");
+  });
+
+  it("writes a non-Latin title verbatim", async () => {
+    bridge.audio.set("dQw4w9WgXcQ", {
+      buffer: asBytes("opus"),
+      mimeType: "audio/opus",
+      titlePercentEncoded: encodeURIComponent("春はゆく"),
+      artistPercentEncoded: encodeURIComponent("Aimer"),
+    });
+
+    enableBridgeAndSelectVideo("dQw4w9WgXcQ");
+    await render(withQueryClient(<HookHost />));
+
+    await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Aimer");
+    expect(useProjectStore.getState().metadata.title).toBe("春はゆく");
   });
 });
 

--- a/src/hooks/useResolveYouTubeTunnel.reload.browser.test.tsx
+++ b/src/hooks/useResolveYouTubeTunnel.reload.browser.test.tsx
@@ -140,7 +140,7 @@ describe("post-reload survival", () => {
       savedAt: Date.now(),
       metadata: {
         title: "Never Gonna Give You Up",
-        artist: "Rick Astley",
+        artists: ["Rick Astley"],
         album: "Whenever You Need Somebody",
         duration: 213,
       },
@@ -167,7 +167,7 @@ describe("post-reload survival", () => {
 
     const md = useProjectStore.getState().metadata;
     expect(md.title).toBe("Never Gonna Give You Up");
-    expect(md.artist).toBe("Rick Astley");
+    expect(md.artists).toEqual(["Rick Astley"]);
     expect(md.album).toBe("Whenever You Need Somebody");
     expect(md.thumbnailDataUrl).toMatch(/^data:image\/png/);
     expect(md.thumbnailForVideoId).toBe("dQw4w9WgXcQ");
@@ -179,7 +179,7 @@ describe("post-reload survival", () => {
     await seedProject({
       version: 1,
       savedAt: Date.now(),
-      metadata: { title: "User Edited Title", artist: "", album: "", duration: 0 },
+      metadata: { title: "User Edited Title", artists: [], album: "", duration: 0 },
       lines: [],
       agents: [{ id: "v1", type: "person", name: "Lead" }],
       granularity: "word",

--- a/src/hooks/useResolveYouTubeTunnel.ts
+++ b/src/hooks/useResolveYouTubeTunnel.ts
@@ -21,6 +21,7 @@ import {
   formatBridgeErrorForToast,
   getAudioFromBridge,
 } from "@/utils/composer-bridge-api";
+import { normalizeIsrc } from "@/utils/isrc";
 
 // -- Constants ----------------------------------------------------------------
 
@@ -35,6 +36,7 @@ interface TunnelResult {
   title?: string;
   artist?: string;
   album?: string;
+  isrc?: string;
   instanceLabel: string;
   instanceId: string;
   wasDefault: boolean;
@@ -66,7 +68,7 @@ function buildAudioFile(buffer: ArrayBuffer, filename: string | undefined, video
 async function fetchViaBridge(videoId: string, signal: AbortSignal): Promise<TunnelResult> {
   const baseUrl = useSettingsStore.getState().composerBridgeUrl;
   try {
-    const { buffer, mimeType, title, artist, album } = await getAudioFromBridge(baseUrl, videoId, signal);
+    const { buffer, mimeType, title, artist, album, isrc } = await getAudioFromBridge(baseUrl, videoId, signal);
     if (signal.aborted) throw new DOMException("aborted", "AbortError");
     const filename = [artist, title].filter(Boolean).join(" - ") || title;
     return {
@@ -75,6 +77,7 @@ async function fetchViaBridge(videoId: string, signal: AbortSignal): Promise<Tun
       title,
       artist,
       album,
+      isrc,
       instanceLabel: BRIDGE_INSTANCE_LABEL,
       instanceId: BRIDGE_INSTANCE_ID,
       wasDefault: false,
@@ -181,8 +184,10 @@ function useResolveYouTubeTunnel(): void {
       const currentTitle = project.metadata.title;
       if (!currentTitle || currentTitle === videoId) {
         const metadataPatch: Partial<typeof project.metadata> = { title: data.filename || videoId };
-        if (data.artist) metadataPatch.artist = data.artist;
+        if (data.artist) metadataPatch.artists = [data.artist];
         if (data.album) metadataPatch.album = data.album;
+        const bridgeIsrc = data.isrc ? normalizeIsrc(data.isrc) : undefined;
+        if (bridgeIsrc) metadataPatch.isrc = bridgeIsrc;
         project.setMetadata(metadataPatch);
         flushPendingSave();
       }

--- a/src/hooks/useResolveYouTubeTunnel.ts
+++ b/src/hooks/useResolveYouTubeTunnel.ts
@@ -183,7 +183,7 @@ function useResolveYouTubeTunnel(): void {
       const project = useProjectStore.getState();
       const currentTitle = project.metadata.title;
       if (!currentTitle || currentTitle === videoId) {
-        const metadataPatch: Partial<typeof project.metadata> = { title: data.filename || videoId };
+        const metadataPatch: Partial<typeof project.metadata> = { title: data.title || data.filename || videoId };
         if (data.artist) metadataPatch.artists = [data.artist];
         if (data.album) metadataPatch.album = data.album;
         const bridgeIsrc = data.isrc ? normalizeIsrc(data.isrc) : undefined;

--- a/src/hooks/useSyncHandlers.browser.test.tsx
+++ b/src/hooks/useSyncHandlers.browser.test.tsx
@@ -1,6 +1,7 @@
-import { REDO_PREROLL_SECONDS, useSyncHandlers } from "@/hooks/useSyncHandlers";
+import { useSyncHandlers } from "@/hooks/useSyncHandlers";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
+import { DEFAULTS, useSettingsStore } from "@/stores/settings";
 import { createLine, createWord } from "@/test/factories";
 import { createBgWordsFromLine, type SyncState } from "@/utils/sync-helpers";
 import { describe, expect, it } from "vitest";
@@ -327,8 +328,28 @@ describe("useSyncHandlers.handleJumpToLine (smart line redo)", () => {
     await act(() => result.current.handleJumpToLine(1));
 
     expect(getSyncState().position).toEqual({ lineIndex: 1, wordIndex: 0 });
-    expect(useAudioStore.getState().currentTime).toBe(3 - REDO_PREROLL_SECONDS);
+    expect(useAudioStore.getState().currentTime).toBe(3 - DEFAULTS.redoPreroll);
     expect(playingCalls).not.toContain(true);
+  });
+
+  it("uses the configured pre-roll instead of the default", async () => {
+    useSettingsStore.setState({ redoPreroll: 0.5 });
+    useProjectStore.getState().setLines(twoSyncedLines());
+    const { result, act } = await mountSyncHandlers();
+
+    await act(() => result.current.handleJumpToLine(1));
+
+    expect(useAudioStore.getState().currentTime).toBe(3 - 0.5);
+  });
+
+  it("seeks exactly to the line begin when the pre-roll is zero", async () => {
+    useSettingsStore.setState({ redoPreroll: 0 });
+    useProjectStore.getState().setLines(twoSyncedLines());
+    const { result, act } = await mountSyncHandlers();
+
+    await act(() => result.current.handleJumpToLine(1));
+
+    expect(useAudioStore.getState().currentTime).toBe(3);
   });
 
   it("clamps the pre-roll seek to zero when the line begins inside the pre-roll window", async () => {
@@ -419,8 +440,18 @@ describe("useSyncHandlers.handleJumpToWord (smart word redo)", () => {
     await act(() => result.current.handleJumpToWord(1, 1));
 
     expect(getSyncState().position).toEqual({ lineIndex: 1, wordIndex: 1 });
-    expect(useAudioStore.getState().currentTime).toBe(3.5 - REDO_PREROLL_SECONDS);
+    expect(useAudioStore.getState().currentTime).toBe(3.5 - DEFAULTS.redoPreroll);
     expect(playingCalls).not.toContain(true);
+  });
+
+  it("uses the configured pre-roll for word redo", async () => {
+    useSettingsStore.setState({ redoPreroll: 0.5 });
+    useProjectStore.getState().setLines(twoSyncedLines());
+    const { result, act } = await mountSyncHandlers();
+
+    await act(() => result.current.handleJumpToWord(1, 1));
+
+    expect(useAudioStore.getState().currentTime).toBe(3.5 - 0.5);
   });
 
   it("only moves the cursor for a word with no timing, without seeking", async () => {

--- a/src/hooks/useSyncHandlers.browser.test.tsx
+++ b/src/hooks/useSyncHandlers.browser.test.tsx
@@ -450,6 +450,63 @@ describe("useSyncHandlers.handleJumpToWord (smart word redo)", () => {
   });
 });
 
+describe("useSyncHandlers.handleStartSync (start at cursor)", () => {
+  function twoSyncedLines() {
+    return [
+      createLine({
+        id: "l0",
+        text: "Hello world",
+        words: [createWord({ text: "Hello ", begin: 0, end: 0.5 }), createWord({ text: "world", begin: 0.5, end: 1 })],
+      }),
+      createLine({
+        id: "l1",
+        text: "Second line",
+        words: [createWord({ text: "Second ", begin: 3, end: 3.5 }), createWord({ text: "line", begin: 3.5, end: 4 })],
+      }),
+    ];
+  }
+
+  it("regression: starts at the navigated line instead of resetting to the top", async () => {
+    useProjectStore.getState().setLines(twoSyncedLines());
+    const { result, act, getSyncState, playingCalls } = await mountSyncHandlers({
+      initialSyncState: { position: { lineIndex: 1, wordIndex: 0 }, isActive: false },
+    });
+
+    await act(() => result.current.handleStartSync());
+
+    expect(getSyncState().position.lineIndex).toBe(1);
+    expect(getSyncState().isActive).toBe(true);
+    expect(playingCalls).toContain(true);
+  });
+
+  it("preserves the navigated word index when starting", async () => {
+    useProjectStore.getState().setLines(twoSyncedLines());
+    const { result, act, getSyncState } = await mountSyncHandlers({
+      initialSyncState: { position: { lineIndex: 1, wordIndex: 1 }, isActive: false },
+    });
+
+    await act(() => result.current.handleStartSync());
+
+    expect(getSyncState().position).toEqual({ lineIndex: 1, wordIndex: 1 });
+  });
+
+  it("falls back to the first syncable line when the cursor sits on a non-syncable line", async () => {
+    useProjectStore
+      .getState()
+      .setLines([
+        createLine({ id: "l0", text: "" }),
+        createLine({ id: "l1", text: "Real line", words: [createWord({ text: "Real ", begin: 2, end: 2.5 })] }),
+      ]);
+    const { result, act, getSyncState } = await mountSyncHandlers({
+      initialSyncState: { position: { lineIndex: 0, wordIndex: 0 }, isActive: false },
+    });
+
+    await act(() => result.current.handleStartSync());
+
+    expect(getSyncState().position).toEqual({ lineIndex: 1, wordIndex: 0 });
+  });
+});
+
 describe("sync-panel bg-init contract", () => {
   it("preserves backgroundText and text when seeding backgroundWords on a synced line", async () => {
     const BG_TEXT = "ooh ahh";

--- a/src/hooks/useSyncHandlers.browser.test.tsx
+++ b/src/hooks/useSyncHandlers.browser.test.tsx
@@ -91,7 +91,7 @@ describe("useSyncHandlers.handleTap (word granularity)", () => {
     expect(useProjectStore.getState().lines[1].text).toBe("Foo bar");
   });
 
-  it("preserves text when re-syncing mid-line over an existing word array", async () => {
+  it("re-syncing mid-line overwrites in place and preserves the line's later words", async () => {
     useProjectStore.getState().setLines([
       createLine({
         id: "l0",
@@ -108,14 +108,20 @@ describe("useSyncHandlers.handleTap (word granularity)", () => {
 
     const { result, act } = await mountSyncHandlers({
       initialSyncState: { position: { lineIndex: 0, wordIndex: 1 }, isActive: true },
+      initialCurrentTime: 5.0,
     });
 
     await act(() => {
       result.current.handleTap();
     });
 
+    const words = useProjectStore.getState().lines[0].words;
     expect(useProjectStore.getState().lines[0].text).toBe(ORIGINAL_TEXT);
-    expect(useProjectStore.getState().lines[0].words?.length).toBe(2);
+    expect(words?.length).toBe(5);
+    expect(words?.[1].begin).toBe(5.0);
+    expect(words?.[0].end).toBe(5.0);
+    expect(words?.[2]).toEqual({ text: "how ", begin: 0.8, end: 1.2 });
+    expect(words?.[4]).toEqual({ text: "you", begin: 1.6, end: 2.0 });
   });
 
   it("regression: skips an empty line and still patches the word before it (issue #114)", async () => {
@@ -314,7 +320,7 @@ describe("useSyncHandlers.handleJumpToLine (smart line redo)", () => {
     ];
   }
 
-  it("seeks to a pre-roll before the line, moves the cursor, and resumes playback", async () => {
+  it("seeks to a pre-roll before the line and moves the cursor, but stays paused", async () => {
     useProjectStore.getState().setLines(twoSyncedLines());
     const { result, act, getSyncState, playingCalls } = await mountSyncHandlers();
 
@@ -322,7 +328,7 @@ describe("useSyncHandlers.handleJumpToLine (smart line redo)", () => {
 
     expect(getSyncState().position).toEqual({ lineIndex: 1, wordIndex: 0 });
     expect(useAudioStore.getState().currentTime).toBe(3 - REDO_PREROLL_SECONDS);
-    expect(playingCalls.at(-1)).toBe(true);
+    expect(playingCalls).not.toContain(true);
   });
 
   it("clamps the pre-roll seek to zero when the line begins inside the pre-roll window", async () => {
@@ -384,6 +390,63 @@ describe("useSyncHandlers.handleJumpToLine (smart line redo)", () => {
     const line = useProjectStore.getState().lines[1];
     expect(line.text).toBe("Second line");
     expect(line.words?.[0].begin).toBe(5.0);
+  });
+});
+
+describe("useSyncHandlers.handleJumpToWord (smart word redo)", () => {
+  function twoSyncedLines() {
+    return [
+      createLine({
+        id: "l0",
+        text: "Hello world",
+        words: [
+          createWord({ text: "Hello ", begin: 0, end: 0.5 }),
+          createWord({ text: "world", begin: 0.5, end: 1.0 }),
+        ],
+      }),
+      createLine({
+        id: "l1",
+        text: "Second line",
+        words: [createWord({ text: "Second ", begin: 3, end: 3.5 }), createWord({ text: "line", begin: 3.5, end: 4 })],
+      }),
+    ];
+  }
+
+  it("seeks to the word's begin minus a pre-roll, moves the cursor to that word, and stays paused", async () => {
+    useProjectStore.getState().setLines(twoSyncedLines());
+    const { result, act, getSyncState, playingCalls } = await mountSyncHandlers();
+
+    await act(() => result.current.handleJumpToWord(1, 1));
+
+    expect(getSyncState().position).toEqual({ lineIndex: 1, wordIndex: 1 });
+    expect(useAudioStore.getState().currentTime).toBe(3.5 - REDO_PREROLL_SECONDS);
+    expect(playingCalls).not.toContain(true);
+  });
+
+  it("only moves the cursor for a word with no timing, without seeking", async () => {
+    useProjectStore
+      .getState()
+      .setLines([
+        createLine({ id: "l0", text: "Synced", words: [createWord({ text: "Synced", begin: 0, end: 1 })] }),
+        createLine({ id: "l1", text: "Not synced yet" }),
+      ]);
+    useAudioStore.getState().seekTo(2.5);
+    const { result, act, getSyncState } = await mountSyncHandlers();
+
+    await act(() => result.current.handleJumpToWord(1, 0));
+
+    expect(getSyncState().position).toEqual({ lineIndex: 1, wordIndex: 0 });
+    expect(useAudioStore.getState().currentTime).toBe(2.5);
+  });
+
+  it("in edit mode scrubs to the word begin without a pre-roll or cursor move", async () => {
+    useProjectStore.getState().setLines(twoSyncedLines());
+    const { result, act, getSyncState } = await mountSyncHandlers({ editMode: true });
+
+    await act(() => result.current.handleJumpToWord(1, 1));
+
+    expect(useAudioStore.getState().currentTime).toBe(3.5);
+    expect(getSyncState().position).toEqual({ lineIndex: 0, wordIndex: 0 });
   });
 });
 

--- a/src/hooks/useSyncHandlers.browser.test.tsx
+++ b/src/hooks/useSyncHandlers.browser.test.tsx
@@ -1,4 +1,5 @@
-import { useSyncHandlers } from "@/hooks/useSyncHandlers";
+import { REDO_PREROLL_SECONDS, useSyncHandlers } from "@/hooks/useSyncHandlers";
+import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { createLine, createWord } from "@/test/factories";
 import { createBgWordsFromLine, type SyncState } from "@/utils/sync-helpers";
@@ -18,6 +19,7 @@ interface MountOptions {
   initialSyncState?: SyncState;
   initialCurrentTime?: number;
   granularity?: "word" | "line";
+  editMode?: boolean;
 }
 
 async function mountSyncHandlers(opts: MountOptions = {}) {
@@ -27,6 +29,7 @@ async function mountSyncHandlers(opts: MountOptions = {}) {
   };
   const getSyncState = () => syncState;
   const startTime = opts.initialCurrentTime ?? 0;
+  const playingCalls: boolean[] = [];
 
   const { result, rerender, act } = await renderHook(
     (props?: HookProps) =>
@@ -35,15 +38,15 @@ async function mountSyncHandlers(opts: MountOptions = {}) {
         syncState: props?.syncState ?? syncState,
         setSyncState,
         currentTime: props?.currentTime ?? startTime,
-        editMode: false,
+        editMode: opts.editMode ?? false,
         granularity: opts.granularity ?? "word",
         setShowPulse: noopBool,
-        setIsPlaying: noopBool,
+        setIsPlaying: (value) => playingCalls.push(value),
       }),
     { initialProps: { syncState, currentTime: startTime } },
   );
 
-  return { result, rerender, act, getSyncState };
+  return { result, rerender, act, getSyncState, playingCalls };
 }
 
 describe("useSyncHandlers.handleTap (word granularity)", () => {
@@ -289,6 +292,98 @@ describe("useSyncHandlers.handleHold (word granularity)", () => {
     const line = useProjectStore.getState().lines[0];
     expect(line.text).toBe(TEXT);
     expect(line.words?.[1].end).toBe(END_TIME);
+  });
+});
+
+describe("useSyncHandlers.handleJumpToLine (smart line redo)", () => {
+  function twoSyncedLines() {
+    return [
+      createLine({
+        id: "l0",
+        text: "Hello world",
+        words: [
+          createWord({ text: "Hello ", begin: 0, end: 0.5 }),
+          createWord({ text: "world", begin: 0.5, end: 1.0 }),
+        ],
+      }),
+      createLine({
+        id: "l1",
+        text: "Second line",
+        words: [createWord({ text: "Second ", begin: 3, end: 3.5 }), createWord({ text: "line", begin: 3.5, end: 4 })],
+      }),
+    ];
+  }
+
+  it("seeks to a pre-roll before the line, moves the cursor, and resumes playback", async () => {
+    useProjectStore.getState().setLines(twoSyncedLines());
+    const { result, act, getSyncState, playingCalls } = await mountSyncHandlers();
+
+    await act(() => result.current.handleJumpToLine(1));
+
+    expect(getSyncState().position).toEqual({ lineIndex: 1, wordIndex: 0 });
+    expect(useAudioStore.getState().currentTime).toBe(3 - REDO_PREROLL_SECONDS);
+    expect(playingCalls.at(-1)).toBe(true);
+  });
+
+  it("clamps the pre-roll seek to zero when the line begins inside the pre-roll window", async () => {
+    useProjectStore.getState().setLines([
+      createLine({
+        id: "l0",
+        text: "Early line",
+        words: [
+          createWord({ text: "Early ", begin: 0.4, end: 0.8 }),
+          createWord({ text: "line", begin: 0.8, end: 1.2 }),
+        ],
+      }),
+    ]);
+    const { result, act } = await mountSyncHandlers({
+      initialSyncState: { position: { lineIndex: 5, wordIndex: 2 }, isActive: true },
+    });
+
+    await act(() => result.current.handleJumpToLine(0));
+
+    expect(useAudioStore.getState().currentTime).toBe(0);
+  });
+
+  it("only moves the cursor for an unsynced line, without seeking or resuming playback", async () => {
+    useProjectStore
+      .getState()
+      .setLines([
+        createLine({ id: "l0", text: "Synced", words: [createWord({ text: "Synced", begin: 0, end: 1 })] }),
+        createLine({ id: "l1", text: "Not synced yet" }),
+      ]);
+    useAudioStore.getState().seekTo(2.5);
+    const { result, act, getSyncState, playingCalls } = await mountSyncHandlers();
+
+    await act(() => result.current.handleJumpToLine(1));
+
+    expect(getSyncState().position).toEqual({ lineIndex: 1, wordIndex: 0 });
+    expect(useAudioStore.getState().currentTime).toBe(2.5);
+    expect(playingCalls).toHaveLength(0);
+  });
+
+  it("in edit mode scrubs to the line begin without a pre-roll, cursor move, or playback", async () => {
+    useProjectStore.getState().setLines(twoSyncedLines());
+    const { result, act, getSyncState, playingCalls } = await mountSyncHandlers({ editMode: true });
+
+    await act(() => result.current.handleJumpToLine(1));
+
+    expect(useAudioStore.getState().currentTime).toBe(3);
+    expect(getSyncState().position).toEqual({ lineIndex: 0, wordIndex: 0 });
+    expect(playingCalls).toHaveLength(0);
+  });
+
+  it("invariant: a redo re-tap commits to the store immediately so it survives a later quit", async () => {
+    useProjectStore.getState().setLines(twoSyncedLines());
+    const { result, rerender, act, getSyncState } = await mountSyncHandlers();
+
+    await act(() => result.current.handleJumpToLine(1));
+    await rerender({ syncState: getSyncState(), currentTime: 5.0 });
+    await act(() => result.current.handleTap());
+
+    const line = useProjectStore.getState().lines[1];
+    expect(line.text).toBe("Second line");
+    expect(line.words?.[0].begin).toBe(5.0);
   });
 });
 

--- a/src/hooks/useSyncHandlers.browser.test.tsx
+++ b/src/hooks/useSyncHandlers.browser.test.tsx
@@ -368,15 +368,15 @@ describe("useSyncHandlers.handleJumpToLine (smart line redo)", () => {
     expect(playingCalls).toHaveLength(0);
   });
 
-  it("in edit mode scrubs to the line begin without a pre-roll, cursor move, or playback", async () => {
+  it("in edit mode scrubs exactly to the line begin (no pre-roll), moves the cursor, and stays paused", async () => {
     useProjectStore.getState().setLines(twoSyncedLines());
     const { result, act, getSyncState, playingCalls } = await mountSyncHandlers({ editMode: true });
 
     await act(() => result.current.handleJumpToLine(1));
 
     expect(useAudioStore.getState().currentTime).toBe(3);
-    expect(getSyncState().position).toEqual({ lineIndex: 0, wordIndex: 0 });
-    expect(playingCalls).toHaveLength(0);
+    expect(getSyncState().position).toEqual({ lineIndex: 1, wordIndex: 0 });
+    expect(playingCalls).not.toContain(true);
   });
 
   it("invariant: a redo re-tap commits to the store immediately so it survives a later quit", async () => {
@@ -439,14 +439,14 @@ describe("useSyncHandlers.handleJumpToWord (smart word redo)", () => {
     expect(useAudioStore.getState().currentTime).toBe(2.5);
   });
 
-  it("in edit mode scrubs to the word begin without a pre-roll or cursor move", async () => {
+  it("in edit mode scrubs exactly to the word begin (no pre-roll) and moves the cursor to that word", async () => {
     useProjectStore.getState().setLines(twoSyncedLines());
     const { result, act, getSyncState } = await mountSyncHandlers({ editMode: true });
 
     await act(() => result.current.handleJumpToWord(1, 1));
 
     expect(useAudioStore.getState().currentTime).toBe(3.5);
-    expect(getSyncState().position).toEqual({ lineIndex: 0, wordIndex: 0 });
+    expect(getSyncState().position).toEqual({ lineIndex: 1, wordIndex: 1 });
   });
 });
 

--- a/src/hooks/useSyncHandlers.browser.test.tsx
+++ b/src/hooks/useSyncHandlers.browser.test.tsx
@@ -694,6 +694,16 @@ describe("useSyncHandlers.handleJumpToWord (smart word redo)", () => {
     expect(playingCalls).toContain(false);
     expect(playingCalls).not.toContain(true);
   });
+
+  it("leaves playback alone in edit mode, where a click is a scrub", async () => {
+    useProjectStore.getState().setLines(twoSyncedLines());
+    const { result, act, playingCalls } = await mountSyncHandlers({ editMode: true });
+
+    await act(() => result.current.handleJumpToWord(1, 1));
+
+    expect(playingCalls).toHaveLength(0);
+    expect(useAudioStore.getState().currentTime).toBe(3.5);
+  });
 });
 
 // -- Background words ---------------------------------------------------------

--- a/src/hooks/useSyncHandlers.browser.test.tsx
+++ b/src/hooks/useSyncHandlers.browser.test.tsx
@@ -695,6 +695,48 @@ describe("useSyncHandlers.handleJumpToWord (smart word redo)", () => {
     expect(playingCalls).not.toContain(true);
   });
 
+  it("regression: re-recording a jumped-to line does not stretch the line before it (issue #132)", async () => {
+    useProjectStore.getState().setLines([
+      createLine({
+        id: "l0",
+        text: "first line",
+        words: [createWord({ text: "first ", begin: 0, end: 0.5 }), createWord({ text: "line", begin: 0.5, end: 1 })],
+      }),
+      createLine({
+        id: "l1",
+        text: "second line",
+        words: [createWord({ text: "second ", begin: 8, end: 8.5 }), createWord({ text: "line", begin: 8.5, end: 9 })],
+      }),
+    ]);
+    const { result, act, rerender, getSyncState } = await mountSyncHandlers({ initialCurrentTime: 7 });
+
+    await act(() => result.current.handleJumpToWord(1, 0));
+    await rerender({ syncState: getSyncState(), currentTime: 7 });
+    await act(() => result.current.handleTap());
+
+    const lines = useProjectStore.getState().lines;
+    expect(lines[1].words?.[0].begin).toBe(7);
+    expect(lines[0].words?.[1].end).toBe(1);
+  });
+
+  it("still closes the previous line when the cursor advanced there normally", async () => {
+    useProjectStore.getState().setLines([
+      createLine({
+        id: "l0",
+        text: "one",
+        words: [createWord({ text: "one", begin: 0, end: 0.5 })],
+      }),
+      createLine({ id: "l1", text: "two" }),
+    ]);
+    const { result, act, rerender, getSyncState } = await mountSyncHandlers({ initialCurrentTime: 0 });
+
+    await act(() => result.current.handleTap());
+    await rerender({ syncState: getSyncState(), currentTime: 3 });
+    await act(() => result.current.handleTap());
+
+    expect(useProjectStore.getState().lines[0].words?.[0].end).toBe(3);
+  });
+
   it("leaves playback alone in edit mode, where a click is a scrub", async () => {
     useProjectStore.getState().setLines(twoSyncedLines());
     const { result, act, playingCalls } = await mountSyncHandlers({ editMode: true });

--- a/src/hooks/useSyncHandlers.browser.test.tsx
+++ b/src/hooks/useSyncHandlers.browser.test.tsx
@@ -302,6 +302,149 @@ describe("useSyncHandlers.handleHold (word granularity)", () => {
   });
 });
 
+// -- Mid-line hold redo -------------------------------------------------------
+
+describe("useSyncHandlers.handleHold (mid-line redo)", () => {
+  const REDO_TEXT = "one two three";
+
+  function seedFullyTimedLine() {
+    useProjectStore.getState().setLines([
+      createLine({
+        id: "l0",
+        text: REDO_TEXT,
+        words: [
+          createWord({ text: "one ", begin: 0, end: 1 }),
+          createWord({ text: "two ", begin: 1, end: 2 }),
+          createWord({ text: "three", begin: 2, end: 3 }),
+        ],
+      }),
+    ]);
+  }
+
+  it("regression: handleHoldEnd closes the held word, not the last word of the line", async () => {
+    seedFullyTimedLine();
+
+    const { result, rerender, act } = await mountSyncHandlers({
+      initialSyncState: { position: { lineIndex: 0, wordIndex: 1 }, isActive: true },
+      initialCurrentTime: 5,
+    });
+
+    await act(() => {
+      result.current.handleHoldStart();
+    });
+    await rerender({ syncState: { position: { lineIndex: 0, wordIndex: 1 }, isActive: true }, currentTime: 6 });
+    await act(() => {
+      result.current.handleHoldEnd();
+    });
+
+    const words = useProjectStore.getState().lines[0].words ?? [];
+    expect(words[1]).toMatchObject({ begin: 5, end: 6 });
+    expect(words[2]).toMatchObject({ begin: 2, end: 3 });
+  });
+
+  it("regression: handleHoldEnd never leaves a word ending before it begins", async () => {
+    useProjectStore.getState().setLines([
+      createLine({
+        id: "l0",
+        text: REDO_TEXT,
+        words: [
+          createWord({ text: "one ", begin: 0, end: 1 }),
+          createWord({ text: "two ", begin: 1, end: 2 }),
+          createWord({ text: "three", begin: 10, end: 11 }),
+        ],
+      }),
+    ]);
+
+    const { result, rerender, act } = await mountSyncHandlers({
+      initialSyncState: { position: { lineIndex: 0, wordIndex: 1 }, isActive: true },
+      initialCurrentTime: 5,
+    });
+
+    await act(() => {
+      result.current.handleHoldStart();
+    });
+    await rerender({ syncState: { position: { lineIndex: 0, wordIndex: 1 }, isActive: true }, currentTime: 6 });
+    await act(() => {
+      result.current.handleHoldEnd();
+    });
+
+    for (const word of useProjectStore.getState().lines[0].words ?? []) {
+      expect(word.end).toBeGreaterThanOrEqual(word.begin);
+    }
+  });
+
+  it("regression: handleHoldTap keeps one timing per word instead of appending a duplicate", async () => {
+    seedFullyTimedLine();
+
+    const { result, rerender, act } = await mountSyncHandlers({
+      initialSyncState: { position: { lineIndex: 0, wordIndex: 1 }, isActive: true },
+      initialCurrentTime: 5,
+    });
+
+    await act(() => {
+      result.current.handleHoldStart();
+    });
+    await rerender({ syncState: { position: { lineIndex: 0, wordIndex: 1 }, isActive: true }, currentTime: 6 });
+    await act(() => {
+      result.current.handleHoldTap();
+    });
+
+    const line = useProjectStore.getState().lines[0];
+    expect(line.text).toBe(REDO_TEXT);
+    expect(line.words).toHaveLength(3);
+    expect(line.words?.filter((word) => word.text.trim() === "three")).toHaveLength(1);
+  });
+
+  it("handleHoldTap opens the next word in place and moves the cursor onto it", async () => {
+    seedFullyTimedLine();
+
+    const { result, rerender, act, getSyncState } = await mountSyncHandlers({
+      initialSyncState: { position: { lineIndex: 0, wordIndex: 1 }, isActive: true },
+      initialCurrentTime: 5,
+    });
+
+    await act(() => {
+      result.current.handleHoldStart();
+    });
+    await rerender({ syncState: { position: { lineIndex: 0, wordIndex: 1 }, isActive: true }, currentTime: 6 });
+    await act(() => {
+      result.current.handleHoldTap();
+    });
+
+    const words = useProjectStore.getState().lines[0].words ?? [];
+    expect(words[1]).toMatchObject({ begin: 5, end: 6 });
+    expect(words[2]).toMatchObject({ text: "three", begin: 6, end: 6 });
+    expect(getSyncState().position.wordIndex).toBe(2);
+  });
+
+  it("preserves explicit and syllableGroupId when re-holding a mid-line word", async () => {
+    useProjectStore.getState().setLines([
+      createLine({
+        id: "l0",
+        text: REDO_TEXT,
+        words: [
+          createWord({ text: "one ", begin: 0, end: 1 }),
+          createWord({ text: "two ", begin: 1, end: 2, explicit: true, syllableGroupId: "g1" }),
+          createWord({ text: "three", begin: 2, end: 3 }),
+        ],
+      }),
+    ]);
+
+    const { result, act } = await mountSyncHandlers({
+      initialSyncState: { position: { lineIndex: 0, wordIndex: 1 }, isActive: true },
+      initialCurrentTime: 5,
+    });
+
+    await act(() => {
+      result.current.handleHoldStart();
+    });
+
+    const words = useProjectStore.getState().lines[0].words ?? [];
+    expect(words[1].explicit).toBe(true);
+    expect(words[1].syllableGroupId).toBe("g1");
+  });
+});
+
 describe("useSyncHandlers.handleJumpToLine (smart line redo)", () => {
   function twoSyncedLines() {
     return [

--- a/src/hooks/useSyncHandlers.browser.test.tsx
+++ b/src/hooks/useSyncHandlers.browser.test.tsx
@@ -684,6 +684,73 @@ describe("useSyncHandlers.handleJumpToWord (smart word redo)", () => {
     expect(useAudioStore.getState().currentTime).toBe(3.5);
     expect(getSyncState().position).toEqual({ lineIndex: 1, wordIndex: 1 });
   });
+
+  it("pauses playback so a jump never leaves the transport running", async () => {
+    useProjectStore.getState().setLines(twoSyncedLines());
+    const { result, act, playingCalls } = await mountSyncHandlers();
+
+    await act(() => result.current.handleJumpToWord(1, 1));
+
+    expect(playingCalls).toContain(false);
+    expect(playingCalls).not.toContain(true);
+  });
+});
+
+// -- Background words ---------------------------------------------------------
+
+describe("useSyncHandlers.handleJumpToBgWord", () => {
+  it("scrubs to a background word with the same pre-roll", async () => {
+    useProjectStore.getState().setLines([
+      createLine({
+        id: "l0",
+        text: "Main line",
+        words: [createWord({ text: "Main ", begin: 0, end: 1 }), createWord({ text: "line", begin: 1, end: 2 })],
+        backgroundText: "ooh ahh",
+        backgroundWords: [
+          createWord({ text: "ooh ", begin: 4, end: 4.5 }),
+          createWord({ text: "ahh", begin: 4.5, end: 5 }),
+        ],
+      }),
+    ]);
+    const { result, act } = await mountSyncHandlers();
+
+    await act(() => result.current.handleJumpToBgWord(0, 1));
+
+    expect(useAudioStore.getState().currentTime).toBe(4.5 - 1.5);
+  });
+
+  it("leaves the sync cursor alone, since it addresses main words only", async () => {
+    useProjectStore.getState().setLines([
+      createLine({
+        id: "l0",
+        text: "Main line",
+        words: [createWord({ text: "Main ", begin: 0, end: 1 }), createWord({ text: "line", begin: 1, end: 2 })],
+        backgroundText: "ooh ahh",
+        backgroundWords: [
+          createWord({ text: "ooh ", begin: 4, end: 4.5 }),
+          createWord({ text: "ahh", begin: 4.5, end: 5 }),
+        ],
+      }),
+    ]);
+    const { result, act, getSyncState } = await mountSyncHandlers();
+    const before = getSyncState().position;
+
+    await act(() => result.current.handleJumpToBgWord(0, 1));
+
+    expect(getSyncState().position).toEqual(before);
+  });
+
+  it("ignores a background word that has no timing", async () => {
+    useProjectStore
+      .getState()
+      .setLines([createLine({ id: "l0", text: "Main", words: [createWord({ text: "Main", begin: 0, end: 1 })] })]);
+    useAudioStore.getState().seekTo(2.5);
+    const { result, act } = await mountSyncHandlers();
+
+    await act(() => result.current.handleJumpToBgWord(0, 0));
+
+    expect(useAudioStore.getState().currentTime).toBe(2.5);
+  });
 });
 
 describe("useSyncHandlers.handleStartSync (start at cursor)", () => {

--- a/src/hooks/useSyncHandlers.browser.test.tsx
+++ b/src/hooks/useSyncHandlers.browser.test.tsx
@@ -121,8 +121,42 @@ describe("useSyncHandlers.handleTap (word granularity)", () => {
     expect(words?.length).toBe(5);
     expect(words?.[1].begin).toBe(5.0);
     expect(words?.[0].end).toBe(5.0);
-    expect(words?.[2]).toEqual({ text: "how ", begin: 0.8, end: 1.2 });
-    expect(words?.[4]).toEqual({ text: "you", begin: 1.6, end: 2.0 });
+    expect(words?.map((w) => w.text)).toEqual(["Hello ", "world ", "how ", "are ", "you"]);
+    for (let i = 0; i < (words?.length ?? 0); i++) {
+      const word = words?.[i];
+      if (!word) continue;
+      expect(word.end).toBeGreaterThanOrEqual(word.begin);
+      if (i > 0) expect(word.begin).toBeGreaterThanOrEqual(words![i - 1].end);
+    }
+  });
+
+  it("regression: a redo past the line's later words never exports a line ending before it begins", async () => {
+    useProjectStore.getState().setLines([
+      createLine({
+        id: "l0",
+        text: ORIGINAL_TEXT,
+        words: [
+          { text: "Hello ", begin: 0, end: 0.4 },
+          { text: "world ", begin: 0.4, end: 0.8 },
+          { text: "how ", begin: 0.8, end: 1.2 },
+          { text: "are ", begin: 1.2, end: 1.6 },
+          { text: "you", begin: 1.6, end: 2.0 },
+        ],
+      }),
+    ]);
+
+    const { result, act } = await mountSyncHandlers({
+      initialSyncState: { position: { lineIndex: 0, wordIndex: 0 }, isActive: true },
+      initialCurrentTime: 5.0,
+    });
+
+    await act(() => {
+      result.current.handleTap();
+    });
+
+    const words = useProjectStore.getState().lines[0].words ?? [];
+    expect(words).toHaveLength(5);
+    expect(words[0].begin).toBeLessThanOrEqual(words[words.length - 1].end);
   });
 
   it("regression: skips an empty line and still patches the word before it (issue #114)", async () => {
@@ -339,7 +373,8 @@ describe("useSyncHandlers.handleHold (mid-line redo)", () => {
 
     const words = useProjectStore.getState().lines[0].words ?? [];
     expect(words[1]).toMatchObject({ begin: 5, end: 6 });
-    expect(words[2]).toMatchObject({ begin: 2, end: 3 });
+    expect(words).toHaveLength(3);
+    expect(words[2].begin).toBeGreaterThanOrEqual(words[1].end);
   });
 
   it("regression: handleHoldEnd never leaves a word ending before it begins", async () => {
@@ -597,7 +632,7 @@ describe("useSyncHandlers.handleJumpToWord (smart word redo)", () => {
     expect(useAudioStore.getState().currentTime).toBe(3.5 - 0.5);
   });
 
-  it("only moves the cursor for a word with no timing, without seeking", async () => {
+  it("regression: ignores a word with no timing so the cursor cannot desync from the line's text", async () => {
     useProjectStore
       .getState()
       .setLines([
@@ -606,11 +641,38 @@ describe("useSyncHandlers.handleJumpToWord (smart word redo)", () => {
       ]);
     useAudioStore.getState().seekTo(2.5);
     const { result, act, getSyncState } = await mountSyncHandlers();
+    const before = getSyncState().position;
 
-    await act(() => result.current.handleJumpToWord(1, 0));
+    await act(() => result.current.handleJumpToWord(1, 2));
 
-    expect(getSyncState().position).toEqual({ lineIndex: 1, wordIndex: 0 });
+    expect(getSyncState().position).toEqual(before);
     expect(useAudioStore.getState().currentTime).toBe(2.5);
+  });
+
+  it("regression: tapping after a jump writes the word at the cursor, not into slot 0", async () => {
+    useProjectStore.getState().setLines([
+      createLine({
+        id: "l0",
+        text: "one two three",
+        words: [
+          createWord({ text: "one ", begin: 0, end: 0.5 }),
+          createWord({ text: "two ", begin: 0.5, end: 1 }),
+          createWord({ text: "three", begin: 1, end: 1.5 }),
+        ],
+      }),
+    ]);
+    const { result, act, rerender, getSyncState } = await mountSyncHandlers({ initialCurrentTime: 4 });
+
+    await act(() => result.current.handleJumpToWord(0, 2));
+    expect(getSyncState().position).toEqual({ lineIndex: 0, wordIndex: 2 });
+
+    await rerender({ syncState: { position: { lineIndex: 0, wordIndex: 2 }, isActive: true }, currentTime: 4 });
+    await act(() => result.current.handleTap());
+
+    const words = useProjectStore.getState().lines[0].words ?? [];
+    expect(words).toHaveLength(3);
+    expect(words.map((w) => w.text)).toEqual(["one ", "two ", "three"]);
+    expect(words[2].begin).toBe(4);
   });
 
   it("in edit mode scrubs exactly to the word begin (no pre-roll) and moves the cursor to that word", async () => {

--- a/src/hooks/useSyncHandlers.browser.test.tsx
+++ b/src/hooks/useSyncHandlers.browser.test.tsx
@@ -719,6 +719,50 @@ describe("useSyncHandlers.handleJumpToWord (smart word redo)", () => {
     expect(lines[0].words?.[1].end).toBe(1);
   });
 
+  it("regression: pressing play after a jump still suppresses the previous-line close (issue #132)", async () => {
+    useProjectStore.getState().setLines([
+      createLine({
+        id: "l0",
+        text: "first line",
+        words: [createWord({ text: "first ", begin: 0, end: 0.5 }), createWord({ text: "line", begin: 0.5, end: 1 })],
+      }),
+      createLine({
+        id: "l1",
+        text: "second line",
+        words: [createWord({ text: "second ", begin: 8, end: 8.5 }), createWord({ text: "line", begin: 8.5, end: 9 })],
+      }),
+    ]);
+    const { result, act, rerender, getSyncState } = await mountSyncHandlers({ initialCurrentTime: 7 });
+
+    await act(() => result.current.handleJumpToWord(1, 0));
+    await rerender({ syncState: getSyncState(), currentTime: 7 });
+    await act(() => result.current.handleStartSync());
+    await rerender({ syncState: getSyncState(), currentTime: 7 });
+    await act(() => result.current.handleTap());
+
+    expect(useProjectStore.getState().lines[0].words?.[1].end).toBe(1);
+  });
+
+  it("regression: a jumped-to line re-record does not stretch the previous line at line granularity", async () => {
+    useProjectStore
+      .getState()
+      .setLines([
+        createLine({ id: "l0", text: "first line", begin: 0, end: 1 }),
+        createLine({ id: "l1", text: "second line", begin: 8, end: 9 }),
+      ]);
+    const { result, act, rerender, getSyncState } = await mountSyncHandlers({
+      granularity: "line",
+      initialCurrentTime: 7,
+    });
+
+    await act(() => result.current.handleJumpToLine(1));
+    await rerender({ syncState: getSyncState(), currentTime: 7 });
+    await act(() => result.current.handleTap());
+
+    expect(useProjectStore.getState().lines[0].end).toBe(1);
+    expect(useProjectStore.getState().lines[1].begin).toBe(7);
+  });
+
   it("still closes the previous line when the cursor advanced there normally", async () => {
     useProjectStore.getState().setLines([
       createLine({

--- a/src/hooks/useSyncHandlers.helpers.ts
+++ b/src/hooks/useSyncHandlers.helpers.ts
@@ -92,6 +92,7 @@ export {
   withBgSeedIfNeeded,
   buildInitialWordUpdates,
   advanceSyncPosition,
+  isSyncableLine,
   nextSyncableLineIndex,
   prevSyncableLine,
   triggerPulse,

--- a/src/hooks/useSyncHandlers.helpers.ts
+++ b/src/hooks/useSyncHandlers.helpers.ts
@@ -74,9 +74,17 @@ function advanceSyncPosition(
   const nextWordIndex = wordIndex + 1;
   if (nextWordIndex >= totalWords) {
     const nextLineIndex = nextSyncableLineIndex(lines, lineIndex);
-    setSyncState((prev) => ({ ...prev, position: { lineIndex: nextLineIndex, wordIndex: 0 } }));
+    setSyncState((prev) => ({
+      ...prev,
+      position: { lineIndex: nextLineIndex, wordIndex: 0 },
+      jumpedToPosition: false,
+    }));
   } else {
-    setSyncState((prev) => ({ ...prev, position: { ...prev.position, wordIndex: nextWordIndex } }));
+    setSyncState((prev) => ({
+      ...prev,
+      position: { ...prev.position, wordIndex: nextWordIndex },
+      jumpedToPosition: false,
+    }));
   }
 }
 

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -273,8 +273,6 @@ function useSyncHandlers({
       }));
       const bounds = effectiveBounds(lines[index]);
       if (!bounds) return;
-      // Edit mode scrubs exactly to the line to inspect timing; sync mode adds a
-      // pre-roll run-up to re-record. Both stay paused and move the cursor.
       seekTo(editMode ? bounds.begin : Math.max(0, bounds.begin - REDO_PREROLL_SECONDS));
     },
     [editMode, lines, seekTo, setSyncState],

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -27,10 +27,6 @@ import { nudgeLineBegin, setLineBegin } from "@/utils/timing/line-timing";
 import { nudgeWordBegin, setWordBegin, nudgeWordEnd, setWordEnd } from "@/utils/timing/word-timing";
 import { useCallback } from "react";
 
-// -- Constants ----------------------------------------------------------------
-
-const REDO_PREROLL_SECONDS = 1.5;
-
 // -- Types --------------------------------------------------------------------
 
 interface UseSyncHandlersProps {
@@ -277,7 +273,8 @@ function useSyncHandlers({
       }));
       const bounds = effectiveBounds(lines[index]);
       if (!bounds) return;
-      seekTo(editMode ? bounds.begin : Math.max(0, bounds.begin - REDO_PREROLL_SECONDS));
+      const preroll = useSettingsStore.getState().redoPreroll;
+      seekTo(editMode ? bounds.begin : Math.max(0, bounds.begin - preroll));
     },
     [editMode, lines, seekTo, setSyncState],
   );
@@ -290,7 +287,8 @@ function useSyncHandlers({
       }));
       const begin = lines[lineIdx]?.words?.[wordIdx]?.begin ?? effectiveBounds(lines[lineIdx])?.begin;
       if (begin === undefined) return;
-      seekTo(editMode ? begin : Math.max(0, begin - REDO_PREROLL_SECONDS));
+      const preroll = useSettingsStore.getState().redoPreroll;
+      seekTo(editMode ? begin : Math.max(0, begin - preroll));
     },
     [editMode, lines, seekTo, setSyncState],
   );
@@ -421,4 +419,4 @@ function useSyncHandlers({
 
 // -- Exports ------------------------------------------------------------------
 
-export { useSyncHandlers, REDO_PREROLL_SECONDS };
+export { useSyncHandlers };

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -281,10 +281,27 @@ function useSyncHandlers({
       const bounds = effectiveBounds(lines[index]);
       if (bounds) {
         seekTo(Math.max(0, bounds.begin - REDO_PREROLL_SECONDS));
-        setIsPlaying(true);
       }
     },
-    [editMode, lines, seekTo, setSyncState, setIsPlaying],
+    [editMode, lines, seekTo, setSyncState],
+  );
+
+  const handleJumpToWord = useCallback(
+    (lineIdx: number, wordIdx: number) => {
+      const begin = lines[lineIdx]?.words?.[wordIdx]?.begin ?? effectiveBounds(lines[lineIdx])?.begin;
+      if (editMode) {
+        if (begin !== undefined) seekTo(begin);
+        return;
+      }
+      setSyncState((prev) => ({
+        ...prev,
+        position: { lineIndex: lineIdx, wordIndex: wordIdx },
+      }));
+      if (begin !== undefined) {
+        seekTo(Math.max(0, begin - REDO_PREROLL_SECONDS));
+      }
+    },
+    [editMode, lines, seekTo, setSyncState],
   );
 
   const handleNudgeWord = useCallback(
@@ -392,6 +409,7 @@ function useSyncHandlers({
     handleReset,
     handleStartSync,
     handleJumpToLine,
+    handleJumpToWord,
     handleNudgeWord,
     handleSetWordTime,
     handleNudgeWordEnd,

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -26,6 +26,10 @@ import { nudgeLineBegin, setLineBegin } from "@/utils/timing/line-timing";
 import { nudgeWordBegin, setWordBegin, nudgeWordEnd, setWordEnd } from "@/utils/timing/word-timing";
 import { useCallback } from "react";
 
+// -- Constants ----------------------------------------------------------------
+
+const REDO_PREROLL_SECONDS = 1.5;
+
 // -- Types --------------------------------------------------------------------
 
 interface UseSyncHandlersProps {
@@ -274,8 +278,13 @@ function useSyncHandlers({
         ...prev,
         position: { lineIndex: index, wordIndex: 0 },
       }));
+      const bounds = effectiveBounds(lines[index]);
+      if (bounds) {
+        seekTo(Math.max(0, bounds.begin - REDO_PREROLL_SECONDS));
+        setIsPlaying(true);
+      }
     },
-    [editMode, lines, seekTo, setSyncState],
+    [editMode, lines, seekTo, setSyncState, setIsPlaying],
   );
 
   const handleNudgeWord = useCallback(
@@ -403,4 +412,4 @@ function useSyncHandlers({
 
 // -- Exports ------------------------------------------------------------------
 
-export { useSyncHandlers };
+export { useSyncHandlers, REDO_PREROLL_SECONDS };

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -15,6 +15,7 @@ import {
 import {
   advanceSyncPosition,
   buildInitialWordUpdates,
+  isSyncableLine,
   nextSyncableLineIndex,
   prepareSyncWord,
   prevSyncableLine,
@@ -261,9 +262,12 @@ function useSyncHandlers({
   }, [lines, setSyncState, confirm]);
 
   const handleStartSync = useCallback(() => {
-    setSyncState({ position: { lineIndex: nextSyncableLineIndex(lines, -1), wordIndex: 0 }, isActive: true });
+    const { lineIndex: cursorLine, wordIndex: cursorWord } = syncState.position;
+    const startLine = isSyncableLine(lines[cursorLine]) ? cursorLine : nextSyncableLineIndex(lines, -1);
+    const startWord = startLine === cursorLine ? cursorWord : 0;
+    setSyncState({ position: { lineIndex: startLine, wordIndex: startWord }, isActive: true });
     setIsPlaying(true);
-  }, [lines, setIsPlaying, setSyncState]);
+  }, [lines, syncState.position, setIsPlaying, setSyncState]);
 
   const handleJumpToLine = useCallback(
     (index: number) => {

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -267,39 +267,28 @@ function useSyncHandlers({
 
   const handleJumpToLine = useCallback(
     (index: number) => {
-      if (editMode) {
-        const timing = effectiveBounds(lines[index]);
-        if (timing) {
-          seekTo(timing.begin);
-        }
-        return;
-      }
       setSyncState((prev) => ({
         ...prev,
         position: { lineIndex: index, wordIndex: 0 },
       }));
       const bounds = effectiveBounds(lines[index]);
-      if (bounds) {
-        seekTo(Math.max(0, bounds.begin - REDO_PREROLL_SECONDS));
-      }
+      if (!bounds) return;
+      // Edit mode scrubs exactly to the line to inspect timing; sync mode adds a
+      // pre-roll run-up to re-record. Both stay paused and move the cursor.
+      seekTo(editMode ? bounds.begin : Math.max(0, bounds.begin - REDO_PREROLL_SECONDS));
     },
     [editMode, lines, seekTo, setSyncState],
   );
 
   const handleJumpToWord = useCallback(
     (lineIdx: number, wordIdx: number) => {
-      const begin = lines[lineIdx]?.words?.[wordIdx]?.begin ?? effectiveBounds(lines[lineIdx])?.begin;
-      if (editMode) {
-        if (begin !== undefined) seekTo(begin);
-        return;
-      }
       setSyncState((prev) => ({
         ...prev,
         position: { lineIndex: lineIdx, wordIndex: wordIdx },
       }));
-      if (begin !== undefined) {
-        seekTo(Math.max(0, begin - REDO_PREROLL_SECONDS));
-      }
+      const begin = lines[lineIdx]?.words?.[wordIdx]?.begin ?? effectiveBounds(lines[lineIdx])?.begin;
+      if (begin === undefined) return;
+      seekTo(editMode ? begin : Math.max(0, begin - REDO_PREROLL_SECONDS));
     },
     [editMode, lines, seekTo, setSyncState],
   );

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -265,7 +265,15 @@ function useSyncHandlers({
     const { lineIndex: cursorLine, wordIndex: cursorWord } = syncState.position;
     const startLine = isSyncableLine(lines[cursorLine]) ? cursorLine : nextSyncableLineIndex(lines, -1);
     const startWord = startLine === cursorLine ? cursorWord : 0;
-    setSyncState({ position: { lineIndex: startLine, wordIndex: startWord }, isActive: true });
+    // Pressing play is how a re-record actually starts, so it has to carry the
+    // jump forward. Only a cursor that had to be relocated counts as a fresh
+    // forward pass.
+    setSyncState((prev) => ({
+      ...prev,
+      position: { lineIndex: startLine, wordIndex: startWord },
+      isActive: true,
+      jumpedToPosition: startLine === cursorLine ? prev.jumpedToPosition : false,
+    }));
     setIsPlaying(true);
   }, [lines, syncState.position, setIsPlaying, setSyncState]);
 

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -266,6 +266,17 @@ function useSyncHandlers({
     setIsPlaying(true);
   }, [lines, syncState.position, setIsPlaying, setSyncState]);
 
+  // Re-recording seeks back and waits for the user to start playback, so a jump
+  // never leaves the transport running underneath them.
+  const seekForRedo = useCallback(
+    (begin: number) => {
+      setIsPlaying(false);
+      const preroll = useSettingsStore.getState().redoPreroll;
+      seekTo(editMode ? begin : Math.max(0, begin - preroll));
+    },
+    [editMode, seekTo, setIsPlaying],
+  );
+
   const handleJumpToLine = useCallback(
     (index: number) => {
       setSyncState((prev) => ({
@@ -274,24 +285,25 @@ function useSyncHandlers({
       }));
       const bounds = effectiveBounds(lines[index]);
       if (!bounds) return;
-      const preroll = useSettingsStore.getState().redoPreroll;
-      seekTo(editMode ? bounds.begin : Math.max(0, bounds.begin - preroll));
+      seekForRedo(bounds.begin);
     },
-    [editMode, lines, seekTo, setSyncState],
+    [lines, seekForRedo, setSyncState],
   );
 
+  // Only a word that already carries timing can be re-recorded: parking the
+  // cursor on an untimed word would make the next tap write it into slot 0 and
+  // silently drop every word before it.
   const handleJumpToWord = useCallback(
     (lineIdx: number, wordIdx: number) => {
+      const word = lines[lineIdx]?.words?.[wordIdx];
+      if (!word) return;
       setSyncState((prev) => ({
         ...prev,
         position: { lineIndex: lineIdx, wordIndex: wordIdx },
       }));
-      const begin = lines[lineIdx]?.words?.[wordIdx]?.begin ?? effectiveBounds(lines[lineIdx])?.begin;
-      if (begin === undefined) return;
-      const preroll = useSettingsStore.getState().redoPreroll;
-      seekTo(editMode ? begin : Math.max(0, begin - preroll));
+      seekForRedo(word.begin);
     },
-    [editMode, lines, seekTo, setSyncState],
+    [lines, seekForRedo, setSyncState],
   );
 
   const handleNudgeWord = useCallback(

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -79,7 +79,7 @@ function useSyncHandlers({
       updateLineWithHistory(line.id, updates, { deriveText: false, propagateToSiblings: false });
     }
 
-    if (wordIndex === 0 && prevLine?.words?.length) {
+    if (wordIndex === 0 && !syncState.jumpedToPosition && prevLine?.words?.length) {
       const prevWords = [...prevLine.words];
       prevWords[prevWords.length - 1] = {
         ...prevWords[prevWords.length - 1],
@@ -101,6 +101,7 @@ function useSyncHandlers({
     prevLine,
     setShowPulse,
     setSyncState,
+    syncState.jumpedToPosition,
   ]);
 
   const handleTapLine = useCallback(() => {
@@ -109,7 +110,7 @@ function useSyncHandlers({
     const line = lines[lineIndex];
     if (!line) return;
 
-    if (prevLine?.begin !== undefined) {
+    if (prevLine?.begin !== undefined && !syncState.jumpedToPosition) {
       updateLine(prevLine.id, { end: currentTime }, { deriveText: false });
     }
 
@@ -120,6 +121,7 @@ function useSyncHandlers({
     setSyncState((prev) => ({
       ...prev,
       position: { lineIndex: nextSyncableLineIndex(lines, lineIndex), wordIndex: 0 },
+      jumpedToPosition: false,
     }));
   }, [
     lines,
@@ -131,6 +133,7 @@ function useSyncHandlers({
     prevLine,
     setShowPulse,
     setSyncState,
+    syncState.jumpedToPosition,
   ]);
 
   const handleHoldStart = useCallback(() => {
@@ -287,6 +290,7 @@ function useSyncHandlers({
       setSyncState((prev) => ({
         ...prev,
         position: { lineIndex: index, wordIndex: 0 },
+        jumpedToPosition: true,
       }));
       const bounds = effectiveBounds(lines[index]);
       if (!bounds) return;
@@ -305,6 +309,7 @@ function useSyncHandlers({
       setSyncState((prev) => ({
         ...prev,
         position: { lineIndex: lineIdx, wordIndex: wordIdx },
+        jumpedToPosition: true,
       }));
       seekForRedo(word.begin);
     },

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -6,6 +6,7 @@ import type { WordTiming } from "@/domain/word/timing";
 import { useSettingsStore } from "@/stores/settings";
 import { effectiveBounds } from "@/domain/line/bounds";
 import {
+  closeHeldWord,
   commitHeldWord,
   commitTappedWord,
   type SyncState,
@@ -165,9 +166,7 @@ function useSyncHandlers({
 
     const { parts: lineWords } = splitIntoWordsWithMeta(line.text);
 
-    const updatedWords = [...line.words];
-    const currentWordEntry = updatedWords[updatedWords.length - 1];
-    updatedWords[updatedWords.length - 1] = { ...currentWordEntry, end: currentTime };
+    const updatedWords = closeHeldWord(line.words, wordIndex, currentTime);
     updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false, propagateToSiblings: false });
 
     triggerPulse(setShowPulse);
@@ -182,15 +181,13 @@ function useSyncHandlers({
 
     const { parts: lineWords, trailingSpace } = splitIntoWordsWithMeta(line.text);
 
-    const updatedWords = [...line.words];
-    const currentWordEntry = updatedWords[updatedWords.length - 1];
-    updatedWords[updatedWords.length - 1] = { ...currentWordEntry, end: currentTime };
+    const closedWords = closeHeldWord(line.words, wordIndex, currentTime);
 
     const nextWordIndex = wordIndex + 1;
     const advancesToNextLine = nextWordIndex >= lineWords.length;
 
     if (advancesToNextLine) {
-      updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false, propagateToSiblings: false });
+      updateLineWithHistory(line.id, { words: closedWords }, { deriveText: false, propagateToSiblings: false });
 
       const nextLineIndex = nextSyncableLineIndex(lines, lineIndex);
       const nextLine = lines[nextLineIndex];
@@ -210,11 +207,15 @@ function useSyncHandlers({
       }));
     } else {
       const nextWordText = lineWords[nextWordIndex];
-      if (nextWordText) {
-        const textWithSpace = trailingSpace[nextWordIndex] ? `${nextWordText} ` : nextWordText;
-        updatedWords.push({ text: textWithSpace, begin: currentTime, end: currentTime });
-      }
-      updateLineWithHistory(line.id, { words: updatedWords }, { deriveText: false, propagateToSiblings: false });
+      const openedWords = nextWordText
+        ? commitHeldWord(
+            closedWords,
+            nextWordIndex,
+            trailingSpace[nextWordIndex] ? `${nextWordText} ` : nextWordText,
+            currentTime,
+          )
+        : closedWords;
+      updateLineWithHistory(line.id, { words: openedWords }, { deriveText: false, propagateToSiblings: false });
 
       setSyncState((prev) => ({
         ...prev,

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -266,13 +266,18 @@ function useSyncHandlers({
     setIsPlaying(true);
   }, [lines, syncState.position, setIsPlaying, setSyncState]);
 
-  // Re-recording seeks back and waits for the user to start playback, so a jump
-  // never leaves the transport running underneath them.
+  // Re-recording seeks back and waits for the user to start playback. Edit mode
+  // is the exception: there a click is a scrub for auditioning timings, so
+  // playback is left alone.
   const seekForRedo = useCallback(
     (begin: number) => {
+      if (editMode) {
+        seekTo(begin);
+        return;
+      }
       setIsPlaying(false);
       const preroll = useSettingsStore.getState().redoPreroll;
-      seekTo(editMode ? begin : Math.max(0, begin - preroll));
+      seekTo(Math.max(0, begin - preroll));
     },
     [editMode, seekTo, setIsPlaying],
   );

--- a/src/hooks/useSyncHandlers.ts
+++ b/src/hooks/useSyncHandlers.ts
@@ -306,6 +306,18 @@ function useSyncHandlers({
     [lines, seekForRedo, setSyncState],
   );
 
+  // The sync cursor addresses main words only, so a background word can be
+  // scrubbed to but not re-recorded from. Moving the cursor here would make the
+  // next tap overwrite the main word at the same index.
+  const handleJumpToBgWord = useCallback(
+    (lineIdx: number, wordIdx: number) => {
+      const word = lines[lineIdx]?.backgroundWords?.[wordIdx];
+      if (!word) return;
+      seekForRedo(word.begin);
+    },
+    [lines, seekForRedo],
+  );
+
   const handleNudgeWord = useCallback(
     (lineIdx: number, wordIdx: number, delta: number) =>
       nudgeWordBegin(lines, lineIdx, wordIdx, delta, updateLineWithHistory),
@@ -412,6 +424,7 @@ function useSyncHandlers({
     handleStartSync,
     handleJumpToLine,
     handleJumpToWord,
+    handleJumpToBgWord,
     handleNudgeWord,
     handleSetWordTime,
     handleNudgeWordEnd,

--- a/src/lib/persistence.snap-points.browser.test.ts
+++ b/src/lib/persistence.snap-points.browser.test.ts
@@ -13,7 +13,7 @@ import { snapPoints } from "@/test/factories";
 
 function saveWithSnapPoints(customSnapPoints: SnapPoint[]): Promise<void> {
   return saveCurrentProject(
-    { title: "snap", artist: "", album: "", duration: 0 },
+    { title: "snap", artists: [], album: "", duration: 0 },
     DEFAULT_AGENTS,
     [{ id: "L1", text: "hello", agentId: DEFAULT_AGENTS[0].id }],
     [],
@@ -71,7 +71,7 @@ describe("persistence · customSnapPoints", () => {
     const legacyRecord: SavedProject = {
       version: 1,
       savedAt: Date.now(),
-      metadata: { title: "legacy", artist: "", album: "", duration: 0 },
+      metadata: { title: "legacy", artists: [], album: "", duration: 0 },
       agents: DEFAULT_AGENTS,
       lines: [{ id: "L1", text: "hello", agentId: DEFAULT_AGENTS[0].id }],
       groups: [],

--- a/src/lib/persistence.test.ts
+++ b/src/lib/persistence.test.ts
@@ -4,7 +4,7 @@ import { importProjectFromFile } from "@/lib/persistence";
 
 describe("persistence: syllableSplitDefaults", () => {
   it("round-trips syllableSplitDefaults through importProjectFromFile", async () => {
-    const metadata = { title: "Song", artist: "", album: "", duration: 0 };
+    const metadata = { title: "Song", artists: [], album: "", duration: 0 };
     const payload = {
       version: 1 as const,
       savedAt: Date.now(),
@@ -23,7 +23,7 @@ describe("persistence: syllableSplitDefaults", () => {
   });
 
   it("fills in defaults when older project file is missing syllableSplitDefaults", async () => {
-    const metadata = { title: "Old Song", artist: "", album: "", duration: 0 };
+    const metadata = { title: "Old Song", artists: [], album: "", duration: 0 };
     const legacyPayload = {
       version: 1 as const,
       savedAt: Date.now(),
@@ -43,7 +43,7 @@ describe("persistence: syllableSplitDefaults", () => {
 
 describe("persistence: primingStripped round-trip", () => {
   it("persists and reads back primingStripped through importProjectFromFile", async () => {
-    const metadata = { title: "Song", artist: "", album: "", duration: 0 };
+    const metadata = { title: "Song", artists: [], album: "", duration: 0 };
     const payload = {
       version: 1 as const,
       savedAt: Date.now(),
@@ -63,7 +63,7 @@ describe("persistence: primingStripped round-trip", () => {
   });
 
   it("leaves primingStripped undefined when importing a pre-strip project", async () => {
-    const metadata = { title: "Old", artist: "", album: "", duration: 0 };
+    const metadata = { title: "Old", artists: [], album: "", duration: 0 };
     const legacy = {
       version: 1 as const,
       savedAt: Date.now(),
@@ -81,7 +81,7 @@ describe("persistence: primingStripped round-trip", () => {
   });
 
   it("preserves primingStripped=false explicitly", async () => {
-    const metadata = { title: "Mid", artist: "", album: "", duration: 0 };
+    const metadata = { title: "Mid", artists: [], album: "", duration: 0 };
     const payload = {
       version: 1 as const,
       savedAt: Date.now(),
@@ -102,7 +102,7 @@ describe("persistence: primingStripped round-trip", () => {
 
 describe("persistence: customSnapPoints round-trip", () => {
   it("importProjectFromFile preserves customSnapPoints when present", async () => {
-    const metadata = { title: "Song", artist: "", album: "", duration: 0 };
+    const metadata = { title: "Song", artists: [], album: "", duration: 0 };
     const payload = {
       version: 1 as const,
       savedAt: Date.now(),
@@ -121,7 +121,7 @@ describe("persistence: customSnapPoints round-trip", () => {
   });
 
   it("leaves customSnapPoints undefined when importing a legacy project without the field", async () => {
-    const metadata = { title: "Old", artist: "", album: "", duration: 0 };
+    const metadata = { title: "Old", artists: [], album: "", duration: 0 };
     const legacy = {
       version: 1 as const,
       savedAt: Date.now(),

--- a/src/lib/project-non-empty.ts
+++ b/src/lib/project-non-empty.ts
@@ -1,0 +1,34 @@
+import { normalizeLoadedMetadata } from "@/domain/project/normalize-metadata";
+import { loadCurrentProject } from "@/lib/persistence";
+import { useProjectStore } from "@/stores/project";
+
+// -- Constants ----------------------------------------------------------------
+
+const LOG_PREFIX = "[Composer]";
+
+// -- Emptiness ----------------------------------------------------------------
+
+// Checks the live store first, then the persisted project, so a deep link that
+// lands before persistence restores still sees the work it would overwrite.
+async function isProjectNonEmpty(): Promise<boolean> {
+  const state = useProjectStore.getState();
+  if (state.lines.length > 0) return true;
+  const { title, artists, album } = state.metadata;
+  if (title || artists.length || album) return true;
+
+  let saved: Awaited<ReturnType<typeof loadCurrentProject>>;
+  try {
+    saved = await loadCurrentProject();
+  } catch (error) {
+    console.warn(`${LOG_PREFIX} could not read the saved project`, error);
+    return false;
+  }
+  if (!saved) return false;
+  if (saved.lines.length > 0) return true;
+  const savedMetadata = normalizeLoadedMetadata(saved.metadata);
+  return Boolean(savedMetadata.title || savedMetadata.artists.length || savedMetadata.album);
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { isProjectNonEmpty };

--- a/src/lib/project-non-empty.ts
+++ b/src/lib/project-non-empty.ts
@@ -2,10 +2,6 @@ import { normalizeLoadedMetadata } from "@/domain/project/normalize-metadata";
 import { loadCurrentProject } from "@/lib/persistence";
 import { useProjectStore } from "@/stores/project";
 
-// -- Constants ----------------------------------------------------------------
-
-const LOG_PREFIX = "[Composer]";
-
 // -- Emptiness ----------------------------------------------------------------
 
 // Checks the live store first, then the persisted project, so a deep link that
@@ -16,13 +12,10 @@ async function isProjectNonEmpty(): Promise<boolean> {
   const { title, artists, album } = state.metadata;
   if (title || artists.length || album) return true;
 
-  let saved: Awaited<ReturnType<typeof loadCurrentProject>>;
-  try {
-    saved = await loadCurrentProject();
-  } catch (error) {
-    console.warn(`${LOG_PREFIX} could not read the saved project`, error);
-    return false;
-  }
+  // A read failure is reported, not swallowed: whether an unreadable project
+  // should block a destructive action depends on what that action replaces, so
+  // the decision belongs to the caller.
+  const saved = await loadCurrentProject();
   if (!saved) return false;
   if (saved.lines.length > 0) return true;
   const savedMetadata = normalizeLoadedMetadata(saved.metadata);

--- a/src/pages/converters/lrc-to-ttml.tsx
+++ b/src/pages/converters/lrc-to-ttml.tsx
@@ -64,7 +64,7 @@ function convertLrc({ input, filename }: ConvertArgs): { ttml: string; projectPa
     }
     const metadata: ProjectMetadata = {
       title: result.metadata.title ?? "",
-      artist: result.metadata.artist ?? "",
+      artists: result.metadata.artists ?? [],
       album: result.metadata.album ?? "",
       duration: 0,
       language: result.metadata.language,

--- a/src/pages/converters/srt-to-ttml.tsx
+++ b/src/pages/converters/srt-to-ttml.tsx
@@ -67,7 +67,7 @@ function convertSrt({ input, filename }: ConvertArgs): { ttml: string; projectPa
     }
     const metadata: ProjectMetadata = {
       title: result.metadata.title ?? "",
-      artist: result.metadata.artist ?? "",
+      artists: result.metadata.artists ?? [],
       album: result.metadata.album ?? "",
       duration: 0,
       language: result.metadata.language,

--- a/src/stores/project.propagation-opt-out.test.ts
+++ b/src/stores/project.propagation-opt-out.test.ts
@@ -301,32 +301,35 @@ describe("instance resync · issue #96 reproduction", () => {
     expect(getLine("a2").words).toEqual(cWords);
   });
 
-  it("a single partial tap (the worst-case squash state) leaves the sibling intact", () => {
+  it("a partial re-tap keeps the source's later words and leaves the sibling intact", () => {
     seedTwoWordSyncedInstances();
 
-    // Resync only word 0 and stop. Mid-resync the source array transiently
-    // holds one word: this is the state that previously collapsed the sibling.
+    // Re-tap only word 0 and stop. Preserve-in-place re-tap keeps the source's later
+    // words (no transient one-word squash), and the propagation opt-out keeps the
+    // sibling untouched.
     tapResync("a0", 0, 0.5, 0.8);
 
-    expect(getLine("a0").words).toHaveLength(1);
+    expect(getLine("a0").words).toHaveLength(3);
+    expect(getLine("a0").words?.[0].begin).toBe(0.5);
     expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
     expect(getLine("a1").words).toHaveLength(3);
   });
 
-  it("characterizes the bug: a resync left to propagate DOES squash the sibling", () => {
+  it("preserve-in-place keeps the word count stable, so a propagating re-tap no longer squashes the sibling", () => {
     seedTwoWordSyncedInstances();
 
-    // The pre-fix call signature: handleTapWord passed only { deriveText: false }
-    // with no opt-out, so propagation fired on the transient one-word array and
-    // collapsed the sibling. This is the behavior the opt-out must prevent.
+    // Pre-fix, re-tapping word 0 truncated the source to one word; that transient count
+    // change made propagation collapse the sibling (issue #96). Preserve-in-place keeps
+    // all three words, so even with propagation on (no opt-out), the smart word-count
+    // propagation leaves the sibling's per-word timing untouched.
     const line = getLine("a0");
     const { parts, trailingSpace } = splitIntoWordsWithMeta(line.text);
     const text = trailingSpace[0] ? `${parts[0]} ` : parts[0];
     const updated = commitTappedWord(line.words ?? [], 0, text, 0.5, 0.8);
     useProjectStore.getState().updateLineWithHistory("a0", { words: updated }, { deriveText: false });
 
-    expect(getLine("a1").words).toHaveLength(1);
-    expect(getLine("a1").words).not.toEqual(INSTANCE_B_WORDS);
+    expect(getLine("a1").words).toHaveLength(3);
+    expect(getLine("a1").words).toEqual(INSTANCE_B_WORDS);
   });
 });
 

--- a/src/stores/project.propagation-opt-out.test.ts
+++ b/src/stores/project.propagation-opt-out.test.ts
@@ -304,9 +304,6 @@ describe("instance resync · issue #96 reproduction", () => {
   it("a partial re-tap keeps the source's later words and leaves the sibling intact", () => {
     seedTwoWordSyncedInstances();
 
-    // Re-tap only word 0 and stop. Preserve-in-place re-tap keeps the source's later
-    // words (no transient one-word squash), and the propagation opt-out keeps the
-    // sibling untouched.
     tapResync("a0", 0, 0.5, 0.8);
 
     expect(getLine("a0").words).toHaveLength(3);
@@ -318,10 +315,7 @@ describe("instance resync · issue #96 reproduction", () => {
   it("preserve-in-place keeps the word count stable, so a propagating re-tap no longer squashes the sibling", () => {
     seedTwoWordSyncedInstances();
 
-    // Pre-fix, re-tapping word 0 truncated the source to one word; that transient count
-    // change made propagation collapse the sibling (issue #96). Preserve-in-place keeps
-    // all three words, so even with propagation on (no opt-out), the smart word-count
-    // propagation leaves the sibling's per-word timing untouched.
+    // Regression guard for issue #96.
     const line = getLine("a0");
     const { parts, trailingSpace } = splitIntoWordsWithMeta(line.text);
     const text = trailingSpace[0] ? `${parts[0]} ` : parts[0];

--- a/src/stores/project/metadata-slice.ts
+++ b/src/stores/project/metadata-slice.ts
@@ -14,7 +14,7 @@ function createMetadataInitialState(): MetadataState {
   return {
     metadata: {
       title: "",
-      artist: "",
+      artists: [],
       album: "",
       duration: 0,
     },

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -277,3 +277,41 @@ describe("timeline store reads header-toggle defaults at init", () => {
     expect(useTimelineStore.getState().rollingEditMode).toBe(useSettingsStore.getState().defaultRollingEdit);
   });
 });
+
+describe("re-record pre-roll setting", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ ...DEFAULTS });
+  });
+
+  it("defaults to 1.5 seconds", () => {
+    expect(useSettingsStore.getState().redoPreroll).toBe(1.5);
+  });
+
+  it("can be changed via set()", () => {
+    useSettingsStore.getState().set("redoPreroll", 0.5);
+    expect(useSettingsStore.getState().redoPreroll).toBe(0.5);
+  });
+
+  it("allows zero for an exact-begin seek", () => {
+    useSettingsStore.getState().set("redoPreroll", 0);
+    expect(useSettingsStore.getState().redoPreroll).toBe(0);
+  });
+
+  it("resetToDefaults restores the default pre-roll", () => {
+    useSettingsStore.getState().set("redoPreroll", 3);
+    useSettingsStore.getState().resetToDefaults();
+    expect(useSettingsStore.getState().redoPreroll).toBe(1.5);
+  });
+
+  it("migration backfills a missing pre-roll to the default", async () => {
+    const { migrateSettingsForTest } = await import("@/stores/settings");
+    const migrated = migrateSettingsForTest({ defaultZoom: 200 }, 5) as { redoPreroll: number };
+    expect(migrated.redoPreroll).toBe(1.5);
+  });
+
+  it("migration preserves an explicitly set pre-roll", async () => {
+    const { migrateSettingsForTest } = await import("@/stores/settings");
+    const migrated = migrateSettingsForTest({ redoPreroll: 0.25 }, 5) as { redoPreroll: number };
+    expect(migrated.redoPreroll).toBe(0.25);
+  });
+});

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -47,6 +47,7 @@ interface SettingsState {
   nudgeAmount: number;
   defaultWordDuration: number;
   minWordDuration: number;
+  redoPreroll: number;
   defaultGranularity: GranularityDefault;
 
   autoSaveDelay: number;
@@ -113,6 +114,7 @@ const DEFAULTS: SettingsState = {
   nudgeAmount: 0.05,
   defaultWordDuration: 0.3,
   minWordDuration: 0.05,
+  redoPreroll: 1.5,
   defaultGranularity: "word",
 
   autoSaveDelay: 2000,
@@ -166,6 +168,7 @@ function migrateSettings(persistedState: unknown, version: number): unknown {
   if (next.defaultPreviewSidebar === undefined) next.defaultPreviewSidebar = false;
   if (next.vocalOnsetSnap === undefined) next.vocalOnsetSnap = true;
   if (next.snapPlayheadToPoints === undefined) next.snapPlayheadToPoints = true;
+  if (next.redoPreroll === undefined) next.redoPreroll = 1.5;
   return next;
 }
 

--- a/src/ui/settings/sync-section.browser.test.tsx
+++ b/src/ui/settings/sync-section.browser.test.tsx
@@ -7,8 +7,9 @@ describe("SyncSection", () => {
   it("renders the split character control, sliders, and granularity select", async () => {
     const screen = await render(<SyncSection />);
     await expect.element(screen.getByText("Split character")).toBeInTheDocument();
+    await expect.element(screen.getByText("Re-record pre-roll")).toBeInTheDocument();
     await expect.element(screen.getByRole("button", { name: "Default granularity" })).toBeInTheDocument();
-    expect(screen.container.querySelectorAll('input[type="range"]').length).toBe(3);
+    expect(screen.container.querySelectorAll('input[type="range"]').length).toBe(4);
   });
 
   it("updates the default granularity from the select", async () => {

--- a/src/ui/settings/sync-section.tsx
+++ b/src/ui/settings/sync-section.tsx
@@ -33,6 +33,15 @@ const SyncSection: React.FC = () => (
       step={0.01}
       format={(v) => `${(v * 1000).toFixed(0)}ms`}
     />
+    <SliderSetting
+      label="Re-record pre-roll"
+      description="How far before the selected line or word playback starts when re-recording in Sync."
+      settingKey="redoPreroll"
+      min={0}
+      max={5}
+      step={0.1}
+      format={(v) => `${(v * 1000).toFixed(0)}ms`}
+    />
     <SelectSetting
       label="Default granularity"
       description="Whether new projects start in word or line timing mode."

--- a/src/utils/animationVariants.ts
+++ b/src/utils/animationVariants.ts
@@ -97,6 +97,19 @@ const snapFlashVariants: Variants = {
   },
 };
 
+// -- Accordion ----------------------------------------------------------------
+
+const accordionTransition: Transition = {
+  type: "spring",
+  stiffness: 500,
+  damping: 40,
+};
+
+const accordionVariants: Variants = {
+  hidden: { height: 0, opacity: 0 },
+  visible: { height: "auto", opacity: 1 },
+};
+
 // -- Stagger Container --------------------------------------------------------
 
 // -- Exports ------------------------------------------------------------------
@@ -111,4 +124,6 @@ export {
   shimmerVariants,
   pinDropInVariants,
   snapFlashVariants,
+  accordionTransition,
+  accordionVariants,
 };

--- a/src/utils/audio-tags.test.ts
+++ b/src/utils/audio-tags.test.ts
@@ -1,0 +1,88 @@
+import { parseBlob } from "music-metadata";
+import { describe, expect, it } from "vitest";
+import { audioTagsToMetadata } from "@/utils/audio-tags";
+
+// -- Helpers ------------------------------------------------------------------
+
+function id3v2(frames: Array<[string, string]>): Uint8Array {
+  const enc = new TextEncoder();
+  const body: number[] = [];
+  for (const [id, text] of frames) {
+    const content = [0x03, ...enc.encode(text)];
+    const size = content.length;
+    body.push(
+      ...enc.encode(id),
+      (size >> 24) & 0xff,
+      (size >> 16) & 0xff,
+      (size >> 8) & 0xff,
+      size & 0xff,
+      0,
+      0,
+      ...content,
+    );
+  }
+  const synch = (n: number) => [(n >> 21) & 0x7f, (n >> 14) & 0x7f, (n >> 7) & 0x7f, n & 0x7f];
+  return new Uint8Array([0x49, 0x44, 0x33, 3, 0, 0, ...synch(body.length), ...body]);
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("audioTagsToMetadata", () => {
+  it("maps title/artist/album/isrc from real ID3 tags", async () => {
+    const bytes = id3v2([
+      ["TIT2", "Song"],
+      ["TPE1", "Tyler, The Creator"],
+      ["TALB", "Flower Boy"],
+      ["TSRC", "USQX91700001"],
+    ]);
+    const { common } = await parseBlob(new Blob([bytes], { type: "audio/mpeg" }));
+    expect(audioTagsToMetadata(common)).toEqual({
+      title: "Song",
+      artists: ["Tyler, The Creator"],
+      album: "Flower Boy",
+      isrc: "USQX91700001",
+    });
+  });
+
+  describe("edge cases", () => {
+    it("omits absent fields", () => expect(audioTagsToMetadata({})).toEqual({}));
+
+    it("drops an invalid isrc", () => expect(audioTagsToMetadata({ isrc: ["nope"] })).toEqual({}));
+
+    it("prefers common.artists over common.artist", () => {
+      expect(audioTagsToMetadata({ artists: ["A", "B"], artist: "A; B" }).artists).toEqual(["A", "B"]);
+    });
+
+    it("falls back to common.artist when artists is absent", () => {
+      expect(audioTagsToMetadata({ artist: "Solo" }).artists).toEqual(["Solo"]);
+    });
+
+    it("filters out empty/falsy entries in common.artists", () => {
+      expect(audioTagsToMetadata({ artists: ["A", "", "B"] }).artists).toEqual(["A", "B"]);
+    });
+
+    it("omits artists when every entry is empty", () => {
+      expect(audioTagsToMetadata({ artists: ["", ""] }).artists).toBeUndefined();
+    });
+
+    it("normalizes a lowercase isrc to uppercase", () => {
+      expect(audioTagsToMetadata({ isrc: ["usqx91700001"] }).isrc).toBe("USQX91700001");
+    });
+
+    it("picks the first valid isrc when multiple are present", () => {
+      expect(audioTagsToMetadata({ isrc: ["nope", "USQX91700001", "USQX91700002"] }).isrc).toBe("USQX91700001");
+    });
+  });
+
+  describe("invariants", () => {
+    it("never returns title/album when blank strings are passed", () => {
+      expect(audioTagsToMetadata({ title: "", album: "" })).toEqual({});
+    });
+
+    it("does not mutate the input common object", () => {
+      const common = { artists: ["A", ""], isrc: ["usqx91700001"] };
+      audioTagsToMetadata(common);
+      expect(common).toEqual({ artists: ["A", ""], isrc: ["usqx91700001"] });
+    });
+  });
+});

--- a/src/utils/audio-tags.ts
+++ b/src/utils/audio-tags.ts
@@ -1,0 +1,20 @@
+import type { ICommonTagsResult } from "music-metadata";
+import type { ProjectMetadata } from "@/domain/project/metadata";
+import { normalizeIsrc } from "@/utils/isrc";
+
+// -- Mapper -------------------------------------------------------------------
+
+function audioTagsToMetadata(common: Partial<ICommonTagsResult>): Partial<ProjectMetadata> {
+  const out: Partial<ProjectMetadata> = {};
+  if (common.title) out.title = common.title;
+  const artists = common.artists?.filter(Boolean) ?? (common.artist ? [common.artist] : []);
+  if (artists.length) out.artists = artists;
+  if (common.album) out.album = common.album;
+  const isrc = common.isrc?.map(normalizeIsrc).find(Boolean);
+  if (isrc) out.isrc = isrc;
+  return out;
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { audioTagsToMetadata };

--- a/src/utils/composer-bridge-api.test.ts
+++ b/src/utils/composer-bridge-api.test.ts
@@ -6,6 +6,7 @@ import {
   decodeHeader,
   extensionForBridgeMime,
   formatBridgeErrorForToast,
+  getAudioFromBridge,
   normalizeBaseUrl,
 } from "@/utils/composer-bridge-api";
 
@@ -327,5 +328,53 @@ describe("formatBridgeErrorForToast", () => {
     expect(formatBridgeErrorForToast(new Error("boom"))).toMatch(/unknown reason/);
     expect(formatBridgeErrorForToast("string error")).toMatch(/unknown reason/);
     expect(formatBridgeErrorForToast(null)).toMatch(/unknown reason/);
+  });
+});
+
+// -- getAudioFromBridge -------------------------------------------------------
+
+describe("getAudioFromBridge", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubAudioResponse(headers: Record<string, string>): void {
+    vi.stubGlobal("fetch", async (): Promise<Response> => {
+      const responseHeaders = new Headers({ "content-type": "audio/opus", ...headers });
+      return new Response(new TextEncoder().encode("opus-bytes").buffer, { headers: responseHeaders });
+    });
+  }
+
+  it("reads isrc from the x-track-isrc header", async () => {
+    stubAudioResponse({ "x-track-isrc": encodeURIComponent("GBARL9300135") });
+
+    const audio = await getAudioFromBridge("http://localhost:7777", "dQw4w9WgXcQ");
+
+    expect(audio.isrc).toBe("GBARL9300135");
+  });
+
+  it("leaves isrc undefined when the x-track-isrc header is absent", async () => {
+    stubAudioResponse({ "x-track-title": encodeURIComponent("Never Gonna Give You Up") });
+
+    const audio = await getAudioFromBridge("http://localhost:7777", "dQw4w9WgXcQ");
+
+    expect(audio.isrc).toBeUndefined();
+    expect(audio.title).toBe("Never Gonna Give You Up");
+  });
+
+  it("decodes percent-encoded title/artist/album/isrc together", async () => {
+    stubAudioResponse({
+      "x-track-title": encodeURIComponent("Never Gonna Give You Up"),
+      "x-track-artist": encodeURIComponent("Rick Astley"),
+      "x-track-album": encodeURIComponent("Whenever You Need Somebody"),
+      "x-track-isrc": encodeURIComponent("GBARL9300135"),
+    });
+
+    const audio = await getAudioFromBridge("http://localhost:7777", "dQw4w9WgXcQ");
+
+    expect(audio.title).toBe("Never Gonna Give You Up");
+    expect(audio.artist).toBe("Rick Astley");
+    expect(audio.album).toBe("Whenever You Need Somebody");
+    expect(audio.isrc).toBe("GBARL9300135");
   });
 });

--- a/src/utils/composer-bridge-api.ts
+++ b/src/utils/composer-bridge-api.ts
@@ -36,6 +36,7 @@ interface BridgeAudio {
   title?: string;
   artist?: string;
   album?: string;
+  isrc?: string;
 }
 
 class BridgeError extends Error {
@@ -101,6 +102,7 @@ async function getAudioFromBridge(baseUrl: string, videoId: string, signal?: Abo
       title: decodeHeader(res.headers.get("x-track-title")),
       artist: decodeHeader(res.headers.get("x-track-artist")),
       album: decodeHeader(res.headers.get("x-track-album")),
+      isrc: decodeHeader(res.headers.get("x-track-isrc")),
     };
   } catch (err) {
     if (err instanceof BridgeError) throw err;

--- a/src/utils/isrc.test.ts
+++ b/src/utils/isrc.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { isValidIsrc, normalizeIsrc } from "@/utils/isrc";
+
+describe("isValidIsrc", () => {
+  it("accepts a canonical ISRC", () => {
+    expect(isValidIsrc("USQX91700001")).toBe(true);
+  });
+  it("is case-insensitive on the country/registrant", () => {
+    expect(isValidIsrc("usqx91700001")).toBe(true);
+  });
+  describe("edge cases", () => {
+    it("rejects wrong length", () => expect(isValidIsrc("USQX9170001")).toBe(false));
+    it("rejects empty", () => expect(isValidIsrc("")).toBe(false));
+    it("rejects letters in the year/designation digits", () => expect(isValidIsrc("USQX9170000A")).toBe(false));
+    it("trims surrounding whitespace before validating", () => expect(isValidIsrc(" USQX91700001 ")).toBe(true));
+  });
+  describe("invariants", () => {
+    it("accepts digits in the registrant positions", () => expect(isValidIsrc("US3X91700001")).toBe(true));
+    it("normalizer trims surrounding whitespace", () => expect(normalizeIsrc(" usqx91700001 ")).toBe("USQX91700001"));
+    it("normalizer is idempotent on its own output", () => {
+      const once = normalizeIsrc("usqx91700001");
+      expect(normalizeIsrc(once as string)).toBe(once);
+    });
+    it("isValidIsrc agrees with normalizeIsrc for a clean valid code", () =>
+      expect(isValidIsrc("USQX91700001")).toBe(normalizeIsrc("USQX91700001") !== undefined));
+  });
+});
+
+describe("normalizeIsrc", () => {
+  it("uppercases a valid code", () => expect(normalizeIsrc("usqx91700001")).toBe("USQX91700001"));
+  it("returns undefined for invalid", () => expect(normalizeIsrc("nope")).toBeUndefined());
+  it("returns undefined for empty", () => expect(normalizeIsrc("")).toBeUndefined());
+});

--- a/src/utils/isrc.test.ts
+++ b/src/utils/isrc.test.ts
@@ -30,4 +30,23 @@ describe("normalizeIsrc", () => {
   it("uppercases a valid code", () => expect(normalizeIsrc("usqx91700001")).toBe("USQX91700001"));
   it("returns undefined for invalid", () => expect(normalizeIsrc("nope")).toBeUndefined());
   it("returns undefined for empty", () => expect(normalizeIsrc("")).toBeUndefined());
+
+  describe("display formatting", () => {
+    it("accepts the hyphenated form printed on releases", () => {
+      expect(normalizeIsrc("US-QX9-17-00001")).toBe("USQX91700001");
+    });
+    it("accepts a space-separated form", () => {
+      expect(normalizeIsrc("US QX9 17 00001")).toBe("USQX91700001");
+    });
+    it("accepts a lowercase hyphenated form", () => {
+      expect(isValidIsrc("us-qx9-17-00001")).toBe(true);
+    });
+    it("still rejects a hyphenated code of the wrong length", () => {
+      expect(normalizeIsrc("US-QX9-17-0001")).toBeUndefined();
+    });
+    it("does not treat separators as filler for missing characters", () => {
+      expect(normalizeIsrc("US-QX9-17-000-01")).toBe("USQX91700001");
+      expect(normalizeIsrc("-----------")).toBeUndefined();
+    });
+  });
 });

--- a/src/utils/isrc.ts
+++ b/src/utils/isrc.ts
@@ -1,0 +1,12 @@
+const ISRC_PATTERN = /^[A-Z]{2}[A-Z0-9]{3}\d{7}$/;
+
+function normalizeIsrc(value: string): string | undefined {
+  const normalized = value.trim().toUpperCase();
+  return ISRC_PATTERN.test(normalized) ? normalized : undefined;
+}
+
+function isValidIsrc(value: string): boolean {
+  return normalizeIsrc(value) !== undefined;
+}
+
+export { isValidIsrc, normalizeIsrc };

--- a/src/utils/isrc.ts
+++ b/src/utils/isrc.ts
@@ -1,7 +1,10 @@
 const ISRC_PATTERN = /^[A-Z]{2}[A-Z0-9]{3}\d{7}$/;
 
+// ISO 3901 codes are 12 alphanumeric characters. Hyphens and spaces are a
+// display convention (US-RC1-24-00001), so they are stripped before matching:
+// a code pasted from a label, a catalogue or the bridge is still valid.
 function normalizeIsrc(value: string): string | undefined {
-  const normalized = value.trim().toUpperCase();
+  const normalized = value.replace(/[\s-]/g, "").toUpperCase();
   return ISRC_PATTERN.test(normalized) ? normalized : undefined;
 }
 

--- a/src/utils/lyrics-parsers.test.ts
+++ b/src/utils/lyrics-parsers.test.ts
@@ -49,7 +49,7 @@ describe("parseLyricsFile - plain LRC", () => {
     const result = parseLyricsFile("song.lrc", content);
 
     expect(result.metadata.title).toBe("Test Song");
-    expect(result.metadata.artist).toBe("Test Artist");
+    expect(result.metadata.artists).toEqual(["Test Artist"]);
     expect(result.metadata.album).toBe("Test Album");
   });
 
@@ -106,7 +106,7 @@ describe("parseLyricsFile - enhanced LRC (eLRC)", () => {
     const result = parseLyricsFile("song.lrc", content);
 
     expect(result.metadata.title).toBe("eLRC Test");
-    expect(result.metadata.artist).toBe("Artist");
+    expect(result.metadata.artists).toEqual(["Artist"]);
     expect(result.lines).toHaveLength(1);
     expect(result.lines[0].words).toHaveLength(2);
   });

--- a/src/utils/lyrics-parsers/lrc.ts
+++ b/src/utils/lyrics-parsers/lrc.ts
@@ -92,7 +92,7 @@ function parseLrc(content: string, fallbackDuration?: number): ParseResult {
       if (tagLower === "ti" || tagLower === "title") {
         metadata.title = value.trim();
       } else if (tagLower === "ar" || tagLower === "artist") {
-        metadata.artist = value.trim();
+        metadata.artists = [value.trim()];
       } else if (tagLower === "al" || tagLower === "album") {
         metadata.album = value.trim();
       } else if (tagLower === "length") {

--- a/src/utils/lyrics-parsers/ttml.metadata.test.ts
+++ b/src/utils/lyrics-parsers/ttml.metadata.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectMetadata } from "@/domain/project/metadata";
+import { generateTTML } from "@/utils/ttml";
+import { parseTtml } from "@/utils/lyrics-parsers/ttml";
+
+const metadata: ProjectMetadata = {
+  title: "Song",
+  artists: ["Tyler, The Creator", "Kali Uchis"],
+  album: "Flower Boy",
+  duration: 0,
+  isrc: "USQX91700001",
+  songwriters: ["W1"],
+  extra: { spotifyId: "abc" },
+};
+const lines = [{ id: "l1", text: "hi", begin: 1, end: 2, agentId: "v1" }];
+
+describe("parseTtml metadata round-trip", () => {
+  const ttml = generateTTML({ metadata, agents: [], lines, granularity: "line" });
+  const parsed = parseTtml(ttml).metadata;
+  it("recovers title from ttm:title", () => expect(parsed.title).toBe("Song"));
+  it("recovers all artists including comma names", () => {
+    expect(parsed.artists).toEqual(["Tyler, The Creator", "Kali Uchis"]);
+  });
+  it("recovers album/isrc/songwriters/extra", () => {
+    expect(parsed.album).toBe("Flower Boy");
+    expect(parsed.isrc).toBe("USQX91700001");
+    expect(parsed.songwriters).toEqual(["W1"]);
+    expect(parsed.extra).toEqual({ spotifyId: "abc" });
+  });
+  it("still reads the legacy [type=artist] fallback when no composer:meta", () => {
+    const legacy =
+      '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"><head><metadata><ttm:agent type="person" xml:id="v1"/><ttm:name type="artist">Legacy Artist</ttm:name></metadata></head><body><div><p begin="1" end="2" ttm:agent="v1">hi</p></div></body></tt>';
+    expect(parseTtml(legacy).metadata.artists).toEqual(["Legacy Artist"]);
+  });
+  it("round-trips XML-special characters in metadata values", () => {
+    const special: ProjectMetadata = {
+      title: "T",
+      artists: ["Tom & Jerry", 'A "Q" B'],
+      album: "a < b",
+      duration: 0,
+      extra: { url: "x<y&z" },
+    };
+    const out = parseTtml(generateTTML({ metadata: special, agents: [], lines, granularity: "line" })).metadata;
+    expect(out.artists).toEqual(["Tom & Jerry", 'A "Q" B']);
+    expect(out.album).toBe("a < b");
+    expect(out.extra).toEqual({ url: "x<y&z" });
+  });
+  it("parses composer:meta and dedupes artists when the composer namespace is undeclared", () => {
+    const undeclared =
+      '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata">' +
+      "<head><metadata>" +
+      '<ttm:agent type="person" xml:id="v1"/>' +
+      '<composer:meta key="artists" value="A"/>' +
+      '<composer:meta key="artists" value="B"/>' +
+      '<composer:meta key="album" value="Al"/>' +
+      "</metadata></head>" +
+      '<body><div><p begin="1" end="2" ttm:agent="v1">hi</p></div></body></tt>';
+    const out = parseTtml(undeclared).metadata;
+    expect(out.artists).toEqual(["A", "B"]);
+    expect(out.album).toBe("Al");
+  });
+});

--- a/src/utils/lyrics-parsers/ttml.ts
+++ b/src/utils/lyrics-parsers/ttml.ts
@@ -3,6 +3,7 @@ import type { LinkGroup } from "@/domain/group/template";
 import { reconcileLine, type LyricLine } from "@/domain/line/model";
 import { reconstructLineText } from "@/domain/line/reconstruct-text";
 import type { ProjectMetadata } from "@/domain/project/metadata";
+import { fromComposerMeta } from "@/domain/project/metadata-ttml";
 import { inferSyllableGroupIds } from "@/domain/word/syllable-groups";
 import type { WordTiming } from "@/domain/word/timing";
 import { getSplitCharacter } from "@/utils/split-character";
@@ -47,11 +48,25 @@ function parseTtml(content: string, _fallbackDuration?: number): ParseResult {
   const ttmTitleEl = doc.getElementsByTagName("ttm:title")[0];
   if (ttmTitleEl?.textContent && !metadata.title) metadata.title = ttmTitleEl.textContent;
 
+  const metaEls = Array.from(
+    new Set(
+      Array.from(doc.getElementsByTagName("composer:meta")).concat(
+        COMPOSER_NAMESPACES.flatMap((ns) => Array.from(doc.getElementsByTagNameNS(ns, "meta"))),
+      ),
+    ),
+  );
+  Object.assign(
+    metadata,
+    fromComposerMeta(
+      metaEls.map((el) => ({ key: el.getAttribute("key") ?? "", value: el.getAttribute("value") ?? "" })),
+    ),
+  );
+
   const artistEl = doc.querySelector('[type="artist"]');
-  if (artistEl?.textContent) metadata.artist = artistEl.textContent;
+  if (!metadata.artists && artistEl?.textContent) metadata.artists = [artistEl.textContent];
 
   const albumEl = doc.querySelector('[type="album"]');
-  if (albumEl?.textContent) metadata.album = albumEl.textContent;
+  if (!metadata.album && albumEl?.textContent) metadata.album = albumEl.textContent;
 
   // Extract agents from metadata
   const agents: Agent[] = [];

--- a/src/utils/lyrics-search/providers/binimum.ts
+++ b/src/utils/lyrics-search/providers/binimum.ts
@@ -1,5 +1,6 @@
 import type { LyricsSearchPayload, LyricsSearchResult } from "@/domain/lyrics-search/result";
 import type { SyncType } from "@/domain/lyrics-search/sync-type";
+import { isValidIsrc, normalizeIsrc } from "@/utils/isrc";
 import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } from "@/utils/lyrics-search/types";
 
 // -- Constants ----------------------------------------------------------------
@@ -7,7 +8,6 @@ import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } 
 const BINIMUM_BASE_URL = "https://lyrics-api.binimum.org/";
 const ID_PREFIX = "binimum-";
 const USER_AGENT = "Better Lyrics Composer (https://composer.betterlyrics.org)";
-const ISRC_REGEX = /^[A-Z]{2}[A-Z0-9]{3}\d{7}$/;
 const VALID_TIMING_TYPES: ReadonlySet<SyncType> = new Set<SyncType>(["syllable", "word", "line"]);
 
 // -- Types --------------------------------------------------------------------
@@ -35,28 +35,18 @@ function hasNonEmptyString(value: string | undefined): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function normalizeIsrc(input: string | undefined): string | null {
-  if (!hasNonEmptyString(input)) return null;
-  const candidate = input.trim().toUpperCase();
-  return ISRC_REGEX.test(candidate) ? candidate : null;
-}
-
-function isValidIsrc(input: string | undefined): boolean {
-  return normalizeIsrc(input) !== null;
-}
-
 function hasTrackAndArtist(query: LyricsSearchQuery): boolean {
   return hasNonEmptyString(query.track) && hasNonEmptyString(query.artist);
 }
 
 function canSearch(query: LyricsSearchQuery): boolean {
   if (hasTrackAndArtist(query)) return true;
-  return isValidIsrc(query.isrc);
+  return hasNonEmptyString(query.isrc) && isValidIsrc(query.isrc);
 }
 
 function buildSearchUrl(query: LyricsSearchQuery): URL {
   const url = new URL(BINIMUM_BASE_URL);
-  const isrc = normalizeIsrc(query.isrc);
+  const isrc = hasNonEmptyString(query.isrc) ? normalizeIsrc(query.isrc) : undefined;
 
   if (isrc && !hasTrackAndArtist(query)) {
     url.searchParams.set("isrc", isrc);

--- a/src/utils/sync-helpers.test.ts
+++ b/src/utils/sync-helpers.test.ts
@@ -15,16 +15,19 @@ describe("commitTappedWord", () => {
     expect(result).toEqual([{ text: "hello", begin: 5, end: 6 }]);
   });
 
-  it("replaces the first word when wordIndex is 0", () => {
+  it("redo at wordIndex 0 overwrites the first word in place and keeps later words", () => {
     const existing: WordTiming[] = [
       { text: "one ", begin: 0, end: 1 },
       { text: "two", begin: 1, end: 2 },
     ];
     const result = commitTappedWord(existing, 0, "ONE", 5, 6);
-    expect(result).toEqual([{ text: "ONE", begin: 5, end: 6 }]);
+    expect(result).toEqual([
+      { text: "ONE", begin: 5, end: 6 },
+      { text: "two", begin: 1, end: 2 },
+    ]);
   });
 
-  it("re-syncs from the middle: truncates and closes the prior word at begin", () => {
+  it("re-syncs from the middle: overwrites in place, closes the prior word, and preserves later words", () => {
     const existing: WordTiming[] = [
       { text: "one ", begin: 0, end: 1 },
       { text: "two ", begin: 1, end: 2 },
@@ -34,6 +37,7 @@ describe("commitTappedWord", () => {
     expect(result).toEqual([
       { text: "one ", begin: 0, end: 5 },
       { text: "TWO", begin: 5, end: 6 },
+      { text: "three", begin: 2, end: 3 },
     ]);
   });
 
@@ -83,7 +87,7 @@ describe("commitHeldWord", () => {
     expect(result).toEqual([{ text: "ONE", begin: 5, end: 1 }]);
   });
 
-  it("truncates to wordIndex and appends a held word", () => {
+  it("redo at a mid-line word overwrites it in place and preserves later words", () => {
     const existing: WordTiming[] = [
       { text: "one ", begin: 0, end: 1 },
       { text: "two ", begin: 1, end: 2 },
@@ -93,6 +97,7 @@ describe("commitHeldWord", () => {
     expect(result).toEqual([
       { text: "one ", begin: 0, end: 1 },
       { text: "TWO", begin: 5, end: 5 },
+      { text: "three", begin: 2, end: 3 },
     ]);
   });
 

--- a/src/utils/sync-helpers.test.ts
+++ b/src/utils/sync-helpers.test.ts
@@ -1,5 +1,5 @@
 import type { WordTiming } from "@/domain/word/timing";
-import { commitHeldWord, commitTappedWord } from "@/utils/sync-helpers";
+import { closeHeldWord, commitHeldWord, commitTappedWord } from "@/utils/sync-helpers";
 import { describe, expect, it } from "vitest";
 
 // -- commitTappedWord ---------------------------------------------------------
@@ -119,5 +119,120 @@ describe("commitHeldWord", () => {
     }
     expect(result[0]).toEqual({ text: "one ", begin: 0, end: 1 });
     expect(result[1]).toEqual({ text: "two", begin: 5, end: 5 });
+  });
+
+  describe("regressions", () => {
+    it("regression: preserves explicit and syllableGroupId when re-holding a mid-line word", () => {
+      const existing: WordTiming[] = [
+        { text: "one ", begin: 0, end: 1 },
+        { text: "two ", begin: 1, end: 2 },
+        { text: "three", begin: 2, end: 3, explicit: true, syllableGroupId: "g1" },
+      ];
+      const result = commitHeldWord(existing, 2, "three", 5);
+      expect(result[2].explicit).toBe(true);
+      expect(result[2].syllableGroupId).toBe("g1");
+    });
+
+    it("regression: hold and tap agree on which metadata survives a mid-line redo", () => {
+      const existing: WordTiming[] = [
+        { text: "one ", begin: 0, end: 1 },
+        { text: "two ", begin: 1, end: 2, explicit: true, syllableGroupId: "g1" },
+      ];
+      const held = commitHeldWord(existing, 1, "two ", 5);
+      const tapped = commitTappedWord(existing, 1, "two ", 5, 6);
+      expect(held[1].explicit).toBe(tapped[1].explicit);
+      expect(held[1].syllableGroupId).toBe(tapped[1].syllableGroupId);
+    });
+  });
+
+  describe("invariants", () => {
+    it("does not mutate the input array or its entries", () => {
+      const entry: WordTiming = { text: "two ", begin: 1, end: 2, explicit: true };
+      const existing: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }, entry];
+      const snapshot = structuredClone(existing);
+      commitHeldWord(existing, 1, "TWO", 5);
+      expect(existing).toEqual(snapshot);
+      expect(entry).toEqual({ text: "two ", begin: 1, end: 2, explicit: true });
+    });
+
+    it("never changes the array length when overwriting an existing word", () => {
+      const existing: WordTiming[] = [
+        { text: "one ", begin: 0, end: 1 },
+        { text: "two ", begin: 1, end: 2 },
+        { text: "three", begin: 2, end: 3 },
+      ];
+      expect(commitHeldWord(existing, 1, "TWO", 5)).toHaveLength(3);
+    });
+  });
+});
+
+// -- closeHeldWord ------------------------------------------------------------
+
+describe("closeHeldWord", () => {
+  it("closes the word at wordIndex, not the last word", () => {
+    const existing: WordTiming[] = [
+      { text: "one ", begin: 0, end: 1 },
+      { text: "two ", begin: 5, end: 5 },
+      { text: "three", begin: 2, end: 3 },
+    ];
+    const result = closeHeldWord(existing, 1, 6);
+    expect(result[1]).toEqual({ text: "two ", begin: 5, end: 6 });
+    expect(result[2]).toEqual({ text: "three", begin: 2, end: 3 });
+  });
+
+  it("preserves explicit and syllableGroupId on the closed word", () => {
+    const existing: WordTiming[] = [{ text: "one ", begin: 5, end: 5, explicit: true, syllableGroupId: "g1" }];
+    const result = closeHeldWord(existing, 0, 6);
+    expect(result[0]).toEqual({ text: "one ", begin: 5, end: 6, explicit: true, syllableGroupId: "g1" });
+  });
+
+  describe("edge cases", () => {
+    it("returns an empty array unchanged", () => {
+      expect(closeHeldWord([], 0, 6)).toEqual([]);
+    });
+
+    it("clamps a cursor past the end onto the last word", () => {
+      const existing: WordTiming[] = [
+        { text: "one ", begin: 0, end: 1 },
+        { text: "two ", begin: 5, end: 5 },
+      ];
+      const result = closeHeldWord(existing, 9, 6);
+      expect(result).toHaveLength(2);
+      expect(result[1]).toEqual({ text: "two ", begin: 5, end: 6 });
+    });
+
+    it("clamps a negative cursor onto the first word", () => {
+      const existing: WordTiming[] = [{ text: "one ", begin: 5, end: 5 }];
+      const result = closeHeldWord(existing, -1, 6);
+      expect(result[0]).toEqual({ text: "one ", begin: 5, end: 6 });
+    });
+  });
+
+  describe("invariants", () => {
+    it("does not mutate the input array or its entries", () => {
+      const entry: WordTiming = { text: "two ", begin: 5, end: 5 };
+      const existing: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }, entry];
+      const snapshot = structuredClone(existing);
+      closeHeldWord(existing, 1, 6);
+      expect(existing).toEqual(snapshot);
+      expect(entry).toEqual({ text: "two ", begin: 5, end: 5 });
+    });
+
+    it("is idempotent for the same end value", () => {
+      const existing: WordTiming[] = [{ text: "one ", begin: 5, end: 5 }];
+      const once = closeHeldWord(existing, 0, 6);
+      expect(closeHeldWord(once, 0, 6)).toEqual(once);
+    });
+
+    it("leaves every word other than the closed one untouched", () => {
+      const existing: WordTiming[] = [
+        { text: "one ", begin: 0, end: 1 },
+        { text: "two ", begin: 5, end: 5 },
+        { text: "three", begin: 2, end: 3 },
+      ];
+      const result = closeHeldWord(existing, 1, 6);
+      expect(result[0]).toBe(existing[0]);
+      expect(result[2]).toBe(existing[2]);
+    });
   });
 });

--- a/src/utils/sync-helpers.test.ts
+++ b/src/utils/sync-helpers.test.ts
@@ -20,9 +20,9 @@ describe("commitTappedWord", () => {
       { text: "one ", begin: 0, end: 1 },
       { text: "two", begin: 1, end: 2 },
     ];
-    const result = commitTappedWord(existing, 0, "ONE", 5, 6);
+    const result = commitTappedWord(existing, 0, "ONE", 0.2, 0.8);
     expect(result).toEqual([
-      { text: "ONE", begin: 5, end: 6 },
+      { text: "ONE", begin: 0.2, end: 0.8 },
       { text: "two", begin: 1, end: 2 },
     ]);
   });
@@ -33,11 +33,25 @@ describe("commitTappedWord", () => {
       { text: "two ", begin: 1, end: 2 },
       { text: "three", begin: 2, end: 3 },
     ];
+    const result = commitTappedWord(existing, 1, "TWO", 1.2, 1.8);
+    expect(result).toEqual([
+      { text: "one ", begin: 0, end: 1.2 },
+      { text: "TWO", begin: 1.2, end: 1.8 },
+      { text: "three", begin: 2, end: 3 },
+    ]);
+  });
+
+  it("squeezes later words forward when the redo lands past them", () => {
+    const existing: WordTiming[] = [
+      { text: "one ", begin: 0, end: 1 },
+      { text: "two ", begin: 1, end: 2 },
+      { text: "three", begin: 2, end: 3 },
+    ];
     const result = commitTappedWord(existing, 1, "TWO", 5, 6);
     expect(result).toEqual([
       { text: "one ", begin: 0, end: 5 },
       { text: "TWO", begin: 5, end: 6 },
-      { text: "three", begin: 2, end: 3 },
+      { text: "three", begin: 6, end: 6 },
     ]);
   });
 
@@ -71,6 +85,44 @@ describe("commitTappedWord", () => {
       expect(result[i]).toBeDefined();
     }
   });
+
+  describe("invariants", () => {
+    it("regression: a redo never leaves the line ending before it begins", () => {
+      const existing: WordTiming[] = [
+        { text: "Tercero ", begin: 0.508, end: 1.106 },
+        { text: "line ", begin: 1.106, end: 1.508 },
+        { text: "song", begin: 2.502, end: 2.897 },
+      ];
+      const result = commitTappedWord(existing, 0, "Tercero ", 2.916, 3.216);
+      expect(result[0].begin).toBeLessThanOrEqual(result[result.length - 1].end);
+    });
+
+    it("keeps every word chronologically ordered whatever the redo time", () => {
+      const existing: WordTiming[] = [
+        { text: "one ", begin: 0, end: 1 },
+        { text: "two ", begin: 1, end: 2 },
+        { text: "three", begin: 2, end: 3 },
+      ];
+      for (const wordIndex of [0, 1, 2]) {
+        for (const begin of [0, 0.5, 1.5, 2.5, 10]) {
+          const result = commitTappedWord(existing, wordIndex, "X", begin, begin + 0.3);
+          for (let i = 0; i < result.length; i++) {
+            expect(result[i].end).toBeGreaterThanOrEqual(result[i].begin);
+            if (i > 0) expect(result[i].begin).toBeGreaterThanOrEqual(result[i - 1].end);
+          }
+        }
+      }
+    });
+
+    it("does not mutate the input array or its entries", () => {
+      const entry: WordTiming = { text: "two ", begin: 1, end: 2, explicit: true };
+      const existing: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }, entry];
+      const snapshot = structuredClone(existing);
+      commitTappedWord(existing, 0, "ONE", 5, 6);
+      expect(existing).toEqual(snapshot);
+      expect(entry).toEqual({ text: "two ", begin: 1, end: 2, explicit: true });
+    });
+  });
 });
 
 // -- commitHeldWord -----------------------------------------------------------
@@ -81,13 +133,27 @@ describe("commitHeldWord", () => {
     expect(result).toEqual([{ text: "hello", begin: 5, end: 5 }]);
   });
 
-  it("replaces the first word's text and begin but preserves its end when wordIndex is 0", () => {
+  it("opens the first word at the held time without leaving it ending before it begins", () => {
     const existing: WordTiming[] = [{ text: "one ", begin: 0, end: 1 }];
     const result = commitHeldWord(existing, 0, "ONE", 5);
-    expect(result).toEqual([{ text: "ONE", begin: 5, end: 1 }]);
+    expect(result).toEqual([{ text: "ONE", begin: 5, end: 5 }]);
   });
 
   it("redo at a mid-line word overwrites it in place and preserves later words", () => {
+    const existing: WordTiming[] = [
+      { text: "one ", begin: 0, end: 1 },
+      { text: "two ", begin: 1, end: 2 },
+      { text: "three", begin: 2, end: 3 },
+    ];
+    const result = commitHeldWord(existing, 1, "TWO", 1.5);
+    expect(result).toEqual([
+      { text: "one ", begin: 0, end: 1 },
+      { text: "TWO", begin: 1.5, end: 1.5 },
+      { text: "three", begin: 2, end: 3 },
+    ]);
+  });
+
+  it("squeezes later words forward when the held word lands past them", () => {
     const existing: WordTiming[] = [
       { text: "one ", begin: 0, end: 1 },
       { text: "two ", begin: 1, end: 2 },
@@ -97,7 +163,7 @@ describe("commitHeldWord", () => {
     expect(result).toEqual([
       { text: "one ", begin: 0, end: 1 },
       { text: "TWO", begin: 5, end: 5 },
-      { text: "three", begin: 2, end: 3 },
+      { text: "three", begin: 5, end: 5 },
     ]);
   });
 
@@ -172,12 +238,26 @@ describe("closeHeldWord", () => {
   it("closes the word at wordIndex, not the last word", () => {
     const existing: WordTiming[] = [
       { text: "one ", begin: 0, end: 1 },
-      { text: "two ", begin: 5, end: 5 },
-      { text: "three", begin: 2, end: 3 },
+      { text: "two ", begin: 1, end: 1 },
+      { text: "three", begin: 3, end: 4 },
     ];
-    const result = closeHeldWord(existing, 1, 6);
-    expect(result[1]).toEqual({ text: "two ", begin: 5, end: 6 });
-    expect(result[2]).toEqual({ text: "three", begin: 2, end: 3 });
+    const result = closeHeldWord(existing, 1, 2);
+    expect(result[1]).toEqual({ text: "two ", begin: 1, end: 2 });
+    expect(result[2]).toEqual({ text: "three", begin: 3, end: 4 });
+  });
+
+  it("squeezes later words forward when the closed word overruns them", () => {
+    const existing: WordTiming[] = [
+      { text: "one ", begin: 0, end: 1 },
+      { text: "two ", begin: 1, end: 1 },
+      { text: "three", begin: 3, end: 4 },
+    ];
+    const result = closeHeldWord(existing, 1, 5);
+    expect(result).toEqual([
+      { text: "one ", begin: 0, end: 1 },
+      { text: "two ", begin: 1, end: 5 },
+      { text: "three", begin: 5, end: 5 },
+    ]);
   });
 
   it("preserves explicit and syllableGroupId on the closed word", () => {
@@ -227,10 +307,10 @@ describe("closeHeldWord", () => {
     it("leaves every word other than the closed one untouched", () => {
       const existing: WordTiming[] = [
         { text: "one ", begin: 0, end: 1 },
-        { text: "two ", begin: 5, end: 5 },
-        { text: "three", begin: 2, end: 3 },
+        { text: "two ", begin: 1, end: 1 },
+        { text: "three", begin: 3, end: 4 },
       ];
-      const result = closeHeldWord(existing, 1, 6);
+      const result = closeHeldWord(existing, 1, 2);
       expect(result[0]).toBe(existing[0]);
       expect(result[2]).toBe(existing[2]);
     });

--- a/src/utils/sync-helpers.ts
+++ b/src/utils/sync-helpers.ts
@@ -151,6 +151,9 @@ function createBgWordsFromLine(line: LyricLine): WordTiming[] | null {
 
 // -- Tap and hold commit ------------------------------------------------------
 
+// Re-tapping a word that already has later words (redo) overwrites it in place and
+// keeps the untapped words, so a partial redo never wipes the tail. Tapping at or past
+// the end is forward live-sync: close the prior word and append.
 function commitTappedWord(
   existingWords: WordTiming[],
   wordIndex: number,
@@ -159,21 +162,24 @@ function commitTappedWord(
   end: number,
 ): WordTiming[] {
   if (existingWords.length === 0) return [{ text, begin, end }];
-  if (wordIndex === 0) return [{ ...existingWords[0], text, begin, end }];
-  const keepCount = Math.min(wordIndex, existingWords.length);
-  const result = existingWords.slice(0, keepCount);
-  const lastIdx = result.length - 1;
-  result[lastIdx] = { ...result[lastIdx], end: begin };
-  result.push({ text, begin, end });
+  if (wordIndex >= existingWords.length) {
+    const result = [...existingWords];
+    const lastIdx = result.length - 1;
+    result[lastIdx] = { ...result[lastIdx], end: begin };
+    result.push({ text, begin, end });
+    return result;
+  }
+  const result = [...existingWords];
+  result[wordIndex] = { ...result[wordIndex], text, begin, end };
+  if (wordIndex > 0) result[wordIndex - 1] = { ...result[wordIndex - 1], end: begin };
   return result;
 }
 
 function commitHeldWord(existingWords: WordTiming[], wordIndex: number, text: string, begin: number): WordTiming[] {
   if (existingWords.length === 0) return [{ text, begin, end: begin }];
-  if (wordIndex === 0) return [{ ...existingWords[0], text, begin }];
-  const keepCount = Math.min(wordIndex, existingWords.length);
-  const result = existingWords.slice(0, keepCount);
-  result.push({ text, begin, end: begin });
+  if (wordIndex >= existingWords.length) return [...existingWords, { text, begin, end: begin }];
+  const result = [...existingWords];
+  result[wordIndex] = wordIndex === 0 ? { ...result[0], text, begin } : { text, begin, end: begin };
   return result;
 }
 

--- a/src/utils/sync-helpers.ts
+++ b/src/utils/sync-helpers.ts
@@ -17,6 +17,11 @@ interface SyncPosition {
 interface SyncState {
   position: SyncPosition;
   isActive: boolean;
+  // True when the cursor was placed by a jump rather than by advancing through
+  // the song. Tapping the first word of a line closes the previous line so the
+  // two meet, which is right in a forward pass but stretches an already-correct
+  // line when the user jumped back to re-record this one.
+  jumpedToPosition?: boolean;
 }
 
 // -- Constants ----------------------------------------------------------------

--- a/src/utils/sync-helpers.ts
+++ b/src/utils/sync-helpers.ts
@@ -151,9 +151,7 @@ function createBgWordsFromLine(line: LyricLine): WordTiming[] | null {
 
 // -- Tap and hold commit ------------------------------------------------------
 
-// Re-tapping a word that already has later words (redo) overwrites it in place and
-// keeps the untapped words, so a partial redo never wipes the tail. Tapping at or past
-// the end is forward live-sync: close the prior word and append.
+// Redo overwrites in place and keeps the tail; tapping past the end appends.
 function commitTappedWord(
   existingWords: WordTiming[],
   wordIndex: number,
@@ -179,13 +177,23 @@ function commitHeldWord(existingWords: WordTiming[], wordIndex: number, text: st
   if (existingWords.length === 0) return [{ text, begin, end: begin }];
   if (wordIndex >= existingWords.length) return [...existingWords, { text, begin, end: begin }];
   const result = [...existingWords];
-  result[wordIndex] = wordIndex === 0 ? { ...result[0], text, begin } : { text, begin, end: begin };
+  result[wordIndex] =
+    wordIndex === 0 ? { ...result[0], text, begin } : { ...result[wordIndex], text, begin, end: begin };
+  return result;
+}
+
+function closeHeldWord(existingWords: WordTiming[], wordIndex: number, end: number): WordTiming[] {
+  if (existingWords.length === 0) return existingWords;
+  const target = Math.min(Math.max(wordIndex, 0), existingWords.length - 1);
+  const result = [...existingWords];
+  result[target] = { ...result[target], end };
   return result;
 }
 
 // -- Exports ------------------------------------------------------------------
 
 export {
+  closeHeldWord,
   commitHeldWord,
   commitTappedWord,
   createBgWordsFromLine,

--- a/src/utils/sync-helpers.ts
+++ b/src/utils/sync-helpers.ts
@@ -1,6 +1,7 @@
 import { effectiveBounds } from "@/domain/line/bounds";
 import { isLineSynced } from "@/domain/line/predicates";
 import type { LyricLine } from "@/domain/line/model";
+import { enforceOrderAround } from "@/domain/word/order";
 import type { WordTiming } from "@/domain/word/timing";
 import { useSettingsStore } from "@/stores/settings";
 import { formatTime } from "@/utils/format-time";
@@ -169,17 +170,19 @@ function commitTappedWord(
   }
   const result = [...existingWords];
   result[wordIndex] = { ...result[wordIndex], text, begin, end };
-  if (wordIndex > 0) result[wordIndex - 1] = { ...result[wordIndex - 1], end: begin };
-  return result;
+  if (wordIndex === 0) return enforceOrderAround(result, 0);
+
+  const previous = result[wordIndex - 1];
+  result[wordIndex - 1] = { ...previous, begin: Math.min(previous.begin, begin), end: begin };
+  return enforceOrderAround(enforceOrderAround(result, wordIndex), wordIndex - 1);
 }
 
 function commitHeldWord(existingWords: WordTiming[], wordIndex: number, text: string, begin: number): WordTiming[] {
   if (existingWords.length === 0) return [{ text, begin, end: begin }];
   if (wordIndex >= existingWords.length) return [...existingWords, { text, begin, end: begin }];
   const result = [...existingWords];
-  result[wordIndex] =
-    wordIndex === 0 ? { ...result[0], text, begin } : { ...result[wordIndex], text, begin, end: begin };
-  return result;
+  result[wordIndex] = { ...result[wordIndex], text, begin, end: begin };
+  return enforceOrderAround(result, wordIndex);
 }
 
 function closeHeldWord(existingWords: WordTiming[], wordIndex: number, end: number): WordTiming[] {
@@ -187,7 +190,7 @@ function closeHeldWord(existingWords: WordTiming[], wordIndex: number, end: numb
   const target = Math.min(Math.max(wordIndex, 0), existingWords.length - 1);
   const result = [...existingWords];
   result[target] = { ...result[target], end };
-  return result;
+  return enforceOrderAround(result, target);
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/src/utils/ttml-merge.test.ts
+++ b/src/utils/ttml-merge.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { rebaseTtmlEdits } from "@/utils/ttml-merge";
+
+// -- Fixtures -----------------------------------------------------------------
+
+const BASE = [
+  '<tt dur="10">',
+  "  <body>",
+  "    <div>",
+  '      <p begin="0">one</p>',
+  '      <p begin="1">two</p>',
+  '      <p begin="2">three</p>',
+  "    </div>",
+  "  </body>",
+  "</tt>",
+].join("\n");
+
+// -- Tests --------------------------------------------------------------------
+
+describe("rebaseTtmlEdits", () => {
+  describe("happy paths", () => {
+    it("cleanly rebases a user edit onto a disjoint regeneration", () => {
+      const mine = BASE.replace("one", "ONE EDITED");
+      const next = BASE.replace('dur="10"', 'dur="20"');
+      const result = rebaseTtmlEdits(BASE, mine, next);
+      expect(result.status).toBe("clean");
+      if (result.status !== "clean") throw new Error("expected clean");
+      expect(result.content).toContain("ONE EDITED");
+      expect(result.content).toContain('dur="20"');
+    });
+
+    it("merges an insertion in the regeneration with an edit elsewhere", () => {
+      const mine = BASE.replace("one", "ONE EDITED");
+      const next = BASE.replace(
+        '      <p begin="1">two</p>',
+        '      <p begin="1">two</p>\n      <p begin="1.5">inserted</p>',
+      );
+      const result = rebaseTtmlEdits(BASE, mine, next);
+      expect(result.status).toBe("clean");
+      if (result.status !== "clean") throw new Error("expected clean");
+      expect(result.content).toContain("ONE EDITED");
+      expect(result.content).toContain("inserted");
+    });
+  });
+
+  describe("conflicts", () => {
+    it("reports a conflict when both sides change the same line differently", () => {
+      const mine = BASE.replace("two", "TWO MINE");
+      const next = BASE.replace("two", "two NEXT");
+      expect(rebaseTtmlEdits(BASE, mine, next).status).toBe("conflict");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns next when the user made no edits (mine === base)", () => {
+      const next = BASE.replace('dur="10"', 'dur="20"');
+      const result = rebaseTtmlEdits(BASE, BASE, next);
+      expect(result.status).toBe("clean");
+      if (result.status !== "clean") throw new Error("expected clean");
+      expect(result.content).toBe(next);
+    });
+
+    it("returns mine when there was no drift (base === next)", () => {
+      const mine = BASE.replace("one", "ONE EDITED");
+      const result = rebaseTtmlEdits(BASE, mine, BASE);
+      expect(result.status).toBe("clean");
+      if (result.status !== "clean") throw new Error("expected clean");
+      expect(result.content).toBe(mine);
+    });
+
+    it("treats identical edits on both sides as clean, not a conflict", () => {
+      const both = BASE.replace("two", "TWO BOTH");
+      const result = rebaseTtmlEdits(BASE, both, both);
+      expect(result.status).toBe("clean");
+      if (result.status !== "clean") throw new Error("expected clean");
+      expect(result.content).toBe(both);
+    });
+
+    it("handles empty strings", () => {
+      expect(rebaseTtmlEdits("", "", "").status).toBe("clean");
+    });
+
+    it("preserves a trailing newline across a clean merge", () => {
+      const base = `${BASE}\n`;
+      const mine = base.replace("one", "ONE EDITED");
+      const next = base.replace('dur="10"', 'dur="20"');
+      const result = rebaseTtmlEdits(base, mine, next);
+      expect(result.status).toBe("clean");
+      if (result.status !== "clean") throw new Error("expected clean");
+      expect(result.content.endsWith("\n")).toBe(true);
+    });
+  });
+
+  describe("invariants", () => {
+    it("a clean rebase is idempotent when re-applied to its own output", () => {
+      const mine = BASE.replace("one", "ONE EDITED");
+      const next = BASE.replace('dur="10"', 'dur="20"');
+      const first = rebaseTtmlEdits(BASE, mine, next);
+      if (first.status !== "clean") throw new Error("expected clean");
+      const second = rebaseTtmlEdits(next, first.content, next);
+      expect(second.status).toBe("clean");
+      if (second.status !== "clean") throw new Error("expected clean");
+      expect(second.content).toBe(first.content);
+    });
+  });
+});

--- a/src/utils/ttml-merge.ts
+++ b/src/utils/ttml-merge.ts
@@ -1,0 +1,25 @@
+import { diff3Merge } from "node-diff3";
+
+// -- Types --------------------------------------------------------------------
+
+type RebaseResult = { status: "clean"; content: string } | { status: "conflict" };
+
+// -- Functions ----------------------------------------------------------------
+
+function rebaseTtmlEdits(base: string, mine: string, next: string): RebaseResult {
+  const regions = diff3Merge(mine, base, next, {
+    stringSeparator: "\n",
+    excludeFalseConflicts: true,
+  });
+
+  if (regions.some((region) => region.conflict !== undefined)) {
+    return { status: "conflict" };
+  }
+
+  const lines = regions.flatMap((region) => region.ok ?? []);
+  return { status: "clean", content: lines.join("\n") };
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { rebaseTtmlEdits };

--- a/src/utils/ttml.groups.test.ts
+++ b/src/utils/ttml.groups.test.ts
@@ -5,7 +5,7 @@ import { parseLyricsFile } from "@/utils/lyrics-parsers";
 import { generateTTML } from "@/utils/ttml";
 import { describe, expect, it } from "vitest";
 
-const baseMetadata: ProjectMetadata = { title: "Test", artist: "", album: "", duration: 60 };
+const baseMetadata: ProjectMetadata = { title: "Test", artists: [], album: "", duration: 60 };
 const baseAgents: Agent[] = [{ id: "v1", type: "person", name: "Lead" }];
 
 describe("ttml export · groups registry", () => {

--- a/src/utils/ttml.itunes-namespace.test.ts
+++ b/src/utils/ttml.itunes-namespace.test.ts
@@ -5,7 +5,7 @@ import { generateTTML } from "@/utils/ttml";
 import { describe, expect, it } from "vitest";
 
 const ITUNES_NS = "http://music.apple.com/lyric-ttml-internal";
-const baseMetadata: ProjectMetadata = { title: "Test", artist: "", album: "", duration: 60 };
+const baseMetadata: ProjectMetadata = { title: "Test", artists: [], album: "", duration: 60 };
 const baseAgents: Agent[] = [{ id: "v1", type: "person", name: "Lead" }];
 
 const wordLine: LyricLine = {

--- a/src/utils/ttml.metadata.test.ts
+++ b/src/utils/ttml.metadata.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectMetadata } from "@/domain/project/metadata";
+import { generateTTML } from "@/utils/ttml";
+
+const metadata: ProjectMetadata = {
+  title: "Song & Dance",
+  artists: ['A "Q" B', "Kali Uchis"],
+  album: "Flower Boy",
+  duration: 0,
+  isrc: "USQX91700001",
+  songwriters: ["W1"],
+  extra: { spotifyId: "abc" },
+};
+const lines = [{ id: "l1", text: "hi", begin: 1, end: 2, agentId: "v1" }];
+
+describe("generateTTML metadata", () => {
+  const ttml = generateTTML({ metadata, agents: [], lines, granularity: "line" });
+  it("keeps the title in ttm:title", () => expect(ttml).toContain("<ttm:title>Song &amp; Dance</ttm:title>"));
+  it("emits one composer:meta per artist", () => {
+    expect(ttml).toContain('<composer:meta key="artists" value="Kali Uchis"/>');
+  });
+  it("escapes quotes inside attribute values", () => {
+    expect(ttml).toContain('<composer:meta key="artists" value="A &quot;Q&quot; B"/>');
+  });
+  it("emits album, isrc, songwriter, extra", () => {
+    expect(ttml).toContain('<composer:meta key="album" value="Flower Boy"/>');
+    expect(ttml).toContain('<composer:meta key="isrc" value="USQX91700001"/>');
+    expect(ttml).toContain('<composer:meta key="songwriter" value="W1"/>');
+    expect(ttml).toContain('<composer:meta key="spotifyId" value="abc"/>');
+  });
+  it("emits no composer:meta when there is no extended metadata", () => {
+    const bare = generateTTML({
+      metadata: { title: "x", artists: [], album: "", duration: 0 },
+      agents: [],
+      lines,
+      granularity: "line",
+    });
+    expect(bare).not.toContain("composer:meta");
+  });
+});

--- a/src/utils/ttml.metadata.test.ts
+++ b/src/utils/ttml.metadata.test.ts
@@ -38,3 +38,46 @@ describe("generateTTML metadata", () => {
     expect(bare).not.toContain("composer:meta");
   });
 });
+
+describe("generateTTML attribute escaping", () => {
+  function parse(xml: string): Document {
+    return new DOMParser().parseFromString(xml, "application/xml");
+  }
+
+  it("regression: a group label containing quotes stays well-formed", () => {
+    const xml = generateTTML({
+      metadata: { title: "t", artists: [], album: "", duration: 0 },
+      agents: [],
+      lines,
+      groups: [{ id: "g1", label: 'The "Big" Chorus', color: "#fff", templateVersion: 1 }],
+      granularity: "line",
+    });
+
+    expect(xml).toContain('label="The &quot;Big&quot; Chorus"');
+    expect(parse(xml).querySelector("parsererror")).toBeNull();
+  });
+
+  it("regression: an agent name and id containing quotes stay well-formed", () => {
+    const xml = generateTTML({
+      metadata: { title: "t", artists: [], album: "", duration: 0 },
+      agents: [{ id: 'v"1', type: "person", name: 'The "Lead"' }],
+      lines,
+      granularity: "line",
+    });
+
+    expect(xml).toContain('xml:id="v&quot;1"');
+    expect(parse(xml).querySelector("parsererror")).toBeNull();
+  });
+
+  it("regression: a language tag containing quotes stays well-formed", () => {
+    const xml = generateTTML({
+      metadata: { title: "t", artists: [], album: "", duration: 0, language: 'en"US' },
+      agents: [],
+      lines,
+      granularity: "line",
+    });
+
+    expect(xml).toContain('xml:lang="en&quot;US"');
+    expect(parse(xml).querySelector("parsererror")).toBeNull();
+  });
+});

--- a/src/utils/ttml.ts
+++ b/src/utils/ttml.ts
@@ -2,6 +2,7 @@ import type { Agent } from "@/domain/agent/model";
 import type { LinkGroup } from "@/domain/group/template";
 import type { LyricLine } from "@/domain/line/model";
 import type { ProjectMetadata } from "@/domain/project/metadata";
+import { toComposerMeta } from "@/domain/project/metadata-ttml";
 import { formatTime } from "@/utils/format-time";
 import { stripSplitCharacter } from "@/utils/split-character";
 import { COMPOSER_NS } from "@/utils/lyrics-parsers/composer-namespace";
@@ -11,6 +12,10 @@ import { effectiveBounds } from "@/domain/line/bounds";
 
 function escapeXml(str: string): string {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+}
+
+function escapeXmlAttribute(str: string): string {
+  return escapeXml(str).replace(/"/g, "&quot;");
 }
 
 function emitWordSpan(word: { text: string; begin: number; end: number; explicit?: true }, text: string): string {
@@ -48,6 +53,9 @@ function generateTTML({ metadata, agents, lines, groups, granularity, minify = f
   parts.push(`${ind(2)}<metadata>`);
   if (metadata.title) {
     parts.push(`${ind(3)}<ttm:title>${escapeXml(metadata.title)}</ttm:title>`);
+  }
+  for (const { key, value } of toComposerMeta(metadata)) {
+    parts.push(`${ind(3)}<composer:meta key="${escapeXmlAttribute(key)}" value="${escapeXmlAttribute(value)}"/>`);
   }
   for (const agent of agents) {
     if (agent.name) {

--- a/src/utils/ttml.ts
+++ b/src/utils/ttml.ts
@@ -51,7 +51,7 @@ function generateTTML({ metadata, agents, lines, groups, granularity, minify = f
   // Apple Music lyric dialect, not strict W3C TTML1. Absolute span times and the
   // Apple timestamp shape are intentional; don't "fix" them to generic TTML.
   parts.push(
-    `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:itunes="${APPLE_LYRIC_NS}" xmlns:composer="${COMPOSER_NS}" ttp:timeBase="media" xml:lang="${escapeXml(metadata.language || "en")}" itunes:timing="${timingValue}" composer:timing="${timingValue}">`,
+    `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:itunes="${APPLE_LYRIC_NS}" xmlns:composer="${COMPOSER_NS}" ttp:timeBase="media" xml:lang="${escapeXmlAttribute(metadata.language || "en")}" itunes:timing="${timingValue}" composer:timing="${timingValue}">`,
   );
 
   // Head section
@@ -65,18 +65,18 @@ function generateTTML({ metadata, agents, lines, groups, granularity, minify = f
   }
   for (const agent of agents) {
     if (agent.name) {
-      parts.push(`${ind(3)}<ttm:agent xml:id="${escapeXml(agent.id)}" type="${agent.type}">`);
+      parts.push(`${ind(3)}<ttm:agent xml:id="${escapeXmlAttribute(agent.id)}" type="${agent.type}">`);
       parts.push(`${ind(4)}<ttm:name>${escapeXml(agent.name)}</ttm:name>`);
       parts.push(`${ind(3)}</ttm:agent>`);
     } else {
-      parts.push(`${ind(3)}<ttm:agent xml:id="${escapeXml(agent.id)}" type="${agent.type}"/>`);
+      parts.push(`${ind(3)}<ttm:agent xml:id="${escapeXmlAttribute(agent.id)}" type="${agent.type}"/>`);
     }
   }
   if (groups && groups.length > 0) {
     parts.push(`${ind(3)}<composer:groups>`);
     for (const g of groups) {
       parts.push(
-        `${ind(4)}<composer:group id="${escapeXml(g.id)}" label="${escapeXml(g.label)}" color="${escapeXml(g.color)}" templateVersion="${g.templateVersion}"/>`,
+        `${ind(4)}<composer:group id="${escapeXmlAttribute(g.id)}" label="${escapeXmlAttribute(g.label)}" color="${escapeXmlAttribute(g.color)}" templateVersion="${g.templateVersion}"/>`,
       );
     }
     parts.push(`${ind(3)}</composer:groups>`);
@@ -93,9 +93,9 @@ function generateTTML({ metadata, agents, lines, groups, granularity, minify = f
     const timing = effectiveBounds(line);
     if (!timing) continue;
 
-    const agentAttr = line.agentId ? ` ttm:agent="${escapeXml(line.agentId)}"` : "";
+    const agentAttr = line.agentId ? ` ttm:agent="${escapeXmlAttribute(line.agentId)}"` : "";
     const groupAttr = line.groupId
-      ? ` composer:groupId="${escapeXml(line.groupId)}" composer:instanceIdx="${line.instanceIdx ?? 0}" composer:templateLineIdx="${line.templateLineIdx ?? 0}"${line.detached ? ' composer:detached="true"' : ""}`
+      ? ` composer:groupId="${escapeXmlAttribute(line.groupId)}" composer:instanceIdx="${line.instanceIdx ?? 0}" composer:templateLineIdx="${line.templateLineIdx ?? 0}"${line.detached ? ' composer:detached="true"' : ""}`
       : "";
     let content = "";
 

--- a/src/views/export.browser.test.tsx
+++ b/src/views/export.browser.test.tsx
@@ -112,6 +112,25 @@ describe("ExportPanel · edits across regeneration", () => {
     await expect.element(screen.getByText("The lyrics changed", { exact: false })).toBeInTheDocument();
     expect((textarea.element() as HTMLTextAreaElement).value).toContain("HELLO EDITED");
   });
+
+  it("surfaces the conflict notice in preview mode, not only while editing", async () => {
+    useProjectStore.setState({
+      lines: [createLine({ text: "Hello", begin: 0, end: 1 }), createLine({ text: "World", begin: 1, end: 2 })],
+    });
+    const screen = await render(<ExportPanel />);
+    await screen.getByRole("button", { name: /Edit$/ }).click();
+    const textarea = screen.getByRole("textbox", { name: "Edit TTML content" });
+    const generated = (textarea.element() as HTMLTextAreaElement).value;
+    await textarea.fill(generated.replace("Hello", "HELLO EDITED"));
+    await screen.getByRole("button", { name: "Done" }).click();
+
+    useProjectStore.setState((state) => ({
+      lines: state.lines.map((line, index) => (index === 0 ? { ...line, text: "HELLO REGEN" } : line)),
+    }));
+
+    await expect.element(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.container.querySelector("textarea")).toBeNull();
+  });
 });
 
 describe("ExportPanel · project file customSnapPoints", () => {

--- a/src/views/export.browser.test.tsx
+++ b/src/views/export.browser.test.tsx
@@ -167,7 +167,7 @@ describe("ExportPanel · project file customSnapPoints", () => {
     const payload = {
       version: 1 as const,
       savedAt: Date.now(),
-      metadata: { title: "Imported", artist: "", album: "", duration: 0 },
+      metadata: { title: "Imported", artists: [], album: "", duration: 0 },
       agents: DEFAULT_AGENTS,
       lines: [createLine({ text: "Hi", words: [createWord({ text: "Hi", begin: 0, end: 1 })] })],
       groups: [],

--- a/src/views/export.browser.test.tsx
+++ b/src/views/export.browser.test.tsx
@@ -71,6 +71,49 @@ describe("ExportPanel", () => {
   });
 });
 
+describe("ExportPanel · edits across regeneration", () => {
+  it("regression: preserves a disjoint edit when the underlying TTML regenerates", async () => {
+    useProjectStore.setState({
+      lines: [
+        createLine({ text: "Hello", begin: 0, end: 1 }),
+        createLine({ text: "World", begin: 1, end: 2 }),
+        createLine({ text: "Third", begin: 2, end: 3 }),
+      ],
+    });
+    const screen = await render(<ExportPanel />);
+    await screen.getByRole("button", { name: /Edit$/ }).click();
+    const textarea = screen.getByRole("textbox", { name: "Edit TTML content" });
+    const generated = (textarea.element() as HTMLTextAreaElement).value;
+    await textarea.fill(generated.replace("Hello", "HELLO EDITED"));
+
+    useProjectStore.setState((state) => ({
+      lines: state.lines.map((line, index) => (index === 2 ? { ...line, text: "THIRD CHANGED" } : line)),
+    }));
+
+    await expect.poll(() => (textarea.element() as HTMLTextAreaElement).value).toContain("HELLO EDITED");
+    expect((textarea.element() as HTMLTextAreaElement).value).toContain("THIRD CHANGED");
+  });
+
+  it("flags a conflict when the edited region itself regenerates, keeping the user's text", async () => {
+    useProjectStore.setState({
+      lines: [createLine({ text: "Hello", begin: 0, end: 1 }), createLine({ text: "World", begin: 1, end: 2 })],
+    });
+    const screen = await render(<ExportPanel />);
+    await screen.getByRole("button", { name: /Edit$/ }).click();
+    const textarea = screen.getByRole("textbox", { name: "Edit TTML content" });
+    const generated = (textarea.element() as HTMLTextAreaElement).value;
+    await textarea.fill(generated.replace("Hello", "HELLO EDITED"));
+
+    useProjectStore.setState((state) => ({
+      lines: state.lines.map((line, index) => (index === 0 ? { ...line, text: "HELLO REGEN" } : line)),
+    }));
+
+    await expect.element(screen.getByRole("alert")).toBeInTheDocument();
+    await expect.element(screen.getByText("The lyrics changed", { exact: false })).toBeInTheDocument();
+    expect((textarea.element() as HTMLTextAreaElement).value).toContain("HELLO EDITED");
+  });
+});
+
 describe("ExportPanel · project file customSnapPoints", () => {
   it("writes customSnapPoints into the exported project JSON", async () => {
     useProjectStore.setState({

--- a/src/views/export.browser.test.tsx
+++ b/src/views/export.browser.test.tsx
@@ -113,6 +113,47 @@ describe("ExportPanel · edits across regeneration", () => {
     expect((textarea.element() as HTMLTextAreaElement).value).toContain("HELLO EDITED");
   });
 
+  it("regression: typing in the editor does not silently resolve a conflict", async () => {
+    useProjectStore.setState({
+      lines: [createLine({ text: "Hello", begin: 0, end: 1 }), createLine({ text: "World", begin: 1, end: 2 })],
+    });
+    const screen = await render(<ExportPanel />);
+    await screen.getByRole("button", { name: /Edit$/ }).click();
+    const textarea = screen.getByRole("textbox", { name: "Edit TTML content" });
+    const generated = (textarea.element() as HTMLTextAreaElement).value;
+    await textarea.fill(generated.replace("Hello", "HELLO EDITED"));
+
+    useProjectStore.setState((state) => ({
+      lines: state.lines.map((line, index) => (index === 0 ? { ...line, text: "HELLO REGEN" } : line)),
+    }));
+    await expect.element(screen.getByRole("alert")).toBeInTheDocument();
+
+    await textarea.fill(`${(textarea.element() as HTMLTextAreaElement).value} `);
+
+    await expect.element(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("clears the conflict only when the user keeps their edits explicitly", async () => {
+    useProjectStore.setState({
+      lines: [createLine({ text: "Hello", begin: 0, end: 1 }), createLine({ text: "World", begin: 1, end: 2 })],
+    });
+    const screen = await render(<ExportPanel />);
+    await screen.getByRole("button", { name: /Edit$/ }).click();
+    const textarea = screen.getByRole("textbox", { name: "Edit TTML content" });
+    const generated = (textarea.element() as HTMLTextAreaElement).value;
+    await textarea.fill(generated.replace("Hello", "HELLO EDITED"));
+
+    useProjectStore.setState((state) => ({
+      lines: state.lines.map((line, index) => (index === 0 ? { ...line, text: "HELLO REGEN" } : line)),
+    }));
+    await expect.element(screen.getByRole("alert")).toBeInTheDocument();
+
+    await screen.getByRole("button", { name: "Keep my edits" }).click();
+
+    await expect.poll(() => screen.container.querySelector("[role=alert]")).toBeNull();
+    expect((textarea.element() as HTMLTextAreaElement).value).toContain("HELLO EDITED");
+  });
+
   it("surfaces the conflict notice in preview mode, not only while editing", async () => {
     useProjectStore.setState({
       lines: [createLine({ text: "Hello", begin: 0, end: 1 }), createLine({ text: "World", begin: 1, end: 2 })],

--- a/src/views/export.tsx
+++ b/src/views/export.tsx
@@ -6,6 +6,8 @@ import { EmptyState } from "@/ui/empty-state";
 import { Scroll } from "@/ui/scroll";
 import { effectiveBounds } from "@/domain/line/bounds";
 import { generateTTML } from "@/utils/ttml";
+import { rebaseTtmlEdits } from "@/utils/ttml-merge";
+import { TtmlEditor } from "@/views/export/ttml-editor";
 import {
   IconCheck,
   IconCopy,
@@ -48,7 +50,20 @@ const ExportPanel: React.FC = () => {
     return generateTTML({ metadata, agents, lines, groups, granularity, minify: true, duration });
   }, [metadata, agents, lines, groups, granularity, duration, hasSyncedContent]);
 
-  const editedContent = editState && editState.source === generatedTtml ? editState.content : null;
+  const drift = editState !== null && editState.source !== generatedTtml;
+  const rebased = useMemo(
+    () => (editState !== null && drift ? rebaseTtmlEdits(editState.source, editState.content, generatedTtml) : null),
+    [editState, drift, generatedTtml],
+  );
+  const editedContent =
+    editState === null
+      ? null
+      : !drift
+        ? editState.content
+        : rebased?.status === "clean"
+          ? rebased.content
+          : editState.content;
+  const hasConflict = drift && rebased?.status === "conflict";
   const displayContent = editedContent ?? generatedTtml;
   const exportContent = editedContent ?? minifiedTtml;
 
@@ -176,15 +191,14 @@ const ExportPanel: React.FC = () => {
 
       {/* Preview / Editor */}
       {isEditing ? (
-        <div className="flex flex-col flex-1 min-h-0 p-6">
-          <textarea
-            value={displayContent}
-            aria-label="Edit TTML content"
-            onChange={(e) => setEditState({ source: generatedTtml, content: e.target.value })}
-            className="w-full flex-1 p-4 rounded-lg font-mono text-xs bg-composer-bg-elevated text-composer-text resize-none focus:outline-none focus:ring-1 focus:ring-composer-accent"
-            spellCheck={false}
-          />
-        </div>
+        <TtmlEditor
+          value={displayContent}
+          generatedTtml={generatedTtml}
+          hasEdits={editedContent !== null}
+          hasConflict={hasConflict}
+          onChange={(content) => setEditState({ source: generatedTtml, content })}
+          onRegenerate={handleRegenerate}
+        />
       ) : (
         <Scroll className="flex-1 p-6">
           <Highlight theme={themes.nightOwl} code={displayContent} language="xml">

--- a/src/views/export.tsx
+++ b/src/views/export.tsx
@@ -7,6 +7,7 @@ import { Scroll } from "@/ui/scroll";
 import { effectiveBounds } from "@/domain/line/bounds";
 import { generateTTML } from "@/utils/ttml";
 import { rebaseTtmlEdits } from "@/utils/ttml-merge";
+import { MetadataPanel } from "@/views/export/metadata-panel";
 import { TtmlConflictNotice } from "@/views/export/ttml-conflict-notice";
 import { TtmlEditor } from "@/views/export/ttml-editor";
 import {
@@ -189,6 +190,8 @@ const ExportPanel: React.FC = () => {
           </Button>
         </div>
       </div>
+
+      <MetadataPanel />
 
       {hasConflict && <TtmlConflictNotice onRegenerate={handleRegenerate} />}
 

--- a/src/views/export.tsx
+++ b/src/views/export.tsx
@@ -7,6 +7,7 @@ import { Scroll } from "@/ui/scroll";
 import { effectiveBounds } from "@/domain/line/bounds";
 import { generateTTML } from "@/utils/ttml";
 import { rebaseTtmlEdits } from "@/utils/ttml-merge";
+import { TtmlConflictNotice } from "@/views/export/ttml-conflict-notice";
 import { TtmlEditor } from "@/views/export/ttml-editor";
 import {
   IconCheck,
@@ -189,15 +190,15 @@ const ExportPanel: React.FC = () => {
         </div>
       </div>
 
+      {hasConflict && <TtmlConflictNotice onRegenerate={handleRegenerate} />}
+
       {/* Preview / Editor */}
       {isEditing ? (
         <TtmlEditor
           value={displayContent}
           generatedTtml={generatedTtml}
           hasEdits={editedContent !== null}
-          hasConflict={hasConflict}
           onChange={(content) => setEditState({ source: generatedTtml, content })}
-          onRegenerate={handleRegenerate}
         />
       ) : (
         <Scroll className="flex-1 p-6">

--- a/src/views/export.tsx
+++ b/src/views/export.tsx
@@ -102,6 +102,23 @@ const ExportPanel: React.FC = () => {
     setIsEditing(false);
   }, []);
 
+  // Resolving a conflict rebases the edit onto the current output, which is what
+  // makes the notice go away. It has to be a deliberate action: letting an
+  // incidental keystroke do it would silently drop the regenerated changes.
+  const handleKeepEdits = useCallback(() => {
+    setEditState((prev) => (prev === null ? prev : { source: generatedTtml, content: prev.content }));
+  }, [generatedTtml]);
+
+  const handleEditContent = useCallback(
+    (content: string) => {
+      setEditState((prev) => {
+        if (prev !== null && hasConflict) return { ...prev, content };
+        return { source: generatedTtml, content };
+      });
+    },
+    [generatedTtml, hasConflict],
+  );
+
   const projectFileInput = (
     <input
       ref={fileInputRef}
@@ -193,7 +210,7 @@ const ExportPanel: React.FC = () => {
 
       <MetadataPanel />
 
-      {hasConflict && <TtmlConflictNotice onRegenerate={handleRegenerate} />}
+      {hasConflict && <TtmlConflictNotice onRegenerate={handleRegenerate} onKeepEdits={handleKeepEdits} />}
 
       {/* Preview / Editor */}
       {isEditing ? (
@@ -201,7 +218,7 @@ const ExportPanel: React.FC = () => {
           value={displayContent}
           generatedTtml={generatedTtml}
           hasEdits={editedContent !== null}
-          onChange={(content) => setEditState({ source: generatedTtml, content })}
+          onChange={handleEditContent}
         />
       ) : (
         <Scroll className="flex-1 p-6">

--- a/src/views/export.tsx
+++ b/src/views/export.tsx
@@ -214,12 +214,7 @@ const ExportPanel: React.FC = () => {
 
       {/* Preview / Editor */}
       {isEditing ? (
-        <TtmlEditor
-          value={displayContent}
-          generatedTtml={generatedTtml}
-          hasEdits={editedContent !== null}
-          onChange={handleEditContent}
-        />
+        <TtmlEditor value={displayContent} generatedTtml={generatedTtml} onChange={handleEditContent} />
       ) : (
         <Scroll className="flex-1 p-6">
           <Highlight theme={themes.nightOwl} code={displayContent} language="xml">

--- a/src/views/export/extra-field-list.browser.test.tsx
+++ b/src/views/export/extra-field-list.browser.test.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
+import { render } from "@/test/render";
+import { ExtraFieldList } from "@/views/export/extra-field-list";
+
+// -- Helpers ------------------------------------------------------------------
+
+function ExtraHost({ initial = {} as Record<string, string> }) {
+  const [extra, setExtra] = useState(initial);
+  return (
+    <div>
+      <button type="button" onClick={() => setExtra({ imported: "x" })}>
+        external
+      </button>
+      <ExtraFieldList values={extra} onChange={setExtra} />
+    </div>
+  );
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("ExtraFieldList", () => {
+  it("seeds pairs from the initial record", async () => {
+    const screen = await render(<ExtraHost initial={{ spotifyId: "abc" }} />);
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 key" })).toHaveValue("spotifyId");
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 value" })).toHaveValue("abc");
+  });
+
+  it("adds a key/value pair through onChange", async () => {
+    const screen = await render(<ExtraHost />);
+    await screen.getByRole("button", { name: "Add field" }).click();
+    await screen.getByRole("textbox", { name: "Field 1 key" }).fill("k");
+    await screen.getByRole("textbox", { name: "Field 1 value" }).fill("v");
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 key" })).toHaveValue("k");
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 value" })).toHaveValue("v");
+  });
+
+  it("reseeds when the record changes externally", async () => {
+    const screen = await render(<ExtraHost initial={{ old: "1" }} />);
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 key" })).toHaveValue("old");
+
+    await screen.getByRole("button", { name: "external" }).click();
+
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 key" })).toHaveValue("imported");
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 value" })).toHaveValue("x");
+  });
+
+  describe("invariants", () => {
+    it("keeps an in-progress empty pair after its no-op echo to the store", async () => {
+      const screen = await render(<ExtraHost />);
+      await screen.getByRole("button", { name: "Add field" }).click();
+
+      // The empty key maps to nothing in the record, so onChange echoes {}. The
+      // buffer must NOT treat that echo as an external clear and drop the row.
+      await expect.element(screen.getByRole("textbox", { name: "Field 1 key" })).toHaveValue("");
+      await screen.getByRole("textbox", { name: "Field 1 key" }).fill("k");
+      await expect.element(screen.getByRole("textbox", { name: "Field 1 key" })).toHaveValue("k");
+    });
+
+    it("keeps focus across consecutive keystrokes in a key input", async () => {
+      const screen = await render(<ExtraHost />);
+      await screen.getByRole("button", { name: "Add field" }).click();
+
+      const input = screen.getByRole("textbox", { name: "Field 1 key" }).element() as HTMLInputElement;
+      await userEvent.click(input);
+      await userEvent.type(input, "spotify");
+
+      await expect.poll(() => document.activeElement).toBe(input);
+      expect(input.value).toBe("spotify");
+    });
+  });
+});

--- a/src/views/export/extra-field-list.browser.test.tsx
+++ b/src/views/export/extra-field-list.browser.test.tsx
@@ -51,8 +51,6 @@ describe("ExtraFieldList", () => {
       const screen = await render(<ExtraHost />);
       await screen.getByRole("button", { name: "Add field" }).click();
 
-      // The empty key maps to nothing in the record, so onChange echoes {}. The
-      // buffer must NOT treat that echo as an external clear and drop the row.
       await expect.element(screen.getByRole("textbox", { name: "Field 1 key" })).toHaveValue("");
       await screen.getByRole("textbox", { name: "Field 1 key" }).fill("k");
       await expect.element(screen.getByRole("textbox", { name: "Field 1 key" })).toHaveValue("k");
@@ -69,5 +67,33 @@ describe("ExtraFieldList", () => {
       await expect.poll(() => document.activeElement).toBe(input);
       expect(input.value).toBe("spotify");
     });
+  });
+});
+
+// -- Reserved keys ------------------------------------------------------------
+
+describe("ExtraFieldList reserved keys", () => {
+  it("warns when a key collides with a dedicated metadata field", async () => {
+    const screen = await render(<ExtraHost initial={{ mood: "calm" }} />);
+    const keyInput = screen.getByRole("textbox", { name: "Field 1 key" });
+
+    await userEvent.fill(keyInput, "songwriter");
+
+    await expect.element(screen.getByText(/reserved key/i)).toBeInTheDocument();
+  });
+
+  it("keeps the warning text selectable so it can be copied", async () => {
+    const screen = await render(<ExtraHost initial={{ mood: "calm" }} />);
+    await userEvent.fill(screen.getByRole("textbox", { name: "Field 1 key" }), "album");
+
+    const warning = screen.getByText(/reserved key/i);
+    await expect.element(warning).toHaveClass(/select-text/);
+  });
+
+  it("shows no warning for an ordinary key", async () => {
+    const screen = await render(<ExtraHost initial={{ mood: "calm" }} />);
+    await userEvent.fill(screen.getByRole("textbox", { name: "Field 1 key" }), "spotifyId");
+
+    expect(screen.container.textContent).not.toMatch(/reserved key/i);
   });
 });

--- a/src/views/export/extra-field-list.reconcile.test.ts
+++ b/src/views/export/extra-field-list.reconcile.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { pairsToRecord, reconcilePairs, sameRecord, seedPairs } from "@/views/export/extra-field-list";
+
+describe("seedPairs", () => {
+  it("maps each entry to a pair with a unique id", () => {
+    const pairs = seedPairs({ a: "1", b: "2" });
+    expect(pairs.map(({ key, value }) => ({ key, value }))).toEqual([
+      { key: "a", value: "1" },
+      { key: "b", value: "2" },
+    ]);
+    expect(new Set(pairs.map((p) => p.id)).size).toBe(2);
+  });
+
+  describe("edge cases", () => {
+    it("returns an empty array for an empty record", () => {
+      expect(seedPairs({})).toEqual([]);
+    });
+  });
+});
+
+describe("pairsToRecord", () => {
+  it("drops pairs with blank keys", () => {
+    expect(pairsToRecord([{ id: "1", key: "  ", value: "x" }])).toEqual({});
+  });
+
+  it("collapses duplicate keys with the last value winning", () => {
+    const record = pairsToRecord([
+      { id: "1", key: "k", value: "first" },
+      { id: "2", key: "k", value: "second" },
+    ]);
+    expect(record).toEqual({ k: "second" });
+  });
+
+  it("keeps a blank value under a real key", () => {
+    expect(pairsToRecord([{ id: "1", key: "k", value: "" }])).toEqual({ k: "" });
+  });
+});
+
+describe("sameRecord", () => {
+  it("is true regardless of key order", () => {
+    expect(sameRecord({ a: "1", b: "2" }, { b: "2", a: "1" })).toBe(true);
+  });
+
+  describe("edge cases", () => {
+    it("is true for two empty records", () => {
+      expect(sameRecord({}, {})).toBe(true);
+    });
+
+    it("is false when a key is missing", () => {
+      expect(sameRecord({ a: "1" }, { a: "1", b: "2" })).toBe(false);
+    });
+
+    it("is false when a value differs", () => {
+      expect(sameRecord({ a: "1" }, { a: "2" })).toBe(false);
+    });
+  });
+});
+
+describe("reconcilePairs", () => {
+  it("preserves pair identity for unchanged positions", () => {
+    const previous = seedPairs({ a: "1", b: "2" });
+    const next = reconcilePairs(previous, { a: "1", b: "2" });
+    expect(next[0]).toBe(previous[0]);
+    expect(next[1]).toBe(previous[1]);
+  });
+
+  it("keeps the stable id when only the value changed at a position", () => {
+    const previous = seedPairs({ a: "1" });
+    const next = reconcilePairs(previous, { a: "2" });
+    expect(next[0].id).toBe(previous[0].id);
+    expect(next[0].value).toBe("2");
+    expect(next[0]).not.toBe(previous[0]);
+  });
+
+  describe("edge cases", () => {
+    it("mints ids for entries beyond the previous length", () => {
+      const previous = seedPairs({ a: "1" });
+      const next = reconcilePairs(previous, { a: "1", b: "2" });
+      expect(next[0]).toBe(previous[0]);
+      expect(next[1].key).toBe("b");
+      expect(next[1].id).not.toBe(previous[0].id);
+    });
+
+    it("reseeds to empty when the record is cleared", () => {
+      expect(reconcilePairs(seedPairs({ a: "1" }), {})).toEqual([]);
+    });
+  });
+
+  describe("invariants", () => {
+    it("output length always matches the incoming entries", () => {
+      const previous = seedPairs({ a: "1", b: "2" });
+      expect(reconcilePairs(previous, { a: "1", b: "2", c: "3" })).toHaveLength(3);
+      expect(reconcilePairs(previous, {})).toHaveLength(0);
+    });
+
+    it("does not mutate the previous pairs", () => {
+      const previous = seedPairs({ a: "1", b: "2" });
+      const snapshot = previous.map((p) => ({ ...p }));
+      reconcilePairs(previous, { a: "1", b: "changed", c: "3" });
+      expect(previous).toEqual(snapshot);
+    });
+  });
+});

--- a/src/views/export/extra-field-list.tsx
+++ b/src/views/export/extra-field-list.tsx
@@ -1,0 +1,104 @@
+import { useReconciledBuffer } from "@/hooks/useReconciledBuffer";
+import { Button } from "@/ui/button";
+import { INPUT_STYLES } from "@/views/export/metadata-field-list";
+import { IconPlus, IconX } from "@tabler/icons-react";
+import { nanoid } from "nanoid";
+
+// -- Interfaces ---------------------------------------------------------------
+
+interface ExtraFieldListProps {
+  values: Record<string, string>;
+  onChange: (next: Record<string, string>) => void;
+}
+
+interface Pair {
+  id: string;
+  key: string;
+  value: string;
+}
+
+// -- Reconciliation -----------------------------------------------------------
+
+const seedPairs = (extra: Record<string, string>): Pair[] =>
+  Object.entries(extra).map(([key, value]) => ({ id: nanoid(), key, value }));
+
+const reconcilePairs = (previous: Pair[], extra: Record<string, string>): Pair[] =>
+  Object.entries(extra).map(([key, value], index) =>
+    previous[index]?.key === key && previous[index]?.value === value
+      ? previous[index]
+      : { id: previous[index]?.id ?? nanoid(), key, value },
+  );
+
+const sameRecord = (a: Record<string, string>, b: Record<string, string>): boolean => {
+  const keys = Object.keys(a);
+  return keys.length === Object.keys(b).length && keys.every((key) => a[key] === b[key]);
+};
+
+const pairsToRecord = (pairs: Pair[]): Record<string, string> => {
+  const record: Record<string, string> = {};
+  for (const { key, value } of pairs) {
+    if (key.trim() !== "") record[key] = value;
+  }
+  return record;
+};
+
+// -- Component ----------------------------------------------------------------
+
+const ExtraFieldList: React.FC<ExtraFieldListProps> = ({ values, onChange }) => {
+  // Pairs carry a stable id so reorders/removals keep input focus and identity.
+  // The buffer re-seeds whenever extra is written from outside (load, import).
+  const { rows: pairs, commit } = useReconciledBuffer<Pair, Record<string, string>>(values, onChange, {
+    seed: seedPairs,
+    reconcile: reconcilePairs,
+    equal: sameRecord,
+    emit: pairsToRecord,
+  });
+
+  const handleEdit = (id: string, patch: Partial<Pair>) =>
+    commit(pairs.map((pair) => (pair.id === id ? { ...pair, ...patch } : pair)));
+  const handleRemove = (id: string) => commit(pairs.filter((pair) => pair.id !== id));
+  const handleAdd = () => commit([...pairs, { id: nanoid(), key: "", value: "" }]);
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs font-medium text-composer-text-secondary select-none">Extra fields</span>
+      {pairs.map((pair, index) => (
+        <div key={pair.id} className="flex items-center gap-2">
+          <input
+            type="text"
+            aria-label={`Field ${index + 1} key`}
+            value={pair.key}
+            placeholder="Key"
+            onChange={(e) => handleEdit(pair.id, { key: e.target.value })}
+            className={INPUT_STYLES}
+          />
+          <input
+            type="text"
+            aria-label={`Field ${index + 1} value`}
+            value={pair.value}
+            placeholder="Value"
+            onChange={(e) => handleEdit(pair.id, { value: e.target.value })}
+            className={INPUT_STYLES}
+          />
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={`Remove field ${index + 1}`}
+            onClick={() => handleRemove(pair.id)}
+          >
+            <IconX className="size-4" />
+          </Button>
+        </div>
+      ))}
+      <Button hasIcon size="sm" variant="secondary" className="self-start" aria-label="Add field" onClick={handleAdd}>
+        <IconPlus className="size-3.5" />
+        Add field
+      </Button>
+    </div>
+  );
+};
+
+// -- Exports ------------------------------------------------------------------
+
+export { ExtraFieldList, seedPairs, reconcilePairs, sameRecord, pairsToRecord };
+export type { Pair };

--- a/src/views/export/extra-field-list.tsx
+++ b/src/views/export/extra-field-list.tsx
@@ -1,5 +1,6 @@
 import { useReconciledBuffer } from "@/hooks/useReconciledBuffer";
 import { Button } from "@/ui/button";
+import { type Pair, pairsToRecord, reconcilePairs, sameRecord, seedPairs } from "@/views/export/extra-field-pairs";
 import { INPUT_STYLES } from "@/views/export/metadata-field-list";
 import { IconPlus, IconX } from "@tabler/icons-react";
 import { nanoid } from "nanoid";
@@ -10,37 +11,6 @@ interface ExtraFieldListProps {
   values: Record<string, string>;
   onChange: (next: Record<string, string>) => void;
 }
-
-interface Pair {
-  id: string;
-  key: string;
-  value: string;
-}
-
-// -- Reconciliation -----------------------------------------------------------
-
-const seedPairs = (extra: Record<string, string>): Pair[] =>
-  Object.entries(extra).map(([key, value]) => ({ id: nanoid(), key, value }));
-
-const reconcilePairs = (previous: Pair[], extra: Record<string, string>): Pair[] =>
-  Object.entries(extra).map(([key, value], index) =>
-    previous[index]?.key === key && previous[index]?.value === value
-      ? previous[index]
-      : { id: previous[index]?.id ?? nanoid(), key, value },
-  );
-
-const sameRecord = (a: Record<string, string>, b: Record<string, string>): boolean => {
-  const keys = Object.keys(a);
-  return keys.length === Object.keys(b).length && keys.every((key) => a[key] === b[key]);
-};
-
-const pairsToRecord = (pairs: Pair[]): Record<string, string> => {
-  const record: Record<string, string> = {};
-  for (const { key, value } of pairs) {
-    if (key.trim() !== "") record[key] = value;
-  }
-  return record;
-};
 
 // -- Component ----------------------------------------------------------------
 
@@ -100,5 +70,4 @@ const ExtraFieldList: React.FC<ExtraFieldListProps> = ({ values, onChange }) => 
 
 // -- Exports ------------------------------------------------------------------
 
-export { ExtraFieldList, seedPairs, reconcilePairs, sameRecord, pairsToRecord };
-export type { Pair };
+export { ExtraFieldList };

--- a/src/views/export/extra-field-list.tsx
+++ b/src/views/export/extra-field-list.tsx
@@ -1,6 +1,13 @@
 import { useReconciledBuffer } from "@/hooks/useReconciledBuffer";
 import { Button } from "@/ui/button";
-import { type Pair, pairsToRecord, reconcilePairs, sameRecord, seedPairs } from "@/views/export/extra-field-pairs";
+import {
+  isReservedExtraKey,
+  type Pair,
+  pairsToRecord,
+  reconcilePairs,
+  sameRecord,
+  seedPairs,
+} from "@/views/export/extra-field-pairs";
 import { INPUT_STYLES } from "@/views/export/metadata-field-list";
 import { IconPlus, IconX } from "@tabler/icons-react";
 import { nanoid } from "nanoid";
@@ -15,8 +22,6 @@ interface ExtraFieldListProps {
 // -- Component ----------------------------------------------------------------
 
 const ExtraFieldList: React.FC<ExtraFieldListProps> = ({ values, onChange }) => {
-  // Pairs carry a stable id so reorders/removals keep input focus and identity.
-  // The buffer re-seeds whenever extra is written from outside (load, import).
   const { rows: pairs, commit } = useReconciledBuffer<Pair, Record<string, string>>(values, onChange, {
     seed: seedPairs,
     reconcile: reconcilePairs,
@@ -33,31 +38,38 @@ const ExtraFieldList: React.FC<ExtraFieldListProps> = ({ values, onChange }) => 
     <div className="flex flex-col gap-1.5">
       <span className="text-xs font-medium text-composer-text-secondary select-none">Extra fields</span>
       {pairs.map((pair, index) => (
-        <div key={pair.id} className="flex items-center gap-2">
-          <input
-            type="text"
-            aria-label={`Field ${index + 1} key`}
-            value={pair.key}
-            placeholder="Key"
-            onChange={(e) => handleEdit(pair.id, { key: e.target.value })}
-            className={INPUT_STYLES}
-          />
-          <input
-            type="text"
-            aria-label={`Field ${index + 1} value`}
-            value={pair.value}
-            placeholder="Value"
-            onChange={(e) => handleEdit(pair.id, { value: e.target.value })}
-            className={INPUT_STYLES}
-          />
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label={`Remove field ${index + 1}`}
-            onClick={() => handleRemove(pair.id)}
-          >
-            <IconX className="size-4" />
-          </Button>
+        <div key={pair.id} className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              aria-label={`Field ${index + 1} key`}
+              value={pair.key}
+              placeholder="Key"
+              onChange={(e) => handleEdit(pair.id, { key: e.target.value })}
+              className={INPUT_STYLES}
+            />
+            <input
+              type="text"
+              aria-label={`Field ${index + 1} value`}
+              value={pair.value}
+              placeholder="Value"
+              onChange={(e) => handleEdit(pair.id, { value: e.target.value })}
+              className={INPUT_STYLES}
+            />
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={`Remove field ${index + 1}`}
+              onClick={() => handleRemove(pair.id)}
+            >
+              <IconX className="size-4" />
+            </Button>
+          </div>
+          {isReservedExtraKey(pair.key) && (
+            <span className="text-xs text-composer-error-text select-text cursor-text">
+              Reserved key ・ use the matching field above instead
+            </span>
+          )}
         </div>
       ))}
       <Button hasIcon size="sm" variant="secondary" className="self-start" aria-label="Add field" onClick={handleAdd}>

--- a/src/views/export/extra-field-list.tsx
+++ b/src/views/export/extra-field-list.tsx
@@ -1,6 +1,7 @@
 import { useReconciledBuffer } from "@/hooks/useReconciledBuffer";
 import { Button } from "@/ui/button";
 import {
+  duplicateKeyIds,
   isReservedExtraKey,
   type Pair,
   pairsToRecord,
@@ -28,6 +29,8 @@ const ExtraFieldList: React.FC<ExtraFieldListProps> = ({ values, onChange }) => 
     equal: sameRecord,
     emit: pairsToRecord,
   });
+
+  const duplicates = duplicateKeyIds(pairs);
 
   const handleEdit = (id: string, patch: Partial<Pair>) =>
     commit(pairs.map((pair) => (pair.id === id ? { ...pair, ...patch } : pair)));
@@ -68,6 +71,11 @@ const ExtraFieldList: React.FC<ExtraFieldListProps> = ({ values, onChange }) => 
           {isReservedExtraKey(pair.key) && (
             <span className="text-xs text-composer-error-text select-text cursor-text">
               Reserved key ・ use the matching field above instead
+            </span>
+          )}
+          {duplicates.has(pair.id) && (
+            <span className="text-xs text-composer-error-text select-text cursor-text">
+              Duplicate key ・ rename it or the first field with this key wins
             </span>
           )}
         </div>

--- a/src/views/export/extra-field-pairs.test.ts
+++ b/src/views/export/extra-field-pairs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { pairsToRecord, reconcilePairs, sameRecord, seedPairs } from "@/views/export/extra-field-list";
+import { pairsToRecord, reconcilePairs, sameRecord, seedPairs } from "@/views/export/extra-field-pairs";
 
 describe("seedPairs", () => {
   it("maps each entry to a pair with a unique id", () => {

--- a/src/views/export/extra-field-pairs.test.ts
+++ b/src/views/export/extra-field-pairs.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { pairsToRecord, reconcilePairs, sameRecord, seedPairs } from "@/views/export/extra-field-pairs";
+import {
+  isReservedExtraKey,
+  pairsToRecord,
+  reconcilePairs,
+  sameRecord,
+  seedPairs,
+} from "@/views/export/extra-field-pairs";
 
 describe("seedPairs", () => {
   it("maps each entry to a pair with a unique id", () => {
@@ -98,6 +104,57 @@ describe("reconcilePairs", () => {
       const snapshot = previous.map((p) => ({ ...p }));
       reconcilePairs(previous, { a: "1", b: "changed", c: "3" });
       expect(previous).toEqual(snapshot);
+    });
+  });
+});
+
+// -- Reserved keys ------------------------------------------------------------
+
+describe("isReservedExtraKey", () => {
+  it("flags a key that collides with a dedicated metadata field", () => {
+    expect(isReservedExtraKey("songwriter")).toBe(true);
+    expect(isReservedExtraKey("album")).toBe(true);
+  });
+
+  it("allows an ordinary key", () => {
+    expect(isReservedExtraKey("spotifyId")).toBe(false);
+  });
+
+  describe("edge cases", () => {
+    it("ignores surrounding whitespace", () => {
+      expect(isReservedExtraKey("  album  ")).toBe(true);
+    });
+
+    it("treats a blank key as not reserved", () => {
+      expect(isReservedExtraKey("   ")).toBe(false);
+    });
+
+    it("is case sensitive, matching the TTML key exactly", () => {
+      expect(isReservedExtraKey("Album")).toBe(false);
+    });
+  });
+});
+
+describe("pairsToRecord reserved-key handling", () => {
+  it("drops a reserved key so it can never reach metadata.extra", () => {
+    const record = pairsToRecord([
+      { id: "1", key: "songwriter", value: "Typed By User" },
+      { id: "2", key: "spotifyId", value: "abc" },
+    ]);
+    expect(record).toEqual({ spotifyId: "abc" });
+  });
+
+  describe("invariants", () => {
+    it("never emits a key that isReservedExtraKey rejects", () => {
+      const record = pairsToRecord([
+        { id: "1", key: "album", value: "Deluxe" },
+        { id: "2", key: "artists", value: "Injected" },
+        { id: "3", key: "musicName", value: "Hijacked" },
+        { id: "4", key: "mood", value: "calm" },
+      ]);
+      for (const key of Object.keys(record)) {
+        expect(isReservedExtraKey(key)).toBe(false);
+      }
     });
   });
 });

--- a/src/views/export/extra-field-pairs.test.ts
+++ b/src/views/export/extra-field-pairs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  duplicateKeyIds,
   isReservedExtraKey,
   pairsToRecord,
   reconcilePairs,
@@ -29,12 +30,36 @@ describe("pairsToRecord", () => {
     expect(pairsToRecord([{ id: "1", key: "  ", value: "x" }])).toEqual({});
   });
 
-  it("collapses duplicate keys with the last value winning", () => {
+  it("keeps the first of two rows sharing a key, so the visible order decides", () => {
     const record = pairsToRecord([
       { id: "1", key: "k", value: "first" },
       { id: "2", key: "k", value: "second" },
     ]);
-    expect(record).toEqual({ k: "second" });
+    expect(record).toEqual({ k: "first" });
+  });
+
+  it("trims a key before storing it so padding cannot fork one field into two", () => {
+    const record = pairsToRecord([{ id: "1", key: "  producer  ", value: "Rick" }]);
+    expect(record).toEqual({ producer: "Rick" });
+  });
+
+  it("reports the losing row of a duplicate key", () => {
+    const duplicates = duplicateKeyIds([
+      { id: "1", key: "k", value: "first" },
+      { id: "2", key: " k ", value: "second" },
+      { id: "3", key: "other", value: "x" },
+    ]);
+    expect([...duplicates]).toEqual(["2"]);
+  });
+
+  it("reports no duplicates for blank or reserved keys", () => {
+    const duplicates = duplicateKeyIds([
+      { id: "1", key: "", value: "a" },
+      { id: "2", key: "", value: "b" },
+      { id: "3", key: "artists", value: "c" },
+      { id: "4", key: "artists", value: "d" },
+    ]);
+    expect([...duplicates]).toEqual([]);
   });
 
   it("keeps a blank value under a real key", () => {

--- a/src/views/export/extra-field-pairs.ts
+++ b/src/views/export/extra-field-pairs.ts
@@ -1,0 +1,39 @@
+import { nanoid } from "nanoid";
+
+// -- Interfaces ---------------------------------------------------------------
+
+interface Pair {
+  id: string;
+  key: string;
+  value: string;
+}
+
+// -- Reconciliation -----------------------------------------------------------
+
+const seedPairs = (extra: Record<string, string>): Pair[] =>
+  Object.entries(extra).map(([key, value]) => ({ id: nanoid(), key, value }));
+
+const reconcilePairs = (previous: Pair[], extra: Record<string, string>): Pair[] =>
+  Object.entries(extra).map(([key, value], index) =>
+    previous[index]?.key === key && previous[index]?.value === value
+      ? previous[index]
+      : { id: previous[index]?.id ?? nanoid(), key, value },
+  );
+
+const sameRecord = (a: Record<string, string>, b: Record<string, string>): boolean => {
+  const keys = Object.keys(a);
+  return keys.length === Object.keys(b).length && keys.every((key) => a[key] === b[key]);
+};
+
+const pairsToRecord = (pairs: Pair[]): Record<string, string> => {
+  const record: Record<string, string> = {};
+  for (const { key, value } of pairs) {
+    if (key.trim() !== "") record[key] = value;
+  }
+  return record;
+};
+
+// -- Exports ------------------------------------------------------------------
+
+export { seedPairs, reconcilePairs, sameRecord, pairsToRecord };
+export type { Pair };

--- a/src/views/export/extra-field-pairs.ts
+++ b/src/views/export/extra-field-pairs.ts
@@ -1,4 +1,5 @@
 import { RESERVED_META_KEYS } from "@/domain/project/metadata-ttml";
+import { reconcileKeyedRows } from "@/views/export/reconcile-keyed-rows";
 import { nanoid } from "nanoid";
 
 // -- Interfaces ---------------------------------------------------------------
@@ -15,10 +16,11 @@ const seedPairs = (extra: Record<string, string>): Pair[] =>
   Object.entries(extra).map(([key, value]) => ({ id: nanoid(), key, value }));
 
 const reconcilePairs = (previous: Pair[], extra: Record<string, string>): Pair[] =>
-  Object.entries(extra).map(([key, value], index) =>
-    previous[index]?.key === key && previous[index]?.value === value
-      ? previous[index]
-      : { id: previous[index]?.id ?? nanoid(), key, value },
+  reconcileKeyedRows(
+    previous,
+    Object.entries(extra),
+    (row, [key, value]) => row.key === key && row.value === value,
+    (id, [key, value]) => ({ id, key, value }),
   );
 
 const sameRecord = (a: Record<string, string>, b: Record<string, string>): boolean => {

--- a/src/views/export/extra-field-pairs.ts
+++ b/src/views/export/extra-field-pairs.ts
@@ -28,15 +28,36 @@ const sameRecord = (a: Record<string, string>, b: Record<string, string>): boole
 
 const isReservedExtraKey = (key: string): boolean => RESERVED_META_KEYS.has(key.trim());
 
+// `extra` is keyed by name, so two rows sharing a key can only ever store one
+// value. The row that loses is reported rather than silently dropped.
+const duplicateKeyIds = (pairs: Pair[]): ReadonlySet<string> => {
+  const seen = new Map<string, string>();
+  const duplicates = new Set<string>();
+  for (const { id, key } of pairs) {
+    const normalized = key.trim();
+    if (normalized === "" || isReservedExtraKey(normalized)) continue;
+    const firstId = seen.get(normalized);
+    if (firstId === undefined) {
+      seen.set(normalized, id);
+      continue;
+    }
+    duplicates.add(id);
+  }
+  return duplicates;
+};
+
 const pairsToRecord = (pairs: Pair[]): Record<string, string> => {
   const record: Record<string, string> = {};
-  for (const { key, value } of pairs) {
-    if (key.trim() !== "" && !isReservedExtraKey(key)) record[key] = value;
+  const duplicates = duplicateKeyIds(pairs);
+  for (const { id, key, value } of pairs) {
+    const normalized = key.trim();
+    if (normalized === "" || isReservedExtraKey(normalized) || duplicates.has(id)) continue;
+    record[normalized] = value;
   }
   return record;
 };
 
 // -- Exports ------------------------------------------------------------------
 
-export { seedPairs, reconcilePairs, sameRecord, pairsToRecord, isReservedExtraKey };
+export { seedPairs, reconcilePairs, sameRecord, pairsToRecord, isReservedExtraKey, duplicateKeyIds };
 export type { Pair };

--- a/src/views/export/extra-field-pairs.ts
+++ b/src/views/export/extra-field-pairs.ts
@@ -1,3 +1,4 @@
+import { RESERVED_META_KEYS } from "@/domain/project/metadata-ttml";
 import { nanoid } from "nanoid";
 
 // -- Interfaces ---------------------------------------------------------------
@@ -25,15 +26,17 @@ const sameRecord = (a: Record<string, string>, b: Record<string, string>): boole
   return keys.length === Object.keys(b).length && keys.every((key) => a[key] === b[key]);
 };
 
+const isReservedExtraKey = (key: string): boolean => RESERVED_META_KEYS.has(key.trim());
+
 const pairsToRecord = (pairs: Pair[]): Record<string, string> => {
   const record: Record<string, string> = {};
   for (const { key, value } of pairs) {
-    if (key.trim() !== "") record[key] = value;
+    if (key.trim() !== "" && !isReservedExtraKey(key)) record[key] = value;
   }
   return record;
 };
 
 // -- Exports ------------------------------------------------------------------
 
-export { seedPairs, reconcilePairs, sameRecord, pairsToRecord };
+export { seedPairs, reconcilePairs, sameRecord, pairsToRecord, isReservedExtraKey };
 export type { Pair };

--- a/src/views/export/metadata-field-list.browser.test.tsx
+++ b/src/views/export/metadata-field-list.browser.test.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
+import { render } from "@/test/render";
+import { MetadataFieldList } from "@/views/export/metadata-field-list";
+
+// -- Helpers ------------------------------------------------------------------
+
+// Controlled host so the field list behaves exactly as it does under the store:
+// every edit echoes back through `values`, and the "external" button simulates a
+// foreign write (project load / import) that must reseed the buffer.
+function ArtistsHost({ initial = [] as string[] }) {
+  const [values, setValues] = useState(initial);
+  return (
+    <div>
+      <button type="button" onClick={() => setValues(["Imported A", "Imported B"])}>
+        external
+      </button>
+      <MetadataFieldList
+        label="Artists"
+        itemNoun="Artist"
+        placeholder="Artist name"
+        values={values}
+        onChange={setValues}
+      />
+    </div>
+  );
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("MetadataFieldList", () => {
+  it("seeds rows from the initial values", async () => {
+    const screen = await render(<ArtistsHost initial={["Alpha", "Beta"]} />);
+    await expect.element(screen.getByRole("textbox", { name: "Artist 1" })).toHaveValue("Alpha");
+    await expect.element(screen.getByRole("textbox", { name: "Artist 2" })).toHaveValue("Beta");
+  });
+
+  it("adds, edits, and removes rows through onChange", async () => {
+    const screen = await render(<ArtistsHost />);
+    await screen.getByRole("button", { name: "Add artist" }).click();
+    await screen.getByRole("textbox", { name: "Artist 1" }).fill("Sia");
+    await expect.element(screen.getByRole("textbox", { name: "Artist 1" })).toHaveValue("Sia");
+
+    await screen.getByRole("button", { name: "Remove artist 1" }).click();
+    await expect.poll(() => screen.container.querySelector("[aria-label='Artist 1']")).toBeNull();
+  });
+
+  it("reseeds when values change externally", async () => {
+    const screen = await render(<ArtistsHost initial={["Alpha"]} />);
+    await expect.element(screen.getByRole("textbox", { name: "Artist 1" })).toHaveValue("Alpha");
+
+    await screen.getByRole("button", { name: "external" }).click();
+
+    await expect.element(screen.getByRole("textbox", { name: "Artist 1" })).toHaveValue("Imported A");
+    await expect.element(screen.getByRole("textbox", { name: "Artist 2" })).toHaveValue("Imported B");
+  });
+
+  describe("invariants", () => {
+    it("keeps input focus across consecutive keystrokes (no reseed on own edits)", async () => {
+      const screen = await render(<ArtistsHost />);
+      await screen.getByRole("button", { name: "Add artist" }).click();
+
+      const input = screen.getByRole("textbox", { name: "Artist 1" }).element() as HTMLInputElement;
+      await userEvent.click(input);
+      await userEvent.type(input, "Sia");
+
+      await expect.poll(() => document.activeElement).toBe(input);
+      expect(input.value).toBe("Sia");
+    });
+
+    it("supports keyboard: Tab walks from an artist input through its remove button to the next input", async () => {
+      const screen = await render(<ArtistsHost initial={["Alpha", "Beta"]} />);
+      const first = screen.getByRole("textbox", { name: "Artist 1" }).element() as HTMLInputElement;
+
+      await userEvent.click(first);
+      await expect.poll(() => document.activeElement).toBe(first);
+      await userEvent.tab();
+      await expect
+        .poll(() => document.activeElement)
+        .toBe(screen.getByRole("button", { name: "Remove artist 1" }).element());
+      await userEvent.tab();
+      await expect.poll(() => document.activeElement).toBe(screen.getByRole("textbox", { name: "Artist 2" }).element());
+    });
+  });
+});

--- a/src/views/export/metadata-field-list.browser.test.tsx
+++ b/src/views/export/metadata-field-list.browser.test.tsx
@@ -6,9 +6,6 @@ import { MetadataFieldList } from "@/views/export/metadata-field-list";
 
 // -- Helpers ------------------------------------------------------------------
 
-// Controlled host so the field list behaves exactly as it does under the store:
-// every edit echoes back through `values`, and the "external" button simulates a
-// foreign write (project load / import) that must reseed the buffer.
 function ArtistsHost({ initial = [] as string[] }) {
   const [values, setValues] = useState(initial);
   return (

--- a/src/views/export/metadata-field-list.reconcile.test.ts
+++ b/src/views/export/metadata-field-list.reconcile.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { reconcileRows, sameStrings, seedRows } from "@/views/export/metadata-field-list";
+
+describe("seedRows", () => {
+  it("maps each value to a row with a unique id", () => {
+    const rows = seedRows(["a", "b", "c"]);
+    expect(rows.map((r) => r.value)).toEqual(["a", "b", "c"]);
+    expect(new Set(rows.map((r) => r.id)).size).toBe(3);
+  });
+
+  describe("edge cases", () => {
+    it("returns an empty array for no values", () => {
+      expect(seedRows([])).toEqual([]);
+    });
+
+    it("preserves empty strings and gives duplicate values distinct ids", () => {
+      const rows = seedRows(["", "x", "x"]);
+      expect(rows.map((r) => r.value)).toEqual(["", "x", "x"]);
+      expect(new Set(rows.map((r) => r.id)).size).toBe(3);
+    });
+  });
+});
+
+describe("sameStrings", () => {
+  it("is true for equal contents in the same order", () => {
+    expect(sameStrings(["a", "b"], ["a", "b"])).toBe(true);
+  });
+
+  describe("edge cases", () => {
+    it("is true for two empty arrays", () => {
+      expect(sameStrings([], [])).toBe(true);
+    });
+
+    it("is false on length mismatch", () => {
+      expect(sameStrings(["a"], ["a", "b"])).toBe(false);
+    });
+
+    it("is order-sensitive", () => {
+      expect(sameStrings(["a", "b"], ["b", "a"])).toBe(false);
+    });
+
+    it("distinguishes empty string from missing element", () => {
+      expect(sameStrings([""], [])).toBe(false);
+    });
+  });
+});
+
+describe("reconcileRows", () => {
+  it("preserves row identity for unchanged positions", () => {
+    const previous = seedRows(["a", "b"]);
+    const next = reconcileRows(previous, ["a", "b"]);
+    expect(next[0]).toBe(previous[0]);
+    expect(next[1]).toBe(previous[1]);
+  });
+
+  it("keeps the stable id at a position whose value changed", () => {
+    const previous = seedRows(["a", "b"]);
+    const next = reconcileRows(previous, ["a", "B"]);
+    expect(next[1].id).toBe(previous[1].id);
+    expect(next[1].value).toBe("B");
+    expect(next[1]).not.toBe(previous[1]);
+  });
+
+  describe("edge cases", () => {
+    it("mints ids for values beyond the previous length", () => {
+      const previous = seedRows(["a"]);
+      const next = reconcileRows(previous, ["a", "b"]);
+      expect(next[0]).toBe(previous[0]);
+      expect(next[1].value).toBe("b");
+      expect(next[1].id).not.toBe(previous[0].id);
+    });
+
+    it("truncates when fewer values than before", () => {
+      const previous = seedRows(["a", "b", "c"]);
+      const next = reconcileRows(previous, ["a"]);
+      expect(next).toHaveLength(1);
+      expect(next[0]).toBe(previous[0]);
+    });
+
+    it("reseeds to empty when all values are gone", () => {
+      expect(reconcileRows(seedRows(["a", "b"]), [])).toEqual([]);
+    });
+
+    it("reseeds from empty previous rows", () => {
+      const next = reconcileRows([], ["a", "b"]);
+      expect(next.map((r) => r.value)).toEqual(["a", "b"]);
+      expect(new Set(next.map((r) => r.id)).size).toBe(2);
+    });
+  });
+
+  describe("invariants", () => {
+    it("output length always matches the incoming values", () => {
+      const previous = seedRows(["a", "b", "c"]);
+      for (const values of [[], ["a"], ["a", "b", "c", "d"], ["x", "y"]]) {
+        expect(reconcileRows(previous, values)).toHaveLength(values.length);
+      }
+    });
+
+    it("does not mutate the previous rows", () => {
+      const previous = seedRows(["a", "b"]);
+      const snapshot = previous.map((r) => ({ ...r }));
+      reconcileRows(previous, ["a", "B", "c"]);
+      expect(previous).toEqual(snapshot);
+    });
+  });
+});

--- a/src/views/export/metadata-field-list.tsx
+++ b/src/views/export/metadata-field-list.tsx
@@ -1,7 +1,7 @@
+import { useReconciledBuffer } from "@/hooks/useReconciledBuffer";
 import { Button } from "@/ui/button";
 import { IconPlus, IconX } from "@tabler/icons-react";
 import { nanoid } from "nanoid";
-import { useState } from "react";
 
 // -- Constants ----------------------------------------------------------------
 
@@ -23,17 +23,29 @@ interface Row {
   value: string;
 }
 
+// -- Reconciliation -----------------------------------------------------------
+
+const seedRows = (values: string[]): Row[] => values.map((value) => ({ id: nanoid(), value }));
+
+const reconcileRows = (previous: Row[], values: string[]): Row[] =>
+  values.map((value, index) =>
+    previous[index]?.value === value ? previous[index] : { id: previous[index]?.id ?? nanoid(), value },
+  );
+
+const sameStrings = (a: string[], b: string[]): boolean =>
+  a.length === b.length && a.every((value, index) => value === b[index]);
+
 // -- Component ----------------------------------------------------------------
 
 const MetadataFieldList: React.FC<MetadataFieldListProps> = ({ label, itemNoun, values, placeholder, onChange }) => {
   // Rows carry a stable id so reorders/removals keep input focus and identity.
-  // Seeded from the store on mount and re-seeded whenever the panel re-expands.
-  const [rows, setRows] = useState<Row[]>(() => values.map((value) => ({ id: nanoid(), value })));
-
-  const commit = (next: Row[]) => {
-    setRows(next);
-    onChange(next.map((row) => row.value));
-  };
+  // The buffer re-seeds whenever values are written from outside (load, import).
+  const { rows, commit } = useReconciledBuffer<Row, string[]>(values, onChange, {
+    seed: seedRows,
+    reconcile: reconcileRows,
+    equal: sameStrings,
+    emit: (next) => next.map((row) => row.value),
+  });
 
   const handleEdit = (id: string, value: string) =>
     commit(rows.map((row) => (row.id === id ? { ...row, value } : row)));
@@ -80,4 +92,5 @@ const MetadataFieldList: React.FC<MetadataFieldListProps> = ({ label, itemNoun, 
 
 // -- Exports ------------------------------------------------------------------
 
-export { MetadataFieldList, INPUT_STYLES };
+export { MetadataFieldList, INPUT_STYLES, seedRows, reconcileRows, sameStrings };
+export type { Row };

--- a/src/views/export/metadata-field-list.tsx
+++ b/src/views/export/metadata-field-list.tsx
@@ -1,0 +1,83 @@
+import { Button } from "@/ui/button";
+import { IconPlus, IconX } from "@tabler/icons-react";
+import { nanoid } from "nanoid";
+import { useState } from "react";
+
+// -- Constants ----------------------------------------------------------------
+
+const INPUT_STYLES =
+  "flex-1 px-2 py-1.5 text-sm rounded-md cursor-text bg-composer-input border border-composer-border text-composer-text focus:outline-none focus:border-composer-accent";
+
+// -- Interfaces ---------------------------------------------------------------
+
+interface MetadataFieldListProps {
+  label: string;
+  itemNoun: string;
+  values: string[];
+  placeholder?: string;
+  onChange: (next: string[]) => void;
+}
+
+interface Row {
+  id: string;
+  value: string;
+}
+
+// -- Component ----------------------------------------------------------------
+
+const MetadataFieldList: React.FC<MetadataFieldListProps> = ({ label, itemNoun, values, placeholder, onChange }) => {
+  // Rows carry a stable id so reorders/removals keep input focus and identity.
+  // Seeded from the store on mount and re-seeded whenever the panel re-expands.
+  const [rows, setRows] = useState<Row[]>(() => values.map((value) => ({ id: nanoid(), value })));
+
+  const commit = (next: Row[]) => {
+    setRows(next);
+    onChange(next.map((row) => row.value));
+  };
+
+  const handleEdit = (id: string, value: string) =>
+    commit(rows.map((row) => (row.id === id ? { ...row, value } : row)));
+  const handleRemove = (id: string) => commit(rows.filter((row) => row.id !== id));
+  const handleAdd = () => commit([...rows, { id: nanoid(), value: "" }]);
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs font-medium text-composer-text-secondary select-none">{label}</span>
+      {rows.map((row, index) => (
+        <div key={row.id} className="flex items-center gap-2">
+          <input
+            type="text"
+            aria-label={`${itemNoun} ${index + 1}`}
+            value={row.value}
+            placeholder={placeholder}
+            onChange={(e) => handleEdit(row.id, e.target.value)}
+            className={INPUT_STYLES}
+          />
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={`Remove ${itemNoun.toLowerCase()} ${index + 1}`}
+            onClick={() => handleRemove(row.id)}
+          >
+            <IconX className="size-4" />
+          </Button>
+        </div>
+      ))}
+      <Button
+        hasIcon
+        size="sm"
+        variant="secondary"
+        className="self-start"
+        aria-label={`Add ${itemNoun.toLowerCase()}`}
+        onClick={handleAdd}
+      >
+        <IconPlus className="size-3.5" />
+        Add {itemNoun.toLowerCase()}
+      </Button>
+    </div>
+  );
+};
+
+// -- Exports ------------------------------------------------------------------
+
+export { MetadataFieldList, INPUT_STYLES };

--- a/src/views/export/metadata-field-list.tsx
+++ b/src/views/export/metadata-field-list.tsx
@@ -1,5 +1,6 @@
 import { useReconciledBuffer } from "@/hooks/useReconciledBuffer";
 import { Button } from "@/ui/button";
+import { type Row, reconcileRows, sameStrings, seedRows } from "@/views/export/metadata-field-rows";
 import { IconPlus, IconX } from "@tabler/icons-react";
 import { nanoid } from "nanoid";
 
@@ -17,23 +18,6 @@ interface MetadataFieldListProps {
   placeholder?: string;
   onChange: (next: string[]) => void;
 }
-
-interface Row {
-  id: string;
-  value: string;
-}
-
-// -- Reconciliation -----------------------------------------------------------
-
-const seedRows = (values: string[]): Row[] => values.map((value) => ({ id: nanoid(), value }));
-
-const reconcileRows = (previous: Row[], values: string[]): Row[] =>
-  values.map((value, index) =>
-    previous[index]?.value === value ? previous[index] : { id: previous[index]?.id ?? nanoid(), value },
-  );
-
-const sameStrings = (a: string[], b: string[]): boolean =>
-  a.length === b.length && a.every((value, index) => value === b[index]);
 
 // -- Component ----------------------------------------------------------------
 
@@ -92,5 +76,4 @@ const MetadataFieldList: React.FC<MetadataFieldListProps> = ({ label, itemNoun, 
 
 // -- Exports ------------------------------------------------------------------
 
-export { MetadataFieldList, INPUT_STYLES, seedRows, reconcileRows, sameStrings };
-export type { Row };
+export { MetadataFieldList, INPUT_STYLES };

--- a/src/views/export/metadata-field-list.tsx
+++ b/src/views/export/metadata-field-list.tsx
@@ -22,8 +22,6 @@ interface MetadataFieldListProps {
 // -- Component ----------------------------------------------------------------
 
 const MetadataFieldList: React.FC<MetadataFieldListProps> = ({ label, itemNoun, values, placeholder, onChange }) => {
-  // Rows carry a stable id so reorders/removals keep input focus and identity.
-  // The buffer re-seeds whenever values are written from outside (load, import).
   const { rows, commit } = useReconciledBuffer<Row, string[]>(values, onChange, {
     seed: seedRows,
     reconcile: reconcileRows,

--- a/src/views/export/metadata-field-rows.test.ts
+++ b/src/views/export/metadata-field-rows.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { reconcileRows, sameStrings, seedRows } from "@/views/export/metadata-field-list";
+import { reconcileRows, sameStrings, seedRows } from "@/views/export/metadata-field-rows";
 
 describe("seedRows", () => {
   it("maps each value to a row with a unique id", () => {

--- a/src/views/export/metadata-field-rows.ts
+++ b/src/views/export/metadata-field-rows.ts
@@ -1,0 +1,25 @@
+import { nanoid } from "nanoid";
+
+// -- Interfaces ---------------------------------------------------------------
+
+interface Row {
+  id: string;
+  value: string;
+}
+
+// -- Reconciliation -----------------------------------------------------------
+
+const seedRows = (values: string[]): Row[] => values.map((value) => ({ id: nanoid(), value }));
+
+const reconcileRows = (previous: Row[], values: string[]): Row[] =>
+  values.map((value, index) =>
+    previous[index]?.value === value ? previous[index] : { id: previous[index]?.id ?? nanoid(), value },
+  );
+
+const sameStrings = (a: string[], b: string[]): boolean =>
+  a.length === b.length && a.every((value, index) => value === b[index]);
+
+// -- Exports ------------------------------------------------------------------
+
+export { seedRows, reconcileRows, sameStrings };
+export type { Row };

--- a/src/views/export/metadata-field-rows.ts
+++ b/src/views/export/metadata-field-rows.ts
@@ -1,3 +1,4 @@
+import { reconcileKeyedRows } from "@/views/export/reconcile-keyed-rows";
 import { nanoid } from "nanoid";
 
 // -- Interfaces ---------------------------------------------------------------
@@ -12,8 +13,11 @@ interface Row {
 const seedRows = (values: string[]): Row[] => values.map((value) => ({ id: nanoid(), value }));
 
 const reconcileRows = (previous: Row[], values: string[]): Row[] =>
-  values.map((value, index) =>
-    previous[index]?.value === value ? previous[index] : { id: previous[index]?.id ?? nanoid(), value },
+  reconcileKeyedRows(
+    previous,
+    values,
+    (row, value) => row.value === value,
+    (id, value) => ({ id, value }),
   );
 
 const sameStrings = (a: string[], b: string[]): boolean =>

--- a/src/views/export/metadata-panel.browser.test.tsx
+++ b/src/views/export/metadata-panel.browser.test.tsx
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
+import { useProjectStore } from "@/stores/project";
+import { render } from "@/test/render";
+import { MetadataPanel } from "@/views/export/metadata-panel";
+
+// -- Helpers ------------------------------------------------------------------
+
+function seedMetadata(patch: Partial<ReturnType<typeof useProjectStore.getState>["metadata"]> = {}): void {
+  useProjectStore.setState({
+    metadata: { title: "", artists: [], album: "", duration: 0, ...patch },
+  });
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("MetadataPanel", () => {
+  it("starts collapsed and reveals the fields when expanded", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+
+    expect(screen.container.querySelector("[role='textbox'][aria-label='Title']")).toBeNull();
+
+    await screen.getByRole("button", { name: "Metadata" }).click();
+    await expect.element(screen.getByRole("textbox", { name: "Title" })).toBeInTheDocument();
+    await expect.element(screen.getByRole("textbox", { name: "Album" })).toBeInTheDocument();
+    await expect.element(screen.getByRole("textbox", { name: "ISRC" })).toBeInTheDocument();
+  });
+
+  it("typing in Title updates the store", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("textbox", { name: "Title" }).fill("Bad Guy");
+    await expect.poll(() => useProjectStore.getState().metadata.title).toBe("Bad Guy");
+  });
+
+  it("typing in Album updates the store", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("textbox", { name: "Album" }).fill("When We All Fall Asleep");
+    await expect.poll(() => useProjectStore.getState().metadata.album).toBe("When We All Fall Asleep");
+  });
+
+  it("adds an artist row and preserves an exact comma-containing name", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("button", { name: "Add artist" }).click();
+    await screen.getByRole("textbox", { name: "Artist 1" }).fill("Tyler, The Creator");
+    await expect.poll(() => useProjectStore.getState().metadata.artists).toEqual(["Tyler, The Creator"]);
+  });
+
+  it("removes an artist row", async () => {
+    seedMetadata({ artists: ["Alpha", "Beta"] });
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("button", { name: "Remove artist 1" }).click();
+    await expect.poll(() => useProjectStore.getState().metadata.artists).toEqual(["Beta"]);
+  });
+
+  it("adds a producer row backed by songwriters", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("button", { name: "Add producer" }).click();
+    await screen.getByRole("textbox", { name: "Producer 1" }).fill("Finneas");
+    await expect.poll(() => useProjectStore.getState().metadata.songwriters).toEqual(["Finneas"]);
+  });
+
+  it("shows a hint and does not store an invalid ISRC", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("textbox", { name: "ISRC" }).fill("not-valid");
+    await expect.element(screen.getByText(/Invalid ISRC/)).toBeInTheDocument();
+    expect(useProjectStore.getState().metadata.isrc).toBeUndefined();
+  });
+
+  it("stores a normalized uppercase ISRC for valid input", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("textbox", { name: "ISRC" }).fill("usqx91700001");
+    await expect.poll(() => useProjectStore.getState().metadata.isrc).toBe("USQX91700001");
+  });
+
+  it("seeds the ISRC field from the existing store value", async () => {
+    seedMetadata({ isrc: "USQX91700001" });
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await expect.element(screen.getByRole("textbox", { name: "ISRC" })).toHaveValue("USQX91700001");
+  });
+
+  it("re-seeds the ISRC field when isrc is written externally while mounted", async () => {
+    seedMetadata({ isrc: "USQX91700001" });
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+    await expect.element(screen.getByRole("textbox", { name: "ISRC" })).toHaveValue("USQX91700001");
+
+    useProjectStore.getState().setMetadata({ isrc: "GBARL9300135" });
+    await expect.element(screen.getByRole("textbox", { name: "ISRC" })).toHaveValue("GBARL9300135");
+  });
+
+  it("keeps an in-progress ISRC edit instead of overwriting it with the normalized store value", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    const isrc = screen.getByRole("textbox", { name: "ISRC" });
+    await isrc.fill("usqx91700001");
+    await expect.poll(() => useProjectStore.getState().metadata.isrc).toBe("USQX91700001");
+    await expect.element(isrc).toHaveValue("usqx91700001");
+  });
+
+  it("adds an extra key/value row and writes it to the store", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("button", { name: "Add field" }).click();
+    await screen.getByRole("textbox", { name: "Field 1 key" }).fill("spotifyId");
+    await screen.getByRole("textbox", { name: "Field 1 value" }).fill("abc");
+    await expect.poll(() => useProjectStore.getState().metadata.extra).toEqual({ spotifyId: "abc" });
+  });
+
+  it("seeds artists, producers, and extra rows from the existing store value", async () => {
+    seedMetadata({
+      artists: ["Billie Eilish"],
+      songwriters: ["Finneas"],
+      extra: { spotifyId: "abc" },
+    });
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await expect.element(screen.getByRole("textbox", { name: "Artist 1" })).toHaveValue("Billie Eilish");
+    await expect.element(screen.getByRole("textbox", { name: "Producer 1" })).toHaveValue("Finneas");
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 key" })).toHaveValue("spotifyId");
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 value" })).toHaveValue("abc");
+  });
+
+  it("supports keyboard: a real Tab advances focus from the Title input to the Album input", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    const title = screen.getByRole("textbox", { name: "Title" }).element() as HTMLInputElement;
+    const album = screen.getByRole("textbox", { name: "Album" }).element() as HTMLInputElement;
+
+    await userEvent.click(title);
+    await expect.poll(() => document.activeElement).toBe(title);
+
+    await userEvent.tab();
+    await expect.poll(() => document.activeElement).toBe(album);
+  });
+
+  describe("edge cases", () => {
+    it("collapses duplicate extra keys to one store entry with the last value winning", async () => {
+      seedMetadata();
+      const screen = await render(<MetadataPanel />);
+      await screen.getByRole("button", { name: "Metadata" }).click();
+
+      await screen.getByRole("button", { name: "Add field" }).click();
+      await screen.getByRole("button", { name: "Add field" }).click();
+
+      await screen.getByRole("textbox", { name: "Field 1 key" }).fill("spotifyId");
+      await screen.getByRole("textbox", { name: "Field 1 value" }).fill("first");
+      await screen.getByRole("textbox", { name: "Field 2 key" }).fill("spotifyId");
+      await screen.getByRole("textbox", { name: "Field 2 value" }).fill("second");
+
+      await expect.poll(() => useProjectStore.getState().metadata.extra).toEqual({ spotifyId: "second" });
+    });
+  });
+});

--- a/src/views/export/metadata-panel.browser.test.tsx
+++ b/src/views/export/metadata-panel.browser.test.tsx
@@ -64,13 +64,13 @@ describe("MetadataPanel", () => {
     await expect.poll(() => useProjectStore.getState().metadata.artists).toEqual(["Beta"]);
   });
 
-  it("adds a producer row backed by songwriters", async () => {
+  it("adds a songwriter row backed by songwriters", async () => {
     seedMetadata();
     const screen = await render(<MetadataPanel />);
     await screen.getByRole("button", { name: "Metadata" }).click();
 
-    await screen.getByRole("button", { name: "Add producer" }).click();
-    await screen.getByRole("textbox", { name: "Producer 1" }).fill("Finneas");
+    await screen.getByRole("button", { name: "Add songwriter" }).click();
+    await screen.getByRole("textbox", { name: "Songwriter 1" }).fill("Finneas");
     await expect.poll(() => useProjectStore.getState().metadata.songwriters).toEqual(["Finneas"]);
   });
 
@@ -143,7 +143,7 @@ describe("MetadataPanel", () => {
     await screen.getByRole("button", { name: "Metadata" }).click();
 
     await expect.element(screen.getByRole("textbox", { name: "Artist 1" })).toHaveValue("Billie Eilish");
-    await expect.element(screen.getByRole("textbox", { name: "Producer 1" })).toHaveValue("Finneas");
+    await expect.element(screen.getByRole("textbox", { name: "Songwriter 1" })).toHaveValue("Finneas");
     await expect.element(screen.getByRole("textbox", { name: "Field 1 key" })).toHaveValue("spotifyId");
     await expect.element(screen.getByRole("textbox", { name: "Field 1 value" })).toHaveValue("abc");
   });

--- a/src/views/export/metadata-panel.browser.test.tsx
+++ b/src/views/export/metadata-panel.browser.test.tsx
@@ -164,7 +164,7 @@ describe("MetadataPanel", () => {
   });
 
   describe("edge cases", () => {
-    it("collapses duplicate extra keys to one store entry with the last value winning", async () => {
+    it("flags a duplicate extra key instead of silently dropping the row", async () => {
       seedMetadata();
       const screen = await render(<MetadataPanel />);
       await screen.getByRole("button", { name: "Metadata" }).click();
@@ -177,7 +177,30 @@ describe("MetadataPanel", () => {
       await screen.getByRole("textbox", { name: "Field 2 key" }).fill("spotifyId");
       await screen.getByRole("textbox", { name: "Field 2 value" }).fill("second");
 
-      await expect.poll(() => useProjectStore.getState().metadata.extra).toEqual({ spotifyId: "second" });
+      await expect.element(screen.getByText("Duplicate key", { exact: false })).toBeInTheDocument();
+      await expect.poll(() => useProjectStore.getState().metadata.extra).toEqual({ spotifyId: "first" });
+    });
+
+    it("clears the duplicate warning once the key is renamed", async () => {
+      seedMetadata();
+      const screen = await render(<MetadataPanel />);
+      await screen.getByRole("button", { name: "Metadata" }).click();
+
+      await screen.getByRole("button", { name: "Add field" }).click();
+      await screen.getByRole("button", { name: "Add field" }).click();
+
+      await screen.getByRole("textbox", { name: "Field 1 key" }).fill("producer");
+      await screen.getByRole("textbox", { name: "Field 1 value" }).fill("Rick");
+      await screen.getByRole("textbox", { name: "Field 2 key" }).fill("producer");
+      await screen.getByRole("textbox", { name: "Field 2 value" }).fill("Danger Mouse");
+      await expect.element(screen.getByText("Duplicate key", { exact: false })).toBeInTheDocument();
+
+      await screen.getByRole("textbox", { name: "Field 2 key" }).fill("coProducer");
+
+      await expect.poll(() => screen.container.textContent).not.toContain("Duplicate key");
+      await expect
+        .poll(() => useProjectStore.getState().metadata.extra)
+        .toEqual({ producer: "Rick", coProducer: "Danger Mouse" });
     });
   });
 });

--- a/src/views/export/metadata-panel.external.browser.test.tsx
+++ b/src/views/export/metadata-panel.external.browser.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { useProjectStore } from "@/stores/project";
+import { render } from "@/test/render";
+import { MetadataPanel } from "@/views/export/metadata-panel";
+
+// Regression: metadata written externally after the panel mounts (project load,
+// hash/query import, lyrics import) must be reflected in the editing fields, and
+// editing must never drop entries it never saw. See the parent/child lifecycle
+// bug fixed by routing every field list through useReconciledBuffer.
+
+const open = (screen: Awaited<ReturnType<typeof render>>) => screen.getByRole("button", { name: "Metadata" }).click();
+
+describe("MetadataPanel external writes after mount", () => {
+  it("shows extra fields written externally before the panel is first opened", async () => {
+    const screen = await render(<MetadataPanel />);
+
+    useProjectStore.getState().setMetadata({ extra: { spotifyId: "abc" } });
+
+    await open(screen);
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 key" })).toHaveValue("spotifyId");
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 value" })).toHaveValue("abc");
+  });
+
+  it("shows artists written externally before the panel is first opened", async () => {
+    const screen = await render(<MetadataPanel />);
+
+    useProjectStore.getState().setMetadata({ artists: ["Alpha"] });
+
+    await open(screen);
+    await expect.element(screen.getByRole("textbox", { name: "Artist 1" })).toHaveValue("Alpha");
+  });
+
+  it("updates the artist field when artists are written externally while open", async () => {
+    const screen = await render(<MetadataPanel />);
+    await open(screen);
+    await expect.element(screen.getByRole("textbox", { name: "Title" })).toBeInTheDocument();
+
+    useProjectStore.getState().setMetadata({ artists: ["Alpha"] });
+
+    await expect.element(screen.getByRole("textbox", { name: "Artist 1" })).toHaveValue("Alpha");
+  });
+
+  it("updates the extra fields when extra is written externally while open", async () => {
+    const screen = await render(<MetadataPanel />);
+    await open(screen);
+    await expect.element(screen.getByRole("textbox", { name: "Title" })).toBeInTheDocument();
+
+    useProjectStore.getState().setMetadata({ extra: { isrcSource: "manual" } });
+
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 key" })).toHaveValue("isrcSource");
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 value" })).toHaveValue("manual");
+  });
+
+  it("keeps externally-imported extras when the user adds another field", async () => {
+    const screen = await render(<MetadataPanel />);
+
+    useProjectStore.getState().setMetadata({ extra: { imported: "x" } });
+
+    await open(screen);
+    await screen.getByRole("button", { name: "Add field" }).click();
+    await screen.getByRole("textbox", { name: "Field 2 key" }).fill("newKey");
+    await screen.getByRole("textbox", { name: "Field 2 value" }).fill("newVal");
+
+    await expect.poll(() => useProjectStore.getState().metadata.extra).toEqual({ imported: "x", newKey: "newVal" });
+  });
+
+  it("reflects an external artists write after close and reopen", async () => {
+    const screen = await render(<MetadataPanel />);
+    const toggle = screen.getByRole("button", { name: "Metadata" });
+
+    await toggle.click();
+    await expect.element(screen.getByRole("textbox", { name: "Title" })).toBeInTheDocument();
+    useProjectStore.getState().setMetadata({ artists: ["Alpha"] });
+
+    await toggle.click();
+    await expect.poll(() => screen.container.querySelector("[aria-label='Title']")).toBeNull();
+    await toggle.click();
+
+    await expect.element(screen.getByRole("textbox", { name: "Artist 1" })).toHaveValue("Alpha");
+  });
+
+  it("updates the ISRC field when isrc is written externally while open", async () => {
+    const screen = await render(<MetadataPanel />);
+    await open(screen);
+    await expect.element(screen.getByRole("textbox", { name: "ISRC" })).toBeInTheDocument();
+
+    useProjectStore.getState().setMetadata({ isrc: "GBARL9300135" });
+
+    await expect.element(screen.getByRole("textbox", { name: "ISRC" })).toHaveValue("GBARL9300135");
+  });
+});

--- a/src/views/export/metadata-panel.external.browser.test.tsx
+++ b/src/views/export/metadata-panel.external.browser.test.tsx
@@ -3,11 +3,6 @@ import { useProjectStore } from "@/stores/project";
 import { render } from "@/test/render";
 import { MetadataPanel } from "@/views/export/metadata-panel";
 
-// Regression: metadata written externally after the panel mounts (project load,
-// hash/query import, lyrics import) must be reflected in the editing fields, and
-// editing must never drop entries it never saw. See the parent/child lifecycle
-// bug fixed by routing every field list through useReconciledBuffer.
-
 const open = (screen: Awaited<ReturnType<typeof render>>) => screen.getByRole("button", { name: "Metadata" }).click();
 
 describe("MetadataPanel external writes after mount", () => {

--- a/src/views/export/metadata-panel.tsx
+++ b/src/views/export/metadata-panel.tsx
@@ -3,23 +3,11 @@ import { Button } from "@/ui/button";
 import { accordionTransition, accordionVariants } from "@/utils/animationVariants";
 import { cn } from "@/utils/cn";
 import { isValidIsrc, normalizeIsrc } from "@/utils/isrc";
+import { ExtraFieldList } from "@/views/export/extra-field-list";
 import { INPUT_STYLES, MetadataFieldList } from "@/views/export/metadata-field-list";
-import { IconChevronRight, IconPlus, IconX } from "@tabler/icons-react";
+import { IconChevronRight } from "@tabler/icons-react";
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
-import { nanoid } from "nanoid";
 import { useState } from "react";
-
-// -- Helpers ------------------------------------------------------------------
-
-type ExtraPair = { id: string; key: string; value: string };
-
-function pairsToRecord(pairs: ExtraPair[]): Record<string, string> {
-  const record: Record<string, string> = {};
-  for (const { key, value } of pairs) {
-    if (key.trim() !== "") record[key] = value;
-  }
-  return record;
-}
 
 // -- Component ----------------------------------------------------------------
 
@@ -29,9 +17,6 @@ const MetadataPanel: React.FC = () => {
 
   const [open, setOpen] = useState(false);
   const [isrcDraft, setIsrcDraft] = useState(() => metadata.isrc ?? "");
-  const [extraPairs, setExtraPairs] = useState<ExtraPair[]>(() =>
-    Object.entries(metadata.extra ?? {}).map(([key, value]) => ({ id: nanoid(), key, value })),
-  );
 
   // The store keeps only a normalized isrc, but the field must show the raw draft
   // while editing (so the invalid hint can appear). Show the draft as long as it
@@ -44,15 +29,6 @@ const MetadataPanel: React.FC = () => {
   const handleIsrcChange = (value: string) => {
     setIsrcDraft(value);
     setMetadata({ isrc: normalizeIsrc(value) });
-  };
-
-  const handleExtraChange = (next: ExtraPair[]) => {
-    setExtraPairs(next);
-    setMetadata({ extra: pairsToRecord(next) });
-  };
-
-  const handleExtraEdit = (id: string, patch: Partial<ExtraPair>) => {
-    handleExtraChange(extraPairs.map((pair) => (pair.id === id ? { ...pair, ...patch } : pair)));
   };
 
   const reducedMotion = useReducedMotion();
@@ -140,48 +116,7 @@ const MetadataPanel: React.FC = () => {
                 onChange={(next) => setMetadata({ songwriters: next })}
               />
 
-              <div className="flex flex-col gap-1.5">
-                <span className="text-xs font-medium text-composer-text-secondary select-none">Extra fields</span>
-                {extraPairs.map((pair, index) => (
-                  <div key={pair.id} className="flex items-center gap-2">
-                    <input
-                      type="text"
-                      aria-label={`Field ${index + 1} key`}
-                      value={pair.key}
-                      placeholder="Key"
-                      onChange={(e) => handleExtraEdit(pair.id, { key: e.target.value })}
-                      className={INPUT_STYLES}
-                    />
-                    <input
-                      type="text"
-                      aria-label={`Field ${index + 1} value`}
-                      value={pair.value}
-                      placeholder="Value"
-                      onChange={(e) => handleExtraEdit(pair.id, { value: e.target.value })}
-                      className={INPUT_STYLES}
-                    />
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label={`Remove field ${index + 1}`}
-                      onClick={() => handleExtraChange(extraPairs.filter((p) => p.id !== pair.id))}
-                    >
-                      <IconX className="size-4" />
-                    </Button>
-                  </div>
-                ))}
-                <Button
-                  hasIcon
-                  size="sm"
-                  variant="secondary"
-                  className="self-start"
-                  aria-label="Add field"
-                  onClick={() => handleExtraChange([...extraPairs, { id: nanoid(), key: "", value: "" }])}
-                >
-                  <IconPlus className="size-3.5" />
-                  Add field
-                </Button>
-              </div>
+              <ExtraFieldList values={metadata.extra ?? {}} onChange={(next) => setMetadata({ extra: next })} />
             </div>
           </m.div>
         )}

--- a/src/views/export/metadata-panel.tsx
+++ b/src/views/export/metadata-panel.tsx
@@ -1,0 +1,195 @@
+import { useProjectStore } from "@/stores/project";
+import { Button } from "@/ui/button";
+import { accordionTransition, accordionVariants } from "@/utils/animationVariants";
+import { cn } from "@/utils/cn";
+import { isValidIsrc, normalizeIsrc } from "@/utils/isrc";
+import { INPUT_STYLES, MetadataFieldList } from "@/views/export/metadata-field-list";
+import { IconChevronRight, IconPlus, IconX } from "@tabler/icons-react";
+import { AnimatePresence, m, useReducedMotion } from "motion/react";
+import { nanoid } from "nanoid";
+import { useState } from "react";
+
+// -- Helpers ------------------------------------------------------------------
+
+type ExtraPair = { id: string; key: string; value: string };
+
+function pairsToRecord(pairs: ExtraPair[]): Record<string, string> {
+  const record: Record<string, string> = {};
+  for (const { key, value } of pairs) {
+    if (key.trim() !== "") record[key] = value;
+  }
+  return record;
+}
+
+// -- Component ----------------------------------------------------------------
+
+const MetadataPanel: React.FC = () => {
+  const metadata = useProjectStore((s) => s.metadata);
+  const setMetadata = useProjectStore((s) => s.setMetadata);
+
+  const [open, setOpen] = useState(false);
+  const [isrcDraft, setIsrcDraft] = useState(() => metadata.isrc ?? "");
+  const [extraPairs, setExtraPairs] = useState<ExtraPair[]>(() =>
+    Object.entries(metadata.extra ?? {}).map(([key, value]) => ({ id: nanoid(), key, value })),
+  );
+
+  // The store keeps only a normalized isrc, but the field must show the raw draft
+  // while editing (so the invalid hint can appear). Show the draft as long as it
+  // still maps to the stored value; if isrc is written from outside (URL params,
+  // bridge, audio tags), the store wins and the field re-seeds.
+  const isrcValue = normalizeIsrc(isrcDraft) === metadata.isrc ? isrcDraft : (metadata.isrc ?? "");
+  const trimmedIsrc = isrcValue.trim();
+  const isrcInvalid = trimmedIsrc !== "" && !isValidIsrc(trimmedIsrc);
+
+  const handleIsrcChange = (value: string) => {
+    setIsrcDraft(value);
+    setMetadata({ isrc: normalizeIsrc(value) });
+  };
+
+  const handleExtraChange = (next: ExtraPair[]) => {
+    setExtraPairs(next);
+    setMetadata({ extra: pairsToRecord(next) });
+  };
+
+  const handleExtraEdit = (id: string, patch: Partial<ExtraPair>) => {
+    handleExtraChange(extraPairs.map((pair) => (pair.id === id ? { ...pair, ...patch } : pair)));
+  };
+
+  const reducedMotion = useReducedMotion();
+
+  return (
+    <div className="border-b border-composer-border">
+      <Button
+        hasIcon
+        variant="ghost"
+        size="md"
+        className="w-full justify-start rounded-none h-8 px-6 text-composer-text-secondary"
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <IconChevronRight className={cn("size-4 transition-transform", open && "rotate-90")} />
+        Metadata
+      </Button>
+
+      <AnimatePresence initial={false}>
+        {open && (
+          <m.div
+            key="metadata-content"
+            variants={accordionVariants}
+            initial="hidden"
+            animate="visible"
+            exit="hidden"
+            transition={reducedMotion ? { duration: 0 } : accordionTransition}
+            className="overflow-hidden"
+          >
+            <div className="flex flex-col gap-4 px-6 pt-4 pb-4">
+              <label className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-composer-text-secondary select-none">Title</span>
+                <input
+                  type="text"
+                  aria-label="Title"
+                  value={metadata.title}
+                  placeholder="Song title"
+                  onChange={(e) => setMetadata({ title: e.target.value })}
+                  className={INPUT_STYLES}
+                />
+              </label>
+
+              <label className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-composer-text-secondary select-none">Album</span>
+                <input
+                  type="text"
+                  aria-label="Album"
+                  value={metadata.album}
+                  placeholder="Album name"
+                  onChange={(e) => setMetadata({ album: e.target.value })}
+                  className={INPUT_STYLES}
+                />
+              </label>
+
+              <label className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-composer-text-secondary select-none">ISRC</span>
+                <input
+                  type="text"
+                  aria-label="ISRC"
+                  value={isrcValue}
+                  placeholder="e.g. USQX91700001"
+                  onChange={(e) => handleIsrcChange(e.target.value)}
+                  className={INPUT_STYLES}
+                />
+                {isrcInvalid && (
+                  <span className="text-xs text-composer-error-text select-none">
+                    Invalid ISRC ・ expected 12 characters like USQX91700001
+                  </span>
+                )}
+              </label>
+
+              <MetadataFieldList
+                label="Artists"
+                itemNoun="Artist"
+                placeholder="Artist name"
+                values={metadata.artists}
+                onChange={(next) => setMetadata({ artists: next })}
+              />
+
+              <MetadataFieldList
+                label="Producers"
+                itemNoun="Producer"
+                placeholder="Producer name"
+                values={metadata.songwriters ?? []}
+                onChange={(next) => setMetadata({ songwriters: next })}
+              />
+
+              <div className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-composer-text-secondary select-none">Extra fields</span>
+                {extraPairs.map((pair, index) => (
+                  <div key={pair.id} className="flex items-center gap-2">
+                    <input
+                      type="text"
+                      aria-label={`Field ${index + 1} key`}
+                      value={pair.key}
+                      placeholder="Key"
+                      onChange={(e) => handleExtraEdit(pair.id, { key: e.target.value })}
+                      className={INPUT_STYLES}
+                    />
+                    <input
+                      type="text"
+                      aria-label={`Field ${index + 1} value`}
+                      value={pair.value}
+                      placeholder="Value"
+                      onChange={(e) => handleExtraEdit(pair.id, { value: e.target.value })}
+                      className={INPUT_STYLES}
+                    />
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Remove field ${index + 1}`}
+                      onClick={() => handleExtraChange(extraPairs.filter((p) => p.id !== pair.id))}
+                    >
+                      <IconX className="size-4" />
+                    </Button>
+                  </div>
+                ))}
+                <Button
+                  hasIcon
+                  size="sm"
+                  variant="secondary"
+                  className="self-start"
+                  aria-label="Add field"
+                  onClick={() => handleExtraChange([...extraPairs, { id: nanoid(), key: "", value: "" }])}
+                >
+                  <IconPlus className="size-3.5" />
+                  Add field
+                </Button>
+              </div>
+            </div>
+          </m.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+// -- Exports ------------------------------------------------------------------
+
+export { MetadataPanel };

--- a/src/views/export/metadata-panel.tsx
+++ b/src/views/export/metadata-panel.tsx
@@ -18,11 +18,8 @@ const MetadataPanel: React.FC = () => {
   const [open, setOpen] = useState(false);
   const [isrcDraft, setIsrcDraft] = useState(() => metadata.isrc ?? "");
 
-  // The store keeps only a normalized isrc, but the field must show the raw draft
-  // while editing (so the invalid hint can appear). Show the draft as long as it
-  // still maps to the stored value; if isrc is written from outside (URL params,
-  // bridge, audio tags), the store wins and the field re-seeds.
-  const isrcValue = normalizeIsrc(isrcDraft) === metadata.isrc ? isrcDraft : (metadata.isrc ?? "");
+  const draftStillMapsToStored = normalizeIsrc(isrcDraft) === metadata.isrc;
+  const isrcValue = draftStillMapsToStored ? isrcDraft : (metadata.isrc ?? "");
   const trimmedIsrc = isrcValue.trim();
   const isrcInvalid = trimmedIsrc !== "" && !isValidIsrc(trimmedIsrc);
 
@@ -94,7 +91,7 @@ const MetadataPanel: React.FC = () => {
                   className={INPUT_STYLES}
                 />
                 {isrcInvalid && (
-                  <span className="text-xs text-composer-error-text select-none">
+                  <span className="text-xs text-composer-error-text select-text cursor-text">
                     Invalid ISRC ・ expected 12 characters like USQX91700001
                   </span>
                 )}
@@ -109,9 +106,9 @@ const MetadataPanel: React.FC = () => {
               />
 
               <MetadataFieldList
-                label="Producers"
-                itemNoun="Producer"
-                placeholder="Producer name"
+                label="Songwriters"
+                itemNoun="Songwriter"
+                placeholder="Songwriter name"
                 values={metadata.songwriters ?? []}
                 onChange={(next) => setMetadata({ songwriters: next })}
               />

--- a/src/views/export/reconcile-keyed-rows.ts
+++ b/src/views/export/reconcile-keyed-rows.ts
@@ -1,0 +1,23 @@
+import { nanoid } from "nanoid";
+
+// -- Reconciliation -----------------------------------------------------------
+
+// Editable lists are rendered from rows carrying a stable id, so React keys
+// survive edits. Reconciling by position keeps a row's id whenever its content
+// is unchanged and mints one only where the external value actually differs.
+function reconcileKeyedRows<Row extends { id: string }, Source>(
+  previous: Row[],
+  sources: Source[],
+  matches: (row: Row, source: Source) => boolean,
+  create: (id: string, source: Source) => Row,
+): Row[] {
+  return sources.map((source, index) => {
+    const existing = previous[index];
+    if (existing && matches(existing, source)) return existing;
+    return create(existing?.id ?? nanoid(), source);
+  });
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { reconcileKeyedRows };

--- a/src/views/export/ttml-conflict-notice.browser.test.tsx
+++ b/src/views/export/ttml-conflict-notice.browser.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { TtmlConflictNotice } from "@/views/export/ttml-conflict-notice";
+import { render } from "@/test/render";
+
+// -- Tests --------------------------------------------------------------------
+
+describe("TtmlConflictNotice", () => {
+  it("renders an alert with the conflict message", async () => {
+    const screen = await render(<TtmlConflictNotice onRegenerate={() => {}} />);
+    await expect.element(screen.getByRole("alert")).toBeInTheDocument();
+    await expect.element(screen.getByText("The lyrics changed", { exact: false })).toBeInTheDocument();
+  });
+
+  it("regenerates on click", async () => {
+    const onRegenerate = vi.fn();
+    const screen = await render(<TtmlConflictNotice onRegenerate={onRegenerate} />);
+    await screen.getByRole("button", { name: "Regenerate" }).click();
+    expect(onRegenerate).toHaveBeenCalledOnce();
+  });
+});

--- a/src/views/export/ttml-conflict-notice.browser.test.tsx
+++ b/src/views/export/ttml-conflict-notice.browser.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { userEvent } from "vitest/browser";
 import { TtmlConflictNotice } from "@/views/export/ttml-conflict-notice";
 import { render } from "@/test/render";
 
@@ -6,15 +7,38 @@ import { render } from "@/test/render";
 
 describe("TtmlConflictNotice", () => {
   it("renders an alert with the conflict message", async () => {
-    const screen = await render(<TtmlConflictNotice onRegenerate={() => {}} />);
+    const screen = await render(<TtmlConflictNotice onRegenerate={() => {}} onKeepEdits={() => {}} />);
     await expect.element(screen.getByRole("alert")).toBeInTheDocument();
     await expect.element(screen.getByText("The lyrics changed", { exact: false })).toBeInTheDocument();
   });
 
+  it("says which version the export currently uses", async () => {
+    const screen = await render(<TtmlConflictNotice onRegenerate={() => {}} onKeepEdits={() => {}} />);
+    await expect.element(screen.getByText("uses your edits", { exact: false })).toBeInTheDocument();
+  });
+
   it("regenerates on click", async () => {
     const onRegenerate = vi.fn();
-    const screen = await render(<TtmlConflictNotice onRegenerate={onRegenerate} />);
+    const screen = await render(<TtmlConflictNotice onRegenerate={onRegenerate} onKeepEdits={() => {}} />);
     await screen.getByRole("button", { name: "Regenerate" }).click();
     expect(onRegenerate).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the edits on click", async () => {
+    const onKeepEdits = vi.fn();
+    const screen = await render(<TtmlConflictNotice onRegenerate={() => {}} onKeepEdits={onKeepEdits} />);
+    await screen.getByRole("button", { name: "Keep my edits" }).click();
+    expect(onKeepEdits).toHaveBeenCalledOnce();
+  });
+
+  it("resolves from the keyboard", async () => {
+    const onKeepEdits = vi.fn();
+    await render(<TtmlConflictNotice onRegenerate={() => {}} onKeepEdits={onKeepEdits} />);
+
+    await userEvent.tab();
+    await expect.poll(() => document.activeElement?.textContent).toContain("Keep my edits");
+    await userEvent.keyboard("{Enter}");
+
+    expect(onKeepEdits).toHaveBeenCalledOnce();
   });
 });

--- a/src/views/export/ttml-conflict-notice.tsx
+++ b/src/views/export/ttml-conflict-notice.tsx
@@ -1,0 +1,30 @@
+import { Button } from "@/ui/button";
+import { IconAlertTriangle, IconRefresh } from "@tabler/icons-react";
+
+// -- Interfaces ---------------------------------------------------------------
+
+interface TtmlConflictNoticeProps {
+  onRegenerate: () => void;
+}
+
+// -- Components ---------------------------------------------------------------
+
+const TtmlConflictNotice: React.FC<TtmlConflictNoticeProps> = ({ onRegenerate }) => (
+  <div
+    role="alert"
+    className="mx-6 mt-4 flex items-center justify-between gap-3 rounded-lg border border-composer-warning/20 bg-composer-warning/10 px-2.5 py-2 text-xs text-composer-warning"
+  >
+    <span className="flex items-center gap-2 select-text cursor-text">
+      <IconAlertTriangle size={14} className="shrink-0" />
+      The lyrics changed since you edited the TTML. Your edits and the new version differ.
+    </span>
+    <Button hasIcon size="sm" onClick={onRegenerate}>
+      <IconRefresh className="size-4" />
+      Regenerate
+    </Button>
+  </div>
+);
+
+// -- Exports ------------------------------------------------------------------
+
+export { TtmlConflictNotice };

--- a/src/views/export/ttml-conflict-notice.tsx
+++ b/src/views/export/ttml-conflict-notice.tsx
@@ -1,27 +1,34 @@
 import { Button } from "@/ui/button";
-import { IconAlertTriangle, IconRefresh } from "@tabler/icons-react";
+import { IconAlertTriangle, IconCheck, IconRefresh } from "@tabler/icons-react";
 
 // -- Interfaces ---------------------------------------------------------------
 
 interface TtmlConflictNoticeProps {
   onRegenerate: () => void;
+  onKeepEdits: () => void;
 }
 
 // -- Components ---------------------------------------------------------------
 
-const TtmlConflictNotice: React.FC<TtmlConflictNoticeProps> = ({ onRegenerate }) => (
+const TtmlConflictNotice: React.FC<TtmlConflictNoticeProps> = ({ onRegenerate, onKeepEdits }) => (
   <div
     role="alert"
     className="mx-6 mt-4 flex items-center justify-between gap-3 rounded-lg border border-composer-warning/20 bg-composer-warning/10 px-2.5 py-2 text-xs text-composer-warning"
   >
     <span className="flex items-center gap-2 select-text cursor-text">
       <IconAlertTriangle size={14} className="shrink-0" />
-      The lyrics changed since you edited the TTML. Your edits and the new version differ.
+      The lyrics changed since you edited the TTML. Exporting now uses your edits, not the new version.
     </span>
-    <Button hasIcon size="sm" onClick={onRegenerate}>
-      <IconRefresh className="size-4" />
-      Regenerate
-    </Button>
+    <span className="flex shrink-0 items-center gap-2">
+      <Button hasIcon size="sm" onClick={onKeepEdits}>
+        <IconCheck className="size-4" />
+        Keep my edits
+      </Button>
+      <Button hasIcon size="sm" onClick={onRegenerate}>
+        <IconRefresh className="size-4" />
+        Regenerate
+      </Button>
+    </span>
   </div>
 );
 

--- a/src/views/export/ttml-diff-viewer.browser.test.tsx
+++ b/src/views/export/ttml-diff-viewer.browser.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { TtmlDiffViewer } from "@/views/export/ttml-diff-viewer";
+import { render } from "@/test/render";
+
+// -- Tests --------------------------------------------------------------------
+
+describe("TtmlDiffViewer", () => {
+  it("shows both the removed original line and the added edited line", async () => {
+    const oldTtml = ["alpha", "removedword", "omega"].join("\n");
+    const newTtml = ["alpha", "insertedword", "omega"].join("\n");
+    const screen = await render(<TtmlDiffViewer oldTtml={oldTtml} newTtml={newTtml} />);
+    await expect.element(screen.getByText("insertedword")).toBeInTheDocument();
+    await expect.element(screen.getByText("removedword")).toBeInTheDocument();
+  });
+
+  it("keeps unchanged lines as context", async () => {
+    const oldTtml = ["keepmeline", "removedword"].join("\n");
+    const newTtml = ["keepmeline", "insertedword"].join("\n");
+    const screen = await render(<TtmlDiffViewer oldTtml={oldTtml} newTtml={newTtml} />);
+    await expect.element(screen.getByText("keepmeline")).toBeInTheDocument();
+  });
+
+  it("prefixes added lines with + and removed lines with -", async () => {
+    const oldTtml = "removed line";
+    const newTtml = "added line";
+    const screen = await render(<TtmlDiffViewer oldTtml={oldTtml} newTtml={newTtml} />);
+    await expect.element(screen.getByText("+")).toBeInTheDocument();
+    await expect.element(screen.getByText("-")).toBeInTheDocument();
+  });
+});

--- a/src/views/export/ttml-diff-viewer.browser.test.tsx
+++ b/src/views/export/ttml-diff-viewer.browser.test.tsx
@@ -27,4 +27,14 @@ describe("TtmlDiffViewer", () => {
     await expect.element(screen.getByText("+")).toBeInTheDocument();
     await expect.element(screen.getByText("-")).toBeInTheDocument();
   });
+
+  it("emphasizes only the changed word within a modified line", async () => {
+    const screen = await render(<TtmlDiffViewer oldTtml="the quick brown fox" newTtml="the quick red fox" />);
+    await expect.element(screen.getByText("red")).toBeInTheDocument();
+    const marked = [...screen.container.querySelectorAll("mark")].map((node) => node.textContent);
+    expect(marked).toContain("red");
+    expect(marked).toContain("brown");
+    expect(marked).not.toContain("quick");
+    expect(marked).not.toContain("fox");
+  });
 });

--- a/src/views/export/ttml-diff-viewer.tsx
+++ b/src/views/export/ttml-diff-viewer.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/utils/cn";
-import { diffLines } from "diff";
+import { diffLines, diffWordsWithSpace } from "diff";
 import { useMemo } from "react";
 
 // -- Interfaces ---------------------------------------------------------------
@@ -11,45 +11,92 @@ interface TtmlDiffViewerProps {
 
 type DiffKind = "add" | "remove" | "context";
 
-interface DiffLine {
+interface DiffSegment {
   text: string;
+  emphasis: boolean;
+}
+
+interface DiffRow {
   kind: DiffKind;
+  segments: DiffSegment[];
 }
 
 // -- Constants ----------------------------------------------------------------
 
-const LINE_CLASS: Record<DiffKind, string> = {
+const ROW_CLASS: Record<DiffKind, string> = {
   add: "bg-green-500/10 text-green-300",
   remove: "bg-red-500/10 text-red-300",
   context: "text-composer-text-muted",
 };
 
-const PREFIX: Record<DiffKind, string> = {
-  add: "+",
-  remove: "-",
-  context: " ",
+const MARK_CLASS: Record<DiffKind, string> = {
+  add: "bg-green-500/30 text-green-200 rounded-sm",
+  remove: "bg-red-500/30 text-red-200 rounded-sm",
+  context: "",
 };
+
+const PREFIX: Record<DiffKind, string> = { add: "+", remove: "-", context: " " };
+
+// -- Helpers ------------------------------------------------------------------
+
+function toLines(value: string): string[] {
+  const parts = value.split("\n");
+  if (parts.length > 1 && parts[parts.length - 1] === "") parts.pop();
+  return parts;
+}
+
+function buildRows(oldTtml: string, newTtml: string): DiffRow[] {
+  const rows: DiffRow[] = [];
+  const changes = diffLines(oldTtml, newTtml);
+  for (let i = 0; i < changes.length; i += 1) {
+    const change = changes[i];
+    const next = changes[i + 1];
+    const isSingleLineReplace =
+      change.removed && next?.added && toLines(change.value).length === 1 && toLines(next.value).length === 1;
+    if (isSingleLineReplace) {
+      const words = diffWordsWithSpace(toLines(change.value)[0] ?? "", toLines(next.value)[0] ?? "");
+      rows.push({
+        kind: "remove",
+        segments: words
+          .filter((word) => !word.added)
+          .map((word) => ({ text: word.value, emphasis: Boolean(word.removed) })),
+      });
+      rows.push({
+        kind: "add",
+        segments: words
+          .filter((word) => !word.removed)
+          .map((word) => ({ text: word.value, emphasis: Boolean(word.added) })),
+      });
+      i += 1;
+      continue;
+    }
+    const kind: DiffKind = change.added ? "add" : change.removed ? "remove" : "context";
+    for (const line of toLines(change.value)) {
+      rows.push({ kind, segments: [{ text: line, emphasis: false }] });
+    }
+  }
+  return rows;
+}
 
 // -- Components ---------------------------------------------------------------
 
 const TtmlDiffViewer: React.FC<TtmlDiffViewerProps> = ({ oldTtml, newTtml }) => {
-  const lines = useMemo<DiffLine[]>(() => {
-    const out: DiffLine[] = [];
-    for (const change of diffLines(oldTtml, newTtml)) {
-      const kind: DiffKind = change.added ? "add" : change.removed ? "remove" : "context";
-      const parts = change.value.split("\n");
-      if (parts.length > 1 && parts[parts.length - 1] === "") parts.pop();
-      for (const text of parts) out.push({ text, kind });
-    }
-    return out;
-  }, [oldTtml, newTtml]);
+  const rows = useMemo(() => buildRows(oldTtml, newTtml), [oldTtml, newTtml]);
 
   return (
     <pre className="font-mono text-xs leading-5 select-text cursor-text">
-      {lines.map((line, index) => (
-        <div key={`${index}-${line.kind}`} className={cn("px-4 whitespace-pre-wrap break-all", LINE_CLASS[line.kind])}>
-          <span className="select-none opacity-50 mr-2">{PREFIX[line.kind]}</span>
-          {line.text}
+      {rows.map((row, rowIndex) => (
+        <div key={`${rowIndex}-${row.kind}`} className={cn("px-4 whitespace-pre-wrap break-all", ROW_CLASS[row.kind])}>
+          <span className="select-none opacity-50 mr-2">{PREFIX[row.kind]}</span>
+          {row.segments.map((segment, segmentIndex) =>
+            segment.emphasis ? (
+              <mark key={`${segmentIndex}-${row.kind}`} className={MARK_CLASS[row.kind]}>
+                {segment.text}
+              </mark>
+            ) : (
+              <span key={`${segmentIndex}-${row.kind}`}>{segment.text}</span>
+            ),
+          )}
         </div>
       ))}
     </pre>

--- a/src/views/export/ttml-diff-viewer.tsx
+++ b/src/views/export/ttml-diff-viewer.tsx
@@ -1,0 +1,61 @@
+import { cn } from "@/utils/cn";
+import { diffLines } from "diff";
+import { useMemo } from "react";
+
+// -- Interfaces ---------------------------------------------------------------
+
+interface TtmlDiffViewerProps {
+  oldTtml: string;
+  newTtml: string;
+}
+
+type DiffKind = "add" | "remove" | "context";
+
+interface DiffLine {
+  text: string;
+  kind: DiffKind;
+}
+
+// -- Constants ----------------------------------------------------------------
+
+const LINE_CLASS: Record<DiffKind, string> = {
+  add: "bg-green-500/10 text-green-300",
+  remove: "bg-red-500/10 text-red-300",
+  context: "text-composer-text-muted",
+};
+
+const PREFIX: Record<DiffKind, string> = {
+  add: "+",
+  remove: "-",
+  context: " ",
+};
+
+// -- Components ---------------------------------------------------------------
+
+const TtmlDiffViewer: React.FC<TtmlDiffViewerProps> = ({ oldTtml, newTtml }) => {
+  const lines = useMemo<DiffLine[]>(() => {
+    const out: DiffLine[] = [];
+    for (const change of diffLines(oldTtml, newTtml)) {
+      const kind: DiffKind = change.added ? "add" : change.removed ? "remove" : "context";
+      const parts = change.value.split("\n");
+      if (parts.length > 1 && parts[parts.length - 1] === "") parts.pop();
+      for (const text of parts) out.push({ text, kind });
+    }
+    return out;
+  }, [oldTtml, newTtml]);
+
+  return (
+    <pre className="font-mono text-xs leading-5 select-text cursor-text">
+      {lines.map((line, index) => (
+        <div key={`${index}-${line.kind}`} className={cn("px-4 whitespace-pre-wrap break-all", LINE_CLASS[line.kind])}>
+          <span className="select-none opacity-50 mr-2">{PREFIX[line.kind]}</span>
+          {line.text}
+        </div>
+      ))}
+    </pre>
+  );
+};
+
+// -- Exports ------------------------------------------------------------------
+
+export { TtmlDiffViewer };

--- a/src/views/export/ttml-diff-viewer.tsx
+++ b/src/views/export/ttml-diff-viewer.tsx
@@ -57,15 +57,11 @@ function buildRows(oldTtml: string, newTtml: string): DiffRow[] {
       const words = diffWordsWithSpace(toLines(change.value)[0] ?? "", toLines(next.value)[0] ?? "");
       rows.push({
         kind: "remove",
-        segments: words
-          .filter((word) => !word.added)
-          .map((word) => ({ text: word.value, emphasis: Boolean(word.removed) })),
+        segments: words.flatMap((word) => (word.added ? [] : [{ text: word.value, emphasis: Boolean(word.removed) }])),
       });
       rows.push({
         kind: "add",
-        segments: words
-          .filter((word) => !word.removed)
-          .map((word) => ({ text: word.value, emphasis: Boolean(word.added) })),
+        segments: words.flatMap((word) => (word.removed ? [] : [{ text: word.value, emphasis: Boolean(word.added) }])),
       });
       i += 1;
       continue;

--- a/src/views/export/ttml-editor.browser.test.tsx
+++ b/src/views/export/ttml-editor.browser.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import { TtmlEditor } from "@/views/export/ttml-editor";
+import { render } from "@/test/render";
+
+// -- Helpers ------------------------------------------------------------------
+
+type HarnessProps = Omit<React.ComponentProps<typeof TtmlEditor>, "value" | "onChange"> & {
+  initialValue?: string;
+};
+
+function EditorHarness({ initialValue = "", ...rest }: HarnessProps) {
+  const [value, setValue] = useState(initialValue);
+  return <TtmlEditor value={value} onChange={setValue} {...rest} />;
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("TtmlEditor", () => {
+  it("reflects typed edits in the textarea", async () => {
+    const screen = await render(
+      <EditorHarness
+        initialValue="abc"
+        generatedTtml="abc"
+        hasEdits={false}
+        hasConflict={false}
+        onRegenerate={() => {}}
+      />,
+    );
+    const textarea = screen.getByRole("textbox", { name: "Edit TTML content" });
+    await textarea.fill("xyz");
+    await expect.element(textarea).toHaveValue("xyz");
+  });
+
+  it("keeps the textarea outside the overflow-auto scroll container", async () => {
+    const screen = await render(
+      <EditorHarness initialValue="x" generatedTtml="x" hasEdits={false} hasConflict={false} onRegenerate={() => {}} />,
+    );
+    const textarea = screen.getByRole("textbox", { name: "Edit TTML content" });
+    expect((textarea.element() as HTMLTextAreaElement).closest(".overflow-auto")).toBeNull();
+  });
+
+  describe("conflict", () => {
+    it("shows a conflict notice and regenerates on click", async () => {
+      const onRegenerate = vi.fn();
+      const screen = await render(
+        <EditorHarness initialValue="mine" generatedTtml="next" hasEdits hasConflict onRegenerate={onRegenerate} />,
+      );
+      await expect.element(screen.getByText("The lyrics changed", { exact: false })).toBeInTheDocument();
+      await screen.getByRole("button", { name: "Regenerate" }).click();
+      expect(onRegenerate).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("diff view", () => {
+    it("toggles between the editor and a diff of edits vs the latest TTML", async () => {
+      const screen = await render(
+        <EditorHarness
+          initialValue={"line one\nLINE TWO EDITED"}
+          generatedTtml={"line one\nline two"}
+          hasEdits
+          hasConflict={false}
+          onRegenerate={() => {}}
+        />,
+      );
+      await expect.element(screen.getByRole("textbox", { name: "Edit TTML content" })).toBeInTheDocument();
+      await screen.getByRole("button", { name: "View diff" }).click();
+      await expect.element(screen.getByText("LINE TWO EDITED")).toBeInTheDocument();
+      expect(screen.container.querySelector("textarea")).toBeNull();
+      await screen.getByRole("button", { name: "Hide diff" }).click();
+      await expect.element(screen.getByRole("textbox", { name: "Edit TTML content" })).toBeInTheDocument();
+    });
+
+    it("offers no diff toggle when there are no edits", async () => {
+      const screen = await render(
+        <EditorHarness
+          initialValue="same"
+          generatedTtml="same"
+          hasEdits={false}
+          hasConflict={false}
+          onRegenerate={() => {}}
+        />,
+      );
+      expect(screen.container.querySelector("button")).toBeNull();
+    });
+  });
+});

--- a/src/views/export/ttml-editor.browser.test.tsx
+++ b/src/views/export/ttml-editor.browser.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { useState } from "react";
 import { TtmlEditor } from "@/views/export/ttml-editor";
 import { render } from "@/test/render";
@@ -18,50 +18,22 @@ function EditorHarness({ initialValue = "", ...rest }: HarnessProps) {
 
 describe("TtmlEditor", () => {
   it("reflects typed edits in the textarea", async () => {
-    const screen = await render(
-      <EditorHarness
-        initialValue="abc"
-        generatedTtml="abc"
-        hasEdits={false}
-        hasConflict={false}
-        onRegenerate={() => {}}
-      />,
-    );
+    const screen = await render(<EditorHarness initialValue="abc" generatedTtml="abc" hasEdits={false} />);
     const textarea = screen.getByRole("textbox", { name: "Edit TTML content" });
     await textarea.fill("xyz");
     await expect.element(textarea).toHaveValue("xyz");
   });
 
   it("keeps the textarea outside the overflow-auto scroll container", async () => {
-    const screen = await render(
-      <EditorHarness initialValue="x" generatedTtml="x" hasEdits={false} hasConflict={false} onRegenerate={() => {}} />,
-    );
+    const screen = await render(<EditorHarness initialValue="x" generatedTtml="x" hasEdits={false} />);
     const textarea = screen.getByRole("textbox", { name: "Edit TTML content" });
     expect((textarea.element() as HTMLTextAreaElement).closest(".overflow-auto")).toBeNull();
-  });
-
-  describe("conflict", () => {
-    it("shows a conflict notice and regenerates on click", async () => {
-      const onRegenerate = vi.fn();
-      const screen = await render(
-        <EditorHarness initialValue="mine" generatedTtml="next" hasEdits hasConflict onRegenerate={onRegenerate} />,
-      );
-      await expect.element(screen.getByText("The lyrics changed", { exact: false })).toBeInTheDocument();
-      await screen.getByRole("button", { name: "Regenerate" }).click();
-      expect(onRegenerate).toHaveBeenCalledOnce();
-    });
   });
 
   describe("diff view", () => {
     it("toggles between the editor and a diff of edits vs the latest TTML", async () => {
       const screen = await render(
-        <EditorHarness
-          initialValue={"line one\nLINE TWO EDITED"}
-          generatedTtml={"line one\nline two"}
-          hasEdits
-          hasConflict={false}
-          onRegenerate={() => {}}
-        />,
+        <EditorHarness initialValue={"line one\nLINE TWO EDITED"} generatedTtml={"line one\nline two"} hasEdits />,
       );
       await expect.element(screen.getByRole("textbox", { name: "Edit TTML content" })).toBeInTheDocument();
       await screen.getByRole("button", { name: "View diff" }).click();
@@ -72,15 +44,7 @@ describe("TtmlEditor", () => {
     });
 
     it("offers no diff toggle when there are no edits", async () => {
-      const screen = await render(
-        <EditorHarness
-          initialValue="same"
-          generatedTtml="same"
-          hasEdits={false}
-          hasConflict={false}
-          onRegenerate={() => {}}
-        />,
-      );
+      const screen = await render(<EditorHarness initialValue="same" generatedTtml="same" hasEdits={false} />);
       expect(screen.container.querySelector("button")).toBeNull();
     });
   });

--- a/src/views/export/ttml-editor.browser.test.tsx
+++ b/src/views/export/ttml-editor.browser.test.tsx
@@ -18,14 +18,14 @@ function EditorHarness({ initialValue = "", ...rest }: HarnessProps) {
 
 describe("TtmlEditor", () => {
   it("reflects typed edits in the textarea", async () => {
-    const screen = await render(<EditorHarness initialValue="abc" generatedTtml="abc" hasEdits={false} />);
+    const screen = await render(<EditorHarness initialValue="abc" generatedTtml="abc" />);
     const textarea = screen.getByRole("textbox", { name: "Edit TTML content" });
     await textarea.fill("xyz");
     await expect.element(textarea).toHaveValue("xyz");
   });
 
   it("keeps the textarea outside the overflow-auto scroll container", async () => {
-    const screen = await render(<EditorHarness initialValue="x" generatedTtml="x" hasEdits={false} />);
+    const screen = await render(<EditorHarness initialValue="x" generatedTtml="x" />);
     const textarea = screen.getByRole("textbox", { name: "Edit TTML content" });
     expect((textarea.element() as HTMLTextAreaElement).closest(".overflow-auto")).toBeNull();
   });
@@ -33,7 +33,7 @@ describe("TtmlEditor", () => {
   describe("diff view", () => {
     it("toggles between the editor and a diff of edits vs the latest TTML", async () => {
       const screen = await render(
-        <EditorHarness initialValue={"line one\nLINE TWO EDITED"} generatedTtml={"line one\nline two"} hasEdits />,
+        <EditorHarness initialValue={"line one\nLINE TWO EDITED"} generatedTtml={"line one\nline two"} />,
       );
       await expect.element(screen.getByRole("textbox", { name: "Edit TTML content" })).toBeInTheDocument();
       await screen.getByRole("button", { name: "View diff" }).click();
@@ -44,7 +44,7 @@ describe("TtmlEditor", () => {
     });
 
     it("offers no diff toggle when there are no edits", async () => {
-      const screen = await render(<EditorHarness initialValue="same" generatedTtml="same" hasEdits={false} />);
+      const screen = await render(<EditorHarness initialValue="same" generatedTtml="same" />);
       expect(screen.container.querySelector("button")).toBeNull();
     });
   });

--- a/src/views/export/ttml-editor.tsx
+++ b/src/views/export/ttml-editor.tsx
@@ -1,0 +1,75 @@
+import { Button } from "@/ui/button";
+import { Scroll } from "@/ui/scroll";
+import { TtmlDiffViewer } from "@/views/export/ttml-diff-viewer";
+import { IconAlertTriangle, IconRefresh } from "@tabler/icons-react";
+import { useState } from "react";
+
+// -- Interfaces ---------------------------------------------------------------
+
+interface TtmlEditorProps {
+  value: string;
+  generatedTtml: string;
+  hasEdits: boolean;
+  hasConflict: boolean;
+  onChange: (value: string) => void;
+  onRegenerate: () => void;
+}
+
+// -- Components ---------------------------------------------------------------
+
+const TtmlEditor: React.FC<TtmlEditorProps> = ({
+  value,
+  generatedTtml,
+  hasEdits,
+  hasConflict,
+  onChange,
+  onRegenerate,
+}) => {
+  const [showDiff, setShowDiff] = useState(false);
+  const canDiff = hasEdits && value !== generatedTtml;
+  const viewingDiff = showDiff && canDiff;
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0 p-6 gap-3">
+      {hasConflict && (
+        <div
+          role="alert"
+          className="flex items-center justify-between gap-3 rounded-lg border border-composer-warning/20 bg-composer-warning/10 px-2.5 py-2 text-xs text-composer-warning"
+        >
+          <span className="flex items-center gap-2 select-text cursor-text">
+            <IconAlertTriangle size={14} className="shrink-0" />
+            The lyrics changed while you were editing. Your edits and the new version differ.
+          </span>
+          <Button hasIcon size="sm" onClick={onRegenerate}>
+            <IconRefresh className="size-4" />
+            Regenerate
+          </Button>
+        </div>
+      )}
+      {canDiff && (
+        <div className="flex justify-end">
+          <Button variant="ghost" size="sm" onClick={() => setShowDiff((shown) => !shown)}>
+            {viewingDiff ? "Hide diff" : "View diff"}
+          </Button>
+        </div>
+      )}
+      {viewingDiff ? (
+        <Scroll className="flex-1 rounded-lg bg-composer-bg-elevated p-2">
+          <TtmlDiffViewer oldTtml={generatedTtml} newTtml={value} />
+        </Scroll>
+      ) : (
+        <textarea
+          value={value}
+          aria-label="Edit TTML content"
+          onChange={(event) => onChange(event.target.value)}
+          className="w-full flex-1 p-4 rounded-lg font-mono text-xs bg-composer-bg-elevated text-composer-text resize-none focus:outline-none focus:ring-1 focus:ring-composer-accent"
+          spellCheck={false}
+        />
+      )}
+    </div>
+  );
+};
+
+// -- Exports ------------------------------------------------------------------
+
+export { TtmlEditor };

--- a/src/views/export/ttml-editor.tsx
+++ b/src/views/export/ttml-editor.tsx
@@ -1,7 +1,6 @@
 import { Button } from "@/ui/button";
 import { Scroll } from "@/ui/scroll";
 import { TtmlDiffViewer } from "@/views/export/ttml-diff-viewer";
-import { IconAlertTriangle, IconRefresh } from "@tabler/icons-react";
 import { useState } from "react";
 
 // -- Interfaces ---------------------------------------------------------------
@@ -10,42 +9,18 @@ interface TtmlEditorProps {
   value: string;
   generatedTtml: string;
   hasEdits: boolean;
-  hasConflict: boolean;
   onChange: (value: string) => void;
-  onRegenerate: () => void;
 }
 
 // -- Components ---------------------------------------------------------------
 
-const TtmlEditor: React.FC<TtmlEditorProps> = ({
-  value,
-  generatedTtml,
-  hasEdits,
-  hasConflict,
-  onChange,
-  onRegenerate,
-}) => {
+const TtmlEditor: React.FC<TtmlEditorProps> = ({ value, generatedTtml, hasEdits, onChange }) => {
   const [showDiff, setShowDiff] = useState(false);
   const canDiff = hasEdits && value !== generatedTtml;
   const viewingDiff = showDiff && canDiff;
 
   return (
     <div className="flex flex-col flex-1 min-h-0 p-6 gap-3">
-      {hasConflict && (
-        <div
-          role="alert"
-          className="flex items-center justify-between gap-3 rounded-lg border border-composer-warning/20 bg-composer-warning/10 px-2.5 py-2 text-xs text-composer-warning"
-        >
-          <span className="flex items-center gap-2 select-text cursor-text">
-            <IconAlertTriangle size={14} className="shrink-0" />
-            The lyrics changed while you were editing. Your edits and the new version differ.
-          </span>
-          <Button hasIcon size="sm" onClick={onRegenerate}>
-            <IconRefresh className="size-4" />
-            Regenerate
-          </Button>
-        </div>
-      )}
       {canDiff && (
         <div className="flex justify-end">
           <Button variant="ghost" size="sm" onClick={() => setShowDiff((shown) => !shown)}>

--- a/src/views/export/ttml-editor.tsx
+++ b/src/views/export/ttml-editor.tsx
@@ -8,15 +8,14 @@ import { useState } from "react";
 interface TtmlEditorProps {
   value: string;
   generatedTtml: string;
-  hasEdits: boolean;
   onChange: (value: string) => void;
 }
 
 // -- Components ---------------------------------------------------------------
 
-const TtmlEditor: React.FC<TtmlEditorProps> = ({ value, generatedTtml, hasEdits, onChange }) => {
+const TtmlEditor: React.FC<TtmlEditorProps> = ({ value, generatedTtml, onChange }) => {
   const [showDiff, setShowDiff] = useState(false);
-  const canDiff = hasEdits && value !== generatedTtml;
+  const canDiff = value !== generatedTtml;
   const viewingDiff = showDiff && canDiff;
 
   return (

--- a/src/views/import.browser.test.tsx
+++ b/src/views/import.browser.test.tsx
@@ -25,9 +25,38 @@ function withQueryClient(children: ReactNode) {
 const PNG_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
 
+function id3v2(frames: Array<[string, string]>): Uint8Array {
+  const enc = new TextEncoder();
+  const body: number[] = [];
+  for (const [id, text] of frames) {
+    const content = [0x03, ...enc.encode(text)];
+    const size = content.length;
+    body.push(
+      ...enc.encode(id),
+      (size >> 24) & 0xff,
+      (size >> 16) & 0xff,
+      (size >> 8) & 0xff,
+      size & 0xff,
+      0,
+      0,
+      ...content,
+    );
+  }
+  const synch = (n: number) => [(n >> 21) & 0x7f, (n >> 14) & 0x7f, (n >> 7) & 0x7f, n & 0x7f];
+  return new Uint8Array([0x49, 0x44, 0x33, 3, 0, 0, ...synch(body.length), ...body]);
+}
+
+function dispatchDrop(target: Element, file: File) {
+  const dataTransfer = new DataTransfer();
+  dataTransfer.items.add(file);
+  const event = new Event("drop", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+  target.dispatchEvent(event);
+}
+
 // -- Empty state --------------------------------------------------------------
 
-describe("ImportPanel — no source", () => {
+describe("ImportPanel: no source", () => {
   it("renders the audio drop zone when no source is loaded", async () => {
     useAudioStore.setState({ source: null });
     useProjectStore.setState({ lines: [] });
@@ -44,7 +73,7 @@ describe("ImportPanel — no source", () => {
 
 // -- File source --------------------------------------------------------------
 
-describe("ImportPanel — file source", () => {
+describe("ImportPanel: file source", () => {
   it("shows the loading spinner for a file source while it is loading", async () => {
     useAudioStore.setState({
       source: { type: "file", file: createAudioFile() },
@@ -77,9 +106,9 @@ describe("ImportPanel — file source", () => {
   });
 });
 
-// -- YouTube source — title -----------------------------------------------
+// -- YouTube source: title -----------------------------------------------
 
-describe("ImportPanel — YouTube title", () => {
+describe("ImportPanel: YouTube title", () => {
   it("shows the loading spinner while a YouTube source is downloading", async () => {
     useAudioStore.setState({
       source: { type: "youtube", videoId: "abc123" },
@@ -124,9 +153,9 @@ describe("ImportPanel — YouTube title", () => {
   });
 });
 
-// -- YouTube source — thumbnail -------------------------------------------
+// -- YouTube source: thumbnail -------------------------------------------
 
-describe("ImportPanel — YouTube thumbnail", () => {
+describe("ImportPanel: YouTube thumbnail", () => {
   it("renders the persisted thumbnail image when one is in project metadata", async () => {
     useAudioStore.setState({
       source: { type: "youtube", videoId: "dQw4w9WgXcQ" },
@@ -210,9 +239,9 @@ describe("ImportPanel — YouTube thumbnail", () => {
   });
 });
 
-// -- YouTube source — subtitle copy ---------------------------------------
+// -- YouTube source: subtitle copy ---------------------------------------
 
-describe("ImportPanel — YouTube subtitle", () => {
+describe("ImportPanel: YouTube subtitle", () => {
   it("says 'Downloading from YouTube' while downloading", async () => {
     useAudioStore.setState({
       source: { type: "youtube", videoId: "dQw4w9WgXcQ" },
@@ -308,5 +337,58 @@ describe("ImportPanel: videoId-gated thumb fallback", () => {
     const screen = await render(withQueryClient(<ImportPanel />));
     const liveBridgeImg = screen.container.querySelector(`img[src^='${DEFAULT_BRIDGE_URL}']`);
     expect(liveBridgeImg).toBeNull();
+  });
+});
+
+// -- File drop: embedded tag capture --------------------------------------
+
+describe("ImportPanel: audio tag capture", () => {
+  it("sets the filename as the title synchronously on drop", async () => {
+    useAudioStore.setState({ source: null });
+    useProjectStore.setState({ lines: [] });
+    const screen = await render(withQueryClient(<ImportPanel />));
+
+    const file = new File([new Uint8Array(8)], "My Untagged Song.wav", { type: "audio/wav" });
+    const dropZone = screen.container.querySelector("label[for='file-drop-input']");
+    expect(dropZone).not.toBeNull();
+    if (dropZone) dispatchDrop(dropZone, file);
+
+    expect(useProjectStore.getState().metadata.title).toBe("My Untagged Song");
+  });
+
+  it("populates title/artists/album/isrc from a dropped file's embedded ID3 tags", async () => {
+    useAudioStore.setState({ source: null });
+    useProjectStore.setState({ lines: [] });
+    const screen = await render(withQueryClient(<ImportPanel />));
+
+    const bytes = id3v2([
+      ["TIT2", "Tagged Title"],
+      ["TPE1", "The Artist"],
+      ["TALB", "The Album"],
+      ["TSRC", "USQX91700001"],
+    ]);
+    const file = new File([bytes], "filename-fallback.mp3", { type: "audio/mpeg" });
+    const dropZone = screen.container.querySelector("label[for='file-drop-input']");
+    expect(dropZone).not.toBeNull();
+    if (dropZone) dispatchDrop(dropZone, file);
+
+    await expect.poll(() => useProjectStore.getState().metadata.title).toBe("Tagged Title");
+    const metadata = useProjectStore.getState().metadata;
+    expect(metadata.artists).toEqual(["The Artist"]);
+    expect(metadata.album).toBe("The Album");
+    expect(metadata.isrc).toBe("USQX91700001");
+  });
+
+  it("keeps the filename title when the dropped file has no embedded tags", async () => {
+    useAudioStore.setState({ source: null });
+    useProjectStore.setState({ lines: [] });
+    const screen = await render(withQueryClient(<ImportPanel />));
+
+    const file = new File([new Uint8Array(8)], "No Tags Here.wav", { type: "audio/wav" });
+    const dropZone = screen.container.querySelector("label[for='file-drop-input']");
+    if (dropZone) dispatchDrop(dropZone, file);
+
+    expect(useProjectStore.getState().metadata.title).toBe("No Tags Here");
+    await expect.poll(() => useProjectStore.getState().metadata.title).toBe("No Tags Here");
   });
 });

--- a/src/views/import.browser.test.tsx
+++ b/src/views/import.browser.test.tsx
@@ -392,3 +392,49 @@ describe("ImportPanel: audio tag capture", () => {
     await expect.poll(() => useProjectStore.getState().metadata.title).toBe("No Tags Here");
   });
 });
+
+// -- Stale tag writes ---------------------------------------------------------
+
+// Sound because the component started its parse first, so this one finishes later.
+async function waitForStaleParseToResolve(stale: File): Promise<void> {
+  const { parseBlob } = await import("music-metadata");
+  await parseBlob(stale);
+}
+
+describe("ImportPanel: stale audio tag writes", () => {
+  it("regression: a superseded file's tags never overwrite the current file's metadata", async () => {
+    useAudioStore.setState({ source: null });
+    useProjectStore.setState({ lines: [] });
+    const screen = await render(withQueryClient(<ImportPanel />));
+
+    const paddingThatMakesThisTheSlowerParse = new Uint8Array(4_000_000);
+    const stale = new File(
+      [
+        id3v2([
+          ["TIT2", "Stale Title"],
+          ["TPE1", "Stale Artist"],
+          ["TALB", "Stale Album"],
+        ]),
+        paddingThatMakesThisTheSlowerParse,
+      ],
+      "stale.mp3",
+      { type: "audio/mpeg" },
+    );
+    const current = new File([id3v2([["TIT2", "Current Title"]])], "current.mp3", { type: "audio/mpeg" });
+
+    const dropZone = screen.container.querySelector("label[for='file-drop-input']");
+    expect(dropZone).not.toBeNull();
+    if (dropZone) {
+      dispatchDrop(dropZone, stale);
+      dispatchDrop(dropZone, current);
+    }
+
+    await expect.poll(() => useProjectStore.getState().metadata.title).toBe("Current Title");
+
+    await waitForStaleParseToResolve(stale);
+
+    expect(useProjectStore.getState().metadata.title).toBe("Current Title");
+    expect(useProjectStore.getState().metadata.artists).toEqual([]);
+    expect(useProjectStore.getState().metadata.album).toBe("");
+  });
+});

--- a/src/views/import.tsx
+++ b/src/views/import.tsx
@@ -4,6 +4,7 @@ import { useBridgeThumb } from "@/hooks/useBridgeThumb";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
+import { audioTagsToMetadata } from "@/utils/audio-tags";
 import { IconBrandYoutube, IconClock, IconFile, IconLoader2, IconMusic } from "@tabler/icons-react";
 import { useCallback } from "react";
 
@@ -113,6 +114,15 @@ const ImportPanel: React.FC = () => {
     (file: File) => {
       setSource({ type: "file", file });
       setMetadata({ title: file.name.replace(/\.[^/.]+$/, "") });
+      void import("music-metadata")
+        .then(({ parseBlob }) => parseBlob(file))
+        .then(({ common }) => {
+          const patch = audioTagsToMetadata(common);
+          if (Object.keys(patch).length > 0) setMetadata(patch);
+        })
+        .catch((error) => {
+          console.warn("[Composer] could not read audio tags", error);
+        });
     },
     [setSource, setMetadata],
   );

--- a/src/views/import.tsx
+++ b/src/views/import.tsx
@@ -31,6 +31,7 @@ function getFileExtension(filename: string): string {
 
 const GUTTER_WIDTH = 56;
 const ROW_HEIGHT = 56;
+const LOG_PREFIX = "[Composer]";
 
 // -- Sub-components -----------------------------------------------------------
 
@@ -117,11 +118,14 @@ const ImportPanel: React.FC = () => {
       void import("music-metadata")
         .then(({ parseBlob }) => parseBlob(file))
         .then(({ common }) => {
+          const active = useAudioStore.getState().source;
+          const isStillTheActiveFile = active?.type === "file" && active.file === file;
+          if (!isStillTheActiveFile) return;
           const patch = audioTagsToMetadata(common);
           if (Object.keys(patch).length > 0) setMetadata(patch);
         })
         .catch((error) => {
-          console.warn("[Composer] could not read audio tags", error);
+          console.warn(`${LOG_PREFIX} could not read audio tags`, error);
         });
     },
     [setSource, setMetadata],

--- a/src/views/sync/scrollable-line.browser.test.tsx
+++ b/src/views/sync/scrollable-line.browser.test.tsx
@@ -36,4 +36,27 @@ describe("ScrollableLine", () => {
     const screen = await render(<ScrollableLine {...BASE_PROPS} text="" />);
     expect((screen.container.textContent ?? "").trim()).toBe(String(BASE_PROPS.lineNumber));
   });
+
+  it("clicking a word fires onClickWord with its index and does not bubble to the line onClick", async () => {
+    let lineClicks = 0;
+    let clickedWord = -1;
+    const screen = await render(
+      <ScrollableLine
+        {...BASE_PROPS}
+        words={[
+          { text: "Hello ", begin: 0, end: 0.5 },
+          { text: "world", begin: 0.5, end: 1 },
+        ]}
+        onClick={() => {
+          lineClicks++;
+        }}
+        onClickWord={(idx) => {
+          clickedWord = idx;
+        }}
+      />,
+    );
+    await screen.getByRole("button", { name: "world", exact: true }).click();
+    expect(clickedWord).toBe(1);
+    expect(lineClicks).toBe(0);
+  });
 });

--- a/src/views/sync/scrollable-line.tsx
+++ b/src/views/sync/scrollable-line.tsx
@@ -34,6 +34,7 @@ interface ScrollableLineProps {
   editMode: boolean;
   linkInfo?: ScrollableLineLinkInfo;
   onClick: () => void;
+  onClickWord?: (wordIndex: number) => void;
   onNudgeWord?: (wordIndex: number, delta: number) => void;
   onSetWordTime?: (wordIndex: number, newBegin: number) => void;
   onNudgeWordEnd?: (wordIndex: number, delta: number) => void;
@@ -65,6 +66,7 @@ const ScrollableLineInner: React.FC<ScrollableLineProps> = ({
   editMode,
   linkInfo,
   onClick,
+  onClickWord,
   onNudgeWord,
   onSetWordTime,
   onNudgeWordEnd,
@@ -135,6 +137,7 @@ const ScrollableLineInner: React.FC<ScrollableLineProps> = ({
     onNudgeEnd: onNudgeWordEnd,
     onSetEndTime: onSetWordEndTime,
     onSplit: onSplitWord,
+    onClickWord,
   };
 
   const bgWordHandlers: WordHandlers = {

--- a/src/views/sync/scrollable-line.tsx
+++ b/src/views/sync/scrollable-line.tsx
@@ -35,6 +35,7 @@ interface ScrollableLineProps {
   linkInfo?: ScrollableLineLinkInfo;
   onClick: () => void;
   onClickWord?: (wordIndex: number) => void;
+  onClickBgWord?: (wordIndex: number) => void;
   onNudgeWord?: (wordIndex: number, delta: number) => void;
   onSetWordTime?: (wordIndex: number, newBegin: number) => void;
   onNudgeWordEnd?: (wordIndex: number, delta: number) => void;
@@ -67,6 +68,7 @@ const ScrollableLineInner: React.FC<ScrollableLineProps> = ({
   linkInfo,
   onClick,
   onClickWord,
+  onClickBgWord,
   onNudgeWord,
   onSetWordTime,
   onNudgeWordEnd,
@@ -145,6 +147,7 @@ const ScrollableLineInner: React.FC<ScrollableLineProps> = ({
     onSetTime: onSetBgWordTime,
     onNudgeEnd: onNudgeBgWordEnd,
     onSetEndTime: onSetBgWordEndTime,
+    onClickWord: onClickBgWord,
   };
 
   const renderWordList = (

--- a/src/views/sync/sync-panel.browser.test.tsx
+++ b/src/views/sync/sync-panel.browser.test.tsx
@@ -46,3 +46,39 @@ describe("SyncPanel", () => {
     await expect.element(screen.getByText(/Editing timings/)).toBeInTheDocument();
   });
 });
+
+describe("SyncPanel · tap while already playing", () => {
+  function pressTap(): void {
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+  }
+
+  it("regression: a single space taps the current word when playback was started outside the sync flow", async () => {
+    useAudioStore.setState({
+      source: { type: "file", file: createAudioFile() },
+      duration: 10,
+      currentTime: 5,
+      isPlaying: true,
+    });
+    useProjectStore.setState({ lines: [createLine({ text: "Hello world" })], activeTab: "sync" });
+    await render(<SyncPanel />);
+
+    pressTap();
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.begin).toBe(5);
+  });
+
+  it("marks the session active after tapping so Reset becomes available", async () => {
+    useAudioStore.setState({
+      source: { type: "file", file: createAudioFile() },
+      duration: 10,
+      currentTime: 5,
+      isPlaying: true,
+    });
+    useProjectStore.setState({ lines: [createLine({ text: "Hello world" })], activeTab: "sync" });
+    const screen = await render(<SyncPanel />);
+
+    pressTap();
+
+    await expect.element(screen.getByRole("button", { name: "Reset" })).toBeInTheDocument();
+  });
+});

--- a/src/views/sync/sync-panel.browser.test.tsx
+++ b/src/views/sync/sync-panel.browser.test.tsx
@@ -2,7 +2,18 @@ import { describe, expect, it } from "vitest";
 import { SyncPanel } from "@/views/sync/sync-panel";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
+import { createAudioFile } from "@/test/audio-fixtures";
+import { createLine, createWord } from "@/test/factories";
 import { render } from "@/test/render";
+
+// -- Helpers ------------------------------------------------------------------
+
+function loadSyncableProject(): void {
+  useAudioStore.setState({ source: { type: "file", file: createAudioFile() }, duration: 10, currentTime: 0 });
+  useProjectStore.setState({
+    lines: [createLine({ text: "Hello world", words: [createWord({ text: "Hello world", begin: 1, end: 2 })] })],
+  });
+}
 
 describe("SyncPanel", () => {
   it("shows the 'No audio loaded' empty state when no source is set", async () => {
@@ -10,5 +21,28 @@ describe("SyncPanel", () => {
     useProjectStore.setState({ lines: [] });
     const screen = await render(<SyncPanel />);
     await expect.element(screen.getByText("No audio loaded")).toBeInTheDocument();
+  });
+
+  it("toggles the Edit button label between Edit and Done", async () => {
+    loadSyncableProject();
+    const screen = await render(<SyncPanel />);
+    await expect.element(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    await screen.getByRole("button", { name: "Edit" }).click();
+    await expect.element(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+  });
+
+  it("pauses playback when entering edit mode", async () => {
+    loadSyncableProject();
+    useAudioStore.setState({ isPlaying: true });
+    const screen = await render(<SyncPanel />);
+    await screen.getByRole("button", { name: "Edit" }).click();
+    await expect.poll(() => useAudioStore.getState().isPlaying).toBe(false);
+  });
+
+  it("shows the editing hint while in edit mode", async () => {
+    loadSyncableProject();
+    const screen = await render(<SyncPanel />);
+    await screen.getByRole("button", { name: "Edit" }).click();
+    await expect.element(screen.getByText(/Editing timings/)).toBeInTheDocument();
   });
 });

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -213,6 +213,12 @@ const SyncPanel: React.FC = () => {
     [granularity, lines, setLinesWithHistory, setGranularity],
   );
 
+  const handleToggleEdit = useCallback(() => {
+    const entering = !editMode;
+    setEditMode(entering);
+    if (entering && isPlaying) setIsPlaying(false);
+  }, [editMode, isPlaying, setIsPlaying]);
+
   const playingLineIndex = useMemo(() => {
     for (let i = 0; i < lines.length; i++) {
       const timing = effectiveBounds(lines[i]);
@@ -412,11 +418,11 @@ const SyncPanel: React.FC = () => {
           <Button
             hasIcon
             variant={editMode ? "primary" : "secondary"}
-            onClick={() => setEditMode(!editMode)}
-            title={editMode ? "Unlock sync mode" : "Lock to edit mode"}
+            onClick={handleToggleEdit}
+            title={editMode ? "Done editing, back to syncing" : "Edit timings (pauses playback)"}
           >
             {editMode ? <IconLock className="size-4" /> : <IconLockOpen className="size-4" />}
-            Edit
+            {editMode ? "Done" : "Edit"}
           </Button>
           {syncState.isActive && !editMode && (
             <Button hasIcon onClick={handleReset}>
@@ -527,7 +533,13 @@ const SyncPanel: React.FC = () => {
         <div className="flex items-center justify-between h-14">
           <TimingDisplay lastSyncedTime={lastSyncedTime} />
 
-          {!isComplete && isPlaying && (
+          {!isComplete && editMode && (
+            <div className="text-sm text-composer-text-muted">
+              Editing timings ・ click a word to re-record, or press Done to sync
+            </div>
+          )}
+
+          {!isComplete && !editMode && isPlaying && (
             <div className="flex items-center gap-4">
               {currentWord && <span className="text-xl font-medium text-composer-text">{currentWord}</span>}
               <div className="flex items-center gap-2">
@@ -563,7 +575,7 @@ const SyncPanel: React.FC = () => {
             </div>
           )}
 
-          {!isComplete && !isPlaying && syncState.isActive && (
+          {!isComplete && !editMode && !isPlaying && syncState.isActive && (
             <div className="text-sm text-composer-text-muted">Paused ・ Click a line to jump, or play to continue</div>
           )}
         </div>

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -285,10 +285,11 @@ const SyncPanel: React.FC = () => {
           if (editMode) return;
           if (isHolding && isPlaying) {
             handleHoldTap();
-          } else if (!syncState.isActive && lines.length > 0) {
-            handleStartSync();
           } else if (isPlaying) {
+            if (!syncState.isActive) setSyncState((prev) => ({ ...prev, isActive: true }));
             handleTap();
+          } else if (lines.length > 0) {
+            handleStartSync();
           }
           break;
         case "sync.holdSync":

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -103,6 +103,7 @@ const SyncPanel: React.FC = () => {
     handleReset,
     handleStartSync,
     handleJumpToLine,
+    handleJumpToWord,
     handleNudgeWord,
     handleSetWordTime,
     handleNudgeWordEnd,
@@ -467,6 +468,7 @@ const SyncPanel: React.FC = () => {
                   editMode={editMode}
                   linkInfo={linkInfo}
                   onClick={() => handleJumpToLine(index)}
+                  onClickWord={(wordIdx) => handleJumpToWord(index, wordIdx)}
                   onNudgeWord={(wordIdx, delta) => handleNudgeWord(index, wordIdx, delta)}
                   onSetWordTime={(wordIdx, newBegin) => handleSetWordTime(index, wordIdx, newBegin)}
                   onNudgeWordEnd={(wordIdx, delta) => handleNudgeWordEnd(index, wordIdx, delta)}

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -104,6 +104,7 @@ const SyncPanel: React.FC = () => {
     handleStartSync,
     handleJumpToLine,
     handleJumpToWord,
+    handleJumpToBgWord,
     handleNudgeWord,
     handleSetWordTime,
     handleNudgeWordEnd,
@@ -476,6 +477,7 @@ const SyncPanel: React.FC = () => {
                   linkInfo={linkInfo}
                   onClick={() => handleJumpToLine(index)}
                   onClickWord={(wordIdx) => handleJumpToWord(index, wordIdx)}
+                  onClickBgWord={(wordIdx) => handleJumpToBgWord(index, wordIdx)}
                   onNudgeWord={(wordIdx, delta) => handleNudgeWord(index, wordIdx, delta)}
                   onSetWordTime={(wordIdx, newBegin) => handleSetWordTime(index, wordIdx, newBegin)}
                   onNudgeWordEnd={(wordIdx, delta) => handleNudgeWordEnd(index, wordIdx, delta)}

--- a/src/views/sync/word-renderer.browser.test.tsx
+++ b/src/views/sync/word-renderer.browser.test.tsx
@@ -65,4 +65,69 @@ describe("WordRenderer", () => {
     const italic = screen.container.querySelector(".italic");
     expect(italic).not.toBeNull();
   });
+
+  // -- Re-record affordance ---------------------------------------------------
+
+  it("exposes a timed word as a re-record button", async () => {
+    const screen = await render(
+      <WordRenderer
+        lineId="test-line"
+        word="hello"
+        idx={2}
+        timing={{ text: "hello", begin: 1, end: 2 }}
+        allWords={[{ text: "hello", begin: 1, end: 2 }]}
+        handlers={{ onClickWord: () => {} }}
+        editMode={false}
+      />,
+    );
+    await expect.element(screen.getByTitle("Re-record from this word")).toBeInTheDocument();
+  });
+
+  it("reports its own index when clicked", async () => {
+    const clicked: number[] = [];
+    const screen = await render(
+      <WordRenderer
+        lineId="test-line"
+        word="hello"
+        idx={3}
+        timing={{ text: "hello", begin: 1, end: 2 }}
+        allWords={[{ text: "hello", begin: 1, end: 2 }]}
+        handlers={{ onClickWord: (idx) => clicked.push(idx) }}
+        editMode={false}
+      />,
+    );
+    await screen.getByTitle("Re-record from this word").click();
+    expect(clicked).toEqual([3]);
+  });
+
+  it("regression: leaves an untimed word non-interactive so a tap cannot desync the words array", async () => {
+    const screen = await render(
+      <WordRenderer
+        lineId="test-line"
+        word="hello"
+        idx={2}
+        timing={undefined}
+        allWords={undefined}
+        handlers={{ onClickWord: () => {} }}
+        editMode={false}
+      />,
+    );
+    expect(screen.container.querySelector("button")).toBeNull();
+  });
+
+  it("labels a background word as a jump rather than a re-record", async () => {
+    const screen = await render(
+      <WordRenderer
+        lineId="test-line"
+        word="(echo)"
+        idx={0}
+        timing={{ text: "(echo)", begin: 1, end: 2 }}
+        allWords={[{ text: "(echo)", begin: 1, end: 2 }]}
+        handlers={{ onClickWord: () => {} }}
+        isBackground
+        editMode={false}
+      />,
+    );
+    await expect.element(screen.getByTitle("Jump to this word")).toBeInTheDocument();
+  });
 });

--- a/src/views/sync/word-renderer.tsx
+++ b/src/views/sync/word-renderer.tsx
@@ -12,6 +12,7 @@ interface WordHandlers {
   onNudgeEnd?: (idx: number, delta: number) => void;
   onSetEndTime?: (idx: number, newEnd: number) => void;
   onSplit?: (idx: number, newWords: WordTiming[]) => void;
+  onClickWord?: (idx: number) => void;
 }
 
 interface WordRendererProps {
@@ -78,7 +79,21 @@ const WordRenderer: React.FC<WordRendererProps> = ({
   return (
     <span className={`inline-flex flex-col items-start ${isBackground ? "italic" : ""}`}>
       <span className="flex items-center gap-1 group/word">
-        {renderWordContent(word, timing, isBackground, editMode)}
+        {handlers.onClickWord ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              handlers.onClickWord?.(idx);
+            }}
+            title="Re-record from this word"
+            className="appearance-none border-0 bg-transparent p-0 text-left cursor-pointer"
+          >
+            {renderWordContent(word, timing, isBackground, editMode)}
+          </button>
+        ) : (
+          renderWordContent(word, timing, isBackground, editMode)
+        )}
         {isSynced && timing && timing.end === timing.begin && (
           <Tooltip content="No duration - sync the next word to close this one or increase the end time">
             <span className="text-composer-warning">

--- a/src/views/sync/word-renderer.tsx
+++ b/src/views/sync/word-renderer.tsx
@@ -86,7 +86,7 @@ const WordRenderer: React.FC<WordRendererProps> = ({
               e.stopPropagation();
               handlers.onClickWord?.(idx);
             }}
-            title="Re-record from this word"
+            title={isBackground ? "Jump to this word" : "Re-record from this word"}
             className="appearance-none border-0 bg-transparent p-0 text-left cursor-pointer"
           >
             {renderWordContent(word, timing, isBackground, editMode)}

--- a/src/views/sync/word-renderer.tsx
+++ b/src/views/sync/word-renderer.tsx
@@ -79,7 +79,7 @@ const WordRenderer: React.FC<WordRendererProps> = ({
   return (
     <span className={`inline-flex flex-col items-start ${isBackground ? "italic" : ""}`}>
       <span className="flex items-center gap-1 group/word">
-        {handlers.onClickWord ? (
+        {handlers.onClickWord && timing ? (
           <button
             type="button"
             onClick={(e) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
       "motion/react",
       "@dnd-kit/core",
       "react-router-dom",
+      "node-diff3",
+      "diff",
     ],
   },
   test: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,15 @@
+import { setDefaultResultOrder } from "node:dns";
 import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
 import { defineConfig } from "vitest/config";
 import pkg from "./package.json";
+
+// Node 17+ returns `localhost` as ::1 (IPv6) first. When the browser server and
+// the headless-chrome tab land on mismatched loopback stacks the session never
+// connects ("Failed to connect to the browser session within the timeout"). Pin
+// IPv4 first so the handshake is deterministic; Linux/CI already resolve this way.
+setDefaultResultOrder("ipv4first");
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Overview

Clicking a line or word in the Sync view re-records from that spot: it seeks just before the target, moves the cursor there, and stays paused so you hit play when ready. Re-tapping a word overwrites only that word instead of the whole line, and jumping back to re-record no longer stretches the line before it. Entering Edit pauses playback with a clearer mode hint.

Adds song metadata in Export (title, artists, songwriters, ISRC, and free-form extra fields, pulled from audio tags, URL params, or a shared hash and written into the TTML). Regeneration is non-destructive: manual edits rebase onto the new output, with a diff view, and a conflict needs an explicit choice between keeping your edits and regenerating.

Closes #134
Closes #146
Closes #132
