### PR TITLE
feat: allow touch to drive sync tap and hold

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.35.0",
+  "version": "1.36.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/index.css
+++ b/src/index.css
@@ -134,6 +134,11 @@ braccato-lyrics .blyrics-container {
   overflow-anchor: none;
 }
 
+@utility tap-highlight-none {
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+}
+
 @utility snap-onset-line {
   width: 1px;
   background: repeating-linear-gradient(180deg, var(--color-composer-onset) 0 5px, transparent 5px 11px);

--- a/src/stores/shortcut-bindings.ts
+++ b/src/stores/shortcut-bindings.ts
@@ -57,6 +57,10 @@ function getEffectiveKeysArray(id: string): string[] {
   return keys;
 }
 
+function getShortcutDescription(id: string): string {
+  return getShortcutById(id)?.description ?? id;
+}
+
 // -- Exports ------------------------------------------------------------------
 
-export { useShortcutBindingsStore, getEffectiveBinding, getEffectiveKeysArray };
+export { useShortcutBindingsStore, getEffectiveBinding, getEffectiveKeysArray, getShortcutDescription };

--- a/src/stores/shortcut-definitions.test.ts
+++ b/src/stores/shortcut-definitions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { getShortcutDescription } from "@/stores/shortcut-bindings";
 import { SHORTCUT_DEFINITIONS, type ShortcutBinding, type ShortcutScope } from "@/stores/shortcut-definitions";
 
 // -- Helpers ------------------------------------------------------------------
@@ -85,5 +86,26 @@ describe("SHORTCUT_DEFINITIONS", () => {
 
       expect(new Set(signatures).size).toBe(signatures.length);
     });
+  });
+});
+
+describe("getShortcutDescription", () => {
+  it("returns the registry description for a known shortcut", () => {
+    expect(getShortcutDescription("sync.tap")).toBe("Tap to sync");
+    expect(getShortcutDescription("sync.holdSync")).toBe("Hold to sync");
+  });
+
+  it("returns a description for every registered shortcut", () => {
+    for (const definition of SHORTCUT_DEFINITIONS) {
+      expect(getShortcutDescription(definition.id)).toBe(definition.description);
+    }
+  });
+
+  it("edge case: falls back to the id for an unknown shortcut", () => {
+    expect(getShortcutDescription("does.not.exist")).toBe("does.not.exist");
+  });
+
+  it("edge case: falls back to the id for an empty string", () => {
+    expect(getShortcutDescription("")).toBe("");
   });
 });

--- a/src/test/sync-gesture-helpers.ts
+++ b/src/test/sync-gesture-helpers.ts
@@ -1,0 +1,41 @@
+import { flushSync } from "react-dom";
+import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
+import { createAudioFile } from "@/test/audio-fixtures";
+import { createLine } from "@/test/factories";
+
+// -- Helpers ------------------------------------------------------------------
+
+function loadPlayingProject(text = "Hello world"): void {
+  useAudioStore.setState({
+    source: { type: "file", file: createAudioFile() },
+    duration: 10,
+    currentTime: 5,
+    isPlaying: true,
+  });
+  useProjectStore.setState({ lines: [createLine({ text })], activeTab: "sync" });
+}
+
+function firePointer(element: Element, type: string, pointerId = 1): PointerEvent {
+  const event = new PointerEvent(type, { bubbles: true, cancelable: true, pointerId });
+  element.dispatchEvent(event);
+  return event;
+}
+
+// Playback commits a render between a real press and its release; flushSync
+// reproduces that so the release handler reads the advanced clock.
+function setCurrentTime(seconds: number): void {
+  flushSync(() => {
+    useAudioStore.setState({ currentTime: seconds });
+  });
+}
+
+function setIsPlaying(isPlaying: boolean): void {
+  flushSync(() => {
+    useAudioStore.setState({ isPlaying });
+  });
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { loadPlayingProject, firePointer, setCurrentTime, setIsPlaying };

--- a/src/test/tap-highlight-utility.test.ts
+++ b/src/test/tap-highlight-utility.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// Guarded at the source level rather than via getComputedStyle because the
+// browser test project registers no Tailwind plugin and imports no stylesheet,
+// so computed styles there are UA defaults and would never see this rule.
+
+const INDEX_CSS = join(resolve(dirname(fileURLToPath(import.meta.url)), ".."), "index.css");
+const UTILITY_NAME = "tap-highlight-none";
+
+function extractUtilityBlock(css: string, name: string): string | null {
+  const header = new RegExp(`@utility\\s+${name}\\s*\\{`).exec(css);
+  if (!header) return null;
+
+  const bodyStart = header.index + header[0].length;
+  let depth = 1;
+  for (let i = bodyStart; i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}") {
+      depth--;
+      if (depth === 0) return css.slice(bodyStart, i);
+    }
+  }
+  return null;
+}
+
+const UTILITY_BODY = extractUtilityBlock(readFileSync(INDEX_CSS, "utf8"), UTILITY_NAME);
+const DECLARATIONS = UTILITY_BODY ?? `<no @utility ${UTILITY_NAME} block in src/index.css>`;
+
+describe("tap-highlight-none utility", () => {
+  it("is declared as an @utility block in src/index.css", () => {
+    expect(UTILITY_BODY).not.toBeNull();
+  });
+
+  it("suppresses the mobile tap highlight rectangle", () => {
+    expect(DECLARATIONS).toMatch(/-webkit-tap-highlight-color:\s*transparent\s*;/);
+  });
+
+  it("suppresses the iOS long-press callout", () => {
+    expect(DECLARATIONS).toMatch(/-webkit-touch-callout:\s*none\s*;/);
+  });
+});

