### PR TITLE
feat: capture and export song metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.34.0",
+  "version": "1.35.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "driver.js": "^1.4.0",
     "lit": "^3.3.2",
     "motion": "^12.24.12",
+    "music-metadata": "^11.13.0",
     "nanoid": "^5.1.11",
     "node-diff3": "^3.2.1",
     "obscenity": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       motion:
         specifier: ^12.24.12
         version: 12.24.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      music-metadata:
+        specifier: ^11.13.0
+        version: 11.13.0
       nanoid:
         specifier: ^5.1.11
         version: 5.1.11
@@ -338,6 +341,9 @@ packages:
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
   '@braccato/core@0.1.7':
     resolution: {integrity: sha512-z9TXJXiIToCu8uEDDxoLjpQjs7YseQE8De+cDN/iPgYqRJwrFx+xP+2c3se6g91lLqfh3Hyku7FKJtCjGPaXGA==}
@@ -1385,6 +1391,13 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -1656,6 +1669,10 @@ packages:
   constantinople@4.0.1:
     resolution: {integrity: sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==}
 
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -1821,6 +1838,10 @@ packages:
   fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
 
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -1954,6 +1975,9 @@ packages:
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -2199,6 +2223,10 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@2.0.0:
+    resolution: {integrity: sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q==}
+    engines: {node: '>=18'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -2251,6 +2279,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  music-metadata@11.13.0:
+    resolution: {integrity: sha512-uXRaov9dfjSpQufXIU7sMxVZnh+FilCQv2mXn+K5EJ/decP3dTWrgvPYa5r6MtRbieNSCE708Da4J0u1UGfQIw==}
+    engines: {node: '>=18'}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -2627,6 +2659,10 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2687,6 +2723,10 @@ packages:
   token-stream@1.0.0:
     resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
 
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -2714,6 +2754,10 @@ packages:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   unbash@3.0.0:
     resolution: {integrity: sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==}
@@ -2924,6 +2968,9 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  win-guid@0.2.1:
+    resolution: {integrity: sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==}
 
   with@7.0.2:
     resolution: {integrity: sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==}
@@ -3200,6 +3247,8 @@ snapshots:
     optional: true
 
   '@blazediff/core@1.9.1': {}
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@braccato/core@0.1.7':
     dependencies:
@@ -3909,6 +3958,15 @@ snapshots:
       '@tanstack/query-core': 5.100.10
       react: 19.2.3
 
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -4230,6 +4288,8 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
@@ -4407,6 +4467,15 @@ snapshots:
 
   fflate@0.7.4: {}
 
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -4537,6 +4606,8 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
 
   invariant@2.2.4:
     dependencies:
@@ -4814,6 +4885,8 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@2.0.0: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -4850,6 +4923,21 @@ snapshots:
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
+
+  music-metadata@11.13.0:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      content-type: 2.0.0
+      debug: 4.4.3
+      file-type: 21.3.4
+      media-typer: 2.0.0
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+      win-guid: 0.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   nanoid@3.3.12: {}
 
@@ -5325,6 +5413,10 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -5371,6 +5463,12 @@ snapshots:
 
   token-stream@1.0.0: {}
 
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
   totalist@3.0.1: {}
 
   tough-cookie@4.1.4:
@@ -5395,6 +5493,8 @@ snapshots:
   tslib@2.8.1: {}
 
   typescript@5.7.3: {}
+
+  uint8array-extras@1.5.0: {}
 
   unbash@3.0.0: {}
 
@@ -5539,6 +5639,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  win-guid@0.2.1: {}
 
   with@7.0.2:
     dependencies:

--- a/src/domain/project/metadata-ttml.test.ts
+++ b/src/domain/project/metadata-ttml.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectMetadata } from "@/domain/project/metadata";
+import { fromComposerMeta, toComposerMeta } from "@/domain/project/metadata-ttml";
+
+const base: ProjectMetadata = {
+  title: "Song",
+  artists: ["Tyler, The Creator", "Kali Uchis"],
+  album: "Flower Boy",
+  duration: 0,
+  isrc: "USQX91700001",
+  songwriters: ["Tyler Okonma"],
+  extra: { spotifyId: "abc", mood: "chill" },
+};
+
+describe("toComposerMeta", () => {
+  it("emits one pair per artist, plus album/isrc/songwriter/extra, never the title", () => {
+    expect(toComposerMeta(base)).toEqual([
+      { key: "artists", value: "Tyler, The Creator" },
+      { key: "artists", value: "Kali Uchis" },
+      { key: "album", value: "Flower Boy" },
+      { key: "isrc", value: "USQX91700001" },
+      { key: "songwriter", value: "Tyler Okonma" },
+      { key: "mood", value: "chill" },
+      { key: "spotifyId", value: "abc" },
+    ]);
+  });
+  describe("edge cases", () => {
+    it("omits empty fields", () => {
+      expect(toComposerMeta({ title: "x", artists: [], album: "", duration: 0 })).toEqual([]);
+    });
+    it("sorts extra keys deterministically", () => {
+      const pairs = toComposerMeta({ title: "", artists: [], album: "", duration: 0, extra: { z: "1", a: "2" } });
+      expect(pairs.map((p) => p.key)).toEqual(["a", "z"]);
+    });
+    it("skips empty artist and songwriter entries", () => {
+      const pairs = toComposerMeta({ title: "", artists: ["", "A"], album: "", duration: 0, songwriters: ["", "W"] });
+      expect(pairs).toEqual([
+        { key: "artists", value: "A" },
+        { key: "songwriter", value: "W" },
+      ]);
+    });
+  });
+});
+
+describe("fromComposerMeta", () => {
+  it("collects known keys into typed fields and unknown keys into extra", () => {
+    const out = fromComposerMeta([
+      { key: "artists", value: "A" },
+      { key: "artists", value: "B" },
+      { key: "album", value: "Al" },
+      { key: "isrc", value: "USQX91700001" },
+      { key: "songwriter", value: "W1" },
+      { key: "songwriters", value: "W2" },
+      { key: "musicName", value: "T" },
+      { key: "weird", value: "w" },
+    ]);
+    expect(out).toEqual({
+      title: "T",
+      artists: ["A", "B"],
+      album: "Al",
+      isrc: "USQX91700001",
+      songwriters: ["W1", "W2"],
+      extra: { weird: "w" },
+    });
+  });
+  describe("edge cases", () => {
+    it("returns an empty object for no pairs", () => expect(fromComposerMeta([])).toEqual({}));
+    it("ignores pairs with an empty key", () => expect(fromComposerMeta([{ key: "", value: "x" }])).toEqual({}));
+  });
+});
+
+describe("round-trip", () => {
+  it("fromComposerMeta(toComposerMeta(m)) recovers the non-title fields", () => {
+    const out = fromComposerMeta(toComposerMeta(base));
+    expect(out).toEqual({
+      artists: ["Tyler, The Creator", "Kali Uchis"],
+      album: "Flower Boy",
+      isrc: "USQX91700001",
+      songwriters: ["Tyler Okonma"],
+      extra: { mood: "chill", spotifyId: "abc" },
+    });
+  });
+});

--- a/src/domain/project/metadata-ttml.test.ts
+++ b/src/domain/project/metadata-ttml.test.ts
@@ -67,7 +67,12 @@ describe("fromComposerMeta", () => {
     it("returns an empty object for no pairs", () => expect(fromComposerMeta([])).toEqual({}));
     it("ignores pairs with an empty key", () => expect(fromComposerMeta([{ key: "", value: "x" }])).toEqual({}));
     it("ignores pairs with an empty value", () => {
-      expect(fromComposerMeta([{ key: "album", value: "" }, { key: "spotifyId", value: "" }])).toEqual({});
+      expect(
+        fromComposerMeta([
+          { key: "album", value: "" },
+          { key: "spotifyId", value: "" },
+        ]),
+      ).toEqual({});
     });
   });
 });

--- a/src/domain/project/metadata-ttml.test.ts
+++ b/src/domain/project/metadata-ttml.test.ts
@@ -66,6 +66,9 @@ describe("fromComposerMeta", () => {
   describe("edge cases", () => {
     it("returns an empty object for no pairs", () => expect(fromComposerMeta([])).toEqual({}));
     it("ignores pairs with an empty key", () => expect(fromComposerMeta([{ key: "", value: "x" }])).toEqual({}));
+    it("ignores pairs with an empty value", () => {
+      expect(fromComposerMeta([{ key: "album", value: "" }, { key: "spotifyId", value: "" }])).toEqual({});
+    });
   });
 });
 

