### PR TITLE
feat: add itunes:timing and xmlns:itunes to ttml export

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://composer.betterlyrics.org"><img src="https://img.shields.io/badge/Open-composer.betterlyrics.org-F50032?style=flat-square" alt="Open Composer" /></a>
-  <a href="https://www.w3.org/TR/2018/REC-ttml1-20181108/"><img src="https://img.shields.io/badge/TTML%201-W3C%20Compliant-4caf50?style=flat-square" alt="TTML 1 W3C Compliant" /></a>
+  <a href="https://www.w3.org/TR/2018/REC-ttml1-20181108/"><img src="https://img.shields.io/badge/TTML%201-W3C%20subset-4caf50?style=flat-square" alt="TTML 1 W3C subset" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL%203.0-2196f3?style=flat-square" alt="AGPL 3.0 License" /></a>
   <a href="https://betterlyrics.org"><img src="https://img.shields.io/badge/Built%20for-Better%20Lyrics-F50032?style=flat-square" alt="Built for Better Lyrics" /></a>
 </p>
@@ -39,7 +39,7 @@ Four-step workflow:
 
 ## Features
 
-- **W3C TTML 1 compliant** - Standard XML output, works in any TTML 1 parser
+- **W3C TTML 1 subset** - Standard XML output that reads in TTML 1 parsers
 - **Linked groups** - Group repeating sections (choruses, hooks). Edit one instance, every linked instance updates.
 - **Tap-to-sync** - Press Space in time with the music to stamp each word
 - **YouTube import** - Paste a video URL to pull the audio straight in, no manual download needed
@@ -56,7 +56,7 @@ Four-step workflow:
 
 ## Standards
 