--- a/src/views/sync/sync-panel.browser.test.tsx
+++ b/src/views/sync/sync-panel.browser.test.tsx
@@ -1,7 +1,9 @@
+import { flushSync } from "react-dom";
 import { describe, expect, it } from "vitest";
 import { SyncPanel } from "@/views/sync/sync-panel";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
+import { getShortcutDescription } from "@/stores/shortcut-bindings";
 import { createAudioFile } from "@/test/audio-fixtures";
 import { createLine, createWord } from "@/test/factories";
 import { render } from "@/test/render";
@@ -80,5 +82,158 @@ describe("SyncPanel · tap while already playing", () => {
     pressTap();
 
     await expect.element(screen.getByRole("button", { name: "Reset" })).toBeInTheDocument();
+  });
+});
+
+describe("SyncPanel · touch sync", () => {
+  function loadPlayingProject(text = "Hello world"): void {
+    useAudioStore.setState({
+      source: { type: "file", file: createAudioFile() },
+      duration: 10,
+      currentTime: 5,
+      isPlaying: true,
+    });
+    useProjectStore.setState({ lines: [createLine({ text })], activeTab: "sync" });
+  }
+
+  function firePointer(element: Element, type: string): void {
+    element.dispatchEvent(new PointerEvent(type, { bubbles: true, cancelable: true, pointerId: 1 }));
+  }
+
+  // Playback commits a render between a real press and its release; flushSync
+  // reproduces that so the release handler reads the advanced clock.
+  function setCurrentTime(seconds: number): void {
+    flushSync(() => {
+      useAudioStore.setState({ currentTime: seconds });
+    });
+  }
+
+  it("commits the current word when the tap circle is pressed", async () => {
+    loadPlayingProject();
+    const screen = await render(<SyncPanel />);
+
+    firePointer(screen.getByRole("button", { name: "Tap to sync" }).element(), "pointerdown");
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.begin).toBe(5);
+  });
+
+  it("opens the word on hold press and closes it on release", async () => {
+    loadPlayingProject();
+    const screen = await render(<SyncPanel />);
+
+    const holdCircle = screen.getByRole("button", { name: "Hold to sync" });
+    firePointer(holdCircle.element(), "pointerdown");
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.begin).toBe(5);
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(5);
+
+    setCurrentTime(7);
+    firePointer(holdCircle.element(), "pointerup");
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(7);
+  });
+
+  it("advances to the next word when the tap circle is pressed during a hold", async () => {
+    loadPlayingProject();
+    const screen = await render(<SyncPanel />);
+
+    firePointer(screen.getByRole("button", { name: "Hold to sync" }).element(), "pointerdown");
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.length).toBe(1);
+
+    setCurrentTime(7);
+    firePointer(screen.getByRole("button", { name: "Tap to sync" }).element(), "pointerdown");
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(7);
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[1]?.begin).toBe(7);
+  });
+
+  it("releases the hold when the pointer is cancelled", async () => {
+    loadPlayingProject();
+    const screen = await render(<SyncPanel />);
+
+    const holdCircle = screen.getByRole("button", { name: "Hold to sync" });
+    firePointer(holdCircle.element(), "pointerdown");
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.length).toBe(1);
+
+    setCurrentTime(8);
+    firePointer(holdCircle.element(), "pointercancel");
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(8);
+  });
+
+  it("releases the hold when the pointer leaves the circle", async () => {
+    loadPlayingProject();
+    const screen = await render(<SyncPanel />);
+
+    const holdCircle = screen.getByRole("button", { name: "Hold to sync" });
+    firePointer(holdCircle.element(), "pointerdown");
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.length).toBe(1);
+
+    setCurrentTime(8);
+    // React derives onPointerLeave from the native pointerout event, so a raw
+    // "pointerleave" dispatch would never reach the handler.
+    firePointer(holdCircle.element(), "pointerout");
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(8);
+  });
+
+  describe("invariants", () => {
+    it("suppresses the mobile tap highlight and long-press callout on both circles", async () => {
+      loadPlayingProject();
+      const screen = await render(<SyncPanel />);
+
+      for (const name of ["Hold to sync", "Tap to sync"]) {
+        const circle = screen.getByRole("button", { name }).element();
+        expect(circle.className).toContain("tap-highlight-none");
+        expect(circle.className).toContain("touch-none");
+      }
+    });
+
+    it("labels both circles from the shortcut registry, not hardcoded strings", async () => {
+      loadPlayingProject();
+      const screen = await render(<SyncPanel />);
+
+      await expect
+        .element(screen.getByRole("button", { name: getShortcutDescription("sync.tap") }))
+        .toBeInTheDocument();
+      await expect
+        .element(screen.getByRole("button", { name: getShortcutDescription("sync.holdSync") }))
+        .toBeInTheDocument();
+    });
+
+    it("a pointer hold overlapping a keyboard hold opens the word only once", async () => {
+      loadPlayingProject();
+      const screen = await render(<SyncPanel />);
+
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", code: "KeyF", bubbles: true }));
+      await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.begin).toBe(5);
+
+      setCurrentTime(7);
+      firePointer(screen.getByRole("button", { name: "Hold to sync" }).element(), "pointerdown");
+
+      await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.begin).toBe(5);
+      await expect.poll(() => useProjectStore.getState().lines[0].words?.length).toBe(1);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("unmounts the circles in edit mode so presses cannot write timing", async () => {
+      loadPlayingProject();
+      const screen = await render(<SyncPanel />);
+      await screen.getByRole("button", { name: "Edit" }).click();
+
+      await expect.poll(() => screen.getByRole("button", { name: "Tap to sync" }).query()).toBe(null);
+      await expect.poll(() => screen.getByRole("button", { name: "Hold to sync" }).query()).toBe(null);
+      expect(useProjectStore.getState().lines[0].words).toBeUndefined();
+    });
+
+    it("regression: the keyboard tap path still commits after the pointer refactor", async () => {
+      loadPlayingProject();
+      await render(<SyncPanel />);
+
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+
+      await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.begin).toBe(5);
+    });
   });
 });