--- a/src/domain/project/metadata-ttml.ts
+++ b/src/domain/project/metadata-ttml.ts
@@ -1,0 +1,62 @@
+import type { ProjectMetadata } from "@/domain/project/metadata";
+
+// -- Types --------------------------------------------------------------------
+
+interface MetaPair {
+  key: string;
+  value: string;
+}
+
+// -- Mapping ------------------------------------------------------------------
+
+function toComposerMeta(metadata: ProjectMetadata): MetaPair[] {
+  const pairs: MetaPair[] = [];
+  for (const artist of metadata.artists) if (artist) pairs.push({ key: "artists", value: artist });
+  if (metadata.album) pairs.push({ key: "album", value: metadata.album });
+  if (metadata.isrc) pairs.push({ key: "isrc", value: metadata.isrc });
+  for (const writer of metadata.songwriters ?? []) if (writer) pairs.push({ key: "songwriter", value: writer });
+  for (const key of Object.keys(metadata.extra ?? {}).toSorted()) {
+    const value = metadata.extra?.[key];
+    if (value) pairs.push({ key, value });
+  }
+  return pairs;
+}
+
+function fromComposerMeta(pairs: MetaPair[]): Partial<ProjectMetadata> {
+  const out: Partial<ProjectMetadata> = {};
+  const artists: string[] = [];
+  const songwriters: string[] = [];
+  const extra: Record<string, string> = {};
+  for (const { key, value } of pairs) {
+    if (!key || value == null) continue;
+    switch (key) {
+      case "artists":
+        artists.push(value);
+        break;
+      case "album":
+        out.album = value;
+        break;
+      case "isrc":
+        out.isrc = value;
+        break;
+      case "musicName":
+        if (out.title == null) out.title = value;
+        break;
+      case "songwriter":
+      case "songwriters":
+        songwriters.push(value);
+        break;
+      default:
+        extra[key] = value;
+    }
+  }
+  if (artists.length) out.artists = artists;
+  if (songwriters.length) out.songwriters = songwriters;
+  if (Object.keys(extra).length) out.extra = extra;
+  return out;
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { fromComposerMeta, toComposerMeta };
+export type { MetaPair };

--- a/src/domain/project/metadata-ttml.ts
+++ b/src/domain/project/metadata-ttml.ts
@@ -28,7 +28,7 @@ function fromComposerMeta(pairs: MetaPair[]): Partial<ProjectMetadata> {
   const songwriters: string[] = [];
   const extra: Record<string, string> = {};
   for (const { key, value } of pairs) {
-    if (!key || value == null) continue;
+    if (!key || !value) continue;
     switch (key) {
       case "artists":
         artists.push(value);

--- a/src/domain/project/metadata.test.ts
+++ b/src/domain/project/metadata.test.ts
@@ -5,7 +5,7 @@ describe("ProjectMetadata", () => {
   it("preserves thumbnailForVideoId when set alongside thumbnailDataUrl", () => {
     const m: ProjectMetadata = {
       title: "T",
-      artist: "A",
+      artists: ["A"],
       album: "AL",
       duration: 0,
       thumbnailDataUrl: "data:image/png;base64,xyz",
@@ -16,7 +16,7 @@ describe("ProjectMetadata", () => {
   });
 
   it("omits thumbnailForVideoId by default", () => {
-    const m: ProjectMetadata = { title: "", artist: "", album: "", duration: 0 };
+    const m: ProjectMetadata = { title: "", artists: [], album: "", duration: 0 };
     expect(m.thumbnailForVideoId).toBeUndefined();
     expect(m.thumbnailDataUrl).toBeUndefined();
   });
@@ -26,7 +26,7 @@ describe("ProjectMetadata: persistence invariants", () => {
   it("round-trips both thumbnail fields through JSON (the persistence path uses JSON via IndexedDB)", () => {
     const original: ProjectMetadata = {
       title: "Never Gonna Give You Up",
-      artist: "Rick Astley",
+      artists: ["Rick Astley"],
       album: "Whenever You Need Somebody",
       duration: 213,
       thumbnailDataUrl: "data:image/png;base64,ABCD",
@@ -41,14 +41,14 @@ describe("ProjectMetadata: persistence invariants", () => {
   it("distinguishes the legacy persisted state (thumbnailDataUrl only) from the post-refactor state (both set)", () => {
     const legacy: ProjectMetadata = {
       title: "",
-      artist: "",
+      artists: [],
       album: "",
       duration: 0,
       thumbnailDataUrl: "data:image/png;base64,LEGACY",
     };
     const tagged: ProjectMetadata = {
       title: "",
-      artist: "",
+      artists: [],
       album: "",
       duration: 0,
       thumbnailDataUrl: "data:image/png;base64,LEGACY",

--- a/src/domain/project/metadata.ts
+++ b/src/domain/project/metadata.ts
@@ -2,9 +2,12 @@
 
 interface ProjectMetadata {
   title: string;
-  artist: string;
+  artists: string[];
   album: string;
   duration: number;
+  isrc?: string;
+  songwriters?: string[];
+  extra?: Record<string, string>;
   language?: string;
   thumbnailDataUrl?: string;
   thumbnailForVideoId?: string;

--- a/src/domain/project/normalize-metadata.test.ts
+++ b/src/domain/project/normalize-metadata.test.ts
@@ -32,5 +32,26 @@ describe("normalizeLoadedMetadata", () => {
       });
       expect(out).toMatchObject({ isrc: "USQX91700001", songwriters: ["W"], extra: { spotifyId: "z" } });
     });
+    it("drops a whitespace-only legacy artist to an empty array", () => {
+      expect(normalizeLoadedMetadata({ artist: "   " }).artists).toEqual([]);
+    });
+  });
+  describe("invariants", () => {
+    it("prefers artists over a stale legacy artist when both are present", () => {
+      const out = normalizeLoadedMetadata({ artist: "Legacy", artists: ["New"] });
+      expect(out.artists).toEqual(["New"]);
+      expect("artist" in out).toBe(false);
+    });
+    it("never lets a default clobber a present field", () => {
+      const out = normalizeLoadedMetadata({ title: "Keep", artist: "X" });
+      expect(out.title).toBe("Keep");
+      expect(out.artists).toEqual(["X"]);
+    });
+    it("survives a real IndexedDB-style JSON round-trip of a legacy record", () => {
+      const legacy = { title: "T", artist: "Tyler, The Creator", album: "A", duration: 12 };
+      const out = normalizeLoadedMetadata(JSON.parse(JSON.stringify(legacy)));
+      expect(out.artists).toEqual(["Tyler, The Creator"]);
+      expect("artist" in out).toBe(false);
+    });
   });
 });

--- a/src/domain/project/normalize-metadata.test.ts
+++ b/src/domain/project/normalize-metadata.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLoadedMetadata } from "@/domain/project/normalize-metadata";
+
+describe("normalizeLoadedMetadata", () => {
+  it("upgrades legacy single artist string to an array", () => {
+    const out = normalizeLoadedMetadata({ title: "T", artist: "Tyler, The Creator", album: "A", duration: 10 });
+    expect(out.artists).toEqual(["Tyler, The Creator"]);
+    expect("artist" in out).toBe(false);
+  });
+  it("passes through an already-migrated artists array", () => {
+    const out = normalizeLoadedMetadata({ title: "T", artists: ["A", "B"], album: "", duration: 0 });
+    expect(out.artists).toEqual(["A", "B"]);
+  });
+  describe("edge cases", () => {
+    it("fills defaults for a sparse object", () => {
+      const out = normalizeLoadedMetadata({});
+      expect(out).toMatchObject({ title: "", artists: [], album: "", duration: 0 });
+    });
+    it("drops an empty legacy artist string to an empty array", () => {
+      expect(normalizeLoadedMetadata({ artist: "" }).artists).toEqual([]);
+    });
+    it("is idempotent", () => {
+      const once = normalizeLoadedMetadata({ artist: "X" });
+      expect(normalizeLoadedMetadata(once)).toEqual(once);
+    });
+    it("preserves new optional fields", () => {
+      const out = normalizeLoadedMetadata({
+        artists: ["X"],
+        isrc: "USQX91700001",
+        songwriters: ["W"],
+        extra: { spotifyId: "z" },
+      });
+      expect(out).toMatchObject({ isrc: "USQX91700001", songwriters: ["W"], extra: { spotifyId: "z" } });
+    });
+  });
+});

--- a/src/domain/project/normalize-metadata.ts
+++ b/src/domain/project/normalize-metadata.ts
@@ -1,0 +1,27 @@
+import type { ProjectMetadata } from "@/domain/project/metadata";
+
+// -- Types --------------------------------------------------------------------
+
+interface StoredMetadata extends Partial<Omit<ProjectMetadata, "artists">> {
+  artist?: string;
+  artists?: string[];
+}
+
+// -- Normalizer ---------------------------------------------------------------
+
+function normalizeLoadedMetadata(raw: StoredMetadata): ProjectMetadata {
+  const artists = raw.artists ?? (raw.artist?.trim() ? [raw.artist] : []);
+  const { artist: _legacy, ...rest } = raw;
+  return {
+    title: raw.title ?? "",
+    album: raw.album ?? "",
+    duration: raw.duration ?? 0,
+    ...rest,
+    artists,
+  };
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { normalizeLoadedMetadata };
+export type { StoredMetadata };

--- a/src/hooks/useImportFromHash.persistence.browser.test.tsx
+++ b/src/hooks/useImportFromHash.persistence.browser.test.tsx
@@ -72,7 +72,7 @@ function savedSnapshot(audioSource?: { kind: "youtube"; videoId: string } | { ki
 
 // -- Tests --------------------------------------------------------------------
 
-describe("usePersistence + useImportFromHash — hash overrides persistence", () => {
+describe("usePersistence + useImportFromHash: hash overrides persistence", () => {
   beforeEach(() => {
     setQuery("");
     setHash("");

--- a/src/hooks/useImportFromHash.persistence.browser.test.tsx
+++ b/src/hooks/useImportFromHash.persistence.browser.test.tsx
@@ -51,7 +51,7 @@ async function waitForBootSettled(): Promise<void> {
 
 function importedPayload() {
   return {
-    metadata: { title: IMPORTED_TITLE, artist: "", album: "", duration: 0 },
+    metadata: { title: IMPORTED_TITLE, artists: [], album: "", duration: 0 },
     agents: [IMPORTED_AGENT],
     lines: [IMPORTED_LINE],
     granularity: "word" as const,
@@ -62,7 +62,7 @@ function savedSnapshot(audioSource?: { kind: "youtube"; videoId: string } | { ki
   return {
     version: 1,
     savedAt: Date.now(),
-    metadata: { title: SAVED_TITLE, artist: "", album: "", duration: 0 },
+    metadata: { title: SAVED_TITLE, artists: [], album: "", duration: 0 },
     lines: [SAVED_LINE],
     agents: [SAVED_AGENT],
     granularity: "word" as const,

--- a/src/hooks/useImportFromHash.ts
+++ b/src/hooks/useImportFromHash.ts
@@ -5,6 +5,7 @@ import { useProjectStore } from "@/stores/project";
 import type { Agent } from "@/domain/agent/model";
 import type { LyricLine } from "@/domain/line/model";
 import type { ProjectMetadata } from "@/domain/project/metadata";
+import { normalizeLoadedMetadata } from "@/domain/project/normalize-metadata";
 import { useEffect } from "react";
 import { toast } from "sonner";
 
@@ -31,13 +32,13 @@ function isValidPayload(value: unknown): value is ImportPayload {
 async function isProjectNonEmpty(): Promise<boolean> {
   const state = useProjectStore.getState();
   if (state.lines.length > 0) return true;
-  const { title, artist, album } = state.metadata;
-  if (title || artist || album) return true;
+  const { title, artists, album } = state.metadata;
+  if (title || artists.length || album) return true;
 
   const saved = await loadCurrentProject();
   if (!saved) return false;
   if (saved.lines.length > 0) return true;
-  return Boolean(saved.metadata.title || saved.metadata.artist || saved.metadata.album);
+  return Boolean(saved.metadata.title || saved.metadata.artists?.length || saved.metadata.album);
 }
 
 function useImportFromHash(): void {
@@ -86,7 +87,7 @@ function useImportFromHash(): void {
 
         const state = useProjectStore.getState();
         state.reset();
-        state.setMetadata(payload.metadata);
+        state.setMetadata(normalizeLoadedMetadata(payload.metadata));
         state.setLines(payload.lines);
         state.setGranularity(payload.granularity);
         for (const agent of payload.agents) {

--- a/src/hooks/useImportFromHash.ts
+++ b/src/hooks/useImportFromHash.ts
@@ -38,7 +38,8 @@ async function isProjectNonEmpty(): Promise<boolean> {
   const saved = await loadCurrentProject();
   if (!saved) return false;
   if (saved.lines.length > 0) return true;
-  return Boolean(saved.metadata.title || saved.metadata.artists?.length || saved.metadata.album);
+  const savedMetadata = normalizeLoadedMetadata(saved.metadata);
+  return Boolean(savedMetadata.title || savedMetadata.artists.length || savedMetadata.album);
 }
 
 function useImportFromHash(): void {

--- a/src/hooks/useImportFromQuery.test.ts
+++ b/src/hooks/useImportFromQuery.test.ts
@@ -3,6 +3,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { buildMetadataFromUrl, useImportFromQuery } from "@/hooks/useImportFromQuery";
 import { useImportFromYouTube } from "@/hooks/useImportFromYouTube";
+import { getPersistenceSettled, markPersistenceSettled } from "@/lib/persistence-settled";
 import { INITIAL_STATE, useImportModalStore } from "@/stores/import-modal-store";
 import { useProjectStore } from "@/stores/project";
 
@@ -254,6 +255,13 @@ describe("buildMetadataFromUrl", () => {
   });
 });
 
+async function flushSettled(): Promise<void> {
+  markPersistenceSettled();
+  await act(async () => {
+    await getPersistenceSettled();
+  });
+}
+
 describe("useImportFromQuery persists enriched-link metadata", () => {
   let handle: MountHandle | null = null;
 
@@ -270,10 +278,11 @@ describe("useImportFromQuery persists enriched-link metadata", () => {
     setUrl("");
   });
 
-  it("writes title/artists/album/isrc/duration into the project store", () => {
+  it("writes title/artists/album/isrc/duration into the project store once persistence settles", async () => {
     setUrl("?title=Hello&artist=Adele&album=25&isrc=gbum71029604&duration=355");
 
     handle = mountHook();
+    await flushSettled();
 
     expect(useProjectStore.getState().metadata).toMatchObject({
       title: "Hello",
@@ -284,8 +293,55 @@ describe("useImportFromQuery persists enriched-link metadata", () => {
     });
   });
 
-  it("leaves project metadata untouched when no import params are present", () => {
+  it("leaves project metadata untouched when no import params are present", async () => {
     setUrl("?foo=bar");
+
+    handle = mountHook();
+    await flushSettled();
+
+    expect(useProjectStore.getState().metadata).toEqual({
+      title: "",
+      artists: [],
+      album: "",
+      duration: 0,
+    });
+  });
+
+  it("does not write a metadata patch when only videoId is present", async () => {
+    setUrl("?videoId=fJ9rUzIMcZQ");
+
+    handle = mountHook();
+    await flushSettled();
+
+    expect(useProjectStore.getState().metadata).toEqual({
+      title: "",
+      artists: [],
+      album: "",
+      duration: 0,
+    });
+  });
+});
+
+// -- Boot race: gate the project write behind persistence settling ------------
+
+describe("useImportFromQuery gates the metadata write behind persistence", () => {
+  let handle: MountHandle | null = null;
+
+  beforeEach(() => {
+    resetStore();
+    setUrl("");
+  });
+
+  afterEach(() => {
+    if (handle) {
+      handle.unmount();
+      handle = null;
+    }
+    setUrl("");
+  });
+
+  it("does not write enriched-link metadata until persistence has settled", () => {
+    setUrl("?title=Hello&artist=Adele&album=25&isrc=gbum71029604&duration=355");
 
     handle = mountHook();
 
@@ -297,10 +353,50 @@ describe("useImportFromQuery persists enriched-link metadata", () => {
     });
   });
 
-  it("does not write a metadata patch when only videoId is present", () => {
-    setUrl("?videoId=fJ9rUzIMcZQ");
+  it("applies the enriched-link metadata after persistence settles", async () => {
+    setUrl("?title=Hello&artist=Adele&album=25&isrc=gbum71029604&duration=355");
 
     handle = mountHook();
+    await flushSettled();
+
+    expect(useProjectStore.getState().metadata).toMatchObject({
+      title: "Hello",
+      artists: ["Adele"],
+      album: "25",
+      isrc: "GBUM71029604",
+      duration: 355,
+    });
+  });
+
+  it("does not clobber a persistence-restored project when the URL has no import params", async () => {
+    setUrl("?foo=bar");
+    useProjectStore.getState().setMetadata({
+      title: "Restored Title",
+      artists: ["Restored Artist"],
+      album: "Restored Album",
+      isrc: "USQX91700001",
+      duration: 200,
+    });
+
+    handle = mountHook();
+    await flushSettled();
+
+    expect(useProjectStore.getState().metadata).toMatchObject({
+      title: "Restored Title",
+      artists: ["Restored Artist"],
+      album: "Restored Album",
+      isrc: "USQX91700001",
+      duration: 200,
+    });
+  });
+
+  it("does not write after unmount even once persistence settles", async () => {
+    setUrl("?title=Hello&artist=Adele");
+
+    handle = mountHook();
+    handle.unmount();
+    handle = null;
+    await flushSettled();
 
     expect(useProjectStore.getState().metadata).toEqual({
       title: "",

--- a/src/hooks/useImportFromQuery.test.ts
+++ b/src/hooks/useImportFromQuery.test.ts
@@ -1,9 +1,10 @@
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { useImportFromQuery } from "@/hooks/useImportFromQuery";
+import { buildMetadataFromUrl, useImportFromQuery } from "@/hooks/useImportFromQuery";
 import { useImportFromYouTube } from "@/hooks/useImportFromYouTube";
 import { INITIAL_STATE, useImportModalStore } from "@/stores/import-modal-store";
+import { useProjectStore } from "@/stores/project";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -56,6 +57,7 @@ function currentSearch(): string {
 function resetStore(): void {
   useImportModalStore.setState({ ...INITIAL_STATE });
   window.localStorage.removeItem("composer-import-modal");
+  useProjectStore.getState().reset();
 }
 
 // -- Tests --------------------------------------------------------------------
@@ -233,6 +235,79 @@ describe("useImportFromQuery", () => {
     expect(useImportModalStore.getState().defaultPrefill).toEqual({ track: "Hello" });
     useImportModalStore.getState().clearDefaultPrefill();
     expect(useImportModalStore.getState().defaultPrefill).toBeNull();
+  });
+});
+
+describe("buildMetadataFromUrl", () => {
+  it("persists title/artists/album/isrc/duration from the enriched link", () => {
+    const out = buildMetadataFromUrl(new URLSearchParams("title=T&artist=A&album=Al&isrc=usqx91700001&duration=200"));
+    expect(out).toEqual({ title: "T", artists: ["A"], album: "Al", isrc: "USQX91700001", duration: 200 });
+  });
+  it("returns null when no fields present", () => {
+    expect(buildMetadataFromUrl(new URLSearchParams(""))).toBeNull();
+  });
+  it("drops an invalid isrc but keeps the rest", () => {
+    expect(buildMetadataFromUrl(new URLSearchParams("title=T&isrc=bad"))).toEqual({ title: "T" });
+  });
+  it("omits absent fields (no empty strings or zero duration)", () => {
+    expect(buildMetadataFromUrl(new URLSearchParams("artist=A"))).toEqual({ artists: ["A"] });
+  });
+});
+
+describe("useImportFromQuery persists enriched-link metadata", () => {
+  let handle: MountHandle | null = null;
+
+  beforeEach(() => {
+    resetStore();
+    setUrl("");
+  });
+
+  afterEach(() => {
+    if (handle) {
+      handle.unmount();
+      handle = null;
+    }
+    setUrl("");
+  });
+
+  it("writes title/artists/album/isrc/duration into the project store", () => {
+    setUrl("?title=Hello&artist=Adele&album=25&isrc=gbum71029604&duration=355");
+
+    handle = mountHook();
+
+    expect(useProjectStore.getState().metadata).toMatchObject({
+      title: "Hello",
+      artists: ["Adele"],
+      album: "25",
+      isrc: "GBUM71029604",
+      duration: 355,
+    });
+  });
+
+  it("leaves project metadata untouched when no import params are present", () => {
+    setUrl("?foo=bar");
+
+    handle = mountHook();
+
+    expect(useProjectStore.getState().metadata).toEqual({
+      title: "",
+      artists: [],
+      album: "",
+      duration: 0,
+    });
+  });
+
+  it("does not write a metadata patch when only videoId is present", () => {
+    setUrl("?videoId=fJ9rUzIMcZQ");
+
+    handle = mountHook();
+
+    expect(useProjectStore.getState().metadata).toEqual({
+      title: "",
+      artists: [],
+      album: "",
+      duration: 0,
+    });
   });
 });
 

--- a/src/hooks/useImportFromQuery.ts
+++ b/src/hooks/useImportFromQuery.ts
@@ -1,5 +1,7 @@
 import { useEffect } from "react";
+import type { ProjectMetadata } from "@/domain/project/metadata";
 import { useImportModalStore } from "@/stores/import-modal-store";
+import { useProjectStore } from "@/stores/project";
 import { normalizeIsrc } from "@/utils/isrc";
 import { stripQueryParams } from "@/utils/url-params";
 import type { LyricsSearchQuery } from "@/utils/lyrics-search/types";
@@ -44,17 +46,37 @@ function buildPrefillFromUrl(params: URLSearchParams): LyricsSearchQuery | null 
   return Object.keys(prefill).length === 0 ? null : prefill;
 }
 
+function buildMetadataFromUrl(params: URLSearchParams): Partial<ProjectMetadata> | null {
+  const patch: Partial<ProjectMetadata> = {};
+  const title = readTrimmed(params, "title");
+  const artist = readTrimmed(params, "artist");
+  const album = readTrimmed(params, "album");
+  const duration = parseDurationSec(readTrimmed(params, "duration"));
+  const isrcRaw = readTrimmed(params, "isrc");
+  const isrc = isrcRaw ? normalizeIsrc(isrcRaw) : undefined;
+
+  if (title) patch.title = title;
+  if (artist) patch.artists = [artist];
+  if (album) patch.album = album;
+  if (duration !== undefined) patch.duration = duration;
+  if (isrc !== undefined) patch.isrc = isrc;
+
+  return Object.keys(patch).length === 0 ? null : patch;
+}
+
 function useImportFromQuery(): void {
   useEffect(() => {
     if (typeof window === "undefined") return;
     const params = new URLSearchParams(window.location.search);
     const prefill = buildPrefillFromUrl(params);
-    if (prefill === null) return;
+    const metaPatch = buildMetadataFromUrl(params);
+    if (prefill === null && metaPatch === null) return;
     stripQueryParams(IMPORT_PARAM_NAMES);
-    useImportModalStore.getState().setDefaultPrefill(prefill);
+    if (prefill !== null) useImportModalStore.getState().setDefaultPrefill(prefill);
+    if (metaPatch !== null) useProjectStore.getState().setMetadata(metaPatch);
   }, []);
 }
 
 // -- Exports ------------------------------------------------------------------
 
-export { useImportFromQuery };
+export { buildMetadataFromUrl, useImportFromQuery };

--- a/src/hooks/useImportFromQuery.ts
+++ b/src/hooks/useImportFromQuery.ts
@@ -1,12 +1,12 @@
 import { useEffect } from "react";
 import { useImportModalStore } from "@/stores/import-modal-store";
+import { normalizeIsrc } from "@/utils/isrc";
 import { stripQueryParams } from "@/utils/url-params";
 import type { LyricsSearchQuery } from "@/utils/lyrics-search/types";
 
 // -- Constants ----------------------------------------------------------------
 
 const IMPORT_PARAM_NAMES = ["title", "artist", "album", "duration", "isrc"] as const;
-const ISRC_PATTERN = /^[A-Z]{2}[A-Z0-9]{3}\d{7}$/;
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -24,18 +24,13 @@ function parseDurationSec(raw: string | null): number | undefined {
   return value;
 }
 
-function parseIsrc(raw: string | null): string | undefined {
-  if (raw === null) return undefined;
-  const normalized = raw.toUpperCase();
-  return ISRC_PATTERN.test(normalized) ? normalized : undefined;
-}
-
 function buildPrefillFromUrl(params: URLSearchParams): LyricsSearchQuery | null {
   const track = readTrimmed(params, "title");
   const artist = readTrimmed(params, "artist");
   const album = readTrimmed(params, "album");
   const durationSec = parseDurationSec(readTrimmed(params, "duration"));
-  const isrc = parseIsrc(readTrimmed(params, "isrc"));
+  const isrcRaw = readTrimmed(params, "isrc");
+  const isrc = isrcRaw ? normalizeIsrc(isrcRaw) : undefined;
   const videoId = readTrimmed(params, "videoId");
 
   const prefill: LyricsSearchQuery = {};

--- a/src/hooks/useImportFromQuery.ts
+++ b/src/hooks/useImportFromQuery.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import type { ProjectMetadata } from "@/domain/project/metadata";
+import { getPersistenceSettled } from "@/lib/persistence-settled";
 import { useImportModalStore } from "@/stores/import-modal-store";
 import { useProjectStore } from "@/stores/project";
 import { normalizeIsrc } from "@/utils/isrc";
@@ -73,7 +74,18 @@ function useImportFromQuery(): void {
     if (prefill === null && metaPatch === null) return;
     stripQueryParams(IMPORT_PARAM_NAMES);
     if (prefill !== null) useImportModalStore.getState().setDefaultPrefill(prefill);
-    if (metaPatch !== null) useProjectStore.getState().setMetadata(metaPatch);
+
+    if (metaPatch === null) return;
+
+    let cancelled = false;
+    getPersistenceSettled().then(() => {
+      if (cancelled) return;
+      useProjectStore.getState().setMetadata(metaPatch);
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 }
 

--- a/src/hooks/useImportFromYouTube.persistence.browser.test.tsx
+++ b/src/hooks/useImportFromYouTube.persistence.browser.test.tsx
@@ -71,7 +71,7 @@ function baseSavedProject(audioSource: { kind: "youtube"; videoId: string } | { 
   return {
     version: 1,
     savedAt: Date.now(),
-    metadata: { title: SAVED_TITLE, artist: "Saved Artist", album: "Saved Album", duration: 0 },
+    metadata: { title: SAVED_TITLE, artists: ["Saved Artist"], album: "Saved Album", duration: 0 },
     lines: [],
     agents: [{ id: "v1", type: "person", name: "Lead" }],
     granularity: "word" as const,

--- a/src/hooks/useImportFromYouTube.persistence.browser.test.tsx
+++ b/src/hooks/useImportFromYouTube.persistence.browser.test.tsx
@@ -81,7 +81,7 @@ function baseSavedProject(audioSource: { kind: "youtube"; videoId: string } | { 
 
 // -- URL overrides persistence ------------------------------------------------
 
-describe("usePersistence + useImportFromYouTube — URL overrides persistence", () => {
+describe("usePersistence + useImportFromYouTube: URL overrides persistence", () => {
   beforeEach(() => setQuery(""));
   afterEach(() => setQuery(""));
 
@@ -165,7 +165,7 @@ describe("usePersistence + useImportFromYouTube — URL overrides persistence", 
 
 // -- Cold start ---------------------------------------------------------------
 
-describe("usePersistence + useImportFromYouTube — cold start", () => {
+describe("usePersistence + useImportFromYouTube: cold start", () => {
   beforeEach(() => setQuery(""));
   afterEach(() => setQuery(""));
 
@@ -197,7 +197,7 @@ describe("usePersistence + useImportFromYouTube — cold start", () => {
 
 // -- Edge cases ---------------------------------------------------------------
 
-describe("usePersistence + useImportFromYouTube — edge cases", () => {
+describe("usePersistence + useImportFromYouTube: edge cases", () => {
   beforeEach(() => setQuery(""));
   afterEach(() => setQuery(""));
 

--- a/src/hooks/usePersistence.priming-migration.browser.test.tsx
+++ b/src/hooks/usePersistence.priming-migration.browser.test.tsx
@@ -14,7 +14,7 @@ import { createMp3File } from "@/test/audio-fixtures";
 
 function seedSavedProject(opts: { primingStripped: boolean }): Promise<void> {
   return saveCurrentProject(
-    { title: "t", artist: "", album: "", duration: 0 },
+    { title: "t", artists: [], album: "", duration: 0 },
     DEFAULT_AGENTS,
     [
       {
@@ -133,7 +133,7 @@ describe("usePersistence priming-stripped flag survives the post-load debounced 
     expect(parseLamePriming(await mp3.arrayBuffer()).samples).toBeGreaterThan(0);
     await saveAudioFile(mp3);
     await saveCurrentProject(
-      { title: "race", artist: "", album: "", duration: 0 },
+      { title: "race", artists: [], album: "", duration: 0 },
       DEFAULT_AGENTS,
       [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
       [],
@@ -159,7 +159,7 @@ describe("usePersistence priming-stripped flag survives the post-load debounced 
     const noPrimingMp3 = new File([new Uint8Array([0, 1, 2, 3])], "not-mp3.bin", { type: "audio/mpeg" });
     await saveAudioFile(noPrimingMp3);
     await saveCurrentProject(
-      { title: "race-zero", artist: "", album: "", duration: 0 },
+      { title: "race-zero", artists: [], album: "", duration: 0 },
       DEFAULT_AGENTS,
       [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
       [],

--- a/src/hooks/usePersistence.snap-points.browser.test.tsx
+++ b/src/hooks/usePersistence.snap-points.browser.test.tsx
@@ -53,7 +53,7 @@ describe("usePersistence · customSnapPoints hydration", () => {
   it("regression: usePersistence hydrates saved customSnapPoints into the project store", async () => {
     await saveAudioFile(createMp3File());
     await saveCurrentProject(
-      { title: "with-markers", artist: "", album: "", duration: 0 },
+      { title: "with-markers", artists: [], album: "", duration: 0 },
       DEFAULT_AGENTS,
       [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
       [],
@@ -80,7 +80,7 @@ describe("usePersistence · customSnapPoints hydration", () => {
     const legacyRecord: SavedProject = {
       version: 1,
       savedAt: Date.now(),
-      metadata: { title: "legacy", artist: "", album: "", duration: 0 },
+      metadata: { title: "legacy", artists: [], album: "", duration: 0 },
       agents: DEFAULT_AGENTS,
       lines: [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
       groups: [],
@@ -106,7 +106,7 @@ describe("usePersistence · customSnapPoints hydration", () => {
   it("regression: a saved project's markers survive the audio-source clear fired during load", async () => {
     await saveAudioFile(createMp3File());
     await saveCurrentProject(
-      { title: "survives-load", artist: "", album: "", duration: 0 },
+      { title: "survives-load", artists: [], album: "", duration: 0 },
       DEFAULT_AGENTS,
       [{ id: "L1", text: "hi", agentId: DEFAULT_AGENTS[0].id }],
       [],

--- a/src/hooks/usePersistence.stem.browser.test.tsx
+++ b/src/hooks/usePersistence.stem.browser.test.tsx
@@ -25,7 +25,7 @@ function seedSavedProject(currentStem?: "original" | "vocals" | "instrumental"):
   return seedProject({
     version: 1,
     savedAt: Date.now(),
-    metadata: { title: "Seeded Song", artist: "", album: "", duration: 0 },
+    metadata: { title: "Seeded Song", artists: [], album: "", duration: 0 },
     lines: [],
     agents: [{ id: "v1", type: "person", name: "Lead" }],
     granularity: "word",

--- a/src/hooks/usePersistence.ts
+++ b/src/hooks/usePersistence.ts
@@ -12,6 +12,7 @@ import { type AudioSource, useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { DEFAULT_SYLLABLE_SPLIT_DEFAULTS } from "@/stores/project/types";
 import { DEFAULT_AGENTS } from "@/domain/agent/colors";
+import { normalizeLoadedMetadata } from "@/domain/project/normalize-metadata";
 import { useSeparationStore } from "@/stores/separation";
 import { useSettingsStore } from "@/stores/settings";
 import { useEffect } from "react";
@@ -115,7 +116,7 @@ function usePersistence(): void {
           }
 
           const state = useProjectStore.getState();
-          state.setMetadata(project.metadata);
+          state.setMetadata(normalizeLoadedMetadata(project.metadata));
           state.setLines(safeLines);
           state.setGroups(project.groups ?? []);
           state.setGranularity(safeGranularity);

--- a/src/hooks/useProjectFileActions.ts
+++ b/src/hooks/useProjectFileActions.ts
@@ -4,6 +4,7 @@ import { useAudioStore } from "@/stores/audio";
 import { useConfirm } from "@/stores/confirm-store";
 import { useProjectStore } from "@/stores/project";
 import { DEFAULT_SYLLABLE_SPLIT_DEFAULTS } from "@/stores/project/types";
+import { normalizeLoadedMetadata } from "@/domain/project/normalize-metadata";
 import { useCallback } from "react";
 
 // -- Hook ---------------------------------------------------------------------
@@ -63,7 +64,7 @@ function useProjectFileActions(fileInputRef: React.RefObject<HTMLInputElement | 
 
       const project = await importProjectFromFile(file);
       const store = useProjectStore.getState();
-      setMetadata(project.metadata);
+      setMetadata(normalizeLoadedMetadata(project.metadata));
       setLines(project.lines);
       store.setGroups(project.groups ?? []);
       store.setDismissedSuggestions(project.dismissedSuggestions ?? []);

--- a/src/hooks/useResolveYouTubeTunnel.browser.test.tsx
+++ b/src/hooks/useResolveYouTubeTunnel.browser.test.tsx
@@ -207,6 +207,36 @@ describe("useResolveYouTubeTunnel: bridge happy path", () => {
     expect(useProjectStore.getState().metadata.isrc).toBeUndefined();
   });
 
+  it("rejects a malformed bridge isrc instead of writing it to the store", async () => {
+    bridge.audio.set("dQw4w9WgXcQ", {
+      buffer: asBytes("opus"),
+      mimeType: "audio/opus",
+      artistPercentEncoded: encodeURIComponent("Rick Astley"),
+      isrcPercentEncoded: encodeURIComponent("N/A"),
+    });
+
+    enableBridgeAndSelectVideo("dQw4w9WgXcQ");
+    await render(withQueryClient(<HookHost />));
+
+    await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Rick Astley");
+    expect(useProjectStore.getState().metadata.isrc).toBeUndefined();
+  });
+
+  it("uppercases a lowercase-but-otherwise-valid bridge isrc", async () => {
+    bridge.audio.set("dQw4w9WgXcQ", {
+      buffer: asBytes("opus"),
+      mimeType: "audio/opus",
+      artistPercentEncoded: encodeURIComponent("Rick Astley"),
+      isrcPercentEncoded: encodeURIComponent("gbarl9300135"),
+    });
+
+    enableBridgeAndSelectVideo("dQw4w9WgXcQ");
+    await render(withQueryClient(<HookHost />));
+
+    await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Rick Astley");
+    expect(useProjectStore.getState().metadata.isrc).toBe("GBARL9300135");
+  });
+
   it("decodes percent-encoded UTF-8 metadata headers (the fullwidth-comma regression)", async () => {
     bridge.audio.set("dQw4w9WgXcQ", {
       buffer: asBytes("opus"),

--- a/src/hooks/useResolveYouTubeTunnel.browser.test.tsx
+++ b/src/hooks/useResolveYouTubeTunnel.browser.test.tsx
@@ -149,7 +149,7 @@ async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void
 
 // -- Bridge happy path --------------------------------------------------------
 
-describe("useResolveYouTubeTunnel — bridge happy path", () => {
+describe("useResolveYouTubeTunnel: bridge happy path", () => {
   it("writes the file from the bridge audio response into the audio store", async () => {
     bridge.audio.set("dQw4w9WgXcQ", {
       buffer: asBytes("opus-bytes"),
@@ -226,7 +226,7 @@ describe("useResolveYouTubeTunnel — bridge happy path", () => {
 
 // -- Fallback paths -----------------------------------------------------------
 
-describe("useResolveYouTubeTunnel — title fallback", () => {
+describe("useResolveYouTubeTunnel: title fallback", () => {
   it("falls back to videoId as the title when the bridge returns no metadata at all", async () => {
     bridge.audio.set("dQw4w9WgXcQ", { buffer: asBytes("opus"), mimeType: "audio/opus" });
 
@@ -259,7 +259,7 @@ describe("useResolveYouTubeTunnel — title fallback", () => {
 
 // -- mimeType / file format ---------------------------------------------------
 
-describe("useResolveYouTubeTunnel — file format", () => {
+describe("useResolveYouTubeTunnel: file format", () => {
   it("labels the File with the actual bridge mime (regression for the .m4a-hardcode)", async () => {
     bridge.audio.set("dQw4w9WgXcQ", { buffer: asBytes("opus"), mimeType: "audio/opus" });
     enableBridgeAndSelectVideo("dQw4w9WgXcQ");

--- a/src/hooks/useResolveYouTubeTunnel.browser.test.tsx
+++ b/src/hooks/useResolveYouTubeTunnel.browser.test.tsx
@@ -182,10 +182,10 @@ describe("useResolveYouTubeTunnel — bridge happy path", () => {
     enableBridgeAndSelectVideo("dQw4w9WgXcQ");
     await render(withQueryClient(<HookHost />));
 
-    await waitFor(() => useProjectStore.getState().metadata.artist === "Rick Astley");
+    await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Rick Astley");
     const md = useProjectStore.getState().metadata;
     expect(md.title).toBe("Rick Astley - Never Gonna Give You Up");
-    expect(md.artist).toBe("Rick Astley");
+    expect(md.artists).toEqual(["Rick Astley"]);
     expect(md.album).toBe("Whenever You Need Somebody");
   });
 
@@ -200,7 +200,8 @@ describe("useResolveYouTubeTunnel — bridge happy path", () => {
     enableBridgeAndSelectVideo("dQw4w9WgXcQ");
     await render(withQueryClient(<HookHost />));
 
-    await waitFor(() => useProjectStore.getState().metadata.artist === "Tyler, The Creator");
+    await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Tyler, The Creator");
+    expect(useProjectStore.getState().metadata.artists).toEqual(["Tyler, The Creator"]);
     expect(useProjectStore.getState().metadata.title).toContain("RUNNING OUT OF TIME");
   });
 });
@@ -289,7 +290,7 @@ describe("useResolveYouTubeTunnel: reload race", () => {
     await seedProject({
       version: 1,
       savedAt: Date.now(),
-      metadata: { title: "Never Gonna Give You Up", artist: "Rick Astley", album: "", duration: 0 },
+      metadata: { title: "Never Gonna Give You Up", artists: ["Rick Astley"], album: "", duration: 0 },
       lines: [],
       agents: [{ id: "v1", type: "person", name: "Lead" }],
       granularity: "word",
@@ -314,7 +315,7 @@ describe("useResolveYouTubeTunnel: reload race", () => {
       await new Promise((r) => setTimeout(r, 50));
 
       expect(useProjectStore.getState().metadata.title).toBe("Never Gonna Give You Up");
-      expect(useProjectStore.getState().metadata.artist).toBe("Rick Astley");
+      expect(useProjectStore.getState().metadata.artists).toEqual(["Rick Astley"]);
       expect(seenTitles).not.toContain("dQw4w9WgXcQ");
     } finally {
       unsubscribe();

--- a/src/hooks/useResolveYouTubeTunnel.browser.test.tsx
+++ b/src/hooks/useResolveYouTubeTunnel.browser.test.tsx
@@ -39,6 +39,7 @@ interface BridgeAudioResponse {
   titlePercentEncoded?: string;
   artistPercentEncoded?: string;
   albumPercentEncoded?: string;
+  isrcPercentEncoded?: string;
 }
 
 type ThumbBehavior =
@@ -89,6 +90,7 @@ beforeEach(() => {
       if (entry.titlePercentEncoded) headers.set("x-track-title", entry.titlePercentEncoded);
       if (entry.artistPercentEncoded) headers.set("x-track-artist", entry.artistPercentEncoded);
       if (entry.albumPercentEncoded) headers.set("x-track-album", entry.albumPercentEncoded);
+      if (entry.isrcPercentEncoded) headers.set("x-track-isrc", entry.isrcPercentEncoded);
       return new Response(entry.buffer, { headers });
     }
 
@@ -170,13 +172,14 @@ describe("useResolveYouTubeTunnel — bridge happy path", () => {
     expect(file.type).toBe("audio/opus");
   });
 
-  it("sets project metadata title/artist/album from the bridge response", async () => {
+  it("sets project metadata title/artist/album/isrc from the bridge response", async () => {
     bridge.audio.set("dQw4w9WgXcQ", {
       buffer: asBytes("opus"),
       mimeType: "audio/opus",
       titlePercentEncoded: encodeURIComponent("Never Gonna Give You Up"),
       artistPercentEncoded: encodeURIComponent("Rick Astley"),
       albumPercentEncoded: encodeURIComponent("Whenever You Need Somebody"),
+      isrcPercentEncoded: encodeURIComponent("GBARL9300135"),
     });
 
     enableBridgeAndSelectVideo("dQw4w9WgXcQ");
@@ -187,6 +190,21 @@ describe("useResolveYouTubeTunnel — bridge happy path", () => {
     expect(md.title).toBe("Rick Astley - Never Gonna Give You Up");
     expect(md.artists).toEqual(["Rick Astley"]);
     expect(md.album).toBe("Whenever You Need Somebody");
+    expect(md.isrc).toBe("GBARL9300135");
+  });
+
+  it("leaves isrc unset when the bridge omits the x-track-isrc header", async () => {
+    bridge.audio.set("dQw4w9WgXcQ", {
+      buffer: asBytes("opus"),
+      mimeType: "audio/opus",
+      artistPercentEncoded: encodeURIComponent("Rick Astley"),
+    });
+
+    enableBridgeAndSelectVideo("dQw4w9WgXcQ");
+    await render(withQueryClient(<HookHost />));
+
+    await waitFor(() => useProjectStore.getState().metadata.artists[0] === "Rick Astley");
+    expect(useProjectStore.getState().metadata.isrc).toBeUndefined();
   });
 
   it("decodes percent-encoded UTF-8 metadata headers (the fullwidth-comma regression)", async () => {

--- a/src/hooks/useResolveYouTubeTunnel.reload.browser.test.tsx
+++ b/src/hooks/useResolveYouTubeTunnel.reload.browser.test.tsx
@@ -140,7 +140,7 @@ describe("post-reload survival", () => {
       savedAt: Date.now(),
       metadata: {
         title: "Never Gonna Give You Up",
-        artist: "Rick Astley",
+        artists: ["Rick Astley"],
         album: "Whenever You Need Somebody",
         duration: 213,
       },
@@ -167,7 +167,7 @@ describe("post-reload survival", () => {
 
     const md = useProjectStore.getState().metadata;
     expect(md.title).toBe("Never Gonna Give You Up");
-    expect(md.artist).toBe("Rick Astley");
+    expect(md.artists).toEqual(["Rick Astley"]);
     expect(md.album).toBe("Whenever You Need Somebody");
     expect(md.thumbnailDataUrl).toMatch(/^data:image\/png/);
     expect(md.thumbnailForVideoId).toBe("dQw4w9WgXcQ");
@@ -179,7 +179,7 @@ describe("post-reload survival", () => {
     await seedProject({
       version: 1,
       savedAt: Date.now(),
-      metadata: { title: "User Edited Title", artist: "", album: "", duration: 0 },
+      metadata: { title: "User Edited Title", artists: [], album: "", duration: 0 },
       lines: [],
       agents: [{ id: "v1", type: "person", name: "Lead" }],
       granularity: "word",

--- a/src/hooks/useResolveYouTubeTunnel.ts
+++ b/src/hooks/useResolveYouTubeTunnel.ts
@@ -21,6 +21,7 @@ import {
   formatBridgeErrorForToast,
   getAudioFromBridge,
 } from "@/utils/composer-bridge-api";
+import { normalizeIsrc } from "@/utils/isrc";
 
 // -- Constants ----------------------------------------------------------------
 
@@ -185,7 +186,8 @@ function useResolveYouTubeTunnel(): void {
         const metadataPatch: Partial<typeof project.metadata> = { title: data.filename || videoId };
         if (data.artist) metadataPatch.artists = [data.artist];
         if (data.album) metadataPatch.album = data.album;
-        if (data.isrc) metadataPatch.isrc = data.isrc;
+        const bridgeIsrc = data.isrc ? normalizeIsrc(data.isrc) : undefined;
+        if (bridgeIsrc) metadataPatch.isrc = bridgeIsrc;
         project.setMetadata(metadataPatch);
         flushPendingSave();
       }

--- a/src/hooks/useResolveYouTubeTunnel.ts
+++ b/src/hooks/useResolveYouTubeTunnel.ts
@@ -181,7 +181,7 @@ function useResolveYouTubeTunnel(): void {
       const currentTitle = project.metadata.title;
       if (!currentTitle || currentTitle === videoId) {
         const metadataPatch: Partial<typeof project.metadata> = { title: data.filename || videoId };
-        if (data.artist) metadataPatch.artist = data.artist;
+        if (data.artist) metadataPatch.artists = [data.artist];
         if (data.album) metadataPatch.album = data.album;
         project.setMetadata(metadataPatch);
         flushPendingSave();

--- a/src/hooks/useResolveYouTubeTunnel.ts
+++ b/src/hooks/useResolveYouTubeTunnel.ts
@@ -35,6 +35,7 @@ interface TunnelResult {
   title?: string;
   artist?: string;
   album?: string;
+  isrc?: string;
   instanceLabel: string;
   instanceId: string;
   wasDefault: boolean;
@@ -66,7 +67,7 @@ function buildAudioFile(buffer: ArrayBuffer, filename: string | undefined, video
 async function fetchViaBridge(videoId: string, signal: AbortSignal): Promise<TunnelResult> {
   const baseUrl = useSettingsStore.getState().composerBridgeUrl;
   try {
-    const { buffer, mimeType, title, artist, album } = await getAudioFromBridge(baseUrl, videoId, signal);
+    const { buffer, mimeType, title, artist, album, isrc } = await getAudioFromBridge(baseUrl, videoId, signal);
     if (signal.aborted) throw new DOMException("aborted", "AbortError");
     const filename = [artist, title].filter(Boolean).join(" - ") || title;
     return {
@@ -75,6 +76,7 @@ async function fetchViaBridge(videoId: string, signal: AbortSignal): Promise<Tun
       title,
       artist,
       album,
+      isrc,
       instanceLabel: BRIDGE_INSTANCE_LABEL,
       instanceId: BRIDGE_INSTANCE_ID,
       wasDefault: false,
@@ -183,6 +185,7 @@ function useResolveYouTubeTunnel(): void {
         const metadataPatch: Partial<typeof project.metadata> = { title: data.filename || videoId };
         if (data.artist) metadataPatch.artists = [data.artist];
         if (data.album) metadataPatch.album = data.album;
+        if (data.isrc) metadataPatch.isrc = data.isrc;
         project.setMetadata(metadataPatch);
         flushPendingSave();
       }

--- a/src/lib/persistence.snap-points.browser.test.ts
+++ b/src/lib/persistence.snap-points.browser.test.ts
@@ -13,7 +13,7 @@ import { snapPoints } from "@/test/factories";
 
 function saveWithSnapPoints(customSnapPoints: SnapPoint[]): Promise<void> {
   return saveCurrentProject(
-    { title: "snap", artist: "", album: "", duration: 0 },
+    { title: "snap", artists: [], album: "", duration: 0 },
     DEFAULT_AGENTS,
     [{ id: "L1", text: "hello", agentId: DEFAULT_AGENTS[0].id }],
     [],
@@ -71,7 +71,7 @@ describe("persistence · customSnapPoints", () => {
     const legacyRecord: SavedProject = {
       version: 1,
       savedAt: Date.now(),
-      metadata: { title: "legacy", artist: "", album: "", duration: 0 },
+      metadata: { title: "legacy", artists: [], album: "", duration: 0 },
       agents: DEFAULT_AGENTS,
       lines: [{ id: "L1", text: "hello", agentId: DEFAULT_AGENTS[0].id }],
       groups: [],

--- a/src/lib/persistence.test.ts
+++ b/src/lib/persistence.test.ts
@@ -4,7 +4,7 @@ import { importProjectFromFile } from "@/lib/persistence";
 
 describe("persistence: syllableSplitDefaults", () => {
   it("round-trips syllableSplitDefaults through importProjectFromFile", async () => {
-    const metadata = { title: "Song", artist: "", album: "", duration: 0 };
+    const metadata = { title: "Song", artists: [], album: "", duration: 0 };
     const payload = {
       version: 1 as const,
       savedAt: Date.now(),
@@ -23,7 +23,7 @@ describe("persistence: syllableSplitDefaults", () => {
   });
 
   it("fills in defaults when older project file is missing syllableSplitDefaults", async () => {
-    const metadata = { title: "Old Song", artist: "", album: "", duration: 0 };
+    const metadata = { title: "Old Song", artists: [], album: "", duration: 0 };
     const legacyPayload = {
       version: 1 as const,
       savedAt: Date.now(),
@@ -43,7 +43,7 @@ describe("persistence: syllableSplitDefaults", () => {
 
 describe("persistence: primingStripped round-trip", () => {
   it("persists and reads back primingStripped through importProjectFromFile", async () => {
-    const metadata = { title: "Song", artist: "", album: "", duration: 0 };
+    const metadata = { title: "Song", artists: [], album: "", duration: 0 };
     const payload = {
       version: 1 as const,
       savedAt: Date.now(),
@@ -63,7 +63,7 @@ describe("persistence: primingStripped round-trip", () => {
   });
 
   it("leaves primingStripped undefined when importing a pre-strip project", async () => {
-    const metadata = { title: "Old", artist: "", album: "", duration: 0 };
+    const metadata = { title: "Old", artists: [], album: "", duration: 0 };
     const legacy = {
       version: 1 as const,
       savedAt: Date.now(),
@@ -81,7 +81,7 @@ describe("persistence: primingStripped round-trip", () => {
   });
 
   it("preserves primingStripped=false explicitly", async () => {
-    const metadata = { title: "Mid", artist: "", album: "", duration: 0 };
+    const metadata = { title: "Mid", artists: [], album: "", duration: 0 };
     const payload = {
       version: 1 as const,
       savedAt: Date.now(),
@@ -102,7 +102,7 @@ describe("persistence: primingStripped round-trip", () => {
 
 describe("persistence: customSnapPoints round-trip", () => {
   it("importProjectFromFile preserves customSnapPoints when present", async () => {
-    const metadata = { title: "Song", artist: "", album: "", duration: 0 };
+    const metadata = { title: "Song", artists: [], album: "", duration: 0 };
     const payload = {
       version: 1 as const,
       savedAt: Date.now(),
@@ -121,7 +121,7 @@ describe("persistence: customSnapPoints round-trip", () => {
   });
 
   it("leaves customSnapPoints undefined when importing a legacy project without the field", async () => {
-    const metadata = { title: "Old", artist: "", album: "", duration: 0 };
+    const metadata = { title: "Old", artists: [], album: "", duration: 0 };
     const legacy = {
       version: 1 as const,
       savedAt: Date.now(),

--- a/src/pages/converters/lrc-to-ttml.tsx
+++ b/src/pages/converters/lrc-to-ttml.tsx
@@ -64,7 +64,7 @@ function convertLrc({ input, filename }: ConvertArgs): { ttml: string; projectPa
     }
     const metadata: ProjectMetadata = {
       title: result.metadata.title ?? "",
-      artist: result.metadata.artist ?? "",
+      artists: result.metadata.artists ?? [],
       album: result.metadata.album ?? "",
       duration: 0,
       language: result.metadata.language,

--- a/src/pages/converters/srt-to-ttml.tsx
+++ b/src/pages/converters/srt-to-ttml.tsx
@@ -67,7 +67,7 @@ function convertSrt({ input, filename }: ConvertArgs): { ttml: string; projectPa
     }
     const metadata: ProjectMetadata = {
       title: result.metadata.title ?? "",
-      artist: result.metadata.artist ?? "",
+      artists: result.metadata.artists ?? [],
       album: result.metadata.album ?? "",
       duration: 0,
       language: result.metadata.language,

--- a/src/stores/project/metadata-slice.ts
+++ b/src/stores/project/metadata-slice.ts
@@ -14,7 +14,7 @@ function createMetadataInitialState(): MetadataState {
   return {
     metadata: {
       title: "",
-      artist: "",
+      artists: [],
       album: "",
       duration: 0,
     },

--- a/src/utils/animationVariants.ts
+++ b/src/utils/animationVariants.ts
@@ -97,6 +97,19 @@ const snapFlashVariants: Variants = {
   },
 };
 
+// -- Accordion ----------------------------------------------------------------
+
+const accordionTransition: Transition = {
+  type: "spring",
+  stiffness: 500,
+  damping: 40,
+};
+
+const accordionVariants: Variants = {
+  hidden: { height: 0, opacity: 0 },
+  visible: { height: "auto", opacity: 1 },
+};
+
 // -- Stagger Container --------------------------------------------------------
 
 // -- Exports ------------------------------------------------------------------
@@ -111,4 +124,6 @@ export {
   shimmerVariants,
   pinDropInVariants,
   snapFlashVariants,
+  accordionTransition,
+  accordionVariants,
 };

--- a/src/utils/audio-tags.test.ts
+++ b/src/utils/audio-tags.test.ts
@@ -1,0 +1,88 @@
+import { parseBlob } from "music-metadata";
+import { describe, expect, it } from "vitest";
+import { audioTagsToMetadata } from "@/utils/audio-tags";
+
+// -- Helpers ------------------------------------------------------------------
+
+function id3v2(frames: Array<[string, string]>): Uint8Array {
+  const enc = new TextEncoder();
+  const body: number[] = [];
+  for (const [id, text] of frames) {
+    const content = [0x03, ...enc.encode(text)];
+    const size = content.length;
+    body.push(
+      ...enc.encode(id),
+      (size >> 24) & 0xff,
+      (size >> 16) & 0xff,
+      (size >> 8) & 0xff,
+      size & 0xff,
+      0,
+      0,
+      ...content,
+    );
+  }
+  const synch = (n: number) => [(n >> 21) & 0x7f, (n >> 14) & 0x7f, (n >> 7) & 0x7f, n & 0x7f];
+  return new Uint8Array([0x49, 0x44, 0x33, 3, 0, 0, ...synch(body.length), ...body]);
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("audioTagsToMetadata", () => {
+  it("maps title/artist/album/isrc from real ID3 tags", async () => {
+    const bytes = id3v2([
+      ["TIT2", "Song"],
+      ["TPE1", "Tyler, The Creator"],
+      ["TALB", "Flower Boy"],
+      ["TSRC", "USQX91700001"],
+    ]);
+    const { common } = await parseBlob(new Blob([bytes], { type: "audio/mpeg" }));
+    expect(audioTagsToMetadata(common)).toEqual({
+      title: "Song",
+      artists: ["Tyler, The Creator"],
+      album: "Flower Boy",
+      isrc: "USQX91700001",
+    });
+  });
+
+  describe("edge cases", () => {
+    it("omits absent fields", () => expect(audioTagsToMetadata({})).toEqual({}));
+
+    it("drops an invalid isrc", () => expect(audioTagsToMetadata({ isrc: ["nope"] })).toEqual({}));
+
+    it("prefers common.artists over common.artist", () => {
+      expect(audioTagsToMetadata({ artists: ["A", "B"], artist: "A; B" }).artists).toEqual(["A", "B"]);
+    });
+
+    it("falls back to common.artist when artists is absent", () => {
+      expect(audioTagsToMetadata({ artist: "Solo" }).artists).toEqual(["Solo"]);
+    });
+
+    it("filters out empty/falsy entries in common.artists", () => {
+      expect(audioTagsToMetadata({ artists: ["A", "", "B"] }).artists).toEqual(["A", "B"]);
+    });
+
+    it("omits artists when every entry is empty", () => {
+      expect(audioTagsToMetadata({ artists: ["", ""] }).artists).toBeUndefined();
+    });
+
+    it("normalizes a lowercase isrc to uppercase", () => {
+      expect(audioTagsToMetadata({ isrc: ["usqx91700001"] }).isrc).toBe("USQX91700001");
+    });
+
+    it("picks the first valid isrc when multiple are present", () => {
+      expect(audioTagsToMetadata({ isrc: ["nope", "USQX91700001", "USQX91700002"] }).isrc).toBe("USQX91700001");
+    });
+  });
+
+  describe("invariants", () => {
+    it("never returns title/album when blank strings are passed", () => {
+      expect(audioTagsToMetadata({ title: "", album: "" })).toEqual({});
+    });
+
+    it("does not mutate the input common object", () => {
+      const common = { artists: ["A", ""], isrc: ["usqx91700001"] };
+      audioTagsToMetadata(common);
+      expect(common).toEqual({ artists: ["A", ""], isrc: ["usqx91700001"] });
+    });
+  });
+});

--- a/src/utils/audio-tags.ts
+++ b/src/utils/audio-tags.ts
@@ -1,0 +1,20 @@
+import type { ICommonTagsResult } from "music-metadata";
+import type { ProjectMetadata } from "@/domain/project/metadata";
+import { normalizeIsrc } from "@/utils/isrc";
+
+// -- Mapper -------------------------------------------------------------------
+
+function audioTagsToMetadata(common: Partial<ICommonTagsResult>): Partial<ProjectMetadata> {
+  const out: Partial<ProjectMetadata> = {};
+  if (common.title) out.title = common.title;
+  const artists = common.artists?.filter(Boolean) ?? (common.artist ? [common.artist] : []);
+  if (artists.length) out.artists = artists;
+  if (common.album) out.album = common.album;
+  const isrc = common.isrc?.map(normalizeIsrc).find(Boolean);
+  if (isrc) out.isrc = isrc;
+  return out;
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { audioTagsToMetadata };

--- a/src/utils/composer-bridge-api.test.ts
+++ b/src/utils/composer-bridge-api.test.ts
@@ -6,6 +6,7 @@ import {
   decodeHeader,
   extensionForBridgeMime,
   formatBridgeErrorForToast,
+  getAudioFromBridge,
   normalizeBaseUrl,
 } from "@/utils/composer-bridge-api";
 
@@ -327,5 +328,53 @@ describe("formatBridgeErrorForToast", () => {
     expect(formatBridgeErrorForToast(new Error("boom"))).toMatch(/unknown reason/);
     expect(formatBridgeErrorForToast("string error")).toMatch(/unknown reason/);
     expect(formatBridgeErrorForToast(null)).toMatch(/unknown reason/);
+  });
+});
+
+// -- getAudioFromBridge -------------------------------------------------------
+
+describe("getAudioFromBridge", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubAudioResponse(headers: Record<string, string>): void {
+    vi.stubGlobal("fetch", async (): Promise<Response> => {
+      const responseHeaders = new Headers({ "content-type": "audio/opus", ...headers });
+      return new Response(new TextEncoder().encode("opus-bytes").buffer, { headers: responseHeaders });
+    });
+  }
+
+  it("reads isrc from the x-track-isrc header", async () => {
+    stubAudioResponse({ "x-track-isrc": encodeURIComponent("GBARL9300135") });
+
+    const audio = await getAudioFromBridge("http://localhost:7777", "dQw4w9WgXcQ");
+
+    expect(audio.isrc).toBe("GBARL9300135");
+  });
+
+  it("leaves isrc undefined when the x-track-isrc header is absent", async () => {
+    stubAudioResponse({ "x-track-title": encodeURIComponent("Never Gonna Give You Up") });
+
+    const audio = await getAudioFromBridge("http://localhost:7777", "dQw4w9WgXcQ");
+
+    expect(audio.isrc).toBeUndefined();
+    expect(audio.title).toBe("Never Gonna Give You Up");
+  });
+
+  it("decodes percent-encoded title/artist/album/isrc together", async () => {
+    stubAudioResponse({
+      "x-track-title": encodeURIComponent("Never Gonna Give You Up"),
+      "x-track-artist": encodeURIComponent("Rick Astley"),
+      "x-track-album": encodeURIComponent("Whenever You Need Somebody"),
+      "x-track-isrc": encodeURIComponent("GBARL9300135"),
+    });
+
+    const audio = await getAudioFromBridge("http://localhost:7777", "dQw4w9WgXcQ");
+
+    expect(audio.title).toBe("Never Gonna Give You Up");
+    expect(audio.artist).toBe("Rick Astley");
+    expect(audio.album).toBe("Whenever You Need Somebody");
+    expect(audio.isrc).toBe("GBARL9300135");
   });
 });

--- a/src/utils/composer-bridge-api.ts
+++ b/src/utils/composer-bridge-api.ts
@@ -36,6 +36,7 @@ interface BridgeAudio {
   title?: string;
   artist?: string;
   album?: string;
+  isrc?: string;
 }
 
 class BridgeError extends Error {
@@ -101,6 +102,7 @@ async function getAudioFromBridge(baseUrl: string, videoId: string, signal?: Abo
       title: decodeHeader(res.headers.get("x-track-title")),
       artist: decodeHeader(res.headers.get("x-track-artist")),
       album: decodeHeader(res.headers.get("x-track-album")),
+      isrc: decodeHeader(res.headers.get("x-track-isrc")),
     };
   } catch (err) {
     if (err instanceof BridgeError) throw err;

--- a/src/utils/isrc.test.ts
+++ b/src/utils/isrc.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { isValidIsrc, normalizeIsrc } from "@/utils/isrc";
+
+describe("isValidIsrc", () => {
+  it("accepts a canonical ISRC", () => {
+    expect(isValidIsrc("USQX91700001")).toBe(true);
+  });
+  it("is case-insensitive on the country/registrant", () => {
+    expect(isValidIsrc("usqx91700001")).toBe(true);
+  });
+  describe("edge cases", () => {
+    it("rejects wrong length", () => expect(isValidIsrc("USQX9170001")).toBe(false));
+    it("rejects empty", () => expect(isValidIsrc("")).toBe(false));
+    it("rejects letters in the year/designation digits", () => expect(isValidIsrc("USQX9170000A")).toBe(false));
+    it("rejects whitespace padding (caller must trim)", () => expect(isValidIsrc(" USQX91700001 ")).toBe(false));
+  });
+});
+
+describe("normalizeIsrc", () => {
+  it("uppercases a valid code", () => expect(normalizeIsrc("usqx91700001")).toBe("USQX91700001"));
+  it("returns undefined for invalid", () => expect(normalizeIsrc("nope")).toBeUndefined());
+  it("returns undefined for empty", () => expect(normalizeIsrc("")).toBeUndefined());
+});

--- a/src/utils/isrc.test.ts
+++ b/src/utils/isrc.test.ts
@@ -16,8 +16,7 @@ describe("isValidIsrc", () => {
   });
   describe("invariants", () => {
     it("accepts digits in the registrant positions", () => expect(isValidIsrc("US3X91700001")).toBe(true));
-    it("normalizer trims surrounding whitespace", () =>
-      expect(normalizeIsrc(" usqx91700001 ")).toBe("USQX91700001"));
+    it("normalizer trims surrounding whitespace", () => expect(normalizeIsrc(" usqx91700001 ")).toBe("USQX91700001"));
     it("normalizer is idempotent on its own output", () => {
       const once = normalizeIsrc("usqx91700001");
       expect(normalizeIsrc(once as string)).toBe(once);

--- a/src/utils/isrc.test.ts
+++ b/src/utils/isrc.test.ts
@@ -12,7 +12,18 @@ describe("isValidIsrc", () => {
     it("rejects wrong length", () => expect(isValidIsrc("USQX9170001")).toBe(false));
     it("rejects empty", () => expect(isValidIsrc("")).toBe(false));
     it("rejects letters in the year/designation digits", () => expect(isValidIsrc("USQX9170000A")).toBe(false));
-    it("rejects whitespace padding (caller must trim)", () => expect(isValidIsrc(" USQX91700001 ")).toBe(false));
+    it("trims surrounding whitespace before validating", () => expect(isValidIsrc(" USQX91700001 ")).toBe(true));
+  });
+  describe("invariants", () => {
+    it("accepts digits in the registrant positions", () => expect(isValidIsrc("US3X91700001")).toBe(true));
+    it("normalizer trims surrounding whitespace", () =>
+      expect(normalizeIsrc(" usqx91700001 ")).toBe("USQX91700001"));
+    it("normalizer is idempotent on its own output", () => {
+      const once = normalizeIsrc("usqx91700001");
+      expect(normalizeIsrc(once as string)).toBe(once);
+    });
+    it("isValidIsrc agrees with normalizeIsrc for a clean valid code", () =>
+      expect(isValidIsrc("USQX91700001")).toBe(normalizeIsrc("USQX91700001") !== undefined));
   });
 });
 

--- a/src/utils/isrc.ts
+++ b/src/utils/isrc.ts
@@ -1,12 +1,12 @@
 const ISRC_PATTERN = /^[A-Z]{2}[A-Z0-9]{3}\d{7}$/;
 
-function isValidIsrc(value: string): boolean {
-  return ISRC_PATTERN.test(value.toUpperCase()) && value === value.trim();
-}
-
 function normalizeIsrc(value: string): string | undefined {
   const normalized = value.trim().toUpperCase();
   return ISRC_PATTERN.test(normalized) ? normalized : undefined;
+}
+
+function isValidIsrc(value: string): boolean {
+  return normalizeIsrc(value) !== undefined;
 }
 
 export { isValidIsrc, normalizeIsrc };

--- a/src/utils/isrc.ts
+++ b/src/utils/isrc.ts
@@ -1,0 +1,12 @@
+const ISRC_PATTERN = /^[A-Z]{2}[A-Z0-9]{3}\d{7}$/;
+
+function isValidIsrc(value: string): boolean {
+  return ISRC_PATTERN.test(value.toUpperCase()) && value === value.trim();
+}
+
+function normalizeIsrc(value: string): string | undefined {
+  const normalized = value.trim().toUpperCase();
+  return ISRC_PATTERN.test(normalized) ? normalized : undefined;
+}
+
+export { isValidIsrc, normalizeIsrc };

--- a/src/utils/lyrics-parsers.test.ts
+++ b/src/utils/lyrics-parsers.test.ts
@@ -49,7 +49,7 @@ describe("parseLyricsFile - plain LRC", () => {
     const result = parseLyricsFile("song.lrc", content);
 
     expect(result.metadata.title).toBe("Test Song");
-    expect(result.metadata.artist).toBe("Test Artist");
+    expect(result.metadata.artists).toEqual(["Test Artist"]);
     expect(result.metadata.album).toBe("Test Album");
   });
 
@@ -106,7 +106,7 @@ describe("parseLyricsFile - enhanced LRC (eLRC)", () => {
     const result = parseLyricsFile("song.lrc", content);
 
     expect(result.metadata.title).toBe("eLRC Test");
-    expect(result.metadata.artist).toBe("Artist");
+    expect(result.metadata.artists).toEqual(["Artist"]);
     expect(result.lines).toHaveLength(1);
     expect(result.lines[0].words).toHaveLength(2);
   });

--- a/src/utils/lyrics-parsers/lrc.ts
+++ b/src/utils/lyrics-parsers/lrc.ts
@@ -92,7 +92,7 @@ function parseLrc(content: string, fallbackDuration?: number): ParseResult {
       if (tagLower === "ti" || tagLower === "title") {
         metadata.title = value.trim();
       } else if (tagLower === "ar" || tagLower === "artist") {
-        metadata.artist = value.trim();
+        metadata.artists = [value.trim()];
       } else if (tagLower === "al" || tagLower === "album") {
         metadata.album = value.trim();
       } else if (tagLower === "length") {

--- a/src/utils/lyrics-parsers/ttml.metadata.test.ts
+++ b/src/utils/lyrics-parsers/ttml.metadata.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectMetadata } from "@/domain/project/metadata";
+import { generateTTML } from "@/utils/ttml";
+import { parseTtml } from "@/utils/lyrics-parsers/ttml";
+
+const metadata: ProjectMetadata = {
+  title: "Song",
+  artists: ["Tyler, The Creator", "Kali Uchis"],
+  album: "Flower Boy",
+  duration: 0,
+  isrc: "USQX91700001",
+  songwriters: ["W1"],
+  extra: { spotifyId: "abc" },
+};
+const lines = [{ id: "l1", text: "hi", begin: 1, end: 2, agentId: "v1" }];
+
+describe("parseTtml metadata round-trip", () => {
+  const ttml = generateTTML({ metadata, agents: [], lines, granularity: "line" });
+  const parsed = parseTtml(ttml).metadata;
+  it("recovers title from ttm:title", () => expect(parsed.title).toBe("Song"));
+  it("recovers all artists including comma names", () => {
+    expect(parsed.artists).toEqual(["Tyler, The Creator", "Kali Uchis"]);
+  });
+  it("recovers album/isrc/songwriters/extra", () => {
+    expect(parsed.album).toBe("Flower Boy");
+    expect(parsed.isrc).toBe("USQX91700001");
+    expect(parsed.songwriters).toEqual(["W1"]);
+    expect(parsed.extra).toEqual({ spotifyId: "abc" });
+  });
+  it("still reads the legacy [type=artist] fallback when no composer:meta", () => {
+    const legacy =
+      '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"><head><metadata><ttm:agent type="person" xml:id="v1"/><ttm:name type="artist">Legacy Artist</ttm:name></metadata></head><body><div><p begin="1" end="2" ttm:agent="v1">hi</p></div></body></tt>';
+    expect(parseTtml(legacy).metadata.artists).toEqual(["Legacy Artist"]);
+  });
+});

--- a/src/utils/lyrics-parsers/ttml.metadata.test.ts
+++ b/src/utils/lyrics-parsers/ttml.metadata.test.ts
@@ -32,4 +32,31 @@ describe("parseTtml metadata round-trip", () => {
       '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"><head><metadata><ttm:agent type="person" xml:id="v1"/><ttm:name type="artist">Legacy Artist</ttm:name></metadata></head><body><div><p begin="1" end="2" ttm:agent="v1">hi</p></div></body></tt>';
     expect(parseTtml(legacy).metadata.artists).toEqual(["Legacy Artist"]);
   });
+  it("round-trips XML-special characters in metadata values", () => {
+    const special: ProjectMetadata = {
+      title: "T",
+      artists: ["Tom & Jerry", 'A "Q" B'],
+      album: "a < b",
+      duration: 0,
+      extra: { url: "x<y&z" },
+    };
+    const out = parseTtml(generateTTML({ metadata: special, agents: [], lines, granularity: "line" })).metadata;
+    expect(out.artists).toEqual(["Tom & Jerry", 'A "Q" B']);
+    expect(out.album).toBe("a < b");
+    expect(out.extra).toEqual({ url: "x<y&z" });
+  });
+  it("parses composer:meta and dedupes artists when the composer namespace is undeclared", () => {
+    const undeclared =
+      '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata">' +
+      "<head><metadata>" +
+      '<ttm:agent type="person" xml:id="v1"/>' +
+      '<composer:meta key="artists" value="A"/>' +
+      '<composer:meta key="artists" value="B"/>' +
+      '<composer:meta key="album" value="Al"/>' +
+      "</metadata></head>" +
+      '<body><div><p begin="1" end="2" ttm:agent="v1">hi</p></div></body></tt>';
+    const out = parseTtml(undeclared).metadata;
+    expect(out.artists).toEqual(["A", "B"]);
+    expect(out.album).toBe("Al");
+  });
 });

--- a/src/utils/lyrics-parsers/ttml.ts
+++ b/src/utils/lyrics-parsers/ttml.ts
@@ -48,7 +48,7 @@ function parseTtml(content: string, _fallbackDuration?: number): ParseResult {
   if (ttmTitleEl?.textContent && !metadata.title) metadata.title = ttmTitleEl.textContent;
 
   const artistEl = doc.querySelector('[type="artist"]');
-  if (artistEl?.textContent) metadata.artist = artistEl.textContent;
+  if (artistEl?.textContent) metadata.artists = [artistEl.textContent];
 
   const albumEl = doc.querySelector('[type="album"]');
   if (albumEl?.textContent) metadata.album = albumEl.textContent;

--- a/src/utils/lyrics-parsers/ttml.ts
+++ b/src/utils/lyrics-parsers/ttml.ts
@@ -3,6 +3,7 @@ import type { LinkGroup } from "@/domain/group/template";
 import { reconcileLine, type LyricLine } from "@/domain/line/model";
 import { reconstructLineText } from "@/domain/line/reconstruct-text";
 import type { ProjectMetadata } from "@/domain/project/metadata";
+import { fromComposerMeta } from "@/domain/project/metadata-ttml";
 import { inferSyllableGroupIds } from "@/domain/word/syllable-groups";
 import type { WordTiming } from "@/domain/word/timing";
 import { getSplitCharacter } from "@/utils/split-character";
@@ -47,11 +48,25 @@ function parseTtml(content: string, _fallbackDuration?: number): ParseResult {
   const ttmTitleEl = doc.getElementsByTagName("ttm:title")[0];
   if (ttmTitleEl?.textContent && !metadata.title) metadata.title = ttmTitleEl.textContent;
 
+  const metaEls = Array.from(
+    new Set(
+      Array.from(doc.getElementsByTagName("composer:meta")).concat(
+        COMPOSER_NAMESPACES.flatMap((ns) => Array.from(doc.getElementsByTagNameNS(ns, "meta"))),
+      ),
+    ),
+  );
+  Object.assign(
+    metadata,
+    fromComposerMeta(
+      metaEls.map((el) => ({ key: el.getAttribute("key") ?? "", value: el.getAttribute("value") ?? "" })),
+    ),
+  );
+
   const artistEl = doc.querySelector('[type="artist"]');
-  if (artistEl?.textContent) metadata.artists = [artistEl.textContent];
+  if (!metadata.artists && artistEl?.textContent) metadata.artists = [artistEl.textContent];
 
   const albumEl = doc.querySelector('[type="album"]');
-  if (albumEl?.textContent) metadata.album = albumEl.textContent;
+  if (!metadata.album && albumEl?.textContent) metadata.album = albumEl.textContent;
 
   // Extract agents from metadata
   const agents: Agent[] = [];

--- a/src/utils/lyrics-search/providers/binimum.ts
+++ b/src/utils/lyrics-search/providers/binimum.ts
@@ -1,5 +1,6 @@
 import type { LyricsSearchPayload, LyricsSearchResult } from "@/domain/lyrics-search/result";
 import type { SyncType } from "@/domain/lyrics-search/sync-type";
+import { isValidIsrc, normalizeIsrc } from "@/utils/isrc";
 import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } from "@/utils/lyrics-search/types";
 
 // -- Constants ----------------------------------------------------------------
@@ -7,7 +8,6 @@ import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } 
 const BINIMUM_BASE_URL = "https://lyrics-api.binimum.org/";
 const ID_PREFIX = "binimum-";
 const USER_AGENT = "Better Lyrics Composer (https://composer.betterlyrics.org)";
-const ISRC_REGEX = /^[A-Z]{2}[A-Z0-9]{3}\d{7}$/;
 const VALID_TIMING_TYPES: ReadonlySet<SyncType> = new Set<SyncType>(["syllable", "word", "line"]);
 
 // -- Types --------------------------------------------------------------------
@@ -35,28 +35,18 @@ function hasNonEmptyString(value: string | undefined): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function normalizeIsrc(input: string | undefined): string | null {
-  if (!hasNonEmptyString(input)) return null;
-  const candidate = input.trim().toUpperCase();
-  return ISRC_REGEX.test(candidate) ? candidate : null;
-}
-
-function isValidIsrc(input: string | undefined): boolean {
-  return normalizeIsrc(input) !== null;
-}
-
 function hasTrackAndArtist(query: LyricsSearchQuery): boolean {
   return hasNonEmptyString(query.track) && hasNonEmptyString(query.artist);
 }
 
 function canSearch(query: LyricsSearchQuery): boolean {
   if (hasTrackAndArtist(query)) return true;
-  return isValidIsrc(query.isrc);
+  return hasNonEmptyString(query.isrc) && isValidIsrc(query.isrc);
 }
 
 function buildSearchUrl(query: LyricsSearchQuery): URL {
   const url = new URL(BINIMUM_BASE_URL);
-  const isrc = normalizeIsrc(query.isrc);
+  const isrc = hasNonEmptyString(query.isrc) ? normalizeIsrc(query.isrc) : undefined;
 
   if (isrc && !hasTrackAndArtist(query)) {
     url.searchParams.set("isrc", isrc);

--- a/src/utils/ttml.groups.test.ts
+++ b/src/utils/ttml.groups.test.ts
@@ -5,7 +5,7 @@ import { parseLyricsFile } from "@/utils/lyrics-parsers";
 import { generateTTML } from "@/utils/ttml";
 import { describe, expect, it } from "vitest";
 
-const baseMetadata: ProjectMetadata = { title: "Test", artist: "", album: "", duration: 60 };
+const baseMetadata: ProjectMetadata = { title: "Test", artists: [], album: "", duration: 60 };
 const baseAgents: Agent[] = [{ id: "v1", type: "person", name: "Lead" }];
 
 describe("ttml export · groups registry", () => {

--- a/src/utils/ttml.metadata.test.ts
+++ b/src/utils/ttml.metadata.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectMetadata } from "@/domain/project/metadata";
+import { generateTTML } from "@/utils/ttml";
+
+const metadata: ProjectMetadata = {
+  title: "Song & Dance",
+  artists: ['A "Q" B', "Kali Uchis"],
+  album: "Flower Boy",
+  duration: 0,
+  isrc: "USQX91700001",
+  songwriters: ["W1"],
+  extra: { spotifyId: "abc" },
+};
+const lines = [{ id: "l1", text: "hi", begin: 1, end: 2, agentId: "v1" }];
+
+describe("generateTTML metadata", () => {
+  const ttml = generateTTML({ metadata, agents: [], lines, granularity: "line" });
+  it("keeps the title in ttm:title", () => expect(ttml).toContain("<ttm:title>Song &amp; Dance</ttm:title>"));
+  it("emits one composer:meta per artist", () => {
+    expect(ttml).toContain('<composer:meta key="artists" value="Kali Uchis"/>');
+  });
+  it("escapes quotes inside attribute values", () => {
+    expect(ttml).toContain('<composer:meta key="artists" value="A &quot;Q&quot; B"/>');
+  });
+  it("emits album, isrc, songwriter, extra", () => {
+    expect(ttml).toContain('<composer:meta key="album" value="Flower Boy"/>');
+    expect(ttml).toContain('<composer:meta key="isrc" value="USQX91700001"/>');
+    expect(ttml).toContain('<composer:meta key="songwriter" value="W1"/>');
+    expect(ttml).toContain('<composer:meta key="spotifyId" value="abc"/>');
+  });
+  it("emits no composer:meta when there is no extended metadata", () => {
+    const bare = generateTTML({
+      metadata: { title: "x", artists: [], album: "", duration: 0 },
+      agents: [],
+      lines,
+      granularity: "line",
+    });
+    expect(bare).not.toContain("composer:meta");
+  });
+});

--- a/src/utils/ttml.ts
+++ b/src/utils/ttml.ts
@@ -2,6 +2,7 @@ import type { Agent } from "@/domain/agent/model";
 import type { LinkGroup } from "@/domain/group/template";
 import type { LyricLine } from "@/domain/line/model";
 import type { ProjectMetadata } from "@/domain/project/metadata";
+import { toComposerMeta } from "@/domain/project/metadata-ttml";
 import { formatTime } from "@/utils/format-time";
 import { stripSplitCharacter } from "@/utils/split-character";
 import { COMPOSER_NS } from "@/utils/lyrics-parsers/composer-namespace";
@@ -11,6 +12,10 @@ import { effectiveBounds } from "@/domain/line/bounds";
 
 function escapeXml(str: string): string {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+}
+
+function escapeXmlAttribute(str: string): string {
+  return escapeXml(str).replace(/"/g, "&quot;");
 }
 
 function emitWordSpan(word: { text: string; begin: number; end: number; explicit?: true }, text: string): string {
@@ -48,6 +53,9 @@ function generateTTML({ metadata, agents, lines, groups, granularity, minify = f
   parts.push(`${ind(2)}<metadata>`);
   if (metadata.title) {
     parts.push(`${ind(3)}<ttm:title>${escapeXml(metadata.title)}</ttm:title>`);
+  }
+  for (const { key, value } of toComposerMeta(metadata)) {
+    parts.push(`${ind(3)}<composer:meta key="${escapeXmlAttribute(key)}" value="${escapeXmlAttribute(value)}"/>`);
   }
   for (const agent of agents) {
     if (agent.name) {

--- a/src/views/export.browser.test.tsx
+++ b/src/views/export.browser.test.tsx
@@ -167,7 +167,7 @@ describe("ExportPanel · project file customSnapPoints", () => {
     const payload = {
       version: 1 as const,
       savedAt: Date.now(),
-      metadata: { title: "Imported", artist: "", album: "", duration: 0 },
+      metadata: { title: "Imported", artists: [], album: "", duration: 0 },
       agents: DEFAULT_AGENTS,
       lines: [createLine({ text: "Hi", words: [createWord({ text: "Hi", begin: 0, end: 1 })] })],
       groups: [],

--- a/src/views/export.tsx
+++ b/src/views/export.tsx
@@ -7,6 +7,7 @@ import { Scroll } from "@/ui/scroll";
 import { effectiveBounds } from "@/domain/line/bounds";
 import { generateTTML } from "@/utils/ttml";
 import { rebaseTtmlEdits } from "@/utils/ttml-merge";
+import { MetadataPanel } from "@/views/export/metadata-panel";
 import { TtmlConflictNotice } from "@/views/export/ttml-conflict-notice";
 import { TtmlEditor } from "@/views/export/ttml-editor";
 import {
@@ -189,6 +190,8 @@ const ExportPanel: React.FC = () => {
           </Button>
         </div>
       </div>
+
+      <MetadataPanel />
 
       {hasConflict && <TtmlConflictNotice onRegenerate={handleRegenerate} />}
 

--- a/src/views/export/metadata-field-list.tsx
+++ b/src/views/export/metadata-field-list.tsx
@@ -1,0 +1,76 @@
+import { Button } from "@/ui/button";
+import { IconPlus, IconX } from "@tabler/icons-react";
+
+// -- Constants ----------------------------------------------------------------
+
+const INPUT_STYLES =
+  "flex-1 px-2 py-1.5 text-sm rounded-md cursor-text bg-composer-input border border-composer-border text-composer-text focus:outline-none focus:border-composer-accent";
+
+// -- Interfaces ---------------------------------------------------------------
+
+interface MetadataFieldListProps {
+  label: string;
+  itemNoun: string;
+  values: string[];
+  placeholder?: string;
+  onChange: (next: string[]) => void;
+}
+
+// -- Component ----------------------------------------------------------------
+
+const MetadataFieldList: React.FC<MetadataFieldListProps> = ({ label, itemNoun, values, placeholder, onChange }) => {
+  const handleEdit = (index: number, value: string) => {
+    const next = values.map((existing, i) => (i === index ? value : existing));
+    onChange(next);
+  };
+
+  const handleRemove = (index: number) => {
+    onChange(values.filter((_, i) => i !== index));
+  };
+
+  const handleAdd = () => {
+    onChange([...values, ""]);
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs font-medium text-composer-text-secondary select-none">{label}</span>
+      {values.map((value, index) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional, identity follows index
+        <div key={index} className="flex items-center gap-2">
+          <input
+            type="text"
+            aria-label={`${itemNoun} ${index + 1}`}
+            value={value}
+            placeholder={placeholder}
+            onChange={(e) => handleEdit(index, e.target.value)}
+            className={INPUT_STYLES}
+          />
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={`Remove ${itemNoun.toLowerCase()} ${index + 1}`}
+            onClick={() => handleRemove(index)}
+          >
+            <IconX className="size-4" />
+          </Button>
+        </div>
+      ))}
+      <Button
+        hasIcon
+        size="sm"
+        variant="ghost"
+        className="self-start"
+        aria-label={`Add ${itemNoun.toLowerCase()}`}
+        onClick={handleAdd}
+      >
+        <IconPlus className="size-3.5" />
+        Add {itemNoun.toLowerCase()}
+      </Button>
+    </div>
+  );
+};
+
+// -- Exports ------------------------------------------------------------------
+
+export { MetadataFieldList, INPUT_STYLES };

--- a/src/views/export/metadata-field-list.tsx
+++ b/src/views/export/metadata-field-list.tsx
@@ -1,5 +1,7 @@
 import { Button } from "@/ui/button";
 import { IconPlus, IconX } from "@tabler/icons-react";
+import { nanoid } from "nanoid";
+import { useState } from "react";
 
 // -- Constants ----------------------------------------------------------------
 
@@ -16,41 +18,46 @@ interface MetadataFieldListProps {
   onChange: (next: string[]) => void;
 }
 
+interface Row {
+  id: string;
+  value: string;
+}
+
 // -- Component ----------------------------------------------------------------
 
 const MetadataFieldList: React.FC<MetadataFieldListProps> = ({ label, itemNoun, values, placeholder, onChange }) => {
-  const handleEdit = (index: number, value: string) => {
-    const next = values.map((existing, i) => (i === index ? value : existing));
-    onChange(next);
+  // Rows carry a stable id so reorders/removals keep input focus and identity.
+  // Seeded from the store on mount and re-seeded whenever the panel re-expands.
+  const [rows, setRows] = useState<Row[]>(() => values.map((value) => ({ id: nanoid(), value })));
+
+  const commit = (next: Row[]) => {
+    setRows(next);
+    onChange(next.map((row) => row.value));
   };
 
-  const handleRemove = (index: number) => {
-    onChange(values.filter((_, i) => i !== index));
-  };
-
-  const handleAdd = () => {
-    onChange([...values, ""]);
-  };
+  const handleEdit = (id: string, value: string) =>
+    commit(rows.map((row) => (row.id === id ? { ...row, value } : row)));
+  const handleRemove = (id: string) => commit(rows.filter((row) => row.id !== id));
+  const handleAdd = () => commit([...rows, { id: nanoid(), value: "" }]);
 
   return (
     <div className="flex flex-col gap-1.5">
       <span className="text-xs font-medium text-composer-text-secondary select-none">{label}</span>
-      {values.map((value, index) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional, identity follows index
-        <div key={index} className="flex items-center gap-2">
+      {rows.map((row, index) => (
+        <div key={row.id} className="flex items-center gap-2">
           <input
             type="text"
             aria-label={`${itemNoun} ${index + 1}`}
-            value={value}
+            value={row.value}
             placeholder={placeholder}
-            onChange={(e) => handleEdit(index, e.target.value)}
+            onChange={(e) => handleEdit(row.id, e.target.value)}
             className={INPUT_STYLES}
           />
           <Button
             variant="ghost"
             size="icon"
             aria-label={`Remove ${itemNoun.toLowerCase()} ${index + 1}`}
-            onClick={() => handleRemove(index)}
+            onClick={() => handleRemove(row.id)}
           >
             <IconX className="size-4" />
           </Button>

--- a/src/views/export/metadata-field-list.tsx
+++ b/src/views/export/metadata-field-list.tsx
@@ -59,7 +59,7 @@ const MetadataFieldList: React.FC<MetadataFieldListProps> = ({ label, itemNoun, 
       <Button
         hasIcon
         size="sm"
-        variant="ghost"
+        variant="secondary"
         className="self-start"
         aria-label={`Add ${itemNoun.toLowerCase()}`}
         onClick={handleAdd}

--- a/src/views/export/metadata-panel.browser.test.tsx
+++ b/src/views/export/metadata-panel.browser.test.tsx
@@ -101,6 +101,27 @@ describe("MetadataPanel", () => {
     await expect.element(screen.getByRole("textbox", { name: "ISRC" })).toHaveValue("USQX91700001");
   });
 
+  it("re-seeds the ISRC field when isrc is written externally while mounted", async () => {
+    seedMetadata({ isrc: "USQX91700001" });
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+    await expect.element(screen.getByRole("textbox", { name: "ISRC" })).toHaveValue("USQX91700001");
+
+    useProjectStore.getState().setMetadata({ isrc: "GBARL9300135" });
+    await expect.element(screen.getByRole("textbox", { name: "ISRC" })).toHaveValue("GBARL9300135");
+  });
+
+  it("keeps an in-progress ISRC edit instead of overwriting it with the normalized store value", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    const isrc = screen.getByRole("textbox", { name: "ISRC" });
+    await isrc.fill("usqx91700001");
+    await expect.poll(() => useProjectStore.getState().metadata.isrc).toBe("USQX91700001");
+    await expect.element(isrc).toHaveValue("usqx91700001");
+  });
+
   it("adds an extra key/value row and writes it to the store", async () => {
     seedMetadata();
     const screen = await render(<MetadataPanel />);

--- a/src/views/export/metadata-panel.browser.test.tsx
+++ b/src/views/export/metadata-panel.browser.test.tsx
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { useProjectStore } from "@/stores/project";
+import { render } from "@/test/render";
+import { MetadataPanel } from "@/views/export/metadata-panel";
+
+// -- Helpers ------------------------------------------------------------------
+
+function seedMetadata(patch: Partial<ReturnType<typeof useProjectStore.getState>["metadata"]> = {}): void {
+  useProjectStore.setState({
+    metadata: { title: "", artists: [], album: "", duration: 0, ...patch },
+  });
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("MetadataPanel", () => {
+  it("starts collapsed and reveals the fields when expanded", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+
+    expect(screen.container.querySelector("[role='textbox'][aria-label='Title']")).toBeNull();
+
+    await screen.getByRole("button", { name: "Metadata" }).click();
+    await expect.element(screen.getByRole("textbox", { name: "Title" })).toBeInTheDocument();
+    await expect.element(screen.getByRole("textbox", { name: "Album" })).toBeInTheDocument();
+    await expect.element(screen.getByRole("textbox", { name: "ISRC" })).toBeInTheDocument();
+  });
+
+  it("typing in Title updates the store", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("textbox", { name: "Title" }).fill("Bad Guy");
+    await expect.poll(() => useProjectStore.getState().metadata.title).toBe("Bad Guy");
+  });
+
+  it("typing in Album updates the store", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("textbox", { name: "Album" }).fill("When We All Fall Asleep");
+    await expect.poll(() => useProjectStore.getState().metadata.album).toBe("When We All Fall Asleep");
+  });
+
+  it("adds an artist row and preserves an exact comma-containing name", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("button", { name: "Add artist" }).click();
+    await screen.getByRole("textbox", { name: "Artist 1" }).fill("Tyler, The Creator");
+    await expect.poll(() => useProjectStore.getState().metadata.artists).toEqual(["Tyler, The Creator"]);
+  });
+
+  it("removes an artist row", async () => {
+    seedMetadata({ artists: ["Alpha", "Beta"] });
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("button", { name: "Remove artist 1" }).click();
+    await expect.poll(() => useProjectStore.getState().metadata.artists).toEqual(["Beta"]);
+  });
+
+  it("adds a producer row backed by songwriters", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("button", { name: "Add producer" }).click();
+    await screen.getByRole("textbox", { name: "Producer 1" }).fill("Finneas");
+    await expect.poll(() => useProjectStore.getState().metadata.songwriters).toEqual(["Finneas"]);
+  });
+
+  it("shows a hint and does not store an invalid ISRC", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("textbox", { name: "ISRC" }).fill("not-valid");
+    await expect.element(screen.getByText(/Invalid ISRC/)).toBeInTheDocument();
+    expect(useProjectStore.getState().metadata.isrc).toBeUndefined();
+  });
+
+  it("stores a normalized uppercase ISRC for valid input", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("textbox", { name: "ISRC" }).fill("usqx91700001");
+    await expect.poll(() => useProjectStore.getState().metadata.isrc).toBe("USQX91700001");
+  });
+
+  it("seeds the ISRC field from the existing store value", async () => {
+    seedMetadata({ isrc: "USQX91700001" });
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await expect.element(screen.getByRole("textbox", { name: "ISRC" })).toHaveValue("USQX91700001");
+  });
+
+  it("adds an extra key/value row and writes it to the store", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("button", { name: "Add field" }).click();
+    await screen.getByRole("textbox", { name: "Field 1 key" }).fill("spotifyId");
+    await screen.getByRole("textbox", { name: "Field 1 value" }).fill("abc");
+    await expect.poll(() => useProjectStore.getState().metadata.extra).toEqual({ spotifyId: "abc" });
+  });
+
+  it("seeds artists, producers, and extra rows from the existing store value", async () => {
+    seedMetadata({
+      artists: ["Billie Eilish"],
+      songwriters: ["Finneas"],
+      extra: { spotifyId: "abc" },
+    });
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await expect.element(screen.getByRole("textbox", { name: "Artist 1" })).toHaveValue("Billie Eilish");
+    await expect.element(screen.getByRole("textbox", { name: "Producer 1" })).toHaveValue("Finneas");
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 key" })).toHaveValue("spotifyId");
+    await expect.element(screen.getByRole("textbox", { name: "Field 1 value" })).toHaveValue("abc");
+  });
+
+  it("supports keyboard: Tab moves focus from the Title input to the Album input", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    const title = screen.getByRole("textbox", { name: "Title" }).element() as HTMLInputElement;
+    title.focus();
+    expect(document.activeElement).toBe(title);
+
+    title.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    const album = screen.getByRole("textbox", { name: "Album" }).element() as HTMLInputElement;
+    album.focus();
+    await expect.poll(() => document.activeElement).toBe(album);
+  });
+});

--- a/src/views/export/metadata-panel.browser.test.tsx
+++ b/src/views/export/metadata-panel.browser.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
 import { useProjectStore } from "@/stores/project";
 import { render } from "@/test/render";
 import { MetadataPanel } from "@/views/export/metadata-panel";
@@ -126,18 +127,36 @@ describe("MetadataPanel", () => {
     await expect.element(screen.getByRole("textbox", { name: "Field 1 value" })).toHaveValue("abc");
   });
 
-  it("supports keyboard: Tab moves focus from the Title input to the Album input", async () => {
+  it("supports keyboard: a real Tab advances focus from the Title input to the Album input", async () => {
     seedMetadata();
     const screen = await render(<MetadataPanel />);
     await screen.getByRole("button", { name: "Metadata" }).click();
 
     const title = screen.getByRole("textbox", { name: "Title" }).element() as HTMLInputElement;
-    title.focus();
-    expect(document.activeElement).toBe(title);
-
-    title.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
     const album = screen.getByRole("textbox", { name: "Album" }).element() as HTMLInputElement;
-    album.focus();
+
+    await userEvent.click(title);
+    await expect.poll(() => document.activeElement).toBe(title);
+
+    await userEvent.tab();
     await expect.poll(() => document.activeElement).toBe(album);
+  });
+
+  describe("edge cases", () => {
+    it("collapses duplicate extra keys to one store entry with the last value winning", async () => {
+      seedMetadata();
+      const screen = await render(<MetadataPanel />);
+      await screen.getByRole("button", { name: "Metadata" }).click();
+
+      await screen.getByRole("button", { name: "Add field" }).click();
+      await screen.getByRole("button", { name: "Add field" }).click();
+
+      await screen.getByRole("textbox", { name: "Field 1 key" }).fill("spotifyId");
+      await screen.getByRole("textbox", { name: "Field 1 value" }).fill("first");
+      await screen.getByRole("textbox", { name: "Field 2 key" }).fill("spotifyId");
+      await screen.getByRole("textbox", { name: "Field 2 value" }).fill("second");
+
+      await expect.poll(() => useProjectStore.getState().metadata.extra).toEqual({ spotifyId: "second" });
+    });
   });
 });

--- a/src/views/export/metadata-panel.tsx
+++ b/src/views/export/metadata-panel.tsx
@@ -25,16 +25,28 @@ const MetadataPanel: React.FC = () => {
 
   const [open, setOpen] = useState(false);
   const [isrcText, setIsrcText] = useState(() => metadata.isrc ?? "");
+  const [syncedIsrc, setSyncedIsrc] = useState(metadata.isrc);
   const [extraPairs, setExtraPairs] = useState<ExtraPair[]>(() =>
     Object.entries(metadata.extra ?? {}).map(([key, value]) => ({ key, value })),
   );
+
+  // Re-seed the local field when isrc is written from outside (URL params,
+  // bridge, audio tags), without disturbing an in-progress edit: our own writes
+  // advance syncedIsrc in step, so only external writes trip this. extra is
+  // panel-only, so it needs no equivalent sync.
+  if (metadata.isrc !== syncedIsrc) {
+    setSyncedIsrc(metadata.isrc);
+    setIsrcText(metadata.isrc ?? "");
+  }
 
   const trimmedIsrc = isrcText.trim();
   const isrcInvalid = trimmedIsrc !== "" && !isValidIsrc(trimmedIsrc);
 
   const handleIsrcChange = (value: string) => {
     setIsrcText(value);
-    setMetadata({ isrc: normalizeIsrc(value) });
+    const normalized = normalizeIsrc(value);
+    setMetadata({ isrc: normalized });
+    setSyncedIsrc(normalized);
   };
 
   const handleExtraChange = (next: ExtraPair[]) => {

--- a/src/views/export/metadata-panel.tsx
+++ b/src/views/export/metadata-panel.tsx
@@ -27,29 +27,22 @@ const MetadataPanel: React.FC = () => {
   const setMetadata = useProjectStore((s) => s.setMetadata);
 
   const [open, setOpen] = useState(false);
-  const [isrcText, setIsrcText] = useState(() => metadata.isrc ?? "");
-  const [syncedIsrc, setSyncedIsrc] = useState(metadata.isrc);
+  const [isrcDraft, setIsrcDraft] = useState(() => metadata.isrc ?? "");
   const [extraPairs, setExtraPairs] = useState<ExtraPair[]>(() =>
     Object.entries(metadata.extra ?? {}).map(([key, value]) => ({ key, value })),
   );
 
-  // Re-seed the local field when isrc is written from outside (URL params,
-  // bridge, audio tags), without disturbing an in-progress edit: our own writes
-  // advance syncedIsrc in step, so only external writes trip this. extra is
-  // panel-only, so it needs no equivalent sync.
-  if (metadata.isrc !== syncedIsrc) {
-    setSyncedIsrc(metadata.isrc);
-    setIsrcText(metadata.isrc ?? "");
-  }
-
-  const trimmedIsrc = isrcText.trim();
+  // The store keeps only a normalized isrc, but the field must show the raw draft
+  // while editing (so the invalid hint can appear). Show the draft as long as it
+  // still maps to the stored value; if isrc is written from outside (URL params,
+  // bridge, audio tags), the store wins and the field re-seeds.
+  const isrcValue = normalizeIsrc(isrcDraft) === metadata.isrc ? isrcDraft : (metadata.isrc ?? "");
+  const trimmedIsrc = isrcValue.trim();
   const isrcInvalid = trimmedIsrc !== "" && !isValidIsrc(trimmedIsrc);
 
   const handleIsrcChange = (value: string) => {
-    setIsrcText(value);
-    const normalized = normalizeIsrc(value);
-    setMetadata({ isrc: normalized });
-    setSyncedIsrc(normalized);
+    setIsrcDraft(value);
+    setMetadata({ isrc: normalizeIsrc(value) });
   };
 
   const handleExtraChange = (next: ExtraPair[]) => {
@@ -118,7 +111,7 @@ const MetadataPanel: React.FC = () => {
                 <input
                   type="text"
                   aria-label="ISRC"
-                  value={isrcText}
+                  value={isrcValue}
                   placeholder="e.g. USQX91700001"
                   onChange={(e) => handleIsrcChange(e.target.value)}
                   className={INPUT_STYLES}

--- a/src/views/export/metadata-panel.tsx
+++ b/src/views/export/metadata-panel.tsx
@@ -1,8 +1,11 @@
 import { useProjectStore } from "@/stores/project";
 import { Button } from "@/ui/button";
+import { accordionTransition, accordionVariants } from "@/utils/animationVariants";
+import { cn } from "@/utils/cn";
 import { isValidIsrc, normalizeIsrc } from "@/utils/isrc";
 import { INPUT_STYLES, MetadataFieldList } from "@/views/export/metadata-field-list";
-import { IconChevronDown, IconChevronRight, IconPlus, IconX } from "@tabler/icons-react";
+import { IconChevronRight, IconPlus, IconX } from "@tabler/icons-react";
+import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { useState } from "react";
 
 // -- Helpers ------------------------------------------------------------------
@@ -58,7 +61,7 @@ const MetadataPanel: React.FC = () => {
     handleExtraChange(extraPairs.map((pair, i) => (i === index ? { ...pair, ...patch } : pair)));
   };
 
-  const ChevronIcon = open ? IconChevronDown : IconChevronRight;
+  const reducedMotion = useReducedMotion();
 
   return (
     <div className="border-b border-composer-border">
@@ -66,118 +69,130 @@ const MetadataPanel: React.FC = () => {
         hasIcon
         variant="ghost"
         size="md"
-        className="w-full justify-start rounded-none px-6 py-3 text-composer-text-secondary"
+        className="w-full justify-start rounded-none h-8 px-6 text-composer-text-secondary"
         aria-expanded={open}
         onClick={() => setOpen((prev) => !prev)}
       >
-        <ChevronIcon className="size-4" />
+        <IconChevronRight className={cn("size-4 transition-transform", open && "rotate-90")} />
         Metadata
       </Button>
 
-      {open && (
-        <div className="flex flex-col gap-4 px-6 pb-4">
-          <label className="flex flex-col gap-1.5">
-            <span className="text-xs font-medium text-composer-text-secondary select-none">Title</span>
-            <input
-              type="text"
-              aria-label="Title"
-              value={metadata.title}
-              placeholder="Song title"
-              onChange={(e) => setMetadata({ title: e.target.value })}
-              className={INPUT_STYLES}
-            />
-          </label>
-
-          <label className="flex flex-col gap-1.5">
-            <span className="text-xs font-medium text-composer-text-secondary select-none">Album</span>
-            <input
-              type="text"
-              aria-label="Album"
-              value={metadata.album}
-              placeholder="Album name"
-              onChange={(e) => setMetadata({ album: e.target.value })}
-              className={INPUT_STYLES}
-            />
-          </label>
-
-          <label className="flex flex-col gap-1.5">
-            <span className="text-xs font-medium text-composer-text-secondary select-none">ISRC</span>
-            <input
-              type="text"
-              aria-label="ISRC"
-              value={isrcText}
-              placeholder="e.g. USQX91700001"
-              onChange={(e) => handleIsrcChange(e.target.value)}
-              className={INPUT_STYLES}
-            />
-            {isrcInvalid && (
-              <span className="text-xs text-composer-error-text select-none">
-                Invalid ISRC ・ expected 12 characters like USQX91700001
-              </span>
-            )}
-          </label>
-
-          <MetadataFieldList
-            label="Artists"
-            itemNoun="Artist"
-            placeholder="Artist name"
-            values={metadata.artists}
-            onChange={(next) => setMetadata({ artists: next })}
-          />
-
-          <MetadataFieldList
-            label="Producers"
-            itemNoun="Producer"
-            placeholder="Producer name"
-            values={metadata.songwriters ?? []}
-            onChange={(next) => setMetadata({ songwriters: next })}
-          />
-
-          <div className="flex flex-col gap-1.5">
-            <span className="text-xs font-medium text-composer-text-secondary select-none">Extra fields</span>
-            {extraPairs.map((pair, index) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional, identity follows index
-              <div key={index} className="flex items-center gap-2">
+      <AnimatePresence initial={false}>
+        {open && (
+          <m.div
+            key="metadata-content"
+            variants={accordionVariants}
+            initial="hidden"
+            animate="visible"
+            exit="hidden"
+            transition={reducedMotion ? { duration: 0 } : accordionTransition}
+            className="overflow-hidden"
+          >
+            <div className="flex flex-col gap-4 px-6 pt-4 pb-4">
+              <label className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-composer-text-secondary select-none">Title</span>
                 <input
                   type="text"
-                  aria-label={`Field ${index + 1} key`}
-                  value={pair.key}
-                  placeholder="Key"
-                  onChange={(e) => handleExtraEdit(index, { key: e.target.value })}
+                  aria-label="Title"
+                  value={metadata.title}
+                  placeholder="Song title"
+                  onChange={(e) => setMetadata({ title: e.target.value })}
                   className={INPUT_STYLES}
                 />
+              </label>
+
+              <label className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-composer-text-secondary select-none">Album</span>
                 <input
                   type="text"
-                  aria-label={`Field ${index + 1} value`}
-                  value={pair.value}
-                  placeholder="Value"
-                  onChange={(e) => handleExtraEdit(index, { value: e.target.value })}
+                  aria-label="Album"
+                  value={metadata.album}
+                  placeholder="Album name"
+                  onChange={(e) => setMetadata({ album: e.target.value })}
                   className={INPUT_STYLES}
                 />
+              </label>
+
+              <label className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-composer-text-secondary select-none">ISRC</span>
+                <input
+                  type="text"
+                  aria-label="ISRC"
+                  value={isrcText}
+                  placeholder="e.g. USQX91700001"
+                  onChange={(e) => handleIsrcChange(e.target.value)}
+                  className={INPUT_STYLES}
+                />
+                {isrcInvalid && (
+                  <span className="text-xs text-composer-error-text select-none">
+                    Invalid ISRC ・ expected 12 characters like USQX91700001
+                  </span>
+                )}
+              </label>
+
+              <MetadataFieldList
+                label="Artists"
+                itemNoun="Artist"
+                placeholder="Artist name"
+                values={metadata.artists}
+                onChange={(next) => setMetadata({ artists: next })}
+              />
+
+              <MetadataFieldList
+                label="Producers"
+                itemNoun="Producer"
+                placeholder="Producer name"
+                values={metadata.songwriters ?? []}
+                onChange={(next) => setMetadata({ songwriters: next })}
+              />
+
+              <div className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-composer-text-secondary select-none">Extra fields</span>
+                {extraPairs.map((pair, index) => (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional, identity follows index
+                  <div key={index} className="flex items-center gap-2">
+                    <input
+                      type="text"
+                      aria-label={`Field ${index + 1} key`}
+                      value={pair.key}
+                      placeholder="Key"
+                      onChange={(e) => handleExtraEdit(index, { key: e.target.value })}
+                      className={INPUT_STYLES}
+                    />
+                    <input
+                      type="text"
+                      aria-label={`Field ${index + 1} value`}
+                      value={pair.value}
+                      placeholder="Value"
+                      onChange={(e) => handleExtraEdit(index, { value: e.target.value })}
+                      className={INPUT_STYLES}
+                    />
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Remove field ${index + 1}`}
+                      onClick={() => handleExtraChange(extraPairs.filter((_, i) => i !== index))}
+                    >
+                      <IconX className="size-4" />
+                    </Button>
+                  </div>
+                ))}
                 <Button
-                  variant="ghost"
-                  size="icon"
-                  aria-label={`Remove field ${index + 1}`}
-                  onClick={() => handleExtraChange(extraPairs.filter((_, i) => i !== index))}
+                  hasIcon
+                  size="sm"
+                  variant="secondary"
+                  className="self-start"
+                  aria-label="Add field"
+                  onClick={() => handleExtraChange([...extraPairs, { key: "", value: "" }])}
                 >
-                  <IconX className="size-4" />
+                  <IconPlus className="size-3.5" />
+                  Add field
                 </Button>
               </div>
-            ))}
-            <Button
-              hasIcon
-              size="sm"
-              variant="ghost"
-              className="self-start"
-              aria-label="Add field"
-              onClick={() => handleExtraChange([...extraPairs, { key: "", value: "" }])}
-            >
-              <IconPlus className="size-3.5" />
-              Add field
-            </Button>
-          </div>
-        </div>
-      )}
+            </div>
+          </m.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 };

--- a/src/views/export/metadata-panel.tsx
+++ b/src/views/export/metadata-panel.tsx
@@ -6,11 +6,12 @@ import { isValidIsrc, normalizeIsrc } from "@/utils/isrc";
 import { INPUT_STYLES, MetadataFieldList } from "@/views/export/metadata-field-list";
 import { IconChevronRight, IconPlus, IconX } from "@tabler/icons-react";
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
+import { nanoid } from "nanoid";
 import { useState } from "react";
 
 // -- Helpers ------------------------------------------------------------------
 
-type ExtraPair = { key: string; value: string };
+type ExtraPair = { id: string; key: string; value: string };
 
 function pairsToRecord(pairs: ExtraPair[]): Record<string, string> {
   const record: Record<string, string> = {};
@@ -29,7 +30,7 @@ const MetadataPanel: React.FC = () => {
   const [open, setOpen] = useState(false);
   const [isrcDraft, setIsrcDraft] = useState(() => metadata.isrc ?? "");
   const [extraPairs, setExtraPairs] = useState<ExtraPair[]>(() =>
-    Object.entries(metadata.extra ?? {}).map(([key, value]) => ({ key, value })),
+    Object.entries(metadata.extra ?? {}).map(([key, value]) => ({ id: nanoid(), key, value })),
   );
 
   // The store keeps only a normalized isrc, but the field must show the raw draft
@@ -50,8 +51,8 @@ const MetadataPanel: React.FC = () => {
     setMetadata({ extra: pairsToRecord(next) });
   };
 
-  const handleExtraEdit = (index: number, patch: Partial<ExtraPair>) => {
-    handleExtraChange(extraPairs.map((pair, i) => (i === index ? { ...pair, ...patch } : pair)));
+  const handleExtraEdit = (id: string, patch: Partial<ExtraPair>) => {
+    handleExtraChange(extraPairs.map((pair) => (pair.id === id ? { ...pair, ...patch } : pair)));
   };
 
   const reducedMotion = useReducedMotion();
@@ -142,14 +143,13 @@ const MetadataPanel: React.FC = () => {
               <div className="flex flex-col gap-1.5">
                 <span className="text-xs font-medium text-composer-text-secondary select-none">Extra fields</span>
                 {extraPairs.map((pair, index) => (
-                  // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional, identity follows index
-                  <div key={index} className="flex items-center gap-2">
+                  <div key={pair.id} className="flex items-center gap-2">
                     <input
                       type="text"
                       aria-label={`Field ${index + 1} key`}
                       value={pair.key}
                       placeholder="Key"
-                      onChange={(e) => handleExtraEdit(index, { key: e.target.value })}
+                      onChange={(e) => handleExtraEdit(pair.id, { key: e.target.value })}
                       className={INPUT_STYLES}
                     />
                     <input
@@ -157,14 +157,14 @@ const MetadataPanel: React.FC = () => {
                       aria-label={`Field ${index + 1} value`}
                       value={pair.value}
                       placeholder="Value"
-                      onChange={(e) => handleExtraEdit(index, { value: e.target.value })}
+                      onChange={(e) => handleExtraEdit(pair.id, { value: e.target.value })}
                       className={INPUT_STYLES}
                     />
                     <Button
                       variant="ghost"
                       size="icon"
                       aria-label={`Remove field ${index + 1}`}
-                      onClick={() => handleExtraChange(extraPairs.filter((_, i) => i !== index))}
+                      onClick={() => handleExtraChange(extraPairs.filter((p) => p.id !== pair.id))}
                     >
                       <IconX className="size-4" />
                     </Button>
@@ -176,7 +176,7 @@ const MetadataPanel: React.FC = () => {
                   variant="secondary"
                   className="self-start"
                   aria-label="Add field"
-                  onClick={() => handleExtraChange([...extraPairs, { key: "", value: "" }])}
+                  onClick={() => handleExtraChange([...extraPairs, { id: nanoid(), key: "", value: "" }])}
                 >
                   <IconPlus className="size-3.5" />
                   Add field

--- a/src/views/export/metadata-panel.tsx
+++ b/src/views/export/metadata-panel.tsx
@@ -1,0 +1,175 @@
+import { useProjectStore } from "@/stores/project";
+import { Button } from "@/ui/button";
+import { isValidIsrc, normalizeIsrc } from "@/utils/isrc";
+import { INPUT_STYLES, MetadataFieldList } from "@/views/export/metadata-field-list";
+import { IconChevronDown, IconChevronRight, IconPlus, IconX } from "@tabler/icons-react";
+import { useState } from "react";
+
+// -- Helpers ------------------------------------------------------------------
+
+type ExtraPair = { key: string; value: string };
+
+function pairsToRecord(pairs: ExtraPair[]): Record<string, string> {
+  const record: Record<string, string> = {};
+  for (const { key, value } of pairs) {
+    if (key.trim() !== "") record[key] = value;
+  }
+  return record;
+}
+
+// -- Component ----------------------------------------------------------------
+
+const MetadataPanel: React.FC = () => {
+  const metadata = useProjectStore((s) => s.metadata);
+  const setMetadata = useProjectStore((s) => s.setMetadata);
+
+  const [open, setOpen] = useState(false);
+  const [isrcText, setIsrcText] = useState(() => metadata.isrc ?? "");
+  const [extraPairs, setExtraPairs] = useState<ExtraPair[]>(() =>
+    Object.entries(metadata.extra ?? {}).map(([key, value]) => ({ key, value })),
+  );
+
+  const trimmedIsrc = isrcText.trim();
+  const isrcInvalid = trimmedIsrc !== "" && !isValidIsrc(trimmedIsrc);
+
+  const handleIsrcChange = (value: string) => {
+    setIsrcText(value);
+    setMetadata({ isrc: normalizeIsrc(value) });
+  };
+
+  const handleExtraChange = (next: ExtraPair[]) => {
+    setExtraPairs(next);
+    setMetadata({ extra: pairsToRecord(next) });
+  };
+
+  const handleExtraEdit = (index: number, patch: Partial<ExtraPair>) => {
+    handleExtraChange(extraPairs.map((pair, i) => (i === index ? { ...pair, ...patch } : pair)));
+  };
+
+  const ChevronIcon = open ? IconChevronDown : IconChevronRight;
+
+  return (
+    <div className="border-b border-composer-border">
+      <Button
+        hasIcon
+        variant="ghost"
+        size="md"
+        className="w-full justify-start rounded-none px-6 py-3 text-composer-text-secondary"
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <ChevronIcon className="size-4" />
+        Metadata
+      </Button>
+
+      {open && (
+        <div className="flex flex-col gap-4 px-6 pb-4">
+          <label className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-composer-text-secondary select-none">Title</span>
+            <input
+              type="text"
+              aria-label="Title"
+              value={metadata.title}
+              placeholder="Song title"
+              onChange={(e) => setMetadata({ title: e.target.value })}
+              className={INPUT_STYLES}
+            />
+          </label>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-composer-text-secondary select-none">Album</span>
+            <input
+              type="text"
+              aria-label="Album"
+              value={metadata.album}
+              placeholder="Album name"
+              onChange={(e) => setMetadata({ album: e.target.value })}
+              className={INPUT_STYLES}
+            />
+          </label>
+
+          <label className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-composer-text-secondary select-none">ISRC</span>
+            <input
+              type="text"
+              aria-label="ISRC"
+              value={isrcText}
+              placeholder="e.g. USQX91700001"
+              onChange={(e) => handleIsrcChange(e.target.value)}
+              className={INPUT_STYLES}
+            />
+            {isrcInvalid && (
+              <span className="text-xs text-composer-error-text select-none">
+                Invalid ISRC ・ expected 12 characters like USQX91700001
+              </span>
+            )}
+          </label>
+
+          <MetadataFieldList
+            label="Artists"
+            itemNoun="Artist"
+            placeholder="Artist name"
+            values={metadata.artists}
+            onChange={(next) => setMetadata({ artists: next })}
+          />
+
+          <MetadataFieldList
+            label="Producers"
+            itemNoun="Producer"
+            placeholder="Producer name"
+            values={metadata.songwriters ?? []}
+            onChange={(next) => setMetadata({ songwriters: next })}
+          />
+
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-composer-text-secondary select-none">Extra fields</span>
+            {extraPairs.map((pair, index) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional, identity follows index
+              <div key={index} className="flex items-center gap-2">
+                <input
+                  type="text"
+                  aria-label={`Field ${index + 1} key`}
+                  value={pair.key}
+                  placeholder="Key"
+                  onChange={(e) => handleExtraEdit(index, { key: e.target.value })}
+                  className={INPUT_STYLES}
+                />
+                <input
+                  type="text"
+                  aria-label={`Field ${index + 1} value`}
+                  value={pair.value}
+                  placeholder="Value"
+                  onChange={(e) => handleExtraEdit(index, { value: e.target.value })}
+                  className={INPUT_STYLES}
+                />
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Remove field ${index + 1}`}
+                  onClick={() => handleExtraChange(extraPairs.filter((_, i) => i !== index))}
+                >
+                  <IconX className="size-4" />
+                </Button>
+              </div>
+            ))}
+            <Button
+              hasIcon
+              size="sm"
+              variant="ghost"
+              className="self-start"
+              aria-label="Add field"
+              onClick={() => handleExtraChange([...extraPairs, { key: "", value: "" }])}
+            >
+              <IconPlus className="size-3.5" />
+              Add field
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// -- Exports ------------------------------------------------------------------
+
+export { MetadataPanel };

--- a/src/views/import.browser.test.tsx
+++ b/src/views/import.browser.test.tsx
@@ -56,7 +56,7 @@ function dispatchDrop(target: Element, file: File) {
 
 // -- Empty state --------------------------------------------------------------
 
-describe("ImportPanel — no source", () => {
+describe("ImportPanel: no source", () => {
   it("renders the audio drop zone when no source is loaded", async () => {
     useAudioStore.setState({ source: null });
     useProjectStore.setState({ lines: [] });
@@ -73,7 +73,7 @@ describe("ImportPanel — no source", () => {
 
 // -- File source --------------------------------------------------------------
 
-describe("ImportPanel — file source", () => {
+describe("ImportPanel: file source", () => {
   it("shows the loading spinner for a file source while it is loading", async () => {
     useAudioStore.setState({
       source: { type: "file", file: createAudioFile() },
@@ -106,9 +106,9 @@ describe("ImportPanel — file source", () => {
   });
 });
 
-// -- YouTube source — title -----------------------------------------------
+// -- YouTube source: title -----------------------------------------------
 
-describe("ImportPanel — YouTube title", () => {
+describe("ImportPanel: YouTube title", () => {
   it("shows the loading spinner while a YouTube source is downloading", async () => {
     useAudioStore.setState({
       source: { type: "youtube", videoId: "abc123" },
@@ -153,9 +153,9 @@ describe("ImportPanel — YouTube title", () => {
   });
 });
 
-// -- YouTube source — thumbnail -------------------------------------------
+// -- YouTube source: thumbnail -------------------------------------------
 
-describe("ImportPanel — YouTube thumbnail", () => {
+describe("ImportPanel: YouTube thumbnail", () => {
   it("renders the persisted thumbnail image when one is in project metadata", async () => {
     useAudioStore.setState({
       source: { type: "youtube", videoId: "dQw4w9WgXcQ" },
@@ -239,9 +239,9 @@ describe("ImportPanel — YouTube thumbnail", () => {
   });
 });
 
-// -- YouTube source — subtitle copy ---------------------------------------
+// -- YouTube source: subtitle copy ---------------------------------------
 
-describe("ImportPanel — YouTube subtitle", () => {
+describe("ImportPanel: YouTube subtitle", () => {
   it("says 'Downloading from YouTube' while downloading", async () => {
     useAudioStore.setState({
       source: { type: "youtube", videoId: "dQw4w9WgXcQ" },

--- a/src/views/import.browser.test.tsx
+++ b/src/views/import.browser.test.tsx
@@ -25,6 +25,35 @@ function withQueryClient(children: ReactNode) {
 const PNG_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
 
+function id3v2(frames: Array<[string, string]>): Uint8Array {
+  const enc = new TextEncoder();
+  const body: number[] = [];
+  for (const [id, text] of frames) {
+    const content = [0x03, ...enc.encode(text)];
+    const size = content.length;
+    body.push(
+      ...enc.encode(id),
+      (size >> 24) & 0xff,
+      (size >> 16) & 0xff,
+      (size >> 8) & 0xff,
+      size & 0xff,
+      0,
+      0,
+      ...content,
+    );
+  }
+  const synch = (n: number) => [(n >> 21) & 0x7f, (n >> 14) & 0x7f, (n >> 7) & 0x7f, n & 0x7f];
+  return new Uint8Array([0x49, 0x44, 0x33, 3, 0, 0, ...synch(body.length), ...body]);
+}
+
+function dispatchDrop(target: Element, file: File) {
+  const dataTransfer = new DataTransfer();
+  dataTransfer.items.add(file);
+  const event = new Event("drop", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+  target.dispatchEvent(event);
+}
+
 // -- Empty state --------------------------------------------------------------
 
 describe("ImportPanel — no source", () => {
@@ -308,5 +337,58 @@ describe("ImportPanel: videoId-gated thumb fallback", () => {
     const screen = await render(withQueryClient(<ImportPanel />));
     const liveBridgeImg = screen.container.querySelector(`img[src^='${DEFAULT_BRIDGE_URL}']`);
     expect(liveBridgeImg).toBeNull();
+  });
+});
+
+// -- File drop: embedded tag capture --------------------------------------
+
+describe("ImportPanel: audio tag capture", () => {
+  it("sets the filename as the title synchronously on drop", async () => {
+    useAudioStore.setState({ source: null });
+    useProjectStore.setState({ lines: [] });
+    const screen = await render(withQueryClient(<ImportPanel />));
+
+    const file = new File([new Uint8Array(8)], "My Untagged Song.wav", { type: "audio/wav" });
+    const dropZone = screen.container.querySelector("label[for='file-drop-input']");
+    expect(dropZone).not.toBeNull();
+    if (dropZone) dispatchDrop(dropZone, file);
+
+    expect(useProjectStore.getState().metadata.title).toBe("My Untagged Song");
+  });
+
+  it("populates title/artists/album/isrc from a dropped file's embedded ID3 tags", async () => {
+    useAudioStore.setState({ source: null });
+    useProjectStore.setState({ lines: [] });
+    const screen = await render(withQueryClient(<ImportPanel />));
+
+    const bytes = id3v2([
+      ["TIT2", "Tagged Title"],
+      ["TPE1", "The Artist"],
+      ["TALB", "The Album"],
+      ["TSRC", "USQX91700001"],
+    ]);
+    const file = new File([bytes], "filename-fallback.mp3", { type: "audio/mpeg" });
+    const dropZone = screen.container.querySelector("label[for='file-drop-input']");
+    expect(dropZone).not.toBeNull();
+    if (dropZone) dispatchDrop(dropZone, file);
+
+    await expect.poll(() => useProjectStore.getState().metadata.title).toBe("Tagged Title");
+    const metadata = useProjectStore.getState().metadata;
+    expect(metadata.artists).toEqual(["The Artist"]);
+    expect(metadata.album).toBe("The Album");
+    expect(metadata.isrc).toBe("USQX91700001");
+  });
+
+  it("keeps the filename title when the dropped file has no embedded tags", async () => {
+    useAudioStore.setState({ source: null });
+    useProjectStore.setState({ lines: [] });
+    const screen = await render(withQueryClient(<ImportPanel />));
+
+    const file = new File([new Uint8Array(8)], "No Tags Here.wav", { type: "audio/wav" });
+    const dropZone = screen.container.querySelector("label[for='file-drop-input']");
+    if (dropZone) dispatchDrop(dropZone, file);
+
+    expect(useProjectStore.getState().metadata.title).toBe("No Tags Here");
+    await expect.poll(() => useProjectStore.getState().metadata.title).toBe("No Tags Here");
   });
 });

--- a/src/views/import.tsx
+++ b/src/views/import.tsx
@@ -4,6 +4,7 @@ import { useBridgeThumb } from "@/hooks/useBridgeThumb";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
+import { audioTagsToMetadata } from "@/utils/audio-tags";
 import { IconBrandYoutube, IconClock, IconFile, IconLoader2, IconMusic } from "@tabler/icons-react";
 import { useCallback } from "react";
 
@@ -113,6 +114,15 @@ const ImportPanel: React.FC = () => {
     (file: File) => {
       setSource({ type: "file", file });
       setMetadata({ title: file.name.replace(/\.[^/.]+$/, "") });
+      void import("music-metadata")
+        .then(({ parseBlob }) => parseBlob(file))
+        .then(({ common }) => {
+          const patch = audioTagsToMetadata(common);
+          if (Object.keys(patch).length > 0) setMetadata(patch);
+        })
+        .catch((error) => {
+          console.warn("[Composer] could not read audio tags", error);
+        });
     },
     [setSource, setMetadata],
   );


### PR DESCRIPTION
## Overview

Composer projects can carry real song metadata now: title, artists, album, isrc, producers, and whatever extra tags come along. Artists are a list instead of one string, so a name like "Tyler, The Creator" stops getting split on the comma. It fills in automatically from enriched links, the composer bridge, and a dropped file's embedded tags, and there's an editable panel at the top of the Export view to fix it up by hand. All of it writes into the exported TTML as composer-namespaced composer:meta and reads back the same on import. Closes #146.