-Composer emits **TTML 1** ([W3C Recommendation, Nov 2018](https://www.w3.org/TR/2018/REC-ttml1-20181108/)) compliant XML. Linked groups and per-instance metadata are exposed via foreign-namespace extensions the spec explicitly permits, so files round-trip through any TTML 1 parser.
+Composer emits a restricted subset of **TTML 1** ([W3C Recommendation, Nov 2018](https://www.w3.org/TR/2018/REC-ttml1-20181108/)). Word-span times are absolute and timestamps omit the hours field when it is zero, so the output is not strict TTML 1. Linked groups and per-instance metadata are exposed via foreign-namespace extensions the spec explicitly permits, which downstream tools can safely ignore.
 
 For the full breakdown, see **Help → TTML & standards** in-app.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.32.4",
+  "version": "1.33.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/ui/help-sections/ttml-standards.browser.test.tsx
+++ b/src/ui/help-sections/ttml-standards.browser.test.tsx
@@ -7,4 +7,9 @@ describe("TtmlStandardsSection", () => {
     const screen = await render(<TtmlStandardsSection />);
     await expect.element(screen.getByRole("heading", { name: "What Composer outputs" })).toBeInTheDocument();
   });
+
+  it("frames the output as a TTML 1 subset, not strict W3C conformance", async () => {
+    const screen = await render(<TtmlStandardsSection />);
+    await expect.element(screen.getByText(/restricted subset of/i)).toBeInTheDocument();
+  });
 });

--- a/src/ui/help-sections/ttml-standards.tsx
+++ b/src/ui/help-sections/ttml-standards.tsx
@@ -6,7 +6,7 @@ const TtmlStandardsSection: React.FC = () => (
   <div className="space-y-5">
     <h4 className={HEADING}>What Composer outputs</h4>
     <p className={PROSE}>
-      Composer emits{" "}
+      Composer emits a restricted subset of{" "}
       <a
         href="https://www.w3.org/TR/2018/REC-ttml1-20181108/"
         target="_blank"
@@ -15,8 +15,8 @@ const TtmlStandardsSection: React.FC = () => (
       >
         TTML 1
       </a>{" "}
-      (W3C Recommendation, November 2018). The output is well-formed XML that any TTML 1 conformant parser can read,
-      including the standard structure: <span className={INLINE_CODE}>&lt;tt&gt;</span> root with the TTML namespace,{" "}
+      (W3C Recommendation, November 2018). The output is well-formed XML that most TTML 1 parsers can read, including
+      the standard structure: <span className={INLINE_CODE}>&lt;tt&gt;</span> root with the TTML namespace,{" "}
       <span className={INLINE_CODE}>&lt;head&gt;</span> with <span className={INLINE_CODE}>&lt;ttm:title&gt;</span> and{" "}
       <span className={INLINE_CODE}>&lt;ttm:agent&gt;</span> declarations, and{" "}
       <span className={INLINE_CODE}>&lt;body&gt;&lt;div&gt;&lt;p&gt;</span> for lines with{" "}
@@ -42,7 +42,7 @@ const TtmlStandardsSection: React.FC = () => (
       </a>{" "}
       of the spec. The spec explicitly permits "arbitrary namespace qualified elements that reside in any namespace
       other than those namespaces defined for use with this specification" and the same for attributes on TTML-defined
-      vocabulary. That's the W3C-sanctioned way to add application-specific data while keeping the document conformant.
+      vocabulary. That's the W3C-sanctioned way to add application-specific data without breaking other TTML tooling.
     </p>
     <p className={PROSE}>
       Composer's namespace URI is <span className={INLINE_CODE}>https://composer.betterlyrics.org/ttml</span>. Custom
@@ -55,7 +55,7 @@ const TtmlStandardsSection: React.FC = () => (
 
     <h4 className={HEADING}>Why this matters</h4>
     <p className={PROSE}>
-      You can hand a Composer file to any TTML 1 parser and it will work. Tools that don't recognize the{" "}
+      Most TTML 1 tooling can read a Composer file. Tools that don't recognize the{" "}
       <span className={INLINE_CODE}>composer:</span> namespace can safely skip the extensions: foreign attributes get
       pruned during validation (per{" "}
       <a

--- a/src/utils/ttml.itunes-namespace.test.ts
+++ b/src/utils/ttml.itunes-namespace.test.ts
@@ -1,0 +1,134 @@
+import type { Agent } from "@/domain/agent/model";
+import type { LyricLine } from "@/domain/line/model";
+import type { ProjectMetadata } from "@/domain/project/metadata";
+import { generateTTML } from "@/utils/ttml";
+import { describe, expect, it } from "vitest";
+
+const ITUNES_NS = "http://music.apple.com/lyric-ttml-internal";
+const baseMetadata: ProjectMetadata = { title: "Test", artist: "", album: "", duration: 60 };
+const baseAgents: Agent[] = [{ id: "v1", type: "person", name: "Lead" }];
+
+const wordLine: LyricLine = {
+  id: "a",
+  text: "hello world",
+  agentId: "v1",
+  words: [
+    { text: "hello ", begin: 1, end: 1.5 },
+    { text: "world", begin: 1.5, end: 2 },
+  ],
+};
+
+const lineSyncedLine: LyricLine = { id: "b", text: "hello world", agentId: "v1", begin: 1, end: 2 };
+
+describe("ttml export · itunes namespace signal", () => {
+  it("declares the itunes namespace on the root element", () => {
+    const ttml = generateTTML({ metadata: baseMetadata, agents: baseAgents, lines: [wordLine], granularity: "word" });
+    expect(ttml).toContain(`xmlns:itunes="${ITUNES_NS}"`);
+  });
+
+  it('emits itunes:timing="Word" when any line has word timing', () => {
+    const ttml = generateTTML({ metadata: baseMetadata, agents: baseAgents, lines: [wordLine], granularity: "word" });
+    expect(ttml).toContain('itunes:timing="Word"');
+  });
+
+  it('emits itunes:timing="Line" for a line-synced-only song', () => {
+    const ttml = generateTTML({
+      metadata: baseMetadata,
+      agents: baseAgents,
+      lines: [lineSyncedLine],
+      granularity: "line",
+    });
+    expect(ttml).toContain('itunes:timing="Line"');
+    expect(ttml).not.toContain('itunes:timing="Word"');
+  });
+
+  it("keeps itunes:timing equal to composer:timing (both are durable detection signals)", () => {
+    const word = generateTTML({ metadata: baseMetadata, agents: baseAgents, lines: [wordLine], granularity: "word" });
+    expect(word).toContain('itunes:timing="Word"');
+    expect(word).toContain('composer:timing="Word"');
+
+    const line = generateTTML({
+      metadata: baseMetadata,
+      agents: baseAgents,
+      lines: [lineSyncedLine],
+      granularity: "line",
+    });
+    expect(line).toContain('itunes:timing="Line"');
+    expect(line).toContain('composer:timing="Line"');
+  });
+
+  describe("edge cases", () => {
+    it('reflects actual data, not the granularity prop: word prop + no word timing exports "Line"', () => {
+      const ttml = generateTTML({
+        metadata: baseMetadata,
+        agents: baseAgents,
+        lines: [lineSyncedLine],
+        granularity: "word",
+      });
+      expect(ttml).toContain('itunes:timing="Line"');
+      expect(ttml).not.toContain('itunes:timing="Word"');
+    });
+
+    it("emits both the namespace and the timing attribute together on an empty project", () => {
+      const ttml = generateTTML({ metadata: baseMetadata, agents: baseAgents, lines: [], granularity: "line" });
+      expect(ttml).toContain(`xmlns:itunes="${ITUNES_NS}"`);
+      expect(ttml).toContain('itunes:timing="Line"');
+    });
+  });
+});
+
+describe("ttml export · Apple Music dialect regressions", () => {
+  it("emits absolute span times, not offsets relative to the parent line", () => {
+    const ttml = generateTTML({
+      metadata: baseMetadata,
+      agents: baseAgents,
+      lines: [
+        {
+          id: "a",
+          text: "hi there",
+          agentId: "v1",
+          words: [
+            { text: "hi ", begin: 65.5, end: 66 },
+            { text: "there", begin: 66, end: 66.75 },
+          ],
+        },
+      ],
+      granularity: "word",
+    });
+    // spans carry absolute media times, not offsets measured from the line begin
+    expect(ttml).toContain('<span begin="1:05.500"');
+    expect(ttml).toContain('begin="1:06.000"');
+    // the relative form (word start minus line begin) would be 0:00.500, and must never appear
+    expect(ttml).not.toContain('begin="0:00.500"');
+  });
+
+  it("marks the Apple dialect with itunes:timing and the itunes namespace", () => {
+    const ttml = generateTTML({ metadata: baseMetadata, agents: baseAgents, lines: [wordLine], granularity: "word" });
+    expect(ttml).toContain(`xmlns:itunes="${ITUNES_NS}"`);
+    expect(ttml).toContain('itunes:timing="Word"');
+  });
+
+  it("keeps composer:timing alongside itunes:timing", () => {
+    const ttml = generateTTML({ metadata: baseMetadata, agents: baseAgents, lines: [wordLine], granularity: "word" });
+    expect(ttml).toContain('composer:timing="Word"');
+    expect(ttml).toContain('itunes:timing="Word"');
+  });
+
+  it("keeps unpadded M:SS timestamps and does not promote to strict HH:MM:SS", () => {
+    const ttml = generateTTML({
+      metadata: baseMetadata,
+      agents: baseAgents,
+      lines: [
+        { id: "a", text: "hi", agentId: "v1", words: [{ text: "hi", begin: 65.25, end: 66 }] },
+        { id: "b", text: "yo", agentId: "v1", words: [{ text: "yo", begin: 3665.25, end: 3666 }] },
+      ],
+      granularity: "word",
+    });
+    // single-digit minutes stay unpadded (1:05.250, never 01:05.250)
+    expect(ttml).toContain('begin="1:05.250"');
+    // past an hour the minutes overflow (61:05) instead of gaining an HH field
+    expect(ttml).toContain('begin="61:05.250"');
+    // never strict clock-time HH:MM:SS anywhere in the document
+    expect(ttml).not.toMatch(/\d{2}:\d{2}:\d{2}/);
+  });
+});

--- a/src/utils/ttml.ts
+++ b/src/utils/ttml.ts
@@ -7,6 +7,10 @@ import { stripSplitCharacter } from "@/utils/split-character";
 import { COMPOSER_NS } from "@/utils/lyrics-parsers/composer-namespace";
 import { effectiveBounds } from "@/domain/line/bounds";
 
+// -- Constants ----------------------------------------------------------------
+
+const APPLE_LYRIC_NS = "http://music.apple.com/lyric-ttml-internal";
+
 // -- Helpers ------------------------------------------------------------------
 
 function escapeXml(str: string): string {
@@ -35,12 +39,14 @@ function generateTTML({ metadata, agents, lines, groups, granularity, minify = f
   const ind = (n: number) => (minify ? "" : "  ".repeat(n));
 
   const effectiveGranularity = lines.some((l) => l.words?.length) ? "word" : "line";
+  const timingValue = effectiveGranularity === "word" ? "Word" : "Line";
 
   const parts: string[] = [];
 
-  // Root element with namespaces
+  // Apple Music lyric dialect, not strict W3C TTML1. Absolute span times and the
+  // Apple timestamp shape are intentional; don't "fix" them to generic TTML.
   parts.push(
-    `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:composer="${COMPOSER_NS}" ttp:timeBase="media" xml:lang="${escapeXml(metadata.language || "en")}" composer:timing="${effectiveGranularity === "word" ? "Word" : "Line"}">`,
+    `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:itunes="${APPLE_LYRIC_NS}" xmlns:composer="${COMPOSER_NS}" ttp:timeBase="media" xml:lang="${escapeXml(metadata.language || "en")}" itunes:timing="${timingValue}" composer:timing="${timingValue}">`,
   );
 
   // Head section


### PR DESCRIPTION
## Overview

Add `itunes:timing` and the `xmlns:itunes` namespace to the root `<tt>` of exported TTML, mirroring the existing `composer:timing`, so other tools can detect the Apple Music lyric subset programmatically. 