--- a/src/views/sync/sync-panel.browser.test.tsx
+++ b/src/views/sync/sync-panel.browser.test.tsx
@@ -1,4 +1,3 @@
-import { flushSync } from "react-dom";
 import { describe, expect, it } from "vitest";
 import { SyncPanel } from "@/views/sync/sync-panel";
 import { useAudioStore } from "@/stores/audio";
@@ -7,6 +6,7 @@ import { getShortcutDescription } from "@/stores/shortcut-bindings";
 import { createAudioFile } from "@/test/audio-fixtures";
 import { createLine, createWord } from "@/test/factories";
 import { render } from "@/test/render";
+import { firePointer, loadPlayingProject, setCurrentTime } from "@/test/sync-gesture-helpers";
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -86,28 +86,6 @@ describe("SyncPanel · tap while already playing", () => {
 });
 
 describe("SyncPanel · touch sync", () => {
-  function loadPlayingProject(text = "Hello world"): void {
-    useAudioStore.setState({
-      source: { type: "file", file: createAudioFile() },
-      duration: 10,
-      currentTime: 5,
-      isPlaying: true,
-    });
-    useProjectStore.setState({ lines: [createLine({ text })], activeTab: "sync" });
-  }
-
-  function firePointer(element: Element, type: string): void {
-    element.dispatchEvent(new PointerEvent(type, { bubbles: true, cancelable: true, pointerId: 1 }));
-  }
-
-  // Playback commits a render between a real press and its release; flushSync
-  // reproduces that so the release handler reads the advanced clock.
-  function setCurrentTime(seconds: number): void {
-    flushSync(() => {
-      useAudioStore.setState({ currentTime: seconds });
-    });
-  }
-
   it("commits the current word when the tap circle is pressed", async () => {
     loadPlayingProject();
     const screen = await render(<SyncPanel />);
@@ -199,6 +177,30 @@ describe("SyncPanel · touch sync", () => {
       await expect
         .element(screen.getByRole("button", { name: getShortcutDescription("sync.holdSync") }))
         .toBeInTheDocument();
+    });
+
+    it("keeps both circles out of the tab order, the gestures are already bound globally", async () => {
+      loadPlayingProject();
+      const screen = await render(<SyncPanel />);
+
+      for (const name of ["Hold to sync", "Tap to sync"]) {
+        expect(screen.getByRole("button", { name }).element().getAttribute("tabindex")).toBe("-1");
+      }
+    });
+
+    it("reports hold state to assistive tech through aria-pressed", async () => {
+      loadPlayingProject();
+      const screen = await render(<SyncPanel />);
+
+      const holdCircle = screen.getByRole("button", { name: "Hold to sync" });
+      expect(holdCircle.element().getAttribute("aria-pressed")).toBe("false");
+
+      firePointer(holdCircle.element(), "pointerdown");
+      await expect.poll(() => holdCircle.element().getAttribute("aria-pressed")).toBe("true");
+
+      setCurrentTime(7);
+      firePointer(holdCircle.element(), "pointerup");
+      await expect.poll(() => holdCircle.element().getAttribute("aria-pressed")).toBe("false");
     });
 
     it("a pointer hold overlapping a keyboard hold opens the word only once", async () => {

--- a/src/views/sync/sync-panel.browser.test.tsx
+++ b/src/views/sync/sync-panel.browser.test.tsx
@@ -6,7 +6,7 @@ import { getShortcutDescription } from "@/stores/shortcut-bindings";
 import { createAudioFile } from "@/test/audio-fixtures";
 import { createLine, createWord } from "@/test/factories";
 import { render } from "@/test/render";
-import { firePointer, loadPlayingProject, setCurrentTime } from "@/test/sync-gesture-helpers";
+import { firePointer, loadPlayingProject, setCurrentTime, setIsPlaying } from "@/test/sync-gesture-helpers";
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -219,14 +219,36 @@ describe("SyncPanel · touch sync", () => {
   });
 
   describe("edge cases", () => {
-    it("unmounts the circles in edit mode so presses cannot write timing", async () => {
+    it("unmounts both circles in edit mode", async () => {
       loadPlayingProject();
       const screen = await render(<SyncPanel />);
       await screen.getByRole("button", { name: "Edit" }).click();
 
       await expect.poll(() => screen.getByRole("button", { name: "Tap to sync" }).query()).toBe(null);
       await expect.poll(() => screen.getByRole("button", { name: "Hold to sync" }).query()).toBe(null);
-      expect(useProjectStore.getState().lines[0].words).toBeUndefined();
+    });
+
+    it("writes no timing when a tap reaches the panel while editing during playback", async () => {
+      loadPlayingProject();
+      const screen = await render(<SyncPanel />);
+      await screen.getByRole("button", { name: "Edit" }).click();
+      await expect.poll(() => screen.getByRole("button", { name: "Tap to sync" }).query()).toBe(null);
+
+      // Entering edit mode pauses, but the transport can be started again.
+      setIsPlaying(true);
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+
+      await expect.poll(() => useProjectStore.getState().lines[0].words).toBeUndefined();
+    });
+
+    it("prevents the default press action on both circles so the press cannot steal focus", async () => {
+      loadPlayingProject();
+      const screen = await render(<SyncPanel />);
+
+      for (const name of ["Hold to sync", "Tap to sync"]) {
+        const pressed = firePointer(screen.getByRole("button", { name }).element(), "pointerdown");
+        expect(pressed.defaultPrevented).toBe(true);
+      }
     });
 
     it("regression: the keyboard tap path still commits after the pointer refactor", async () => {

--- a/src/views/sync/sync-panel.hold-lifecycle.browser.test.tsx
+++ b/src/views/sync/sync-panel.hold-lifecycle.browser.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { SyncPanel } from "@/views/sync/sync-panel";
+import { useProjectStore } from "@/stores/project";
+import { createLine } from "@/test/factories";
+import { render } from "@/test/render";
+import { firePointer, loadPlayingProject, setCurrentTime, setIsPlaying } from "@/test/sync-gesture-helpers";
+
+describe("SyncPanel · hold drained when the circles unmount", () => {
+  it("closes the held word when the song ends mid-hold", async () => {
+    loadPlayingProject();
+    const screen = await render(<SyncPanel />);
+
+    firePointer(screen.getByRole("button", { name: "Hold to sync" }).element(), "pointerdown");
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(5);
+
+    setCurrentTime(7);
+    setIsPlaying(false);
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(7);
+  });
+
+  it("leaves the next tap behaving as a tap after the song ended mid-hold", async () => {
+    loadPlayingProject();
+    const screen = await render(<SyncPanel />);
+
+    firePointer(screen.getByRole("button", { name: "Hold to sync" }).element(), "pointerdown");
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.length).toBe(1);
+
+    setCurrentTime(7);
+    setIsPlaying(false);
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(7);
+
+    setIsPlaying(true);
+    setCurrentTime(9);
+    const holdCircle = screen.getByRole("button", { name: "Hold to sync" });
+    await expect.poll(() => holdCircle.element().getAttribute("aria-pressed")).toBe("false");
+
+    firePointer(screen.getByRole("button", { name: "Tap to sync" }).element(), "pointerdown");
+
+    // A tap closes the word it writes; a hold-tap would leave end === begin.
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[1]?.begin).toBe(9);
+    const tapped = useProjectStore.getState().lines[0].words?.[1];
+    expect(tapped?.end).toBeGreaterThan(9);
+  });
+
+  it("drains the hold when a hold-tap completes the song", async () => {
+    loadPlayingProject("Hello");
+    const screen = await render(<SyncPanel />);
+
+    firePointer(screen.getByRole("button", { name: "Hold to sync" }).element(), "pointerdown");
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.length).toBe(1);
+
+    setCurrentTime(7);
+    firePointer(screen.getByRole("button", { name: "Tap to sync" }).element(), "pointerdown");
+    await expect.element(screen.getByText("Sync complete!")).toBeInTheDocument();
+
+    const existing = useProjectStore.getState().lines;
+    useProjectStore.setState({ lines: [...existing, createLine({ text: "World" })] });
+
+    await expect
+      .poll(() => screen.getByRole("button", { name: "Hold to sync" }).element().getAttribute("aria-pressed"))
+      .toBe("false");
+  });
+});

--- a/src/views/sync/sync-panel.hold-lifecycle.browser.test.tsx
+++ b/src/views/sync/sync-panel.hold-lifecycle.browser.test.tsx
@@ -94,6 +94,25 @@ describe("SyncPanel · keyboard hold release", () => {
     await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(7);
   });
 
+  it("does not let a keyboard press take over a hold the pointer started", async () => {
+    loadPlayingProject();
+    const screen = await render(<SyncPanel />);
+
+    firePointer(screen.getByRole("button", { name: "Hold to sync" }).element(), "pointerdown");
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(5);
+
+    setCurrentTime(6);
+    pressHoldKey("keydown");
+    pressHoldKey("keyup");
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(5);
+
+    setCurrentTime(8);
+    firePointer(screen.getByRole("button", { name: "Hold to sync" }).element(), "pointerup");
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(8);
+  });
+
   it("ignores a keyup that arrives after blur already closed the hold", async () => {
     loadPlayingProject();
     await render(<SyncPanel />);

--- a/src/views/sync/sync-panel.hold-lifecycle.browser.test.tsx
+++ b/src/views/sync/sync-panel.hold-lifecycle.browser.test.tsx
@@ -63,6 +63,63 @@ describe("SyncPanel · hold drained when the circles unmount", () => {
   });
 });
 
+describe("SyncPanel · hold pointer ownership", () => {
+  it("ignores a release from a pointer that did not start the hold", async () => {
+    loadPlayingProject();
+    const screen = await render(<SyncPanel />);
+
+    const holdCircle = screen.getByRole("button", { name: "Hold to sync" });
+    firePointer(holdCircle.element(), "pointerdown", 1);
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(5);
+
+    setCurrentTime(7);
+    firePointer(holdCircle.element(), "pointerup", 2);
+
+    await expect.poll(() => holdCircle.element().getAttribute("aria-pressed")).toBe("true");
+    expect(useProjectStore.getState().lines[0].words?.[0]?.end).toBe(5);
+
+    setCurrentTime(8);
+    firePointer(holdCircle.element(), "pointerup", 1);
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(8);
+  });
+
+  it("lets a second finger drive the tap circle during a hold, the two-finger gesture", async () => {
+    loadPlayingProject();
+    const screen = await render(<SyncPanel />);
+
+    firePointer(screen.getByRole("button", { name: "Hold to sync" }).element(), "pointerdown", 1);
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.length).toBe(1);
+
+    setCurrentTime(7);
+    firePointer(screen.getByRole("button", { name: "Tap to sync" }).element(), "pointerdown", 2);
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[1]?.begin).toBe(7);
+    expect(useProjectStore.getState().lines[0].words?.[0]?.end).toBe(7);
+  });
+
+  it("releases a hold started after an earlier hold was drained by an unmount", async () => {
+    loadPlayingProject();
+    const screen = await render(<SyncPanel />);
+
+    firePointer(screen.getByRole("button", { name: "Hold to sync" }).element(), "pointerdown", 3);
+    setCurrentTime(6);
+    setIsPlaying(false);
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(6);
+
+    setIsPlaying(true);
+    setCurrentTime(7);
+    const holdCircle = screen.getByRole("button", { name: "Hold to sync" });
+    firePointer(holdCircle.element(), "pointerdown", 9);
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[1]?.begin).toBe(7);
+
+    setCurrentTime(9);
+    firePointer(holdCircle.element(), "pointerup", 9);
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[1]?.end).toBe(9);
+  });
+});
+
 describe("SyncPanel · keyboard hold release", () => {
   function pressHoldKey(type: "keydown" | "keyup"): void {
     window.dispatchEvent(new KeyboardEvent(type, { key: "f", code: "KeyF", bubbles: true }));

--- a/src/views/sync/sync-panel.hold-lifecycle.browser.test.tsx
+++ b/src/views/sync/sync-panel.hold-lifecycle.browser.test.tsx
@@ -62,3 +62,51 @@ describe("SyncPanel · hold drained when the circles unmount", () => {
       .toBe("false");
   });
 });
+
+describe("SyncPanel · keyboard hold release", () => {
+  function pressHoldKey(type: "keydown" | "keyup"): void {
+    window.dispatchEvent(new KeyboardEvent(type, { key: "f", code: "KeyF", bubbles: true }));
+  }
+
+  it("closes the held word on keyup", async () => {
+    loadPlayingProject();
+    await render(<SyncPanel />);
+
+    pressHoldKey("keydown");
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(5);
+
+    setCurrentTime(7);
+    pressHoldKey("keyup");
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(7);
+  });
+
+  it("closes the held word when the window loses focus", async () => {
+    loadPlayingProject();
+    await render(<SyncPanel />);
+
+    pressHoldKey("keydown");
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(5);
+
+    setCurrentTime(7);
+    window.dispatchEvent(new Event("blur"));
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(7);
+  });
+
+  it("ignores a keyup that arrives after blur already closed the hold", async () => {
+    loadPlayingProject();
+    await render(<SyncPanel />);
+
+    pressHoldKey("keydown");
+    setCurrentTime(7);
+    window.dispatchEvent(new Event("blur"));
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.[0]?.end).toBe(7);
+
+    setCurrentTime(9);
+    pressHoldKey("keyup");
+
+    await expect.poll(() => useProjectStore.getState().lines[0].words?.length).toBe(1);
+    expect(useProjectStore.getState().lines[0].words?.[0]?.end).toBe(7);
+  });
+});

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -562,7 +562,9 @@ const SyncPanel: React.FC = () => {
               <div className="flex items-center gap-2">
                 <m.button
                   type="button"
+                  tabIndex={-1}
                   aria-label={getShortcutDescription("sync.holdSync")}
+                  aria-pressed={isHolding}
                   onPointerDown={handleHoldPointerDown}
                   onPointerUp={endHold}
                   onPointerCancel={endHold}
@@ -583,6 +585,7 @@ const SyncPanel: React.FC = () => {
                 </m.button>
                 <m.button
                   type="button"
+                  tabIndex={-1}
                   aria-label={getShortcutDescription("sync.tap")}
                   onPointerDown={handleTapPointerDown}
                   variants={syncPulseVariants}

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -260,6 +260,36 @@ const SyncPanel: React.FC = () => {
     return currentLine.words[currentLine.words.length - 1]?.begin;
   }, [granularity, currentLine?.words, prevLine?.words, prevLine?.begin]);
 
+  const performTap = useCallback(() => {
+    if (editMode) return;
+    if (isHolding && isPlaying) {
+      handleHoldTap();
+    } else if (isPlaying) {
+      if (!syncState.isActive) setSyncState((prev) => ({ ...prev, isActive: true }));
+      handleTap();
+    } else if (lines.length > 0) {
+      handleStartSync();
+    }
+  }, [editMode, isHolding, isPlaying, syncState.isActive, lines.length, handleHoldTap, handleTap, handleStartSync]);
+
+  const beginHold = useCallback(() => {
+    if (editMode || isHolding) return;
+    if (!syncState.isActive && lines.length > 0) {
+      handleStartSync();
+      handleHoldStart();
+      setIsHolding(true);
+    } else if (isPlaying) {
+      handleHoldStart();
+      setIsHolding(true);
+    }
+  }, [editMode, isHolding, isPlaying, syncState.isActive, lines.length, handleStartSync, handleHoldStart]);
+
+  const endHold = useCallback(() => {
+    if (!isHolding) return;
+    handleHoldEnd();
+    setIsHolding(false);
+  }, [isHolding, handleHoldEnd]);
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (activeTab !== "sync") return;
@@ -283,28 +313,13 @@ const SyncPanel: React.FC = () => {
       switch (matched) {
         case "sync.tap":
           e.preventDefault();
-          if (editMode) return;
-          if (isHolding && isPlaying) {
-            handleHoldTap();
-          } else if (isPlaying) {
-            if (!syncState.isActive) setSyncState((prev) => ({ ...prev, isActive: true }));
-            handleTap();
-          } else if (lines.length > 0) {
-            handleStartSync();
-          }
+          performTap();
           break;
         case "sync.holdSync":
           e.preventDefault();
           if (editMode) return;
           heldKeyCodeRef.current = e.code;
-          if (!syncState.isActive && lines.length > 0) {
-            handleStartSync();
-            handleHoldStart();
-            setIsHolding(true);
-          } else if (isPlaying) {
-            handleHoldStart();
-            setIsHolding(true);
-          }
+          beginHold();
           break;
         case "sync.nudgeLeft":
           e.preventDefault();
@@ -324,16 +339,14 @@ const SyncPanel: React.FC = () => {
       if (e.code === heldKeyCodeRef.current) {
         e.preventDefault();
         heldKeyCodeRef.current = null;
-        handleHoldEnd();
-        setIsHolding(false);
+        endHold();
       }
     };
 
     const handleBlur = () => {
       if (isHolding) {
         heldKeyCodeRef.current = null;
-        handleHoldEnd();
-        setIsHolding(false);
+        endHold();
       }
     };
 
@@ -345,22 +358,7 @@ const SyncPanel: React.FC = () => {
       window.removeEventListener("keyup", handleKeyUp);
       window.removeEventListener("blur", handleBlur);
     };
-  }, [
-    activeTab,
-    syncState.isActive,
-    lines.length,
-    handleStartSync,
-    handleTap,
-    handleHoldStart,
-    handleHoldEnd,
-    handleHoldTap,
-    isPlaying,
-    undo,
-    redo,
-    handleNudgeLastSynced,
-    editMode,
-    isHolding,
-  ]);
+  }, [activeTab, performTap, beginHold, endHold, undo, redo, handleNudgeLastSynced, editMode, isHolding]);
 
   const showScrollableView = !isPlaying || editMode;
 

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -76,6 +76,7 @@ const SyncPanel: React.FC = () => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number | null>(null);
   const heldKeyCodeRef = useRef<string | null>(null);
+  const holdPointerIdRef = useRef<number | null>(null);
 
   const linesRef = useRef(lines);
   linesRef.current = lines;
@@ -298,12 +299,25 @@ const SyncPanel: React.FC = () => {
     [performTap],
   );
 
+  // Only the pointer that opened the hold may close it, otherwise a second
+  // finger brushing the circle would end the first finger's word early.
   const handleHoldPointerDown = useCallback(
     (e: React.PointerEvent<HTMLButtonElement>) => {
       e.preventDefault();
+      if (isHolding) return;
       beginHold();
+      holdPointerIdRef.current = e.pointerId;
     },
-    [beginHold],
+    [isHolding, beginHold],
+  );
+
+  const handleHoldPointerRelease = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>) => {
+      if (e.pointerId !== holdPointerIdRef.current) return;
+      holdPointerIdRef.current = null;
+      endHold();
+    },
+    [endHold],
   );
 
   const showGestureCircles = !isComplete && !editMode && isPlaying;
@@ -312,7 +326,10 @@ const SyncPanel: React.FC = () => {
   // element (song ends, media-session pause, sync completes) would never close
   // its word and would leave isHolding stuck true.
   useEffect(() => {
-    if (!showGestureCircles && isHolding) endHold();
+    if (!showGestureCircles && isHolding) {
+      holdPointerIdRef.current = null;
+      endHold();
+    }
   }, [showGestureCircles, isHolding, endHold]);
 
   useEffect(() => {
@@ -575,9 +592,9 @@ const SyncPanel: React.FC = () => {
                   aria-label={getShortcutDescription("sync.holdSync")}
                   aria-pressed={isHolding}
                   onPointerDown={handleHoldPointerDown}
-                  onPointerUp={endHold}
-                  onPointerCancel={endHold}
-                  onPointerLeave={endHold}
+                  onPointerUp={handleHoldPointerRelease}
+                  onPointerCancel={handleHoldPointerRelease}
+                  onPointerLeave={handleHoldPointerRelease}
                   variants={syncPulseVariants}
                   initial={false}
                   animate={isHolding ? "pulse" : "idle"}

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -306,6 +306,15 @@ const SyncPanel: React.FC = () => {
     [beginHold],
   );
 
+  const showGestureCircles = !isComplete && !editMode && isPlaying;
+
+  // The release handlers live on the hold circle, so a hold outliving that
+  // element (song ends, media-session pause, sync completes) would never close
+  // its word and would leave isHolding stuck true.
+  useEffect(() => {
+    if (!showGestureCircles && isHolding) endHold();
+  }, [showGestureCircles, isHolding, endHold]);
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (activeTab !== "sync") return;
@@ -556,7 +565,7 @@ const SyncPanel: React.FC = () => {
             </div>
           )}
 
-          {!isComplete && !editMode && isPlaying && (
+          {showGestureCircles && (
             <div className="flex items-center gap-4">
               {currentWord && <span className="text-xl font-medium text-composer-text">{currentWord}</span>}
               <div className="flex items-center gap-2">

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -342,7 +342,7 @@ const SyncPanel: React.FC = () => {
           break;
         case "sync.holdSync":
           e.preventDefault();
-          if (editMode) return;
+          if (editMode || isHolding) return;
           heldKeyCodeRef.current = e.code;
           beginHold();
           break;

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -2,7 +2,7 @@ import { useSyncHandlers } from "@/hooks/useSyncHandlers";
 import { useAudioStore } from "@/stores/audio";
 import { isAnyModalOpen } from "@/stores/modal-stack";
 import { useProjectStore } from "@/stores/project";
-import { getEffectiveKeysArray } from "@/stores/shortcut-bindings";
+import { getEffectiveKeysArray, getShortcutDescription } from "@/stores/shortcut-bindings";
 import { Button } from "@/ui/button";
 import { EmptyState } from "@/ui/empty-state";
 import { findMatchingShortcut } from "@/utils/shortcut-matcher";
@@ -290,6 +290,22 @@ const SyncPanel: React.FC = () => {
     setIsHolding(false);
   }, [isHolding, handleHoldEnd]);
 
+  const handleTapPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      performTap();
+    },
+    [performTap],
+  );
+
+  const handleHoldPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      beginHold();
+    },
+    [beginHold],
+  );
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (activeTab !== "sync") return;
@@ -544,12 +560,18 @@ const SyncPanel: React.FC = () => {
             <div className="flex items-center gap-4">
               {currentWord && <span className="text-xl font-medium text-composer-text">{currentWord}</span>}
               <div className="flex items-center gap-2">
-                <m.div
+                <m.button
+                  type="button"
+                  aria-label={getShortcutDescription("sync.holdSync")}
+                  onPointerDown={handleHoldPointerDown}
+                  onPointerUp={endHold}
+                  onPointerCancel={endHold}
+                  onPointerLeave={endHold}
                   variants={syncPulseVariants}
                   initial={false}
                   animate={isHolding ? "pulse" : "idle"}
                   transition={syncCarouselTransition}
-                  className={`flex items-center justify-center border-2 rounded-full size-14 ${
+                  className={`flex items-center justify-center border-2 rounded-full size-14 cursor-pointer touch-none tap-highlight-none ${
                     isHolding ? "bg-composer-accent/20 border-composer-accent" : "bg-composer-bg-elevated"
                   }`}
                 >
@@ -558,20 +580,23 @@ const SyncPanel: React.FC = () => {
                       .map((k) => k.toUpperCase())
                       .join(" ")}
                   </span>
-                </m.div>
-                <m.div
+                </m.button>
+                <m.button
+                  type="button"
+                  aria-label={getShortcutDescription("sync.tap")}
+                  onPointerDown={handleTapPointerDown}
                   variants={syncPulseVariants}
                   initial={false}
                   animate={showPulse ? "pulse" : "idle"}
                   transition={syncCarouselTransition}
-                  className="flex items-center justify-center border-2 rounded-full size-14 bg-composer-bg-elevated"
+                  className="flex items-center justify-center border-2 rounded-full size-14 cursor-pointer touch-none tap-highlight-none bg-composer-bg-elevated"
                 >
                   <span className="text-xs font-medium text-composer-text-muted">
                     {getEffectiveKeysArray("sync.tap")
                       .map((k) => k.toUpperCase())
                       .join(" ")}
                   </span>
-                </m.div>
+                </m.button>
               </div>
             </div>
           )}


### PR DESCRIPTION
## Overview

Tablets couldn't sync at all: tap and hold were bound to Space and F, with no way to reach either without a keyboard. The two circles in the Sync panel showing those keys were already sitting there doing nothing, so they take presses now and run through the same code path the keyboard uses. Also suppressed the grey highlight box mobile browsers paint over anything you press, and fixed a hold that never let go if the song ended while your finger was still down.

Closes #150.
