### PR TITLE
feat: boundary selection, rolling edits, conform to group and export language

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.36.1",
+  "version": "1.37.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/domain/instance/enumerate.test.ts
+++ b/src/domain/instance/enumerate.test.ts
@@ -1,6 +1,6 @@
 import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
-import { instanceIndicesOf, linesOfInstance } from "@/domain/instance/enumerate";
+import { instanceIndicesOf, linesOfInstance, nextInstanceIdx } from "@/domain/instance/enumerate";
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -83,5 +83,81 @@ describe("instanceIndicesOf", () => {
       line({ id: "b", groupId: "g1", instanceIdx: 2 }),
     ];
     expect(instanceIndicesOf(lines, "g1")).toEqual([2, 10]);
+  });
+});
+
+// -- nextInstanceIdx ----------------------------------------------------------
+
+describe("nextInstanceIdx", () => {
+  function withIndices(indices: number[], groupId = "g1"): LyricLine[] {
+    return indices.map((instanceIdx, i) => line({ id: `${groupId}-${i}`, groupId, instanceIdx }));
+  }
+
+  it("starts at zero for a group with no instances", () => {
+    expect(nextInstanceIdx([], "g1")).toBe(0);
+    expect(nextInstanceIdx(withIndices([0, 1], "g2"), "g1")).toBe(0);
+  });
+
+  it("appends after a contiguous run", () => {
+    expect(nextInstanceIdx(withIndices([0]), "g1")).toBe(1);
+    expect(nextInstanceIdx(withIndices([0, 1, 2]), "g1")).toBe(3);
+  });
+
+  it("fills a hole left by a deleted instance", () => {
+    expect(nextInstanceIdx(withIndices([0, 2]), "g1")).toBe(1);
+    expect(nextInstanceIdx(withIndices([0, 1, 3, 4]), "g1")).toBe(2);
+  });
+
+  it("fills index zero when the run does not start there", () => {
+    expect(nextInstanceIdx(withIndices([1, 2]), "g1")).toBe(0);
+    expect(nextInstanceIdx(withIndices([5]), "g1")).toBe(0);
+  });
+
+  it("counts an instance once however many lines it spans", () => {
+    const lines: LyricLine[] = [
+      line({ id: "a", groupId: "g1", instanceIdx: 0 }),
+      line({ id: "b", groupId: "g1", instanceIdx: 0 }),
+      line({ id: "c", groupId: "g1", instanceIdx: 1 }),
+      line({ id: "d", groupId: "g1", instanceIdx: 1 }),
+    ];
+    expect(nextInstanceIdx(lines, "g1")).toBe(2);
+  });
+
+  describe("edge cases", () => {
+    it("ignores other groups, standalone lines, and lines missing instanceIdx", () => {
+      const lines: LyricLine[] = [
+        line({ id: "a", groupId: "g1", instanceIdx: 0 }),
+        line({ id: "b", groupId: "g2", instanceIdx: 1 }),
+        line({ id: "c", groupId: "g1" }),
+        line({ id: "d" }),
+      ];
+      expect(nextInstanceIdx(lines, "g1")).toBe(1);
+    });
+
+    it("is unaffected by the order the lines appear in", () => {
+      expect(nextInstanceIdx(withIndices([3, 0, 2]), "g1")).toBe(1);
+      expect(nextInstanceIdx(withIndices([2, 3, 0]), "g1")).toBe(1);
+    });
+
+    it("skips past a sparse tail rather than reusing a far index", () => {
+      expect(nextInstanceIdx(withIndices([0, 1, 2, 99]), "g1")).toBe(3);
+    });
+  });
+
+  describe("invariants", () => {
+    it("never returns an index already in use", () => {
+      const cases = [[], [0], [1], [0, 1], [0, 2], [1, 2], [0, 1, 3], [2, 5, 7], [0, 1, 2, 3]];
+      for (const indices of cases) {
+        const lines = withIndices(indices);
+        expect(indices).not.toContain(nextInstanceIdx(lines, "g1"));
+      }
+    });
+
+    it("does not modify its input", () => {
+      const lines = withIndices([0, 2]);
+      const snapshot = structuredClone(lines);
+      nextInstanceIdx(lines, "g1");
+      expect(lines).toEqual(snapshot);
+    });
   });
 });

--- a/src/domain/instance/enumerate.test.ts
+++ b/src/domain/instance/enumerate.test.ts
@@ -1,6 +1,6 @@
 import { reconcileLine, type LooseLine, type LyricLine } from "@/domain/line/model";
 import { describe, expect, it } from "vitest";
-import { linesOfInstance } from "@/domain/instance/enumerate";
+import { instanceIndicesOf, linesOfInstance } from "@/domain/instance/enumerate";
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -43,5 +43,45 @@ describe("linesOfInstance", () => {
   it("excludes lines missing instanceIdx even if groupId matches", () => {
     const lines: LyricLine[] = [line({ id: "a", groupId: "g1", instanceIdx: 0 }), line({ id: "b", groupId: "g1" })];
     expect(linesOfInstance(lines, "g1", 0).map((l) => l.id)).toEqual(["a"]);
+  });
+});
+
+// -- instanceIndicesOf --------------------------------------------------------
+
+describe("instanceIndicesOf", () => {
+  it("returns each instance index once, ascending", () => {
+    const lines: LyricLine[] = [
+      line({ id: "a", groupId: "g1", instanceIdx: 2 }),
+      line({ id: "b", groupId: "g1", instanceIdx: 0 }),
+      line({ id: "c", groupId: "g1", instanceIdx: 2 }),
+      line({ id: "d", groupId: "g1", instanceIdx: 1 }),
+    ];
+    expect(instanceIndicesOf(lines, "g1")).toEqual([0, 1, 2]);
+  });
+
+  it("ignores other groups and standalone lines", () => {
+    const lines: LyricLine[] = [
+      line({ id: "a", groupId: "g1", instanceIdx: 0 }),
+      line({ id: "b", groupId: "g2", instanceIdx: 5 }),
+      line({ id: "c" }),
+    ];
+    expect(instanceIndicesOf(lines, "g1")).toEqual([0]);
+  });
+
+  it("excludes lines missing instanceIdx", () => {
+    const lines: LyricLine[] = [line({ id: "a", groupId: "g1" })];
+    expect(instanceIndicesOf(lines, "g1")).toEqual([]);
+  });
+
+  it("returns an empty array for an unknown group", () => {
+    expect(instanceIndicesOf([line({ id: "a", groupId: "g1", instanceIdx: 0 })], "nope")).toEqual([]);
+  });
+
+  it("sorts numerically, not lexicographically", () => {
+    const lines: LyricLine[] = [
+      line({ id: "a", groupId: "g1", instanceIdx: 10 }),
+      line({ id: "b", groupId: "g1", instanceIdx: 2 }),
+    ];
+    expect(instanceIndicesOf(lines, "g1")).toEqual([2, 10]);
   });
 });

--- a/src/domain/instance/enumerate.ts
+++ b/src/domain/instance/enumerate.ts
@@ -7,6 +7,23 @@ function linesOfInstance(lines: ReadonlyArray<LyricLine>, groupId: string, insta
   return lines.filter((line) => belongsToInstance(line, groupId, instanceIdx));
 }
 
+function instanceIndicesOf(lines: ReadonlyArray<LyricLine>, groupId: string): number[] {
+  const indices = new Set<number>();
+  for (const line of lines) {
+    if (line.groupId === groupId && line.instanceIdx !== undefined) indices.add(line.instanceIdx);
+  }
+  return Array.from(indices).toSorted((a, b) => a - b);
+}
+
+function nextInstanceIdx(lines: ReadonlyArray<LyricLine>, groupId: string): number {
+  let instanceIdx = 0;
+  for (const used of instanceIndicesOf(lines, groupId)) {
+    if (used > instanceIdx) break;
+    if (used === instanceIdx) instanceIdx++;
+  }
+  return instanceIdx;
+}
+
 // -- Exports ------------------------------------------------------------------
 
-export { linesOfInstance };
+export { instanceIndicesOf, linesOfInstance, nextInstanceIdx };

--- a/src/domain/project/normalize-metadata.test.ts
+++ b/src/domain/project/normalize-metadata.test.ts
@@ -29,8 +29,14 @@ describe("normalizeLoadedMetadata", () => {
         isrc: "USQX91700001",
         songwriters: ["W"],
         extra: { spotifyId: "z" },
+        language: "pt-BR",
       });
-      expect(out).toMatchObject({ isrc: "USQX91700001", songwriters: ["W"], extra: { spotifyId: "z" } });
+      expect(out).toMatchObject({
+        isrc: "USQX91700001",
+        songwriters: ["W"],
+        extra: { spotifyId: "z" },
+        language: "pt-BR",
+      });
     });
     it("drops a whitespace-only legacy artist to an empty array", () => {
       expect(normalizeLoadedMetadata({ artist: "   " }).artists).toEqual([]);

--- a/src/domain/word/boundary.roll.test.ts
+++ b/src/domain/word/boundary.roll.test.ts
@@ -1,0 +1,166 @@
+import { shouldRollNeighbour } from "@/domain/word/boundary";
+import type { SyllablePosition } from "@/domain/word/syllable-groups";
+import type { WordTiming } from "@/domain/word/timing";
+import { describe, expect, it } from "vitest";
+
+const w = (text: string, begin: number, end: number): WordTiming => ({ text, begin, end });
+
+describe("shouldRollNeighbour", () => {
+  const flush: WordTiming[] = [w("a ", 0, 1), w("b ", 1, 2), w("c", 2, 3)];
+  const gapped: WordTiming[] = [w("a ", 0, 0.9), w("b ", 1, 1.9), w("c", 2, 3)];
+  const PLAIN: SyllablePosition[] = ["none", "none", "none"];
+  const SYLLABLES: SyllablePosition[] = ["first", "middle", "last"];
+
+  function roll(overrides: Partial<Parameters<typeof shouldRollNeighbour>[0]> = {}): boolean {
+    return shouldRollNeighbour({
+      words: flush,
+      wordIndex: 1,
+      edge: "begin",
+      rollingEdit: false,
+      syllablePositions: PLAIN,
+      ...overrides,
+    });
+  }
+
+  it("leaves separate words alone when rolling edit is off", () => {
+    expect(roll()).toBe(false);
+    expect(roll({ edge: "end" })).toBe(false);
+  });
+
+  it("rolls separate words when rolling edit is on", () => {
+    expect(roll({ rollingEdit: true })).toBe(true);
+    expect(roll({ edge: "end", rollingEdit: true })).toBe(true);
+  });
+
+  it("rolls a boundary inside a syllable group even when rolling edit is off", () => {
+    expect(roll({ syllablePositions: SYLLABLES })).toBe(true);
+    expect(roll({ edge: "end", syllablePositions: SYLLABLES })).toBe(true);
+  });
+
+  it("rolls a boundary inside a syllable group when rolling edit is on", () => {
+    expect(roll({ syllablePositions: SYLLABLES, rollingEdit: true })).toBe(true);
+    expect(roll({ edge: "end", syllablePositions: SYLLABLES, rollingEdit: true })).toBe(true);
+  });
+
+  it("treats the outer edges of a syllable group as separate words", () => {
+    const pair: SyllablePosition[] = ["first", "last", "none"];
+    expect(roll({ wordIndex: 0, edge: "begin", syllablePositions: pair })).toBe(false);
+    expect(roll({ wordIndex: 1, edge: "end", syllablePositions: pair })).toBe(false);
+    expect(roll({ wordIndex: 1, edge: "end", syllablePositions: pair, rollingEdit: true })).toBe(true);
+  });
+
+  describe("alt inversion", () => {
+    it("rolls separate words that would not roll", () => {
+      expect(roll({ altHeld: true })).toBe(true);
+      expect(roll({ edge: "end", altHeld: true })).toBe(true);
+    });
+
+    it("frees separate words that rolling edit would have rolled", () => {
+      expect(roll({ rollingEdit: true, altHeld: true })).toBe(false);
+      expect(roll({ edge: "end", rollingEdit: true, altHeld: true })).toBe(false);
+    });
+
+    it("frees a syllable boundary that would have rolled", () => {
+      expect(roll({ syllablePositions: SYLLABLES, altHeld: true })).toBe(false);
+      expect(roll({ edge: "end", syllablePositions: SYLLABLES, altHeld: true })).toBe(false);
+    });
+
+    it("frees a syllable boundary under rolling edit", () => {
+      expect(roll({ syllablePositions: SYLLABLES, rollingEdit: true, altHeld: true })).toBe(false);
+    });
+
+    it("rejoins a gapped syllable boundary", () => {
+      expect(roll({ words: gapped, syllablePositions: SYLLABLES, altHeld: true })).toBe(true);
+      expect(roll({ words: gapped, edge: "end", syllablePositions: SYLLABLES, altHeld: true })).toBe(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("never rolls across a gap", () => {
+      for (const rollingEdit of [false, true]) {
+        for (const syllablePositions of [PLAIN, SYLLABLES]) {
+          expect(roll({ words: gapped, rollingEdit, syllablePositions })).toBe(false);
+          expect(roll({ words: gapped, edge: "end", rollingEdit, syllablePositions })).toBe(false);
+        }
+      }
+    });
+
+    it("never rolls off the start of the array", () => {
+      for (const altHeld of [false, true]) {
+        for (const rollingEdit of [false, true]) {
+          expect(roll({ wordIndex: 0, edge: "begin", rollingEdit, altHeld })).toBe(false);
+          expect(roll({ wordIndex: 0, edge: "begin", rollingEdit, altHeld, syllablePositions: SYLLABLES })).toBe(false);
+        }
+      }
+    });
+
+    it("never rolls off the end of the array", () => {
+      for (const altHeld of [false, true]) {
+        for (const rollingEdit of [false, true]) {
+          expect(roll({ wordIndex: 2, edge: "end", rollingEdit, altHeld })).toBe(false);
+          expect(roll({ wordIndex: 2, edge: "end", rollingEdit, altHeld, syllablePositions: SYLLABLES })).toBe(false);
+        }
+      }
+    });
+
+    it("is false for an out-of-range index, a negative index, and an empty array", () => {
+      expect(roll({ wordIndex: 99, rollingEdit: true, altHeld: true })).toBe(false);
+      expect(roll({ wordIndex: -1, edge: "end", rollingEdit: true, altHeld: true })).toBe(false);
+      expect(roll({ words: [], wordIndex: 0, rollingEdit: true, altHeld: true })).toBe(false);
+    });
+
+    it("is false for a single-word array on both edges", () => {
+      const single = [w("solo", 1, 2)];
+      expect(roll({ words: single, wordIndex: 0, edge: "begin", rollingEdit: true })).toBe(false);
+      expect(roll({ words: single, wordIndex: 0, edge: "end", rollingEdit: true })).toBe(false);
+    });
+
+    it("treats a missing syllable position as a separate word", () => {
+      expect(roll({ syllablePositions: [] })).toBe(false);
+      expect(roll({ syllablePositions: [], rollingEdit: true })).toBe(true);
+    });
+
+    it("rolls an overlapping pair, which counts as flush", () => {
+      const overlapping = [w("a ", 0, 1.2), w("b", 1, 2)];
+      expect(roll({ words: overlapping, wordIndex: 1, rollingEdit: true })).toBe(true);
+      expect(roll({ words: overlapping, wordIndex: 0, edge: "end", rollingEdit: true })).toBe(true);
+    });
+  });
+
+  describe("invariants", () => {
+    it("does not modify its inputs", () => {
+      const words = [w("a ", 0, 1), w("b", 1, 2)];
+      const positions: SyllablePosition[] = ["first", "last"];
+      const wordsSnapshot = structuredClone(words);
+      const positionsSnapshot = structuredClone(positions);
+      shouldRollNeighbour({
+        words,
+        wordIndex: 1,
+        edge: "begin",
+        rollingEdit: true,
+        syllablePositions: positions,
+        altHeld: true,
+      });
+      expect(words).toEqual(wordsSnapshot);
+      expect(positions).toEqual(positionsSnapshot);
+    });
+
+    it("agrees on both sides of the same boundary", () => {
+      for (const rollingEdit of [false, true]) {
+        for (const altHeld of [false, true]) {
+          for (let i = 0; i < flush.length - 1; i++) {
+            const fromEnd = roll({ wordIndex: i, edge: "end", syllablePositions: SYLLABLES, rollingEdit, altHeld });
+            const fromBegin = roll({
+              wordIndex: i + 1,
+              edge: "begin",
+              syllablePositions: SYLLABLES,
+              rollingEdit,
+              altHeld,
+            });
+            expect(fromEnd).toBe(fromBegin);
+          }
+        }
+      }
+    });
+  });
+});

--- a/src/domain/word/boundary.test.ts
+++ b/src/domain/word/boundary.test.ts
@@ -1,0 +1,86 @@
+import { isBoundaryFlush } from "@/domain/word/boundary";
+import type { WordTiming } from "@/domain/word/timing";
+import { describe, expect, it } from "vitest";
+
+const w = (text: string, begin: number, end: number): WordTiming => ({ text, begin, end });
+
+const conjoined: WordTiming[] = [w("Hel", 0, 0.4), w("lo ", 0.4, 0.9), w("world", 0.9, 1.6)];
+const gapped: WordTiming[] = [w("Hel", 0, 0.4), w("lo ", 0.6, 0.9), w("world", 1.2, 1.6)];
+
+describe("isBoundaryFlush", () => {
+  it("is flush when the previous word ends exactly where this word begins", () => {
+    expect(isBoundaryFlush(conjoined, 1, "begin")).toBe(true);
+  });
+
+  it("is flush when the next word begins exactly where this word ends", () => {
+    expect(isBoundaryFlush(conjoined, 1, "end")).toBe(true);
+  });
+
+  it("is not flush when a gap precedes the word", () => {
+    expect(isBoundaryFlush(gapped, 1, "begin")).toBe(false);
+  });
+
+  it("is not flush when a gap follows the word", () => {
+    expect(isBoundaryFlush(gapped, 1, "end")).toBe(false);
+  });
+
+  describe("edge cases", () => {
+    it("is false at the start of the array for the begin edge", () => {
+      expect(isBoundaryFlush(conjoined, 0, "begin")).toBe(false);
+    });
+
+    it("is false at the end of the array for the end edge", () => {
+      expect(isBoundaryFlush(conjoined, conjoined.length - 1, "end")).toBe(false);
+    });
+
+    it("is false for an empty array", () => {
+      expect(isBoundaryFlush([], 0, "begin")).toBe(false);
+      expect(isBoundaryFlush([], 0, "end")).toBe(false);
+    });
+
+    it("is false for both edges of a single-word array", () => {
+      const single = [w("solo", 1, 2)];
+      expect(isBoundaryFlush(single, 0, "begin")).toBe(false);
+      expect(isBoundaryFlush(single, 0, "end")).toBe(false);
+    });
+
+    it("is false for an index past the end of the array", () => {
+      expect(isBoundaryFlush(conjoined, 99, "begin")).toBe(false);
+      expect(isBoundaryFlush(conjoined, 99, "end")).toBe(false);
+    });
+
+    it("is false for a negative index", () => {
+      expect(isBoundaryFlush(conjoined, -1, "begin")).toBe(false);
+      expect(isBoundaryFlush(conjoined, -1, "end")).toBe(false);
+    });
+
+    it("treats an overlap as flush", () => {
+      const overlapping = [w("Hel", 0, 0.6), w("lo ", 0.4, 0.9), w("world", 0.7, 1.6)];
+      expect(isBoundaryFlush(overlapping, 1, "begin")).toBe(true);
+      expect(isBoundaryFlush(overlapping, 1, "end")).toBe(true);
+    });
+
+    it("treats a zero-length word touching its neighbour as flush", () => {
+      const zeroLength = [w("Hel", 0, 0.4), w("lo ", 0.4, 0.4), w("world", 0.4, 1.6)];
+      expect(isBoundaryFlush(zeroLength, 1, "begin")).toBe(true);
+      expect(isBoundaryFlush(zeroLength, 1, "end")).toBe(true);
+    });
+  });
+
+  describe("invariants", () => {
+    it("does not modify its input", () => {
+      const words = [w("Hel", 0, 0.4), w("lo ", 0.4, 0.9)];
+      const snapshot = structuredClone(words);
+      isBoundaryFlush(words, 1, "begin");
+      isBoundaryFlush(words, 0, "end");
+      expect(words).toEqual(snapshot);
+    });
+
+    it("agrees on both sides of the same boundary", () => {
+      const mixed = [w("a ", 0, 0.4), w("b ", 0.4, 0.9), w("c ", 1.1, 1.5), w("d", 1.5, 2)];
+      for (let i = 0; i < mixed.length - 1; i++) {
+        expect(isBoundaryFlush(mixed, i, "end")).toBe(isBoundaryFlush(mixed, i + 1, "begin"));
+      }
+    });
+  });
+});

--- a/src/domain/word/boundary.test.ts
+++ b/src/domain/word/boundary.test.ts
@@ -1,4 +1,4 @@
-import { isBoundaryFlush } from "@/domain/word/boundary";
+import { clampBoundaryTime, isBoundaryFlush } from "@/domain/word/boundary";
 import type { WordTiming } from "@/domain/word/timing";
 import { describe, expect, it } from "vitest";
 
@@ -81,6 +81,136 @@ describe("isBoundaryFlush", () => {
       for (let i = 0; i < mixed.length - 1; i++) {
         expect(isBoundaryFlush(mixed, i, "end")).toBe(isBoundaryFlush(mixed, i + 1, "begin"));
       }
+    });
+  });
+});
+
+describe("clampBoundaryTime", () => {
+  const trio: WordTiming[] = [w("a", 0, 1), w("b", 1, 2), w("c", 2, 3)];
+
+  function clamp(overrides: Partial<Parameters<typeof clampBoundaryTime>[0]>): number {
+    return clampBoundaryTime({
+      words: trio,
+      wordIndex: 1,
+      edge: "begin",
+      time: 1.5,
+      minDuration: 0.05,
+      rollNeighbour: false,
+      ...overrides,
+    });
+  }
+
+  it("returns the requested time when nothing constrains it", () => {
+    expect(clamp({ time: 1.5 })).toBe(1.5);
+    expect(clamp({ edge: "end", time: 1.5 })).toBe(1.5);
+  });
+
+  it("stops a begin edge at the previous word's end when not rolling", () => {
+    expect(clamp({ time: 0.5 })).toBe(1);
+  });
+
+  it("lets a begin edge pass the previous word's end when rolling", () => {
+    expect(clamp({ time: 0.5, rollNeighbour: true })).toBe(0.5);
+  });
+
+  it("stops an end edge at the next word's begin when not rolling", () => {
+    expect(clamp({ edge: "end", time: 2.5 })).toBe(2);
+  });
+
+  it("lets an end edge pass the next word's begin when rolling", () => {
+    expect(clamp({ edge: "end", time: 2.5, rollNeighbour: true })).toBe(2.5);
+  });
+
+  it("keeps the target word at least minDuration long", () => {
+    expect(clamp({ time: 5 })).toBeCloseTo(1.95, 10);
+    expect(clamp({ edge: "end", time: 0 })).toBeCloseTo(1.05, 10);
+  });
+
+  it("keeps the rolled neighbour at least minDuration long", () => {
+    expect(clamp({ time: -5, rollNeighbour: true })).toBeCloseTo(0.05, 10);
+    expect(clamp({ edge: "end", time: 99, rollNeighbour: true })).toBeCloseTo(2.95, 10);
+  });
+
+  it("caps an end edge at the audio duration", () => {
+    expect(clamp({ wordIndex: 2, edge: "end", time: 99, duration: 5 })).toBe(5);
+  });
+
+  it("prefers the next word's begin over a later audio duration", () => {
+    expect(clamp({ edge: "end", time: 99, duration: 5 })).toBe(2);
+  });
+
+  it("leaves an end edge unbounded when no duration is supplied", () => {
+    expect(clamp({ wordIndex: 2, edge: "end", time: 99 })).toBe(99);
+  });
+
+  describe("edge cases", () => {
+    it("floors the first word's begin at zero", () => {
+      expect(clamp({ wordIndex: 0, time: -5 })).toBe(0);
+      expect(clamp({ wordIndex: 0, time: -5, rollNeighbour: true })).toBe(0);
+    });
+
+    it("returns the requested time when the word does not exist", () => {
+      expect(clamp({ words: [], wordIndex: 0, time: 7 })).toBe(7);
+      expect(clamp({ wordIndex: 99, time: 7 })).toBe(7);
+    });
+
+    it("treats a zero minDuration as no floor of its own", () => {
+      expect(clamp({ time: 99, minDuration: 0 })).toBe(2);
+      expect(clamp({ edge: "end", time: -99, minDuration: 0 })).toBe(1);
+    });
+  });
+
+  describe("regressions", () => {
+    it("regression: never inverts a word when a flush pair is shorter than twice minDuration", () => {
+      const tight: WordTiming[] = [w("a", 0.99, 1), w("b", 1, 1.02)];
+      const rolledBack = clamp({ words: tight, wordIndex: 1, time: 0.95, minDuration: 0.5, rollNeighbour: true });
+      expect(rolledBack).toBeLessThanOrEqual(tight[1].end);
+      expect(rolledBack).toBeGreaterThanOrEqual(tight[0].begin);
+      const rolledOn = clamp({
+        words: tight,
+        wordIndex: 0,
+        edge: "end",
+        time: 0.95,
+        minDuration: 0.5,
+        rollNeighbour: true,
+      });
+      expect(rolledOn).toBeGreaterThanOrEqual(tight[0].begin);
+      expect(rolledOn).toBeLessThanOrEqual(tight[1].end);
+    });
+
+    it("regression: never inverts the last word when the audio ends before it begins", () => {
+      const late: WordTiming[] = [w("a", 0, 1), w("b", 1, 2)];
+      expect(clamp({ words: late, wordIndex: 1, edge: "end", time: 1.7, duration: 0.5 })).toBe(1);
+    });
+
+    it("regression: never inverts a word whose predecessor ends after it does", () => {
+      const overlapping: WordTiming[] = [w("a", 1, 3), w("b", 2, 2.5)];
+      expect(clamp({ words: overlapping, wordIndex: 1, time: 2.3 })).toBe(2.5);
+    });
+  });
+
+  describe("invariants", () => {
+    it("never returns a begin past the word's own end, nor an end before its own begin", () => {
+      const awkward: WordTiming[] = [w("a", 1, 3), w("b", 2, 2.2), w("c", 2.1, 2.15)];
+      for (const time of [-9, 0, 2.1, 5, 99]) {
+        for (const rollNeighbour of [false, true]) {
+          for (const minDuration of [0, 0.05, 0.5]) {
+            for (let i = 0; i < awkward.length; i++) {
+              const begin = clamp({ words: awkward, wordIndex: i, edge: "begin", time, minDuration, rollNeighbour });
+              expect(begin).toBeLessThanOrEqual(awkward[i].end);
+              const end = clamp({ words: awkward, wordIndex: i, edge: "end", time, minDuration, rollNeighbour });
+              expect(end).toBeGreaterThanOrEqual(awkward[i].begin);
+            }
+          }
+        }
+      }
+    });
+
+    it("does not modify its input", () => {
+      const words = [w("a", 0, 1), w("b", 1, 2)];
+      const snapshot = structuredClone(words);
+      clamp({ words, wordIndex: 1, time: 99, rollNeighbour: true });
+      expect(words).toEqual(snapshot);
     });
   });
 });

--- a/src/domain/word/boundary.ts
+++ b/src/domain/word/boundary.ts
@@ -1,0 +1,24 @@
+import type { WordTiming } from "@/domain/word/timing";
+
+// -- Types --------------------------------------------------------------------
+
+type BoundaryEdge = "begin" | "end";
+
+// -- Predicates ---------------------------------------------------------------
+
+// Overlaps count as flush, preserving the drag path's original `prev.end < word.begin` test.
+function isBoundaryFlush(words: readonly WordTiming[], wordIndex: number, edge: BoundaryEdge): boolean {
+  const word = words[wordIndex];
+  if (!word) return false;
+  if (edge === "begin") {
+    const prev = words[wordIndex - 1];
+    return prev !== undefined && prev.end >= word.begin;
+  }
+  const next = words[wordIndex + 1];
+  return next !== undefined && next.begin <= word.end;
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { isBoundaryFlush };
+export type { BoundaryEdge };

--- a/src/domain/word/boundary.ts
+++ b/src/domain/word/boundary.ts
@@ -1,3 +1,4 @@
+import type { SyllablePosition } from "@/domain/word/syllable-groups";
 import type { WordTiming } from "@/domain/word/timing";
 
 // -- Types --------------------------------------------------------------------
@@ -14,6 +15,15 @@ interface BoundaryClampInput {
   duration?: number;
 }
 
+interface RollDecisionInput {
+  words: readonly WordTiming[];
+  wordIndex: number;
+  edge: BoundaryEdge;
+  rollingEdit: boolean;
+  syllablePositions: readonly SyllablePosition[];
+  altHeld?: boolean;
+}
+
 // -- Predicates ---------------------------------------------------------------
 
 // Overlaps count as flush, preserving the drag path's original `prev.end < word.begin` test.
@@ -26,6 +36,33 @@ function isBoundaryFlush(words: readonly WordTiming[], wordIndex: number, edge: 
   }
   const next = words[wordIndex + 1];
   return next !== undefined && next.begin <= word.end;
+}
+
+function isInsideSyllableGroup(position: SyllablePosition | undefined, edge: BoundaryEdge): boolean {
+  if (edge === "end") return position === "first" || position === "middle";
+  return position === "middle" || position === "last";
+}
+
+// -- Roll decision ------------------------------------------------------------
+
+// Syllables of one word carry their neighbour without Rolling; separate words need it.
+// `altHeld` is the drag-only inversion: keyboard paths omit it and take the default.
+function shouldRollNeighbour({
+  words,
+  wordIndex,
+  edge,
+  rollingEdit,
+  syllablePositions,
+  altHeld = false,
+}: RollDecisionInput): boolean {
+  const neighbour = edge === "begin" ? words[wordIndex - 1] : words[wordIndex + 1];
+  // Nothing to roll at the array ends, so Alt has nothing to invert into either.
+  if (!words[wordIndex] || !neighbour) return false;
+
+  const rollsByDefault =
+    (rollingEdit || isInsideSyllableGroup(syllablePositions[wordIndex], edge)) &&
+    isBoundaryFlush(words, wordIndex, edge);
+  return altHeld ? !rollsByDefault : rollsByDefault;
 }
 
 // -- Clamp --------------------------------------------------------------------
@@ -59,5 +96,5 @@ function clampBoundaryTime({
 
 // -- Exports ------------------------------------------------------------------
 
-export { clampBoundaryTime, isBoundaryFlush };
+export { clampBoundaryTime, isBoundaryFlush, shouldRollNeighbour };
 export type { BoundaryEdge };

--- a/src/domain/word/boundary.ts
+++ b/src/domain/word/boundary.ts
@@ -4,6 +4,16 @@ import type { WordTiming } from "@/domain/word/timing";
 
 type BoundaryEdge = "begin" | "end";
 
+interface BoundaryClampInput {
+  words: readonly WordTiming[];
+  wordIndex: number;
+  edge: BoundaryEdge;
+  time: number;
+  minDuration: number;
+  rollNeighbour: boolean;
+  duration?: number;
+}
+
 // -- Predicates ---------------------------------------------------------------
 
 // Overlaps count as flush, preserving the drag path's original `prev.end < word.begin` test.
@@ -18,7 +28,36 @@ function isBoundaryFlush(words: readonly WordTiming[], wordIndex: number, edge: 
   return next !== undefined && next.begin <= word.end;
 }
 
+// -- Clamp --------------------------------------------------------------------
+
+// A pair spanning under twice minDuration cannot satisfy both floors, so the hard
+// ceiling gives up the minimum rather than letting either word invert.
+function clampBoundaryTime({
+  words,
+  wordIndex,
+  edge,
+  time,
+  minDuration,
+  rollNeighbour,
+  duration,
+}: BoundaryClampInput): number {
+  const word = words[wordIndex];
+  if (!word) return time;
+
+  if (edge === "begin") {
+    const prev = words[wordIndex - 1];
+    const floor = rollNeighbour && prev ? prev.begin + minDuration : (prev?.end ?? 0);
+    return Math.min(word.end, Math.max(floor, Math.min(word.end - minDuration, time)));
+  }
+
+  const next = words[wordIndex + 1];
+  const neighbourCeiling = rollNeighbour && next ? next.end : (next?.begin ?? Number.POSITIVE_INFINITY);
+  const hardCeiling = Math.max(word.begin, Math.min(neighbourCeiling, duration ?? Number.POSITIVE_INFINITY));
+  const ceiling = rollNeighbour && next ? next.end - minDuration : hardCeiling;
+  return Math.min(hardCeiling, Math.max(word.begin + minDuration, Math.min(ceiling, time)));
+}
+
 // -- Exports ------------------------------------------------------------------
 
-export { isBoundaryFlush };
+export { clampBoundaryTime, isBoundaryFlush };
 export type { BoundaryEdge };

--- a/src/stores/project/groups-slice.ts
+++ b/src/stores/project/groups-slice.ts
@@ -1,3 +1,4 @@
+import { nextInstanceIdx } from "@/domain/instance/enumerate";
 import { belongsToInstance } from "@/domain/instance/predicates";
 import { type LyricLine, reconcileLine } from "@/domain/line/model";
 import type { LinkGroup } from "@/domain/group/template";
@@ -99,11 +100,7 @@ const createGroupsSlice: StateCreator<ProjectStore, [], [], GroupsState & GroupA
 
   addInstance: (groupId, structure, instanceStart, insertAtIndex) =>
     set((state) => {
-      const usedIndices = new Set(
-        state.lines.flatMap((l) => (l.groupId === groupId && l.instanceIdx !== undefined ? [l.instanceIdx] : [])),
-      );
-      let instanceIdx = 0;
-      while (usedIndices.has(instanceIdx)) instanceIdx++;
+      const instanceIdx = nextInstanceIdx(state.lines, groupId);
 
       const newLines: LyricLine[] = structure.map((tplLine, templateLineIdx) =>
         reconcileLine({

--- a/src/stores/settings.confirm-conform.test.ts
+++ b/src/stores/settings.confirm-conform.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { DEFAULTS, useSettingsStore } from "@/stores/settings";
+
+describe("settings.confirmConformToGroup", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ ...DEFAULTS });
+  });
+
+  it("defaults to true", () => {
+    expect(useSettingsStore.getState().confirmConformToGroup).toBe(true);
+  });
+
+  it("can be toggled via set()", () => {
+    useSettingsStore.getState().set("confirmConformToGroup", false);
+    expect(useSettingsStore.getState().confirmConformToGroup).toBe(false);
+  });
+
+  it("resetToDefaults preserves the user's choice", () => {
+    useSettingsStore.getState().set("confirmConformToGroup", false);
+    useSettingsStore.getState().resetToDefaults();
+    expect(useSettingsStore.getState().confirmConformToGroup).toBe(false);
+  });
+
+  it("is persisted to localStorage", () => {
+    useSettingsStore.setState({ confirmConformToGroup: false });
+    const raw = localStorage.getItem("composer-settings");
+    expect(raw).not.toBeNull();
+    const persisted = JSON.parse(raw ?? "{}");
+    expect(persisted.state.confirmConformToGroup).toBe(false);
+  });
+});

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -67,6 +67,7 @@ interface SettingsState {
   confirmResetShortcuts: boolean;
   confirmGroupDissolution: boolean;
   confirmApplyToAllSyllableSplit: boolean;
+  confirmConformToGroup: boolean;
   linkedDivergenceAction: LinkedDivergenceAction;
 
   previewRenderer: PreviewRenderer;
@@ -134,6 +135,7 @@ const DEFAULTS: SettingsState = {
   confirmResetShortcuts: true,
   confirmGroupDissolution: true,
   confirmApplyToAllSyllableSplit: true,
+  confirmConformToGroup: true,
   linkedDivergenceAction: "ask",
 
   previewRenderer: "braccato",
@@ -191,6 +193,7 @@ const useSettingsStore = create<SettingsState & SettingsActions>()(
           confirmResetShortcuts: state.confirmResetShortcuts,
           confirmGroupDissolution: state.confirmGroupDissolution,
           confirmApplyToAllSyllableSplit: state.confirmApplyToAllSyllableSplit,
+          confirmConformToGroup: state.confirmConformToGroup,
           linkedDivergenceAction: state.linkedDivergenceAction,
           cobaltInstances: state.cobaltInstances,
           selectedCobaltInstanceId: state.selectedCobaltInstanceId,

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { DEFAULT_BRIDGE_URL } from "@/utils/composer-bridge-api";
+import { DEFAULT_MIN_WORD_DURATION } from "@/utils/word-spaces";
 
 // -- Types --------------------------------------------------------------------
 
@@ -114,7 +115,7 @@ const DEFAULTS: SettingsState = {
 
   nudgeAmount: 0.05,
   defaultWordDuration: 0.3,
-  minWordDuration: 0.05,
+  minWordDuration: DEFAULT_MIN_WORD_DURATION,
   redoPreroll: 1.5,
   defaultGranularity: "word",
 

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -15,6 +15,7 @@ interface FactoryLineOptions {
   backgroundTextSource?: "extraction" | "manual";
   groupId?: string;
   instanceIdx?: number;
+  templateLineIdx?: number;
 }
 
 interface FactoryWordOptions {
@@ -61,6 +62,7 @@ function createLine(opts: FactoryLineOptions = {}): LyricLine {
     ...(opts.backgroundTextSource ? { backgroundTextSource: opts.backgroundTextSource } : {}),
     ...(opts.groupId ? { groupId: opts.groupId } : {}),
     ...(opts.instanceIdx !== undefined ? { instanceIdx: opts.instanceIdx } : {}),
+    ...(opts.templateLineIdx !== undefined ? { templateLineIdx: opts.templateLineIdx } : {}),
   });
 }
 

--- a/src/test/file-size-budget.test.ts
+++ b/src/test/file-size-budget.test.ts
@@ -31,7 +31,6 @@ const BASELINE_OVER_BUDGET = new Set<string>([
   // negative value (it would force four new .browser.test.tsx files for a
   // zero-behaviour-change extraction).
   "views/timeline/timeline-context-menu.tsx",
-  "views/timeline/timeline-info-panel.tsx",
   "views/sync/scrollable-line.tsx",
   "views/timeline/line-row.tsx",
   // shortcut-definitions.ts is intentionally exempt: it is a flat declarative

--- a/src/test/no-inline-derivations.test.ts
+++ b/src/test/no-inline-derivations.test.ts
@@ -74,6 +74,11 @@ const FORBIDDEN: ForbiddenPattern[] = [
     use: "isLinked from @/domain/instance/predicates",
   },
   {
+    name: "inline instance-index enumeration",
+    regex: /\.groupId === [\w.]+ &&\s*[\w.]+\.instanceIdx !== undefined/,
+    use: "instanceIndicesOf / nextInstanceIdx from @/domain/instance/enumerate",
+  },
+  {
     name: "inline word-selection identity check",
     regex: /\.wordIndex === [\w.]+\.wordIndex\b/,
     use: "sameWordSelection / isWordSelected from @/domain/selection/identity",

--- a/src/test/word-timing-harness.ts
+++ b/src/test/word-timing-harness.ts
@@ -1,0 +1,45 @@
+import type { LyricLine } from "@/domain/line/model";
+import { createLine } from "@/test/factories";
+import { createWordTimingOps } from "@/utils/timing/word-timing-ops";
+
+// -- Store write seam ---------------------------------------------------------
+
+interface CapturedUpdate {
+  id: string;
+  updates: Partial<LyricLine>;
+  options?: { propagateToSiblings?: boolean };
+}
+
+function captureUpdates() {
+  const calls: CapturedUpdate[] = [];
+  const updateLineWithHistory = (
+    id: string,
+    updates: Partial<LyricLine>,
+    options?: { propagateToSiblings?: boolean },
+  ) => {
+    calls.push({ id, updates, options });
+  };
+  return { calls, updateLineWithHistory };
+}
+
+// -- Factory instances --------------------------------------------------------
+
+const wordsOps = createWordTimingOps({ getWords: (line) => line.words, updateKey: "words" });
+const bgOps = createWordTimingOps({ getWords: (line) => line.backgroundWords, updateKey: "backgroundWords" });
+
+// -- Fixtures -----------------------------------------------------------------
+
+function makeLine() {
+  return createLine({
+    text: "a b c",
+    words: [
+      { text: "a", begin: 0, end: 1 },
+      { text: "b", begin: 1, end: 2 },
+      { text: "c", begin: 2, end: 3 },
+    ],
+  });
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { bgOps, captureUpdates, makeLine, wordsOps };

--- a/src/test/word-timing-harness.ts
+++ b/src/test/word-timing-harness.ts
@@ -29,12 +29,14 @@ const bgOps = createWordTimingOps({ getWords: (line) => line.backgroundWords, up
 
 // -- Fixtures -----------------------------------------------------------------
 
+// Trailing spaces mark word ends: without them these three read as one word
+// split into three syllables, which is a different rolling-boundary case.
 function makeLine() {
   return createLine({
     text: "a b c",
     words: [
-      { text: "a", begin: 0, end: 1 },
-      { text: "b", begin: 1, end: 2 },
+      { text: "a ", begin: 0, end: 1 },
+      { text: "b ", begin: 1, end: 2 },
       { text: "c", begin: 2, end: 3 },
     ],
   });

--- a/src/ui/help-sections/groups-extras.browser.test.tsx
+++ b/src/ui/help-sections/groups-extras.browser.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@/test/render";
+import { GroupsExtras } from "@/ui/help-sections/groups-extras";
+
+describe("GroupsExtras", () => {
+  it("renders the section content", async () => {
+    const screen = await render(<GroupsExtras />);
+    await expect.element(screen.getByRole("heading", { name: "Detaching" })).toBeInTheDocument();
+  });
+
+  it("separates linked fields from per-instance fields", async () => {
+    const screen = await render(<GroupsExtras />);
+    await expect.element(screen.getByRole("heading", { name: "What propagates and what doesn't" })).toBeInTheDocument();
+    expect(screen.container.textContent).toContain("Linked across all instances");
+    expect(screen.container.textContent).toContain("Stays local to one instance");
+  });
+
+  it("documents the three-button split-or-merge prompt", async () => {
+    const screen = await render(<GroupsExtras />);
+    await expect.element(screen.getByRole("heading", { name: "The split-or-merge prompt" })).toBeInTheDocument();
+    expect(screen.container.textContent).toContain("Apply to all");
+    expect(screen.container.textContent).toContain("Detach");
+    expect(screen.container.textContent).toContain("Cancel");
+  });
+
+  it("documents both ways to break a link", async () => {
+    const screen = await render(<GroupsExtras />);
+    expect(screen.container.textContent).toContain("Detach this line");
+    expect(screen.container.textContent).toContain("Detach instance");
+  });
+
+  it("documents emptying an instance and the partial-delete exception", async () => {
+    const screen = await render(<GroupsExtras />);
+    await expect.element(screen.getByRole("heading", { name: "Emptying an instance" })).toBeInTheDocument();
+    expect(screen.container.textContent).toContain("Partial deletes don't trigger this");
+  });
+
+  it("documents the group registry attribute used on export", async () => {
+    const screen = await render(<GroupsExtras />);
+    await expect.element(screen.getByText(/composer:groups/)).toBeInTheDocument();
+  });
+});

--- a/src/ui/help-sections/groups-extras.tsx
+++ b/src/ui/help-sections/groups-extras.tsx
@@ -1,0 +1,113 @@
+import { HEADING, INLINE_CODE, PROSE } from "@/ui/help-sections/shared";
+import { MOD_KEY } from "@/utils/platform";
+
+// -- Linked group extras ------------------------------------------------------
+
+const GroupsExtras: React.FC = () => (
+  <>
+    <div>
+      <h4 className={HEADING}>What propagates and what doesn't</h4>
+      <p className={PROSE}>Linked across all instances:</p>
+      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
+        <li>Word text and line text edits.</li>
+        <li>Agent assignments.</li>
+        <li>Background vocal text.</li>
+        <li>
+          Word splits and merges. Siblings get the new word structure, and Composer keeps the timing of every word that
+          didn't actually change. Only the split or merged word's slot is divided up. Sibling rhythms you carefully
+          synced earlier survive.
+        </li>
+        <li>Moving a word between main and background tracks.</li>
+      </ul>
+      <p className={`${PROSE} mt-2`}>Stays local to one instance:</p>
+      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
+        <li>Absolute begin and end times for each word.</li>
+        <li>Banner shifts and arrow-key nudge.</li>
+        <li>Anything you do on a line that's been detached.</li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 className={HEADING}>The split-or-merge prompt</h4>
+      <p className={PROSE}>
+        When a split or merge on a linked line would actually shift sibling word timings (sibling rhythms differ from
+        the source), Composer pops a three-button modal: <strong>Apply to all</strong> (propagate with timing
+        preservation), <strong>Detach</strong> (keep the change on this line only, unlink it from the group), or{" "}
+        <strong>Cancel</strong>. The modal stays out of the way when sibling rhythms already match the source, since
+        propagation is a no-op for the unchanged words anyway.
+      </p>
+      <p className={`${PROSE} mt-2`}>
+        Tick "Don't ask again" in the modal to default to your choice next time. Reset the preference from{" "}
+        <strong>Settings → Confirmations</strong>.
+      </p>
+    </div>
+
+    <div>
+      <h4 className={HEADING}>Detaching</h4>
+      <p className={PROSE}>
+        Real songs aren't perfectly repetitive. The last chorus might add an extra "yeah" or land on a different agent.
+        Two ways to break the link:
+      </p>
+      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
+        <li>
+          Right-click a line in the gutter and pick <strong>Detach this line</strong>. That single line stops syncing
+          with siblings; everything else stays linked.
+        </li>
+        <li>
+          Right-click the banner and pick <strong>Detach instance</strong>. The whole instance becomes plain standalone
+          lines. Other instances keep their group.
+        </li>
+      </ul>
+      <p className={`${PROSE} mt-2`}>
+        Both are undoable: the toast that appears has an Undo button, or press {MOD_KEY} + Z.
+      </p>
+    </div>
+
+    <div>
+      <h4 className={HEADING}>Emptying an instance</h4>
+      <p className={PROSE}>
+        Click the banner to select every word in an instance, then press <strong>Delete</strong>. Composer clears the
+        timed content and notices the instance is now empty across all its lines, so it strips the group attrs from
+        those rows automatically. You're left with empty placeholders that the fill flow above can repopulate later. The
+        other instances of the group are untouched.
+      </p>
+      <p className={`${PROSE} mt-2`}>
+        Partial deletes don't trigger this: if one line of a multi-line instance still has timed words, the instance
+        stays linked.
+      </p>
+    </div>
+
+    <div>
+      <h4 className={HEADING}>Deleting a group</h4>
+      <p className={PROSE}>
+        Right-click any banner and pick <strong>Delete group</strong>. A confirmation modal warns you that all instances
+        will become standalone (text and timing survive, they just stop syncing). Tick "Don't ask again" to skip the
+        modal next time, or restore the prompt from <strong>Settings → Confirmations</strong>.
+      </p>
+    </div>
+
+    <div>
+      <h4 className={HEADING}>How groups look outside the Timeline</h4>
+      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
+        <li>
+          <strong>Edit view</strong>: a colored divider with the group name and instance count appears before each
+          instance, plus a thin closing line at the end. Each grouped line also gets a left-edge stripe in the group
+          color and a hover tooltip showing the link count.
+        </li>
+        <li>
+          <strong>Sync view</strong>: the gutter cell shows a chain icon and an instance counter so you know which
+          chorus you're syncing.
+        </li>
+        <li>
+          <strong>TTML export</strong>: groups round-trip via a custom{" "}
+          <span className={INLINE_CODE}>composer:groups</span> registry plus per-line attributes. Other TTML players
+          ignore them; Composer reads them back exactly as saved.
+        </li>
+      </ul>
+    </div>
+  </>
+);
+
+// -- Exports ------------------------------------------------------------------
+
+export { GroupsExtras };

--- a/src/ui/help-sections/groups.browser.test.tsx
+++ b/src/ui/help-sections/groups.browser.test.tsx
@@ -12,4 +12,12 @@ describe("GroupsSection", () => {
     const screen = await render(<GroupsSection />);
     await expect.poll(() => screen.container.querySelectorAll("[data-inline-key-badge]").length).toBeGreaterThan(0);
   });
+
+  it("documents conforming lines to an existing group", async () => {
+    const screen = await render(<GroupsSection />);
+    await expect.element(screen.getByRole("heading", { name: "Adding more instances" })).toBeInTheDocument();
+    expect(screen.container.textContent).toContain("Conform");
+    expect(screen.container.textContent).toContain("exactly as long as the group");
+    expect(screen.container.textContent).toContain("at the playhead when those lines had no timing yet");
+  });
 });

--- a/src/ui/help-sections/groups.tsx
+++ b/src/ui/help-sections/groups.tsx
@@ -1,5 +1,6 @@
 import { getEffectiveKeysArray } from "@/stores/shortcut-bindings";
-import { HEADING, INLINE_CODE, PROSE } from "@/ui/help-sections/shared";
+import { GroupsExtras } from "@/ui/help-sections/groups-extras";
+import { HEADING, PROSE } from "@/ui/help-sections/shared";
 import { InlineKeyBadge } from "@/ui/inline-key-badge";
 import { MOD_KEY } from "@/utils/platform";
 
@@ -192,106 +193,7 @@ const GroupsSection: React.FC = () => (
       </p>
     </div>
 
-    <div>
-      <h4 className={HEADING}>What propagates and what doesn't</h4>
-      <p className={PROSE}>Linked across all instances:</p>
-      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
-        <li>Word text and line text edits.</li>
-        <li>Agent assignments.</li>
-        <li>Background vocal text.</li>
-        <li>
-          Word splits and merges. Siblings get the new word structure, and Composer keeps the timing of every word that
-          didn't actually change. Only the split or merged word's slot is divided up. Sibling rhythms you carefully
-          synced earlier survive.
-        </li>
-        <li>Moving a word between main and background tracks.</li>
-      </ul>
-      <p className={`${PROSE} mt-2`}>Stays local to one instance:</p>
-      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
-        <li>Absolute begin and end times for each word.</li>
-        <li>Banner shifts and arrow-key nudge.</li>
-        <li>Anything you do on a line that's been detached.</li>
-      </ul>
-    </div>
-
-    <div>
-      <h4 className={HEADING}>The split-or-merge prompt</h4>
-      <p className={PROSE}>
-        When a split or merge on a linked line would actually shift sibling word timings (sibling rhythms differ from
-        the source), Composer pops a three-button modal: <strong>Apply to all</strong> (propagate with timing
-        preservation), <strong>Detach</strong> (keep the change on this line only, unlink it from the group), or{" "}
-        <strong>Cancel</strong>. The modal stays out of the way when sibling rhythms already match the source, since
-        propagation is a no-op for the unchanged words anyway.
-      </p>
-      <p className={`${PROSE} mt-2`}>
-        Tick "Don't ask again" in the modal to default to your choice next time. Reset the preference from{" "}
-        <strong>Settings → Confirmations</strong>.
-      </p>
-    </div>
-
-    <div>
-      <h4 className={HEADING}>Detaching</h4>
-      <p className={PROSE}>
-        Real songs aren't perfectly repetitive. The last chorus might add an extra "yeah" or land on a different agent.
-        Two ways to break the link:
-      </p>
-      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
-        <li>
-          Right-click a line in the gutter and pick <strong>Detach this line</strong>. That single line stops syncing
-          with siblings; everything else stays linked.
-        </li>
-        <li>
-          Right-click the banner and pick <strong>Detach instance</strong>. The whole instance becomes plain standalone
-          lines. Other instances keep their group.
-        </li>
-      </ul>
-      <p className={`${PROSE} mt-2`}>
-        Both are undoable: the toast that appears has an Undo button, or press {MOD_KEY} + Z.
-      </p>
-    </div>
-
-    <div>
-      <h4 className={HEADING}>Emptying an instance</h4>
-      <p className={PROSE}>
-        Click the banner to select every word in an instance, then press <strong>Delete</strong>. Composer clears the
-        timed content and notices the instance is now empty across all its lines, so it strips the group attrs from
-        those rows automatically. You're left with empty placeholders that the fill flow above can repopulate later. The
-        other instances of the group are untouched.
-      </p>
-      <p className={`${PROSE} mt-2`}>
-        Partial deletes don't trigger this: if one line of a multi-line instance still has timed words, the instance
-        stays linked.
-      </p>
-    </div>
-
-    <div>
-      <h4 className={HEADING}>Deleting a group</h4>
-      <p className={PROSE}>
-        Right-click any banner and pick <strong>Delete group</strong>. A confirmation modal warns you that all instances
-        will become standalone (text and timing survive, they just stop syncing). Tick "Don't ask again" to skip the
-        modal next time, or restore the prompt from <strong>Settings → Confirmations</strong>.
-      </p>
-    </div>
-
-    <div>
-      <h4 className={HEADING}>How groups look outside the Timeline</h4>
-      <ul className={`${PROSE} list-disc pl-4 space-y-1`}>
-        <li>
-          <strong>Edit view</strong>: a colored divider with the group name and instance count appears before each
-          instance, plus a thin closing line at the end. Each grouped line also gets a left-edge stripe in the group
-          color and a hover tooltip showing the link count.
-        </li>
-        <li>
-          <strong>Sync view</strong>: the gutter cell shows a chain icon and an instance counter so you know which
-          chorus you're syncing.
-        </li>
-        <li>
-          <strong>TTML export</strong>: groups round-trip via a custom{" "}
-          <span className={INLINE_CODE}>composer:groups</span> registry plus per-line attributes. Other TTML players
-          ignore them; Composer reads them back exactly as saved.
-        </li>
-      </ul>
-    </div>
+    <GroupsExtras />
   </div>
 );
 

--- a/src/ui/help-sections/groups.tsx
+++ b/src/ui/help-sections/groups.tsx
@@ -65,6 +65,12 @@ const GroupsSection: React.FC = () => (
         You can also use the regular clipboard: select every word of an instance ({MOD_KEY} + C with the banner
         selected), then paste ({MOD_KEY} + V) somewhere else. Same fill/insert behavior at the destination.
       </p>
+      <p className={`${PROSE} mt-2`}>
+        A third route is <strong>Conform</strong>: select contiguous ungrouped lines, right-click, and pick "Conform to
+        [Chorus]". The item only shows when the selection is exactly as long as the group. It swaps those lines' text,
+        timing, agent and background vocals for the group's, landing where the selection already sat, or at the playhead
+        when those lines had no timing yet. Composer asks before overwriting, and {MOD_KEY} + Z undoes it.
+      </p>
     </div>
 
     <div>

--- a/src/ui/help-sections/timeline.browser.test.tsx
+++ b/src/ui/help-sections/timeline.browser.test.tsx
@@ -133,6 +133,15 @@ describe("TimelineSection", () => {
     expect(dropItem?.querySelector("[data-inline-key-badge]")).not.toBeNull();
   });
 
+  it("documents rolling edit on the boundary shortcuts and info panel buttons", async () => {
+    const screen = await render(<TimelineSection />);
+    const items = Array.from(screen.container.querySelectorAll("li"));
+    const boundaryItem = items.find((li) => li.textContent?.includes("snap a word's start or end"));
+    expect(boundaryItem?.textContent).toContain("carries that neighbor along");
+    expect(boundaryItem?.textContent).toContain("buttons in the info panel do the same thing");
+    expect(boundaryItem?.querySelectorAll("[data-inline-key-badge]").length).toBe(2);
+  });
+
   it("drops the stale waveform double-click placement copy", async () => {
     const screen = await render(<TimelineSection />);
     expect(screen.container.textContent).not.toContain("double-click the waveform");

--- a/src/ui/help-sections/timeline.browser.test.tsx
+++ b/src/ui/help-sections/timeline.browser.test.tsx
@@ -142,6 +142,14 @@ describe("TimelineSection", () => {
     expect(boundaryItem?.querySelectorAll("[data-inline-key-badge]").length).toBe(2);
   });
 
+  it("documents that the boundary shortcuts keep syllables joined without Rolling", async () => {
+    const screen = await render(<TimelineSection />);
+    const items = Array.from(screen.container.querySelectorAll("li"));
+    const boundaryItem = items.find((li) => li.textContent?.includes("snap a word's start or end"));
+    expect(boundaryItem?.textContent).toContain("stay joined whether Rolling is on or off");
+    expect(boundaryItem?.textContent).toContain("just as they do when you drag");
+  });
+
   it("drops the stale waveform double-click placement copy", async () => {
     const screen = await render(<TimelineSection />);
     expect(screen.container.textContent).not.toContain("double-click the waveform");

--- a/src/ui/help-sections/timeline.tsx
+++ b/src/ui/help-sections/timeline.tsx
@@ -106,6 +106,14 @@ const TimelineSection: React.FC = () => (
           <strong>Set End</strong> buttons in the info panel do the same thing.
         </li>
         <li>
+          With nothing selected and the playhead resting in the space between two words, those same two keys reach for
+          the nearest word instead of doing nothing.{" "}
+          <InlineKeyBadge keys={getEffectiveKeysArray("timeline.setWordBegin")} /> pulls back the word that starts after
+          the playhead, and <InlineKeyBadge keys={getEffectiveKeysArray("timeline.setWordEnd")} /> pushes forward the
+          word that ended before it, so two keystrokes close a gap from both sides. Neither one drags a neighbor along,
+          since a word across a gap has nothing to stay joined to.
+        </li>
+        <li>
           With one or more words selected, press <InlineKeyBadge keys={getEffectiveKeysArray("timeline.nudgeLeft")} /> /{" "}
           <InlineKeyBadge keys={getEffectiveKeysArray("timeline.nudgeRight")} /> to nudge them as a group. Each word
           keeps its duration, and the nudge stops at the neighboring word so nothing overlaps.

--- a/src/ui/help-sections/timeline.tsx
+++ b/src/ui/help-sections/timeline.tsx
@@ -100,7 +100,9 @@ const TimelineSection: React.FC = () => (
         <li>
           Use <InlineKeyBadge keys={getEffectiveKeysArray("timeline.setWordBegin")} /> and{" "}
           <InlineKeyBadge keys={getEffectiveKeysArray("timeline.setWordEnd")} /> to snap a word's start or end to the
-          current playhead position.
+          current playhead position. With <strong>Rolling</strong> on, moving an edge that sits flush against its
+          neighbor carries that neighbor along, so the two stay joined. The <strong>Set Begin</strong> and{" "}
+          <strong>Set End</strong> buttons in the info panel do the same thing.
         </li>
         <li>
           With one or more words selected, press <InlineKeyBadge keys={getEffectiveKeysArray("timeline.nudgeLeft")} /> /{" "}

--- a/src/ui/help-sections/timeline.tsx
+++ b/src/ui/help-sections/timeline.tsx
@@ -101,7 +101,8 @@ const TimelineSection: React.FC = () => (
           Use <InlineKeyBadge keys={getEffectiveKeysArray("timeline.setWordBegin")} /> and{" "}
           <InlineKeyBadge keys={getEffectiveKeysArray("timeline.setWordEnd")} /> to snap a word's start or end to the
           current playhead position. With <strong>Rolling</strong> on, moving an edge that sits flush against its
-          neighbor carries that neighbor along, so the two stay joined. The <strong>Set Begin</strong> and{" "}
+          neighbor carries that neighbor along, so the two stay joined. Flush syllables of one word stay joined whether
+          Rolling is on or off, just as they do when you drag the boundary. The <strong>Set Begin</strong> and{" "}
           <strong>Set End</strong> buttons in the info panel do the same thing.
         </li>
         <li>

--- a/src/ui/settings/confirmations-section.tsx
+++ b/src/ui/settings/confirmations-section.tsx
@@ -48,6 +48,11 @@ const ConfirmationsSection: React.FC = () => {
           description="Show a warning when a syllable split would also apply to other identical words across the project."
           settingKey="confirmApplyToAllSyllableSplit"
         />
+        <ToggleSetting
+          label="Confirm conforming lines to a group"
+          description="Show a warning before existing lines take on a group's text and timing."
+          settingKey="confirmConformToGroup"
+        />
       </div>
     </div>
   );

--- a/src/utils/lyrics-parsers.ttml.test.ts
+++ b/src/utils/lyrics-parsers.ttml.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import type { ProjectMetadata } from "@/domain/project/metadata";
 import { parseLyricsFile } from "@/utils/lyrics-parsers";
+import { generateTTML } from "@/utils/ttml";
 
 describe("parseLyricsFile - TTML with undeclared namespaces (AMLL)", () => {
   it("parses an AMLL export that uses <amll:meta> without declaring xmlns:amll", () => {
@@ -123,5 +125,48 @@ describe("parseLyricsFile - TTML background provenance", () => {
     const result = parseLyricsFile("song.ttml", content);
     expect(result.lines[0].backgroundText).toBeUndefined();
     expect(result.lines[0].backgroundTextSource).toBeUndefined();
+  });
+});
+
+describe("parseLyricsFile - TTML language", () => {
+  const ttmlWith = (language?: string, metaEls = "") => {
+    const langAttr = language === undefined ? "" : ` xml:lang="${language}"`;
+    return `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:composer="https://composer.betterlyrics.org/ttml"${langAttr}><head><metadata><ttm:agent type="person" xml:id="v1"/>${metaEls}</metadata></head><body><div><p begin="00:01.000" end="00:02.000" ttm:agent="v1"><span begin="00:01.000" end="00:01.500">Ola</span> <span begin="00:01.500" end="00:02.000">mundo</span></p></div></body></tt>`;
+  };
+  const languageOf = (content: string) => parseLyricsFile("song.ttml", content).metadata.language;
+
+  it("reads xml:lang from the root tt element", () => {
+    expect(languageOf(ttmlWith("ja"))).toBe("ja");
+  });
+
+  it("leaves the language undefined when the root has no xml:lang", () => {
+    expect(languageOf(ttmlWith())).toBeUndefined();
+  });
+
+  it("keeps a script subtag intact", () => {
+    expect(languageOf(ttmlWith("zh-Hant"))).toBe("zh-Hant");
+  });
+
+  describe("edge cases", () => {
+    it("treats an empty xml:lang as no language", () => {
+      expect(languageOf(ttmlWith(""))).toBeUndefined();
+    });
+
+    it("trims surrounding whitespace off the language", () => {
+      expect(languageOf(ttmlWith("  ja  "))).toBe("ja");
+    });
+  });
+
+  describe("invariants", () => {
+    it("lets the root xml:lang win over a composer:meta language key", () => {
+      expect(languageOf(ttmlWith("ko", '<composer:meta key="language" value="ja"/>'))).toBe("ko");
+    });
+
+    it("survives a parse, export and re-parse cycle", () => {
+      const first = parseLyricsFile("song.ttml", ttmlWith("pt-BR"));
+      const metadata: ProjectMetadata = { title: "", artists: [], album: "", duration: 0, ...first.metadata };
+      const exported = generateTTML({ metadata, agents: [], lines: first.lines, granularity: "word" });
+      expect(parseLyricsFile("song.ttml", exported).metadata.language).toBe("pt-BR");
+    });
   });
 });

--- a/src/utils/lyrics-parsers/ttml.ts
+++ b/src/utils/lyrics-parsers/ttml.ts
@@ -48,6 +48,9 @@ function parseTtml(content: string, _fallbackDuration?: number): ParseResult {
   const ttmTitleEl = doc.getElementsByTagName("ttm:title")[0];
   if (ttmTitleEl?.textContent && !metadata.title) metadata.title = ttmTitleEl.textContent;
 
+  const documentLanguage = doc.documentElement.getAttribute("xml:lang")?.trim();
+  if (documentLanguage) metadata.language = documentLanguage;
+
   const metaEls = Array.from(
     new Set(
       Array.from(doc.getElementsByTagName("composer:meta")).concat(

--- a/src/utils/timing/bg-word-timing.ts
+++ b/src/utils/timing/bg-word-timing.ts
@@ -4,7 +4,7 @@ import { createWordTimingOps } from "@/utils/timing/word-timing-ops";
 const { nudgeBegin, setBegin, nudgeEnd, setEnd, setBoundary } = createWordTimingOps({
   getWords: (line) => line.backgroundWords,
   updateKey: "backgroundWords",
-  buildUpdate: manualBackgroundWordEdit,
+  buildBoundaryUpdate: manualBackgroundWordEdit,
 });
 
 export {

--- a/src/utils/timing/bg-word-timing.ts
+++ b/src/utils/timing/bg-word-timing.ts
@@ -1,8 +1,10 @@
+import { manualBackgroundWordEdit } from "@/domain/line/background";
 import { createWordTimingOps } from "@/utils/timing/word-timing-ops";
 
-const { nudgeBegin, setBegin, nudgeEnd, setEnd } = createWordTimingOps({
+const { nudgeBegin, setBegin, nudgeEnd, setEnd, setBoundary } = createWordTimingOps({
   getWords: (line) => line.backgroundWords,
   updateKey: "backgroundWords",
+  buildUpdate: manualBackgroundWordEdit,
 });
 
 export {
@@ -10,4 +12,5 @@ export {
   setBegin as setBgWordBegin,
   nudgeEnd as nudgeBgWordEnd,
   setEnd as setBgWordEnd,
+  setBoundary as setBgWordBoundary,
 };

--- a/src/utils/timing/word-timing-ops.boundary.test.ts
+++ b/src/utils/timing/word-timing-ops.boundary.test.ts
@@ -268,7 +268,7 @@ describe("setBoundary write shape vs mutateWord write shape", () => {
     expect((calls[0].updates.backgroundWords ?? [])[1].begin).toBe(1.5);
   });
 
-  it("an instance without a buildUpdate hook writes only the word array", () => {
+  it("an instance without a buildBoundaryUpdate hook writes only the word array", () => {
     const { calls, updateLineWithHistory } = captureUpdates();
     bgOps.setBegin([bgLine()], 0, 1, 1.5, updateLineWithHistory);
     expect(Object.keys(calls[0].updates)).toEqual(["backgroundWords"]);

--- a/src/utils/timing/word-timing-ops.boundary.test.ts
+++ b/src/utils/timing/word-timing-ops.boundary.test.ts
@@ -1,0 +1,259 @@
+import type { LyricLine } from "@/domain/line/model";
+import type { BoundaryEdge } from "@/domain/word/boundary";
+import { createLine } from "@/test/factories";
+import { bgOps, captureUpdates, makeLine, wordsOps } from "@/test/word-timing-harness";
+import { setBgWordBegin, setBgWordBoundary } from "@/utils/timing/bg-word-timing";
+import { describe, expect, it } from "vitest";
+
+describe("createWordTimingOps: setBoundary", () => {
+  interface BoundaryCase {
+    wordIdx: number;
+    edge: BoundaryEdge;
+    time: number;
+    rolling: boolean;
+    minDuration?: number;
+    duration?: number;
+    line?: LyricLine;
+    lines?: LyricLine[];
+  }
+
+  function run(boundaryCase: BoundaryCase) {
+    const { calls, updateLineWithHistory } = captureUpdates();
+    const line = boundaryCase.line ?? makeLine();
+    wordsOps.setBoundary({
+      lines: boundaryCase.lines ?? [line],
+      lineIdx: 0,
+      wordIdx: boundaryCase.wordIdx,
+      edge: boundaryCase.edge,
+      time: boundaryCase.time,
+      minDuration: boundaryCase.minDuration ?? 0.05,
+      rolling: boundaryCase.rolling,
+      ...(boundaryCase.duration !== undefined ? { duration: boundaryCase.duration } : {}),
+      updateLineWithHistory,
+    });
+    return { calls, words: calls[0]?.updates.words ?? [] };
+  }
+
+  const gappedLine = () =>
+    createLine({
+      text: "a b",
+      words: [
+        { text: "a", begin: 0, end: 1 },
+        { text: "b", begin: 1.5, end: 2.5 },
+      ],
+    });
+
+  it("moves only the target word when rolling is off", () => {
+    const { words } = run({ wordIdx: 1, edge: "begin", time: 1.5, rolling: false });
+    expect(words[1].begin).toBe(1.5);
+    expect(words[0]).toEqual({ text: "a", begin: 0, end: 1 });
+  });
+
+  it("drags the previous word's end along a flush begin boundary when rolling", () => {
+    const { words } = run({ wordIdx: 1, edge: "begin", time: 1.5, rolling: true });
+    expect(words[1].begin).toBe(1.5);
+    expect(words[0].end).toBe(1.5);
+  });
+
+  it("drags the next word's begin along a flush end boundary when rolling", () => {
+    const { words } = run({ wordIdx: 1, edge: "end", time: 1.5, rolling: true });
+    expect(words[1].end).toBe(1.5);
+    expect(words[2].begin).toBe(1.5);
+  });
+
+  it("leaves the neighbour alone across a gap, even when rolling", () => {
+    const fromBegin = run({ line: gappedLine(), wordIdx: 1, edge: "begin", time: 1.2, rolling: true });
+    expect(fromBegin.words[1].begin).toBe(1.2);
+    expect(fromBegin.words[0].end).toBe(1);
+    const fromEnd = run({ line: gappedLine(), wordIdx: 0, edge: "end", time: 1.3, rolling: true });
+    expect(fromEnd.words[0].end).toBe(1.3);
+    expect(fromEnd.words[1].begin).toBe(1.5);
+  });
+
+  it("does not roll at the first index for begin", () => {
+    const { words } = run({ wordIdx: 0, edge: "begin", time: 0.5, rolling: true });
+    expect(words[0].begin).toBe(0.5);
+    expect(words[1]).toEqual({ text: "b", begin: 1, end: 2 });
+  });
+
+  it("does not roll at the last index for end", () => {
+    const { words } = run({ wordIdx: 2, edge: "end", time: 4, rolling: true });
+    expect(words[2].end).toBe(4);
+    expect(words[1]).toEqual({ text: "b", begin: 1, end: 2 });
+  });
+
+  it("keeps the target word at least minDuration long", () => {
+    expect(run({ wordIdx: 1, edge: "begin", time: 5, rolling: false }).words[1].begin).toBeCloseTo(1.95, 10);
+    expect(run({ wordIdx: 1, edge: "end", time: 0, rolling: false }).words[1].end).toBeCloseTo(1.05, 10);
+  });
+
+  it("keeps the rolled neighbour at least minDuration long", () => {
+    const rolledBack = run({ wordIdx: 1, edge: "begin", time: -5, rolling: true });
+    expect(rolledBack.words[0].end).toBeCloseTo(0.05, 10);
+    expect(rolledBack.words[1].begin).toBeCloseTo(0.05, 10);
+    const rolledForward = run({ wordIdx: 1, edge: "end", time: 99, rolling: true });
+    expect(rolledForward.words[2].begin).toBeCloseTo(2.95, 10);
+    expect(rolledForward.words[1].end).toBeCloseTo(2.95, 10);
+  });
+
+  it("heals an overlapping pair when rolling a flush begin boundary", () => {
+    const overlapping = createLine({
+      text: "a b",
+      words: [
+        { text: "a", begin: 0, end: 1.2 },
+        { text: "b", begin: 1, end: 2 },
+      ],
+    });
+    const { words } = run({ line: overlapping, wordIdx: 1, edge: "begin", time: 1.5, rolling: true });
+    expect(words[1].begin).toBe(1.5);
+    expect(words[0].end).toBe(1.5);
+  });
+
+  it("caps the last word's end at the audio duration", () => {
+    const { words } = run({ wordIdx: 2, edge: "end", time: 99, rolling: false, duration: 5 });
+    expect(words[2].end).toBe(5);
+  });
+
+  it("caps at the next word's begin when that is earlier than the audio duration", () => {
+    const { words } = run({ wordIdx: 1, edge: "end", time: 99, rolling: false, duration: 5 });
+    expect(words[1].end).toBe(2);
+  });
+
+  it("leaves the end unbounded when no duration is supplied", () => {
+    expect(run({ wordIdx: 2, edge: "end", time: 99, rolling: false }).words[2].end).toBe(99);
+  });
+
+  it("calls updateLineWithHistory exactly once when rolling", () => {
+    expect(run({ wordIdx: 1, edge: "begin", time: 1.5, rolling: true }).calls).toHaveLength(1);
+    expect(run({ wordIdx: 1, edge: "end", time: 1.5, rolling: true }).calls).toHaveLength(1);
+  });
+
+  it("passes propagateToSiblings: false", () => {
+    const { calls } = run({ wordIdx: 1, edge: "begin", time: 1.5, rolling: true });
+    expect(calls[0].options?.propagateToSiblings).toBe(false);
+  });
+
+  describe("edge cases", () => {
+    it("no-ops when the line is missing", () => {
+      expect(run({ lines: [], wordIdx: 0, edge: "begin", time: 1, rolling: true }).calls).toHaveLength(0);
+    });
+
+    it("no-ops when the word index is out of range", () => {
+      expect(run({ wordIdx: 9, edge: "begin", time: 1, rolling: true }).calls).toHaveLength(0);
+    });
+
+    it("no-ops when getWords returns undefined", () => {
+      const { calls, updateLineWithHistory } = captureUpdates();
+      setBgWordBoundary({
+        lines: [createLine({ text: "Lead" })],
+        lineIdx: 0,
+        wordIdx: 0,
+        edge: "begin",
+        time: 1,
+        minDuration: 0.05,
+        rolling: true,
+        updateLineWithHistory,
+      });
+      expect(calls).toHaveLength(0);
+    });
+
+    it("never sets a begin below zero", () => {
+      expect(run({ wordIdx: 0, edge: "begin", time: -5, rolling: false }).words[0].begin).toBe(0);
+      expect(run({ wordIdx: 0, edge: "begin", time: -5, rolling: true }).words[0].begin).toBe(0);
+    });
+  });
+
+  describe("regressions", () => {
+    it("regression: never inverts a word when the flush pair is shorter than twice minDuration", () => {
+      const tight = () =>
+        createLine({
+          text: "a b",
+          words: [
+            { text: "a", begin: 0.9, end: 1 },
+            { text: "b", begin: 1, end: 1.02 },
+          ],
+        });
+      const rolledBack = run({ line: tight(), wordIdx: 1, edge: "begin", time: 0.95, minDuration: 0.5, rolling: true });
+      expect(rolledBack.words[1].begin).toBeLessThanOrEqual(rolledBack.words[1].end);
+      expect(rolledBack.words[0].begin).toBeLessThanOrEqual(rolledBack.words[0].end);
+      const rolledOn = run({ line: tight(), wordIdx: 0, edge: "end", time: 0.95, minDuration: 0.5, rolling: true });
+      expect(rolledOn.words[0].begin).toBeLessThanOrEqual(rolledOn.words[0].end);
+      expect(rolledOn.words[1].begin).toBeLessThanOrEqual(rolledOn.words[1].end);
+    });
+
+    it("regression: never inverts a word whose begin is past a shorter audio duration", () => {
+      const lastWord = run({ wordIdx: 2, edge: "end", time: 99, rolling: false, duration: 1.5 });
+      expect(lastWord.words[2].begin).toBeLessThanOrEqual(lastWord.words[2].end);
+      const rolled = run({ wordIdx: 1, edge: "end", time: 99, rolling: true, duration: 0.5 });
+      expect(rolled.words[1].begin).toBeLessThanOrEqual(rolled.words[1].end);
+      expect(rolled.words[2].begin).toBeLessThanOrEqual(rolled.words[2].end);
+    });
+  });
+
+  describe("invariants", () => {
+    it("never lets a word's begin exceed its end", () => {
+      const { words } = run({ wordIdx: 1, edge: "begin", time: 99, rolling: true });
+      expect(words[1]).toEqual({ text: "b", begin: 1.95, end: 2 });
+    });
+
+    it("does not modify the input words array", () => {
+      const line = makeLine();
+      const snapshot = structuredClone(line.words);
+      const { calls } = run({ line, wordIdx: 1, edge: "begin", time: 1.5, rolling: true });
+      expect(line.words).toEqual(snapshot);
+      expect(calls[0].updates.words).not.toBe(line.words);
+    });
+  });
+});
+
+describe("setBoundary write shape vs mutateWord write shape", () => {
+  function bgLine() {
+    return createLine({
+      text: "Lead",
+      backgroundText: "ooh aah",
+      backgroundWords: [
+        { text: "ooh ", begin: 0, end: 1 },
+        { text: "aah", begin: 1, end: 2 },
+      ],
+    });
+  }
+
+  function runBgBoundary() {
+    const { calls, updateLineWithHistory } = captureUpdates();
+    setBgWordBoundary({
+      lines: [bgLine()],
+      lineIdx: 0,
+      wordIdx: 1,
+      edge: "begin",
+      time: 1.5,
+      minDuration: 0.05,
+      rolling: false,
+      updateLineWithHistory,
+    });
+    return calls;
+  }
+
+  it("setBoundary marks a background edit as manual", () => {
+    const calls = runBgBoundary();
+    expect(calls[0].updates.backgroundTextSource).toBe("manual");
+    expect((calls[0].updates.backgroundWords ?? [])[1].begin).toBe(1.5);
+  });
+
+  it("setBoundary leaves backgroundText unchanged for a timing-only edit", () => {
+    expect(runBgBoundary()[0].updates.backgroundText).toBe("ooh aah");
+  });
+
+  it("setBgWordBegin still writes raw, leaving background provenance untouched", () => {
+    const { calls, updateLineWithHistory } = captureUpdates();
+    setBgWordBegin([bgLine()], 0, 1, 1.5, updateLineWithHistory);
+    expect("backgroundTextSource" in calls[0].updates).toBe(false);
+    expect("backgroundText" in calls[0].updates).toBe(false);
+    expect((calls[0].updates.backgroundWords ?? [])[1].begin).toBe(1.5);
+  });
+
+  it("an instance without a buildUpdate hook writes only the word array", () => {
+    const { calls, updateLineWithHistory } = captureUpdates();
+    bgOps.setBegin([bgLine()], 0, 1, 1.5, updateLineWithHistory);
+    expect(Object.keys(calls[0].updates)).toEqual(["backgroundWords"]);
+  });
+});

--- a/src/utils/timing/word-timing-ops.boundary.test.ts
+++ b/src/utils/timing/word-timing-ops.boundary.test.ts
@@ -46,7 +46,7 @@ describe("createWordTimingOps: setBoundary", () => {
   it("moves only the target word when rolling is off", () => {
     const { words } = run({ wordIdx: 1, edge: "begin", time: 1.5, rolling: false });
     expect(words[1].begin).toBe(1.5);
-    expect(words[0]).toEqual({ text: "a", begin: 0, end: 1 });
+    expect(words[0]).toEqual({ text: "a ", begin: 0, end: 1 });
   });
 
   it("drags the previous word's end along a flush begin boundary when rolling", () => {
@@ -73,13 +73,13 @@ describe("createWordTimingOps: setBoundary", () => {
   it("does not roll at the first index for begin", () => {
     const { words } = run({ wordIdx: 0, edge: "begin", time: 0.5, rolling: true });
     expect(words[0].begin).toBe(0.5);
-    expect(words[1]).toEqual({ text: "b", begin: 1, end: 2 });
+    expect(words[1]).toEqual({ text: "b ", begin: 1, end: 2 });
   });
 
   it("does not roll at the last index for end", () => {
     const { words } = run({ wordIdx: 2, edge: "end", time: 4, rolling: true });
     expect(words[2].end).toBe(4);
-    expect(words[1]).toEqual({ text: "b", begin: 1, end: 2 });
+    expect(words[1]).toEqual({ text: "b ", begin: 1, end: 2 });
   });
 
   it("keeps the target word at least minDuration long", () => {
@@ -181,6 +181,23 @@ describe("createWordTimingOps: setBoundary", () => {
       expect(rolledOn.words[1].begin).toBeLessThanOrEqual(rolledOn.words[1].end);
     });
 
+    it("regression: rolls a syllable boundary with rolling off, so no gap opens inside a word", () => {
+      const syllables = () =>
+        createLine({
+          text: "hello",
+          words: [
+            { text: "hel", begin: 0, end: 1, syllableGroupId: "s1" },
+            { text: "lo", begin: 1, end: 2, syllableGroupId: "s1" },
+          ],
+        });
+      const fromEnd = run({ line: syllables(), wordIdx: 0, edge: "end", time: 1.4, rolling: false });
+      expect(fromEnd.words[0].end).toBe(1.4);
+      expect(fromEnd.words[1].begin).toBe(1.4);
+      const fromBegin = run({ line: syllables(), wordIdx: 1, edge: "begin", time: 0.6, rolling: false });
+      expect(fromBegin.words[1].begin).toBe(0.6);
+      expect(fromBegin.words[0].end).toBe(0.6);
+    });
+
     it("regression: never inverts a word whose begin is past a shorter audio duration", () => {
       const lastWord = run({ wordIdx: 2, edge: "end", time: 99, rolling: false, duration: 1.5 });
       expect(lastWord.words[2].begin).toBeLessThanOrEqual(lastWord.words[2].end);
@@ -193,7 +210,7 @@ describe("createWordTimingOps: setBoundary", () => {
   describe("invariants", () => {
     it("never lets a word's begin exceed its end", () => {
       const { words } = run({ wordIdx: 1, edge: "begin", time: 99, rolling: true });
-      expect(words[1]).toEqual({ text: "b", begin: 1.95, end: 2 });
+      expect(words[1]).toEqual({ text: "b ", begin: 1.95, end: 2 });
     });
 
     it("does not modify the input words array", () => {

--- a/src/utils/timing/word-timing-ops.test.ts
+++ b/src/utils/timing/word-timing-ops.test.ts
@@ -128,7 +128,7 @@ describe("createWordTimingOps: write contract", () => {
     const line = makeLine();
     wordsOps.setBegin([line], 0, 1, 1.5, updateLineWithHistory);
     const out = calls[0].updates.words ?? [];
-    expect(out[0]).toEqual({ text: "a", begin: 0, end: 1 });
+    expect(out[0]).toEqual({ text: "a ", begin: 0, end: 1 });
     expect(out[2]).toEqual({ text: "c", begin: 2, end: 3 });
   });
 });

--- a/src/utils/timing/word-timing-ops.test.ts
+++ b/src/utils/timing/word-timing-ops.test.ts
@@ -1,28 +1,6 @@
-import type { LyricLine } from "@/domain/line/model";
 import { createLine } from "@/test/factories";
-import { createWordTimingOps } from "@/utils/timing/word-timing-ops";
+import { bgOps, captureUpdates, makeLine, wordsOps } from "@/test/word-timing-harness";
 import { describe, expect, it } from "vitest";
-
-interface CapturedUpdate {
-  id: string;
-  updates: Partial<LyricLine>;
-  options?: { propagateToSiblings?: boolean };
-}
-
-function captureUpdates() {
-  const calls: CapturedUpdate[] = [];
-  const updateLineWithHistory = (
-    id: string,
-    updates: Partial<LyricLine>,
-    options?: { propagateToSiblings?: boolean },
-  ) => {
-    calls.push({ id, updates, options });
-  };
-  return { calls, updateLineWithHistory };
-}
-
-const wordsOps = createWordTimingOps({ getWords: (line) => line.words, updateKey: "words" });
-const bgOps = createWordTimingOps({ getWords: (line) => line.backgroundWords, updateKey: "backgroundWords" });
 
 describe("createWordTimingOps: early returns", () => {
   it("nudgeBegin no-ops when line missing", () => {
@@ -47,17 +25,6 @@ describe("createWordTimingOps: early returns", () => {
 });
 
 describe("createWordTimingOps: nudgeBegin / setBegin clamp", () => {
-  function makeLine() {
-    return createLine({
-      text: "a b c",
-      words: [
-        { text: "a", begin: 0, end: 1 },
-        { text: "b", begin: 1, end: 2 },
-        { text: "c", begin: 2, end: 3 },
-      ],
-    });
-  }
-
   it("nudgeBegin caps at prev word's end", () => {
     const { calls, updateLineWithHistory } = captureUpdates();
     wordsOps.nudgeBegin([makeLine()], 0, 1, -5, updateLineWithHistory);
@@ -90,17 +57,6 @@ describe("createWordTimingOps: nudgeBegin / setBegin clamp", () => {
 });
 
 describe("createWordTimingOps: nudgeEnd / setEnd clamp", () => {
-  function makeLine() {
-    return createLine({
-      text: "a b c",
-      words: [
-        { text: "a", begin: 0, end: 1 },
-        { text: "b", begin: 1, end: 2 },
-        { text: "c", begin: 2, end: 3 },
-      ],
-    });
-  }
-
   it("nudgeEnd caps at next word's begin", () => {
     const { calls, updateLineWithHistory } = captureUpdates();
     wordsOps.nudgeEnd([makeLine()], 0, 1, +5, updateLineWithHistory);
@@ -169,14 +125,7 @@ describe("createWordTimingOps: write contract", () => {
 
   it("does not mutate untouched words in the resulting array", () => {
     const { calls, updateLineWithHistory } = captureUpdates();
-    const line = createLine({
-      text: "a b c",
-      words: [
-        { text: "a", begin: 0, end: 1 },
-        { text: "b", begin: 1, end: 2 },
-        { text: "c", begin: 2, end: 3 },
-      ],
-    });
+    const line = makeLine();
     wordsOps.setBegin([line], 0, 1, 1.5, updateLineWithHistory);
     const out = calls[0].updates.words ?? [];
     expect(out[0]).toEqual({ text: "a", begin: 0, end: 1 });

--- a/src/utils/timing/word-timing-ops.ts
+++ b/src/utils/timing/word-timing-ops.ts
@@ -1,5 +1,5 @@
 import type { LyricLine } from "@/domain/line/model";
-import { type BoundaryEdge, isBoundaryFlush } from "@/domain/word/boundary";
+import { type BoundaryEdge, clampBoundaryTime, isBoundaryFlush } from "@/domain/word/boundary";
 import type { WordTiming } from "@/domain/word/timing";
 
 // -- Types --------------------------------------------------------------------
@@ -131,26 +131,16 @@ function createWordTimingOps(config: WordFieldConfig) {
     if (!words?.[wordIdx]) return;
 
     const rollNeighbour = rolling && isBoundaryFlush(words, wordIdx, edge);
+    const clamped = clampBoundaryTime({ words, wordIndex: wordIdx, edge, time, minDuration, rollNeighbour, duration });
     const updatedWords = [...words];
     const word = updatedWords[wordIdx];
 
-    // A flush pair spanning under twice minDuration cannot satisfy both floors, so hardCeiling
-    // gives up the minimum rather than letting either word invert.
     if (edge === "begin") {
       const prev: WordTiming | undefined = updatedWords[wordIdx - 1];
-      const floor = rollNeighbour && prev ? prev.begin + minDuration : (prev?.end ?? 0);
-      const hardCeiling = word.end;
-      const ceiling = word.end - minDuration;
-      const clamped = Math.min(hardCeiling, Math.max(floor, Math.min(ceiling, time)));
       updatedWords[wordIdx] = { ...word, begin: clamped };
       if (rollNeighbour && prev) updatedWords[wordIdx - 1] = { ...prev, end: clamped };
     } else {
       const next: WordTiming | undefined = updatedWords[wordIdx + 1];
-      const floor = word.begin + minDuration;
-      const neighbourCeiling = rollNeighbour && next ? next.end : (next?.begin ?? Number.POSITIVE_INFINITY);
-      const hardCeiling = Math.max(word.begin, Math.min(neighbourCeiling, duration ?? Number.POSITIVE_INFINITY));
-      const ceiling = rollNeighbour && next ? next.end - minDuration : hardCeiling;
-      const clamped = Math.min(hardCeiling, Math.max(floor, Math.min(ceiling, time)));
       updatedWords[wordIdx] = { ...word, end: clamped };
       if (rollNeighbour && next) updatedWords[wordIdx + 1] = { ...next, begin: clamped };
     }

--- a/src/utils/timing/word-timing-ops.ts
+++ b/src/utils/timing/word-timing-ops.ts
@@ -14,8 +14,8 @@ type UpdateLineWithHistory = (
 interface WordFieldConfig {
   getWords: (line: LyricLine) => WordTiming[] | undefined;
   updateKey: "words" | "backgroundWords";
-  // setBoundary only: routing mutateWord here too would newly stamp background provenance in useSyncHandlers.
-  buildUpdate?: (words: WordTiming[]) => Partial<LyricLine>;
+  // mutateWord deliberately writes raw: routing it here too would newly stamp background provenance in useSyncHandlers.
+  buildBoundaryUpdate?: (words: WordTiming[]) => Partial<LyricLine>;
 }
 
 interface NeighborContext {
@@ -42,7 +42,8 @@ interface SetBoundaryInput {
 
 function createWordTimingOps(config: WordFieldConfig) {
   const { getWords, updateKey } = config;
-  const buildUpdate = config.buildUpdate ?? ((words: WordTiming[]) => ({ [updateKey]: words }) as Partial<LyricLine>);
+  const buildBoundaryUpdate =
+    config.buildBoundaryUpdate ?? ((words: WordTiming[]) => ({ [updateKey]: words }) as Partial<LyricLine>);
 
   function mutateWord(
     lines: LyricLine[],
@@ -152,7 +153,7 @@ function createWordTimingOps(config: WordFieldConfig) {
       if (rollNeighbour && next) updatedWords[wordIdx + 1] = { ...next, begin: clamped };
     }
 
-    updateLineWithHistory(line.id, buildUpdate(updatedWords), { propagateToSiblings: false });
+    updateLineWithHistory(line.id, buildBoundaryUpdate(updatedWords), { propagateToSiblings: false });
   }
 
   return { nudgeBegin, setBegin, nudgeEnd, setEnd, setBoundary };

--- a/src/utils/timing/word-timing-ops.ts
+++ b/src/utils/timing/word-timing-ops.ts
@@ -1,5 +1,6 @@
 import type { LyricLine } from "@/domain/line/model";
-import { type BoundaryEdge, clampBoundaryTime, isBoundaryFlush } from "@/domain/word/boundary";
+import { type BoundaryEdge, clampBoundaryTime, shouldRollNeighbour } from "@/domain/word/boundary";
+import { getSyllablePositions } from "@/domain/word/syllable-groups";
 import type { WordTiming } from "@/domain/word/timing";
 
 // -- Types --------------------------------------------------------------------
@@ -130,7 +131,13 @@ function createWordTimingOps(config: WordFieldConfig) {
     const words = getWords(line);
     if (!words?.[wordIdx]) return;
 
-    const rollNeighbour = rolling && isBoundaryFlush(words, wordIdx, edge);
+    const rollNeighbour = shouldRollNeighbour({
+      words,
+      wordIndex: wordIdx,
+      edge,
+      rollingEdit: rolling,
+      syllablePositions: getSyllablePositions(words),
+    });
     const clamped = clampBoundaryTime({ words, wordIndex: wordIdx, edge, time, minDuration, rollNeighbour, duration });
     const updatedWords = [...words];
     const word = updatedWords[wordIdx];

--- a/src/utils/timing/word-timing-ops.ts
+++ b/src/utils/timing/word-timing-ops.ts
@@ -1,4 +1,5 @@
 import type { LyricLine } from "@/domain/line/model";
+import { type BoundaryEdge, isBoundaryFlush } from "@/domain/word/boundary";
 import type { WordTiming } from "@/domain/word/timing";
 
 // -- Types --------------------------------------------------------------------
@@ -12,6 +13,8 @@ type UpdateLineWithHistory = (
 interface WordFieldConfig {
   getWords: (line: LyricLine) => WordTiming[] | undefined;
   updateKey: "words" | "backgroundWords";
+  // setBoundary only: routing mutateWord here too would newly stamp background provenance in useSyncHandlers.
+  buildUpdate?: (words: WordTiming[]) => Partial<LyricLine>;
 }
 
 interface NeighborContext {
@@ -22,10 +25,23 @@ interface NeighborContext {
 
 type WordMutator = (ctx: NeighborContext) => WordTiming;
 
+interface SetBoundaryInput {
+  lines: LyricLine[];
+  lineIdx: number;
+  wordIdx: number;
+  edge: BoundaryEdge;
+  time: number;
+  minDuration: number;
+  rolling: boolean;
+  duration?: number;
+  updateLineWithHistory: UpdateLineWithHistory;
+}
+
 // -- Factory ------------------------------------------------------------------
 
 function createWordTimingOps(config: WordFieldConfig) {
   const { getWords, updateKey } = config;
+  const buildUpdate = config.buildUpdate ?? ((words: WordTiming[]) => ({ [updateKey]: words }) as Partial<LyricLine>);
 
   function mutateWord(
     lines: LyricLine[],
@@ -98,7 +114,51 @@ function createWordTimingOps(config: WordFieldConfig) {
     mutateWord(lines, lineIdx, wordIdx, updateLineWithHistory, (ctx) => clampEnd(ctx, newEnd));
   }
 
-  return { nudgeBegin, setBegin, nudgeEnd, setEnd };
+  function setBoundary({
+    lines,
+    lineIdx,
+    wordIdx,
+    edge,
+    time,
+    minDuration,
+    rolling,
+    duration,
+    updateLineWithHistory,
+  }: SetBoundaryInput): void {
+    const line = lines[lineIdx];
+    if (!line) return;
+    const words = getWords(line);
+    if (!words?.[wordIdx]) return;
+
+    const rollNeighbour = rolling && isBoundaryFlush(words, wordIdx, edge);
+    const updatedWords = [...words];
+    const word = updatedWords[wordIdx];
+
+    // A flush pair spanning under twice minDuration cannot satisfy both floors, so hardCeiling
+    // gives up the minimum rather than letting either word invert.
+    if (edge === "begin") {
+      const prev: WordTiming | undefined = updatedWords[wordIdx - 1];
+      const floor = rollNeighbour && prev ? prev.begin + minDuration : (prev?.end ?? 0);
+      const hardCeiling = word.end;
+      const ceiling = word.end - minDuration;
+      const clamped = Math.min(hardCeiling, Math.max(floor, Math.min(ceiling, time)));
+      updatedWords[wordIdx] = { ...word, begin: clamped };
+      if (rollNeighbour && prev) updatedWords[wordIdx - 1] = { ...prev, end: clamped };
+    } else {
+      const next: WordTiming | undefined = updatedWords[wordIdx + 1];
+      const floor = word.begin + minDuration;
+      const neighbourCeiling = rollNeighbour && next ? next.end : (next?.begin ?? Number.POSITIVE_INFINITY);
+      const hardCeiling = Math.max(word.begin, Math.min(neighbourCeiling, duration ?? Number.POSITIVE_INFINITY));
+      const ceiling = rollNeighbour && next ? next.end - minDuration : hardCeiling;
+      const clamped = Math.min(hardCeiling, Math.max(floor, Math.min(ceiling, time)));
+      updatedWords[wordIdx] = { ...word, end: clamped };
+      if (rollNeighbour && next) updatedWords[wordIdx + 1] = { ...next, begin: clamped };
+    }
+
+    updateLineWithHistory(line.id, buildUpdate(updatedWords), { propagateToSiblings: false });
+  }
+
+  return { nudgeBegin, setBegin, nudgeEnd, setEnd, setBoundary };
 }
 
 // -- Exports -------------------------------------------------------------------

--- a/src/utils/timing/word-timing.ts
+++ b/src/utils/timing/word-timing.ts
@@ -1,8 +1,14 @@
 import { createWordTimingOps } from "@/utils/timing/word-timing-ops";
 
-const { nudgeBegin, setBegin, nudgeEnd, setEnd } = createWordTimingOps({
+const { nudgeBegin, setBegin, nudgeEnd, setEnd, setBoundary } = createWordTimingOps({
   getWords: (line) => line.words,
   updateKey: "words",
 });
 
-export { nudgeBegin as nudgeWordBegin, setBegin as setWordBegin, nudgeEnd as nudgeWordEnd, setEnd as setWordEnd };
+export {
+  nudgeBegin as nudgeWordBegin,
+  setBegin as setWordBegin,
+  nudgeEnd as nudgeWordEnd,
+  setEnd as setWordEnd,
+  setBoundary as setWordBoundary,
+};

--- a/src/utils/ttml.metadata.test.ts
+++ b/src/utils/ttml.metadata.test.ts
@@ -39,6 +39,56 @@ describe("generateTTML metadata", () => {
   });
 });
 
+describe("generateTTML xml:lang", () => {
+  const bare: ProjectMetadata = { title: "t", artists: [], album: "", duration: 0 };
+  const generate = (language?: string) =>
+    generateTTML({ metadata: { ...bare, language }, agents: [], lines, granularity: "line" });
+  const rootOf = (xml: string) => new DOMParser().parseFromString(xml, "application/xml").documentElement;
+
+  it("omits xml:lang when no language is set", () => {
+    expect(rootOf(generate()).hasAttribute("xml:lang")).toBe(false);
+  });
+
+  it("emits the language when set", () => {
+    expect(rootOf(generate("ja")).getAttribute("xml:lang")).toBe("ja");
+  });
+
+  it("keeps a region subtag intact", () => {
+    expect(rootOf(generate("pt-BR")).getAttribute("xml:lang")).toBe("pt-BR");
+  });
+
+  describe("edge cases", () => {
+    it("omits xml:lang when the language is an empty string", () => {
+      expect(rootOf(generate("")).hasAttribute("xml:lang")).toBe(false);
+    });
+
+    it("omits xml:lang when the language is whitespace only", () => {
+      expect(rootOf(generate("   ")).hasAttribute("xml:lang")).toBe(false);
+    });
+
+    it("trims surrounding whitespace off the emitted language", () => {
+      expect(rootOf(generate("  ja  ")).getAttribute("xml:lang")).toBe("ja");
+    });
+  });
+
+  describe("invariants", () => {
+    it("leaves no double space in the tt tag when the language is absent", () => {
+      expect(generate().split("\n")[0]).not.toContain("  ");
+    });
+
+    it("stays well-formed with the attribute omitted", () => {
+      expect(new DOMParser().parseFromString(generate(), "application/xml").querySelector("parsererror")).toBeNull();
+    });
+
+    it("keeps the other tt attributes when the language is absent", () => {
+      const xml = generate();
+      expect(xml).toContain('ttp:timeBase="media"');
+      expect(xml).toContain('itunes:timing="Line"');
+      expect(xml).toContain('composer:timing="Line"');
+    });
+  });
+});
+
 describe("generateTTML attribute escaping", () => {
   function parse(xml: string): Document {
     return new DOMParser().parseFromString(xml, "application/xml");

--- a/src/utils/ttml.ts
+++ b/src/utils/ttml.ts
@@ -48,10 +48,13 @@ function generateTTML({ metadata, agents, lines, groups, granularity, minify = f
 
   const parts: string[] = [];
 
+  const language = metadata.language?.trim();
+  const langAttr = language ? ` xml:lang="${escapeXmlAttribute(language)}"` : "";
+
   // Apple Music lyric dialect, not strict W3C TTML1. Absolute span times and the
   // Apple timestamp shape are intentional; don't "fix" them to generic TTML.
   parts.push(
-    `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:itunes="${APPLE_LYRIC_NS}" xmlns:composer="${COMPOSER_NS}" ttp:timeBase="media" xml:lang="${escapeXmlAttribute(metadata.language || "en")}" itunes:timing="${timingValue}" composer:timing="${timingValue}">`,
+    `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:itunes="${APPLE_LYRIC_NS}" xmlns:composer="${COMPOSER_NS}" ttp:timeBase="media"${langAttr} itunes:timing="${timingValue}" composer:timing="${timingValue}">`,
   );
 
   // Head section

--- a/src/utils/word-spaces.ts
+++ b/src/utils/word-spaces.ts
@@ -81,4 +81,4 @@ function findInsertionSlot(
 
 // -- Exports -------------------------------------------------------------------
 
-export { trimTrailingSpaceFromLast, resolveOverlapsForward, findInsertionSlot };
+export { DEFAULT_MIN_WORD_DURATION, trimTrailingSpaceFromLast, resolveOverlapsForward, findInsertionSlot };

--- a/src/views/export/metadata-panel.browser.test.tsx
+++ b/src/views/export/metadata-panel.browser.test.tsx
@@ -84,6 +84,22 @@ describe("MetadataPanel", () => {
     expect(useProjectStore.getState().metadata.isrc).toBeUndefined();
   });
 
+  it("announces the ISRC error and marks the input invalid", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    const isrc = screen.getByRole("textbox", { name: "ISRC" });
+    await expect.element(isrc).toHaveAttribute("aria-invalid", "false");
+
+    await isrc.fill("not-valid");
+    await expect.element(screen.getByRole("alert")).toHaveTextContent(/Invalid ISRC/);
+    await expect.element(isrc).toHaveAttribute("aria-invalid", "true");
+
+    await isrc.fill("USQX91700001");
+    await expect.element(isrc).toHaveAttribute("aria-invalid", "false");
+  });
+
   it("stores a normalized uppercase ISRC for valid input", async () => {
     seedMetadata();
     const screen = await render(<MetadataPanel />);

--- a/src/views/export/metadata-panel.browser.test.tsx
+++ b/src/views/export/metadata-panel.browser.test.tsx
@@ -122,6 +122,33 @@ describe("MetadataPanel", () => {
     await expect.element(isrc).toHaveValue("usqx91700001");
   });
 
+  it("typing in Language updates the store", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await screen.getByRole("textbox", { name: "Language" }).fill("pt-BR");
+    await expect.poll(() => useProjectStore.getState().metadata.language).toBe("pt-BR");
+  });
+
+  it("describes the Language field with the BCP-47 hint", async () => {
+    seedMetadata();
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await expect
+      .element(screen.getByRole("textbox", { name: "Language" }))
+      .toHaveAccessibleDescription("BCP-47 tag ・ leave blank to let players detect it");
+  });
+
+  it("seeds the Language field from the existing store value", async () => {
+    seedMetadata({ language: "ja-Latn" });
+    const screen = await render(<MetadataPanel />);
+    await screen.getByRole("button", { name: "Metadata" }).click();
+
+    await expect.element(screen.getByRole("textbox", { name: "Language" })).toHaveValue("ja-Latn");
+  });
+
   it("adds an extra key/value row and writes it to the store", async () => {
     seedMetadata();
     const screen = await render(<MetadataPanel />);
@@ -164,6 +191,36 @@ describe("MetadataPanel", () => {
   });
 
   describe("edge cases", () => {
+    it("clears the stored language to undefined rather than an empty string", async () => {
+      seedMetadata({ language: "ja" });
+      const screen = await render(<MetadataPanel />);
+      await screen.getByRole("button", { name: "Metadata" }).click();
+
+      const language = screen.getByRole("textbox", { name: "Language" });
+      await expect.element(language).toHaveValue("ja");
+
+      await language.clear();
+      await expect.poll(() => useProjectStore.getState().metadata.language).toBeUndefined();
+      await expect.element(language).toHaveValue("");
+    });
+
+    it("stores undefined for a whitespace-only language", async () => {
+      seedMetadata();
+      const screen = await render(<MetadataPanel />);
+      await screen.getByRole("button", { name: "Metadata" }).click();
+
+      await screen.getByRole("textbox", { name: "Language" }).fill("   ");
+      await expect.poll(() => useProjectStore.getState().metadata.language).toBeUndefined();
+    });
+
+    it("renders an empty Language field when no language is stored", async () => {
+      seedMetadata();
+      const screen = await render(<MetadataPanel />);
+      await screen.getByRole("button", { name: "Metadata" }).click();
+
+      await expect.element(screen.getByRole("textbox", { name: "Language" })).toHaveValue("");
+    });
+
     it("flags a duplicate extra key instead of silently dropping the row", async () => {
       seedMetadata();
       const screen = await render(<MetadataPanel />);

--- a/src/views/export/metadata-panel.tsx
+++ b/src/views/export/metadata-panel.tsx
@@ -7,7 +7,7 @@ import { ExtraFieldList } from "@/views/export/extra-field-list";
 import { INPUT_STYLES, MetadataFieldList } from "@/views/export/metadata-field-list";
 import { IconChevronRight } from "@tabler/icons-react";
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
-import { useState } from "react";
+import { useId, useState } from "react";
 
 // -- Component ----------------------------------------------------------------
 
@@ -15,6 +15,7 @@ const MetadataPanel: React.FC = () => {
   const metadata = useProjectStore((s) => s.metadata);
   const setMetadata = useProjectStore((s) => s.setMetadata);
 
+  const languageHintId = useId();
   const [open, setOpen] = useState(false);
   const [isrcDraft, setIsrcDraft] = useState(() => metadata.isrc ?? "");
 
@@ -95,6 +96,22 @@ const MetadataPanel: React.FC = () => {
                     Invalid ISRC ・ expected 12 characters like USQX91700001
                   </span>
                 )}
+              </label>
+
+              <label className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-composer-text-secondary select-none">Language</span>
+                <input
+                  type="text"
+                  aria-label="Language"
+                  aria-describedby={languageHintId}
+                  value={metadata.language ?? ""}
+                  placeholder="e.g. en, ja, pt-BR"
+                  onChange={(e) => setMetadata({ language: e.target.value.trim() || undefined })}
+                  className={INPUT_STYLES}
+                />
+                <span id={languageHintId} className="text-xs text-composer-text-muted select-none">
+                  BCP-47 tag ・ leave blank to let players detect it
+                </span>
               </label>
 
               <MetadataFieldList

--- a/src/views/export/metadata-panel.tsx
+++ b/src/views/export/metadata-panel.tsx
@@ -86,13 +86,14 @@ const MetadataPanel: React.FC = () => {
                 <input
                   type="text"
                   aria-label="ISRC"
+                  aria-invalid={isrcInvalid}
                   value={isrcValue}
                   placeholder="e.g. USQX91700001"
                   onChange={(e) => handleIsrcChange(e.target.value)}
                   className={INPUT_STYLES}
                 />
                 {isrcInvalid && (
-                  <span className="text-xs text-composer-error-text select-text cursor-text">
+                  <span role="alert" className="text-xs text-composer-error-text select-text cursor-text">
                     Invalid ISRC ・ expected 12 characters like USQX91700001
                   </span>
                 )}

--- a/src/views/lyrics-import-modal/use-import-modal-actions.test.ts
+++ b/src/views/lyrics-import-modal/use-import-modal-actions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { Agent } from "@/domain/agent/model";
 import type { LyricLine } from "@/domain/line/model";
 import { useProjectStore } from "@/stores/project";
+import { parseLyricsFile } from "@/utils/lyrics-parsers";
 import type { ParseResult } from "@/utils/lyrics-parsers/shared";
 import {
   importParsedLyrics,
@@ -209,6 +210,12 @@ describe("importParsedLyrics metadata", () => {
   it("applies metadata when keys are present", async () => {
     await importParsedLyrics(parseResult({ metadata: { title: "Bohemian Rhapsody" } }), buildContext());
     expect(useProjectStore.getState().metadata.title).toBe("Bohemian Rhapsody");
+  });
+
+  it("lands the language of an imported TTML in the store", async () => {
+    const ttml = `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" xml:lang="pt-BR"><head><metadata><ttm:agent type="person" xml:id="v1"/></metadata></head><body><div><p begin="00:01.000" end="00:02.000" ttm:agent="v1"><span begin="00:01.000" end="00:01.500">Ola</span> <span begin="00:01.500" end="00:02.000">mundo</span></p></div></body></tt>`;
+    await importParsedLyrics(parseLyricsFile("song.ttml", ttml), buildContext());
+    expect(useProjectStore.getState().metadata.language).toBe("pt-BR");
   });
 });
 

--- a/src/views/timeline/apply-instance-template.ts
+++ b/src/views/timeline/apply-instance-template.ts
@@ -18,6 +18,13 @@ interface AppliedInstance {
   instanceIdx: number;
 }
 
+interface InstanceApplyResult<Reason extends string> {
+  ok: boolean;
+  reason?: Reason;
+  updatedLines?: LyricLine[];
+  instanceIdx?: number;
+}
+
 // -- Functions -----------------------------------------------------------------
 
 function offsetWords(words: WordTemplate[], instanceStart: number): WordTiming[] {
@@ -73,3 +80,4 @@ function applyInstanceTemplate({
 // -- Exports -------------------------------------------------------------------
 
 export { applyInstanceTemplate };
+export type { InstanceApplyResult };

--- a/src/views/timeline/apply-instance-template.ts
+++ b/src/views/timeline/apply-instance-template.ts
@@ -1,0 +1,75 @@
+import { nextInstanceIdx } from "@/domain/instance/enumerate";
+import type { LineTemplate, WordTemplate } from "@/domain/group/template";
+import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import type { WordTiming } from "@/domain/word/timing";
+
+// -- Interfaces ----------------------------------------------------------------
+
+interface ApplyInstanceTemplateInput {
+  lines: LyricLine[];
+  groupId: string;
+  template: LineTemplate[];
+  startIndex: number;
+  instanceStart: number;
+}
+
+interface AppliedInstance {
+  updatedLines: LyricLine[];
+  instanceIdx: number;
+}
+
+// -- Functions -----------------------------------------------------------------
+
+function offsetWords(words: WordTemplate[], instanceStart: number): WordTiming[] {
+  return words.map((word) => ({
+    text: word.text,
+    begin: word.relativeBegin + instanceStart,
+    end: word.relativeEnd + instanceStart,
+  }));
+}
+
+// Stamps a group template onto the `template.length` rows starting at
+// `startIndex` as a fresh instance. Callers own eligibility: this overwrites
+// whatever text and timing those rows already hold.
+function applyInstanceTemplate({
+  lines,
+  groupId,
+  template,
+  startIndex,
+  instanceStart,
+}: ApplyInstanceTemplateInput): AppliedInstance {
+  const instanceIdx = nextInstanceIdx(lines, groupId);
+  const endIndex = startIndex + template.length;
+
+  const updatedLines = lines.map((line, idx) => {
+    if (idx < startIndex || idx >= endIndex) return line;
+    const tplLine = template[idx - startIndex];
+    return reconcileLine({
+      ...line,
+      text: tplLine.text,
+      agentId: tplLine.agentId,
+      groupId,
+      instanceIdx,
+      templateLineIdx: idx - startIndex,
+      detached: undefined,
+      ...(tplLine.relativeBegin !== undefined
+        ? { begin: tplLine.relativeBegin + instanceStart }
+        : { begin: undefined }),
+      ...(tplLine.relativeEnd !== undefined ? { end: tplLine.relativeEnd + instanceStart } : { end: undefined }),
+      ...(tplLine.words ? { words: offsetWords(tplLine.words, instanceStart) } : { words: undefined }),
+      ...(tplLine.backgroundText !== undefined
+        ? { backgroundText: tplLine.backgroundText }
+        : { backgroundText: undefined }),
+      ...(tplLine.backgroundWords
+        ? { backgroundWords: offsetWords(tplLine.backgroundWords, instanceStart) }
+        : { backgroundWords: undefined }),
+      backgroundTextSource: tplLine.backgroundTextSource,
+    });
+  });
+
+  return { updatedLines, instanceIdx };
+}
+
+// -- Exports -------------------------------------------------------------------
+
+export { applyInstanceTemplate };

--- a/src/views/timeline/background-text-editor.browser.test.tsx
+++ b/src/views/timeline/background-text-editor.browser.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
+import { useProjectStore } from "@/stores/project";
+import { createLine, createWord } from "@/test/factories";
+import { render } from "@/test/render";
+import { BackgroundTextEditor } from "@/views/timeline/background-text-editor";
+
+// -- Helpers ------------------------------------------------------------------
+
+function seedLine(overrides: Parameters<typeof createLine>[0] = {}) {
+  const line = createLine({
+    id: "l1",
+    text: "hello",
+    words: [createWord({ text: "hello", begin: 0, end: 1 })],
+    ...overrides,
+  });
+  useProjectStore.setState({ lines: [line] });
+  return line;
+}
+
+function storedLine() {
+  return useProjectStore.getState().lines[0];
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("BackgroundTextEditor", () => {
+  it("labels the background vocals input", async () => {
+    const line = seedLine();
+    const screen = await render(<BackgroundTextEditor lineId={line.id} />);
+
+    await screen.getByRole("button", { name: "Add BG" }).click();
+
+    await expect.element(screen.getByRole("textbox", { name: "Background vocals text" })).toBeInTheDocument();
+  });
+
+  it("stamps a manual provenance when adding background text", async () => {
+    const line = seedLine();
+    const screen = await render(<BackgroundTextEditor lineId={line.id} />);
+
+    await screen.getByRole("button", { name: "Add BG" }).click();
+    await screen.getByPlaceholder("Background vocals").fill("ooh");
+    await userEvent.keyboard("{Enter}");
+
+    await expect.poll(() => storedLine().backgroundText).toBe("ooh");
+    expect(storedLine().backgroundTextSource).toBe("manual");
+  });
+
+  it("flips an extraction-sourced background to manual when edited", async () => {
+    const line = seedLine({ backgroundText: "ooh", backgroundTextSource: "extraction" });
+    const screen = await render(<BackgroundTextEditor lineId={line.id} backgroundText={line.backgroundText} />);
+
+    await screen.getByRole("button", { name: "BG: ooh" }).click();
+    await screen.getByPlaceholder("Background vocals").fill("aah");
+    await userEvent.keyboard("{Enter}");
+
+    await expect.poll(() => storedLine().backgroundText).toBe("aah");
+    expect(storedLine().backgroundTextSource).toBe("manual");
+  });
+
+  it("clears all three background fields when the editor is emptied", async () => {
+    const line = seedLine({
+      backgroundText: "ooh",
+      backgroundWords: [{ text: "ooh", begin: 0, end: 1 }],
+      backgroundTextSource: "extraction",
+    });
+    const screen = await render(<BackgroundTextEditor lineId={line.id} backgroundText={line.backgroundText} />);
+
+    await screen.getByRole("button", { name: "BG: ooh" }).click();
+    await screen.getByPlaceholder("Background vocals").fill("");
+    await userEvent.keyboard("{Enter}");
+
+    await expect.poll(() => storedLine().backgroundText).toBeUndefined();
+    expect(storedLine().backgroundWords).toBeUndefined();
+    expect(storedLine().backgroundTextSource).toBeUndefined();
+  });
+
+  it("abandons the edit and keeps the stored text when Escape is pressed", async () => {
+    const line = seedLine({ backgroundText: "ooh", backgroundTextSource: "extraction" });
+    const screen = await render(<BackgroundTextEditor lineId={line.id} backgroundText={line.backgroundText} />);
+
+    await screen.getByRole("button", { name: "BG: ooh" }).click();
+    await screen.getByPlaceholder("Background vocals").fill("aah");
+    await userEvent.keyboard("{Escape}");
+
+    await expect.element(screen.getByRole("button", { name: "BG: ooh" })).toBeInTheDocument();
+    expect(storedLine().backgroundText).toBe("ooh");
+    expect(storedLine().backgroundTextSource).toBe("extraction");
+  });
+
+  describe("edge cases", () => {
+    it("treats whitespace-only input as a clear", async () => {
+      const line = seedLine({ backgroundText: "ooh", backgroundTextSource: "extraction" });
+      const screen = await render(<BackgroundTextEditor lineId={line.id} backgroundText={line.backgroundText} />);
+
+      await screen.getByRole("button", { name: "BG: ooh" }).click();
+      await screen.getByPlaceholder("Background vocals").fill("   ");
+      await userEvent.keyboard("{Enter}");
+
+      await expect.poll(() => storedLine().backgroundText).toBeUndefined();
+      expect(storedLine().backgroundTextSource).toBeUndefined();
+    });
+
+    it("does not let a keystroke reach a parent keyboard handler", async () => {
+      const line = seedLine();
+      const keysSeenByParent: string[] = [];
+      const screen = await render(
+        <div onKeyDown={(e) => keysSeenByParent.push(e.key)}>
+          <BackgroundTextEditor lineId={line.id} />
+        </div>,
+      );
+
+      await screen.getByRole("button", { name: "Add BG" }).click();
+      await screen.getByPlaceholder("Background vocals").fill("o");
+
+      expect(keysSeenByParent).toEqual([]);
+    });
+  });
+});

--- a/src/views/timeline/background-text-editor.tsx
+++ b/src/views/timeline/background-text-editor.tsx
@@ -1,0 +1,72 @@
+import { backgroundFields, CLEARED_BACKGROUND } from "@/domain/line/background";
+import { useProjectStore } from "@/stores/project";
+import { createBgWordsFromLine } from "@/utils/sync-helpers";
+import { useCallback, useState } from "react";
+
+// -- Interfaces ----------------------------------------------------------------
+
+interface BackgroundTextEditorProps {
+  lineId: string;
+  backgroundText?: string;
+}
+
+// -- Components ----------------------------------------------------------------
+
+const BackgroundTextEditor: React.FC<BackgroundTextEditorProps> = ({ lineId, backgroundText }) => {
+  const [value, setValue] = useState(() => backgroundText ?? "");
+  const [isEditing, setIsEditing] = useState(false);
+  const focusOnMount = useCallback((el: HTMLInputElement | null) => {
+    el?.focus();
+  }, []);
+  const updateLineWithHistory = useProjectStore((s) => s.updateLineWithHistory);
+
+  const handleCommit = useCallback(() => {
+    const trimmed = value.trim() || undefined;
+    if (trimmed) {
+      const line = useProjectStore.getState().lines.find((l) => l.id === lineId);
+      const bgWords = line ? createBgWordsFromLine({ ...line, backgroundText: trimmed }) : null;
+      updateLineWithHistory(lineId, backgroundFields({ text: trimmed, words: bgWords ?? undefined, source: "manual" }));
+    } else {
+      updateLineWithHistory(lineId, CLEARED_BACKGROUND);
+    }
+    setIsEditing(false);
+  }, [lineId, value, updateLineWithHistory]);
+
+  if (!isEditing) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          setValue(backgroundText ?? "");
+          setIsEditing(true);
+        }}
+        className="text-xs cursor-pointer text-composer-text-muted hover:text-composer-text px-1.5 py-0.5 rounded hover:bg-composer-button"
+        title="Edit background vocals"
+      >
+        {backgroundText ? `BG: ${backgroundText}` : "Add BG"}
+      </button>
+    );
+  }
+
+  return (
+    <input
+      ref={focusOnMount}
+      type="text"
+      aria-label="Background vocals text"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onBlur={handleCommit}
+      onKeyDown={(e) => {
+        e.stopPropagation();
+        if (e.key === "Enter") handleCommit();
+        if (e.key === "Escape") setIsEditing(false);
+      }}
+      placeholder="Background vocals"
+      className="w-32 px-1.5 py-0.5 text-xs border rounded bg-composer-input border-composer-border focus:outline-none focus:border-composer-accent"
+    />
+  );
+};
+
+// -- Exports -------------------------------------------------------------------
+
+export { BackgroundTextEditor };

--- a/src/views/timeline/background-text-editor.tsx
+++ b/src/views/timeline/background-text-editor.tsx
@@ -10,14 +10,15 @@ interface BackgroundTextEditorProps {
   backgroundText?: string;
 }
 
+// -- Helpers -------------------------------------------------------------------
+
+const focusOnMount = (el: HTMLInputElement | null) => el?.focus();
+
 // -- Components ----------------------------------------------------------------
 
 const BackgroundTextEditor: React.FC<BackgroundTextEditorProps> = ({ lineId, backgroundText }) => {
   const [value, setValue] = useState(() => backgroundText ?? "");
   const [isEditing, setIsEditing] = useState(false);
-  const focusOnMount = useCallback((el: HTMLInputElement | null) => {
-    el?.focus();
-  }, []);
   const updateLineWithHistory = useProjectStore((s) => s.updateLineWithHistory);
 
   const handleCommit = useCallback(() => {

--- a/src/views/timeline/conform-lines-to-instance.edge-cases.test.ts
+++ b/src/views/timeline/conform-lines-to-instance.edge-cases.test.ts
@@ -1,0 +1,277 @@
+/**
+ * @vitest-environment node
+ */
+import type { LineTemplate } from "@/domain/group/template";
+import type { LyricLine } from "@/domain/line/model";
+import { conformLinesToInstance } from "@/views/timeline/conform-lines-to-instance";
+import { fillEmptyLinesWithInstance } from "@/views/timeline/fill-empty-lines-with-instance";
+import { describe, expect, it } from "vitest";
+
+// -- Fixtures -----------------------------------------------------------------
+
+const twoLineTemplate: LineTemplate[] = [
+  {
+    text: "We were dancing in the dark",
+    agentId: "v1",
+    relativeBegin: 0,
+    relativeEnd: 2,
+    words: [{ text: "We were dancing in the dark", relativeBegin: 0, relativeEnd: 2 }],
+  },
+  {
+    text: "Till the morning came",
+    agentId: "v1",
+    relativeBegin: 2.5,
+    relativeEnd: 4,
+    words: [{ text: "Till the morning came", relativeBegin: 2.5, relativeEnd: 4 }],
+  },
+];
+
+function looseChorus(): LyricLine[] {
+  return [
+    {
+      id: "loose1",
+      text: "we were dancin in the dark",
+      agentId: "v1",
+      words: [{ text: "we were dancin in the dark", begin: 20, end: 22 }],
+    },
+    {
+      id: "loose2",
+      text: "till mornin came",
+      agentId: "v1",
+      words: [{ text: "till mornin came", begin: 22.4, end: 24 }],
+    },
+  ];
+}
+
+const looseIds: ReadonlySet<string> = new Set(["loose1", "loose2"]);
+
+// -- Edge cases ---------------------------------------------------------------
+
+describe("conformLinesToInstance · edge cases", () => {
+  it("conforms a single line to a single-line template", () => {
+    const lines: LyricLine[] = [
+      { id: "hook", text: "oh oh oh", agentId: "v1", words: [{ text: "oh oh oh", begin: 8, end: 9 }] },
+    ];
+    const result = conformLinesToInstance({
+      lines,
+      groupId: "g1",
+      template: [
+        {
+          text: "Oh oh oh",
+          agentId: "v1",
+          relativeBegin: 0,
+          relativeEnd: 1.5,
+          words: [{ text: "Oh oh oh", relativeBegin: 0, relativeEnd: 1.5 }],
+        },
+      ],
+      selectedLineIds: new Set(["hook"]),
+      playheadTime: 0,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.updatedLines?.[0].text).toBe("Oh oh oh");
+    expect(result.updatedLines?.[0].words?.[0].begin).toBe(8);
+    expect(result.updatedLines?.[0].words?.[0].end).toBe(9.5);
+  });
+
+  it("keeps a line-synced template line-synced, with no words array", () => {
+    const result = conformLinesToInstance({
+      lines: looseChorus(),
+      groupId: "g1",
+      template: [
+        { text: "We were dancing in the dark", agentId: "v1", relativeBegin: 0, relativeEnd: 2 },
+        { text: "Till the morning came", agentId: "v1", relativeBegin: 2.5, relativeEnd: 4 },
+      ],
+      selectedLineIds: looseIds,
+      playheadTime: 0,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.updatedLines?.[0].words).toBeUndefined();
+    expect(result.updatedLines?.[0].begin).toBe(20);
+    expect(result.updatedLines?.[0].end).toBe(22);
+    expect(result.updatedLines?.[1].begin).toBe(22.5);
+    expect(result.updatedLines?.[1].end).toBe(24);
+  });
+
+  it("carries background vocals from the template onto the conformed lines", () => {
+    const bgTemplate: LineTemplate[] = [
+      {
+        text: "We were dancing in the dark",
+        agentId: "v1",
+        relativeBegin: 0,
+        relativeEnd: 2,
+        words: [{ text: "We were dancing in the dark", relativeBegin: 0, relativeEnd: 2 }],
+        backgroundText: "in the dark",
+        backgroundWords: [
+          { text: "in ", relativeBegin: 1.2, relativeEnd: 1.5 },
+          { text: "the dark", relativeBegin: 1.5, relativeEnd: 2 },
+        ],
+        backgroundTextSource: "extraction",
+      },
+      {
+        text: "Till the morning came",
+        agentId: "v1",
+        relativeBegin: 2.5,
+        relativeEnd: 4,
+        words: [{ text: "Till the morning came", relativeBegin: 2.5, relativeEnd: 4 }],
+      },
+    ];
+    const result = conformLinesToInstance({
+      lines: looseChorus(),
+      groupId: "g1",
+      template: bgTemplate,
+      selectedLineIds: looseIds,
+      playheadTime: 0,
+    });
+
+    expect(result.ok).toBe(true);
+    const first = result.updatedLines?.[0];
+    expect(first?.backgroundText).toBe("in the dark");
+    expect(first?.backgroundWords?.map((w) => w.text)).toEqual(["in ", "the dark"]);
+    expect(first?.backgroundWords?.[0].begin).toBe(21.2);
+    expect(first?.backgroundWords?.[1].end).toBe(22);
+    expect(first?.backgroundTextSource).toBe("extraction");
+    expect(result.updatedLines?.[1].backgroundText).toBeUndefined();
+    expect(result.updatedLines?.[1].backgroundWords).toBeUndefined();
+  });
+
+  it("clears background vocals the selection had but the template does not", () => {
+    const lines: LyricLine[] = looseChorus().map((line, idx) =>
+      idx === 0
+        ? {
+            ...line,
+            backgroundText: "ooh",
+            backgroundWords: [{ text: "ooh", begin: 21, end: 21.5 }],
+            backgroundTextSource: "manual" as const,
+          }
+        : line,
+    );
+    const result = conformLinesToInstance({
+      lines,
+      groupId: "g1",
+      template: twoLineTemplate,
+      selectedLineIds: looseIds,
+      playheadTime: 0,
+    });
+
+    expect(result.updatedLines?.[0].backgroundText).toBeUndefined();
+    expect(result.updatedLines?.[0].backgroundWords).toBeUndefined();
+    expect(result.updatedLines?.[0].backgroundTextSource).toBeUndefined();
+  });
+
+  it("uses background timing when it starts before the main words", () => {
+    const lines: LyricLine[] = looseChorus().map((line, idx) =>
+      idx === 0 ? { ...line, backgroundText: "ooh", backgroundWords: [{ text: "ooh", begin: 18, end: 19 }] } : line,
+    );
+    const result = conformLinesToInstance({
+      lines,
+      groupId: "g1",
+      template: twoLineTemplate,
+      selectedLineIds: looseIds,
+      playheadTime: 0,
+    });
+
+    expect(result.updatedLines?.[0].words?.[0].begin).toBe(18);
+  });
+
+  it("conforms a selection at the very start of the project", () => {
+    const lines: LyricLine[] = [
+      ...looseChorus(),
+      { id: "outro", text: "Goodnight", agentId: "v1", words: [{ text: "Goodnight", begin: 30, end: 32 }] },
+    ];
+    const result = conformLinesToInstance({
+      lines,
+      groupId: "g1",
+      template: twoLineTemplate,
+      selectedLineIds: looseIds,
+      playheadTime: 0,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.updatedLines?.[0].templateLineIdx).toBe(0);
+    expect(result.updatedLines?.[2].groupId).toBeUndefined();
+  });
+
+  it("conforms a selection at the very end of the project", () => {
+    const lines: LyricLine[] = [
+      { id: "verse", text: "I remember", agentId: "v1", words: [{ text: "I remember", begin: 0, end: 4 }] },
+      ...looseChorus(),
+    ];
+    const result = conformLinesToInstance({
+      lines,
+      groupId: "g1",
+      template: twoLineTemplate,
+      selectedLineIds: looseIds,
+      playheadTime: 0,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.updatedLines?.[2].templateLineIdx).toBe(1);
+    expect(result.updatedLines?.[0].groupId).toBeUndefined();
+  });
+});
+
+// -- Invariants ---------------------------------------------------------------
+
+describe("conformLinesToInstance · invariants", () => {
+  it("does not modify the input lines array", () => {
+    const lines = looseChorus();
+    const snapshot = structuredClone(lines);
+    conformLinesToInstance({
+      lines,
+      groupId: "g1",
+      template: twoLineTemplate,
+      selectedLineIds: looseIds,
+      playheadTime: 0,
+    });
+
+    expect(lines).toEqual(snapshot);
+  });
+
+  it("keeps every line outside the selection referentially identical", () => {
+    const lines: LyricLine[] = [
+      { id: "verse", text: "I remember", agentId: "v1", words: [{ text: "I remember", begin: 0, end: 4 }] },
+      ...looseChorus(),
+      { id: "outro", text: "Goodnight", agentId: "v1", words: [{ text: "Goodnight", begin: 30, end: 32 }] },
+    ];
+    const result = conformLinesToInstance({
+      lines,
+      groupId: "g1",
+      template: twoLineTemplate,
+      selectedLineIds: looseIds,
+      playheadTime: 0,
+    });
+
+    expect(result.updatedLines?.[0]).toBe(lines[0]);
+    expect(result.updatedLines?.[3]).toBe(lines[3]);
+    expect(result.updatedLines?.[1]).not.toBe(lines[1]);
+  });
+
+  it("matches fillEmptyLinesWithInstance when the targets happen to be empty", () => {
+    const lines: LyricLine[] = [
+      { id: "verse", text: "I remember", agentId: "v1", words: [{ text: "I remember", begin: 0, end: 4 }] },
+      { id: "loose1", text: "", agentId: "v1" },
+      { id: "loose2", text: "", agentId: "v1" },
+    ];
+    const conformed = conformLinesToInstance({
+      lines,
+      groupId: "g1",
+      template: twoLineTemplate,
+      selectedLineIds: looseIds,
+      playheadTime: 12,
+    });
+    const filled = fillEmptyLinesWithInstance({
+      lines,
+      groupId: "g1",
+      template: twoLineTemplate,
+      startIndex: 1,
+      instanceStart: 12,
+    });
+
+    expect(conformed.ok).toBe(true);
+    expect(filled.ok).toBe(true);
+    expect(conformed.updatedLines).toEqual(filled.updatedLines);
+    expect(conformed.instanceIdx).toBe(filled.instanceIdx);
+  });
+});

--- a/src/views/timeline/conform-lines-to-instance.test.ts
+++ b/src/views/timeline/conform-lines-to-instance.test.ts
@@ -1,0 +1,252 @@
+/**
+ * @vitest-environment node
+ */
+import type { LineTemplate } from "@/domain/group/template";
+import type { LyricLine } from "@/domain/line/model";
+import { conformLinesToInstance } from "@/views/timeline/conform-lines-to-instance";
+import { describe, expect, it } from "vitest";
+
+// -- Fixtures -----------------------------------------------------------------
+
+const chorusTemplate: LineTemplate[] = [
+  {
+    text: "We were dancing in the dark",
+    agentId: "v1",
+    relativeBegin: 0,
+    relativeEnd: 2,
+    words: [
+      { text: "We were ", relativeBegin: 0, relativeEnd: 0.8 },
+      { text: "dancing in the dark", relativeBegin: 0.8, relativeEnd: 2 },
+    ],
+  },
+  {
+    text: "Till the morning came",
+    agentId: "v2",
+    relativeBegin: 2.5,
+    relativeEnd: 4,
+    words: [{ text: "Till the morning came", relativeBegin: 2.5, relativeEnd: 4 }],
+  },
+];
+
+function songWithLooseChorus(): LyricLine[] {
+  return [
+    { id: "verse", text: "I remember", agentId: "v1", words: [{ text: "I remember", begin: 0, end: 4 }] },
+    {
+      id: "loose1",
+      text: "we were dancin in the dark",
+      agentId: "v1",
+      words: [{ text: "we were dancin in the dark", begin: 20, end: 22 }],
+    },
+    {
+      id: "loose2",
+      text: "till mornin came",
+      agentId: "v1",
+      words: [{ text: "till mornin came", begin: 22.4, end: 24 }],
+    },
+    { id: "outro", text: "Goodnight", agentId: "v1", words: [{ text: "Goodnight", begin: 30, end: 32 }] },
+  ];
+}
+
+const looseIds: ReadonlySet<string> = new Set(["loose1", "loose2"]);
+
+// -- Happy paths --------------------------------------------------------------
+
+describe("conformLinesToInstance · happy path", () => {
+  it("turns a contiguous run of ungrouped lines into a new instance of the group", () => {
+    const lines = songWithLooseChorus();
+    const result = conformLinesToInstance({
+      lines,
+      groupId: "g1",
+      template: chorusTemplate,
+      selectedLineIds: looseIds,
+      playheadTime: 0,
+    });
+
+    expect(result.ok).toBe(true);
+    const updated = result.updatedLines ?? [];
+    expect(updated[1].groupId).toBe("g1");
+    expect(updated[2].groupId).toBe("g1");
+    expect(updated[1].text).toBe("We were dancing in the dark");
+    expect(updated[2].text).toBe("Till the morning came");
+    expect(updated[2].agentId).toBe("v2");
+    expect(updated[1].id).toBe("loose1");
+    expect(updated[2].id).toBe("loose2");
+  });
+
+  it("takes the lowest unused instanceIdx", () => {
+    const lines: LyricLine[] = [
+      { id: "c0l1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 0 },
+      { id: "c0l2", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 0, templateLineIdx: 1 },
+      { id: "c2l1", text: "a", agentId: "v1", groupId: "g1", instanceIdx: 2, templateLineIdx: 0 },
+      { id: "c2l2", text: "b", agentId: "v1", groupId: "g1", instanceIdx: 2, templateLineIdx: 1 },
+      ...songWithLooseChorus().slice(1, 3),
+    ];
+    const result = conformLinesToInstance({
+      lines,
+      groupId: "g1",
+      template: chorusTemplate,
+      selectedLineIds: looseIds,
+      playheadTime: 0,
+    });
+
+    expect(result.instanceIdx).toBe(1);
+    expect(result.updatedLines?.[4].instanceIdx).toBe(1);
+    expect(result.updatedLines?.[5].instanceIdx).toBe(1);
+  });
+
+  it("numbers templateLineIdx sequentially from zero", () => {
+    const result = conformLinesToInstance({
+      lines: songWithLooseChorus(),
+      groupId: "g1",
+      template: chorusTemplate,
+      selectedLineIds: looseIds,
+      playheadTime: 0,
+    });
+
+    expect(result.updatedLines?.[1].templateLineIdx).toBe(0);
+    expect(result.updatedLines?.[2].templateLineIdx).toBe(1);
+  });
+
+  it("offsets template timings by the run's own start time, not the playhead", () => {
+    const result = conformLinesToInstance({
+      lines: songWithLooseChorus(),
+      groupId: "g1",
+      template: chorusTemplate,
+      selectedLineIds: looseIds,
+      playheadTime: 99,
+    });
+
+    expect(result.updatedLines?.[1].words?.[0].begin).toBe(20);
+    expect(result.updatedLines?.[1].words?.[1].end).toBe(22);
+    expect(result.updatedLines?.[2].words?.[0].begin).toBe(22.5);
+    expect(result.updatedLines?.[2].words?.[0].end).toBe(24);
+  });
+
+  it("falls back to the playhead when the selected lines carry no timing", () => {
+    const lines: LyricLine[] = [
+      { id: "loose1", text: "we were dancin in the dark", agentId: "v1" },
+      { id: "loose2", text: "till mornin came", agentId: "v1" },
+    ];
+    const result = conformLinesToInstance({
+      lines,
+      groupId: "g1",
+      template: chorusTemplate,
+      selectedLineIds: looseIds,
+      playheadTime: 42,
+    });
+
+    expect(result.updatedLines?.[0].words?.[0].begin).toBe(42);
+    expect(result.updatedLines?.[1].words?.[0].end).toBe(46);
+  });
+});
+
+// -- Rejections ---------------------------------------------------------------
+
+describe("conformLinesToInstance · rejections", () => {
+  it("refuses when the selection length differs from the template length", () => {
+    const result = conformLinesToInstance({
+      lines: songWithLooseChorus(),
+      groupId: "g1",
+      template: chorusTemplate,
+      selectedLineIds: new Set(["loose1"]),
+      playheadTime: 0,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("length_mismatch");
+    expect(result.updatedLines).toBeUndefined();
+  });
+
+  it("refuses when the selection is not contiguous", () => {
+    const result = conformLinesToInstance({
+      lines: songWithLooseChorus(),
+      groupId: "g1",
+      template: chorusTemplate,
+      selectedLineIds: new Set(["verse", "loose2"]),
+      playheadTime: 0,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("not_contiguous");
+  });
+
+  it("refuses when a selected line already belongs to a group", () => {
+    const lines = songWithLooseChorus();
+    lines[2] = { ...lines[2], groupId: "g2", instanceIdx: 0, templateLineIdx: 0 };
+    const result = conformLinesToInstance({
+      lines,
+      groupId: "g1",
+      template: chorusTemplate,
+      selectedLineIds: looseIds,
+      playheadTime: 0,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("already_grouped");
+  });
+
+  it("refuses when the target group has no derivable template", () => {
+    const result = conformLinesToInstance({
+      lines: songWithLooseChorus(),
+      groupId: "g1",
+      template: [],
+      selectedLineIds: looseIds,
+      playheadTime: 0,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("no_template");
+  });
+
+  it("reports the grouped selection ahead of any shape problem", () => {
+    const lines = songWithLooseChorus();
+    lines[2] = { ...lines[2], groupId: "g2", instanceIdx: 0, templateLineIdx: 0 };
+    const result = conformLinesToInstance({
+      lines,
+      groupId: "g1",
+      template: chorusTemplate,
+      selectedLineIds: new Set(["verse", "loose2"]),
+      playheadTime: 0,
+    });
+
+    expect(result.reason).toBe("already_grouped");
+  });
+
+  it("refuses an empty selection", () => {
+    const result = conformLinesToInstance({
+      lines: songWithLooseChorus(),
+      groupId: "g1",
+      template: chorusTemplate,
+      selectedLineIds: new Set<string>(),
+      playheadTime: 0,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("empty_selection");
+  });
+
+  it("refuses when a selected id is not present in the lines", () => {
+    const result = conformLinesToInstance({
+      lines: songWithLooseChorus(),
+      groupId: "g1",
+      template: chorusTemplate,
+      selectedLineIds: new Set(["loose1", "ghost"]),
+      playheadTime: 0,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("unknown_line");
+  });
+
+  it("distinguishes a gap in the selection from an id it cannot find", () => {
+    const gapped = conformLinesToInstance({
+      lines: songWithLooseChorus(),
+      groupId: "g1",
+      template: chorusTemplate,
+      selectedLineIds: new Set(["verse", "loose2"]),
+      playheadTime: 0,
+    });
+
+    expect(gapped.reason).toBe("not_contiguous");
+  });
+});

--- a/src/views/timeline/conform-lines-to-instance.ts
+++ b/src/views/timeline/conform-lines-to-instance.ts
@@ -1,0 +1,70 @@
+import { instanceBounds } from "@/domain/instance/bounds";
+import type { LineTemplate } from "@/domain/group/template";
+import type { LyricLine } from "@/domain/line/model";
+import { applyInstanceTemplate } from "@/views/timeline/apply-instance-template";
+import { lineIdsAreContiguous, selectionTouchesAnyGroup } from "@/views/timeline/group-ops";
+
+// -- Interfaces ----------------------------------------------------------------
+
+interface ConformInput {
+  lines: LyricLine[];
+  groupId: string;
+  template: LineTemplate[];
+  selectedLineIds: ReadonlySet<string>;
+  playheadTime: number;
+}
+
+type ConformFailure =
+  | "empty_selection"
+  | "no_template"
+  | "already_grouped"
+  | "unknown_line"
+  | "not_contiguous"
+  | "length_mismatch";
+
+interface ConformResult {
+  ok: boolean;
+  reason?: ConformFailure;
+  updatedLines?: LyricLine[];
+  instanceIdx?: number;
+}
+
+// -- Operation -----------------------------------------------------------------
+
+function conformLinesToInstance({
+  lines,
+  groupId,
+  template,
+  selectedLineIds,
+  playheadTime,
+}: ConformInput): ConformResult {
+  if (selectedLineIds.size === 0) return { ok: false, reason: "empty_selection" };
+  if (template.length === 0) return { ok: false, reason: "no_template" };
+  if (selectionTouchesAnyGroup(lines, selectedLineIds)) return { ok: false, reason: "already_grouped" };
+
+  const knownIds = new Set(lines.map((line) => line.id));
+  for (const id of selectedLineIds) {
+    if (!knownIds.has(id)) return { ok: false, reason: "unknown_line" };
+  }
+  if (!lineIdsAreContiguous(lines, selectedLineIds)) return { ok: false, reason: "not_contiguous" };
+  if (selectedLineIds.size !== template.length) return { ok: false, reason: "length_mismatch" };
+
+  const startIndex = lines.findIndex((line) => selectedLineIds.has(line.id));
+  const selected = lines.slice(startIndex, startIndex + template.length);
+  const instanceStart = instanceBounds(selected)?.begin ?? playheadTime;
+
+  const { updatedLines, instanceIdx } = applyInstanceTemplate({
+    lines,
+    groupId,
+    template,
+    startIndex,
+    instanceStart,
+  });
+
+  return { ok: true, updatedLines, instanceIdx };
+}
+
+// -- Exports -------------------------------------------------------------------
+
+export { conformLinesToInstance };
+export type { ConformFailure };

--- a/src/views/timeline/conform-lines-to-instance.ts
+++ b/src/views/timeline/conform-lines-to-instance.ts
@@ -1,7 +1,7 @@
 import { instanceBounds } from "@/domain/instance/bounds";
 import type { LineTemplate } from "@/domain/group/template";
 import type { LyricLine } from "@/domain/line/model";
-import { applyInstanceTemplate } from "@/views/timeline/apply-instance-template";
+import { applyInstanceTemplate, type InstanceApplyResult } from "@/views/timeline/apply-instance-template";
 import { lineIdsAreContiguous, selectionTouchesAnyGroup } from "@/views/timeline/group-ops";
 
 // -- Interfaces ----------------------------------------------------------------
@@ -22,12 +22,7 @@ type ConformFailure =
   | "not_contiguous"
   | "length_mismatch";
 
-interface ConformResult {
-  ok: boolean;
-  reason?: ConformFailure;
-  updatedLines?: LyricLine[];
-  instanceIdx?: number;
-}
+type ConformResult = InstanceApplyResult<ConformFailure>;
 
 // -- Operation -----------------------------------------------------------------
 

--- a/src/views/timeline/drag-threshold.ts
+++ b/src/views/timeline/drag-threshold.ts
@@ -1,0 +1,8 @@
+// -- Constants -----------------------------------------------------------------
+
+/** Horizontal travel a pointer must cover before a press counts as a drag rather than a click. */
+const DRAG_THRESHOLD_PX = 3;
+
+// -- Exports -------------------------------------------------------------------
+
+export { DRAG_THRESHOLD_PX };

--- a/src/views/timeline/fill-empty-lines-with-instance.ts
+++ b/src/views/timeline/fill-empty-lines-with-instance.ts
@@ -1,14 +1,10 @@
-import type { LineTemplate, LinkGroup } from "@/domain/group/template";
+import type { LineTemplate } from "@/domain/group/template";
 import type { LyricLine } from "@/domain/line/model";
-import { applyInstanceTemplate } from "@/views/timeline/apply-instance-template";
+import { applyInstanceTemplate, type InstanceApplyResult } from "@/views/timeline/apply-instance-template";
 
-interface FillResult {
-  ok: boolean;
-  reason?: "not_enough_empty_lines" | "out_of_range";
-  updatedLines?: LyricLine[];
-  newGroup?: LinkGroup;
-  instanceIdx?: number;
-}
+type FillFailure = "not_enough_empty_lines" | "out_of_range";
+
+type FillResult = InstanceApplyResult<FillFailure>;
 
 interface FillInput {
   lines: LyricLine[];

--- a/src/views/timeline/fill-empty-lines-with-instance.ts
+++ b/src/views/timeline/fill-empty-lines-with-instance.ts
@@ -1,5 +1,6 @@
 import type { LineTemplate, LinkGroup } from "@/domain/group/template";
-import { reconcileLine, type LyricLine } from "@/domain/line/model";
+import type { LyricLine } from "@/domain/line/model";
+import { applyInstanceTemplate } from "@/views/timeline/apply-instance-template";
 
 interface FillResult {
   ok: boolean;
@@ -35,49 +36,12 @@ function fillEmptyLinesWithInstance(input: FillInput): FillResult {
     }
   }
 
-  const usedIndices = new Set(
-    lines.flatMap((l) => (l.groupId === groupId && l.instanceIdx !== undefined ? [l.instanceIdx] : [])),
-  );
-  let instanceIdx = 0;
-  while (usedIndices.has(instanceIdx)) instanceIdx++;
-
-  const updatedLines = lines.map((line, idx) => {
-    if (idx < startIndex || idx >= startIndex + template.length) return line;
-    const tplLine = template[idx - startIndex];
-    return reconcileLine({
-      ...line,
-      text: tplLine.text,
-      agentId: tplLine.agentId,
-      groupId,
-      instanceIdx,
-      templateLineIdx: idx - startIndex,
-      ...(tplLine.relativeBegin !== undefined
-        ? { begin: tplLine.relativeBegin + instanceStart }
-        : { begin: undefined }),
-      ...(tplLine.relativeEnd !== undefined ? { end: tplLine.relativeEnd + instanceStart } : { end: undefined }),
-      ...(tplLine.words
-        ? {
-            words: tplLine.words.map((w) => ({
-              text: w.text,
-              begin: w.relativeBegin + instanceStart,
-              end: w.relativeEnd + instanceStart,
-            })),
-          }
-        : { words: undefined }),
-      ...(tplLine.backgroundText !== undefined
-        ? { backgroundText: tplLine.backgroundText }
-        : { backgroundText: undefined }),
-      ...(tplLine.backgroundWords
-        ? {
-            backgroundWords: tplLine.backgroundWords.map((w) => ({
-              text: w.text,
-              begin: w.relativeBegin + instanceStart,
-              end: w.relativeEnd + instanceStart,
-            })),
-          }
-        : { backgroundWords: undefined }),
-      backgroundTextSource: tplLine.backgroundTextSource,
-    });
+  const { updatedLines, instanceIdx } = applyInstanceTemplate({
+    lines,
+    groupId,
+    template,
+    startIndex,
+    instanceStart,
   });
 
   return { ok: true, updatedLines, instanceIdx };

--- a/src/views/timeline/group-banner.tsx
+++ b/src/views/timeline/group-banner.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/ui/button";
 import { buildGroupPingVariants } from "@/utils/animationVariants";
 import { cn } from "@/utils/cn";
 import { registerBanner } from "@/views/timeline/banner-progress-registry";
+import { DRAG_THRESHOLD_PX } from "@/views/timeline/drag-threshold";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { getWordsInInstance } from "@/views/timeline/utils";
 import { IconChevronDown, IconLink } from "@tabler/icons-react";
@@ -25,7 +26,6 @@ interface GroupBannerProps {
 // -- Constants -----------------------------------------------------------------
 
 const BANNER_MIN_WIDTH = 80;
-const DRAG_THRESHOLD_PX = 3;
 
 // -- Component -----------------------------------------------------------------
 

--- a/src/views/timeline/line-row.browser.test.tsx
+++ b/src/views/timeline/line-row.browser.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { LineRow } from "@/views/timeline/line-row";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { createLine, createWord } from "@/test/factories";
 import { render } from "@/test/render";
@@ -129,5 +130,28 @@ describe("LineRow", () => {
 
     await expect.poll(() => useProjectStore.getState().lines[0].backgroundWords?.length).toBe(1);
     expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
+  });
+
+  it("honours the minimum word duration setting when creating a word from the drop-zone", async () => {
+    useAudioStore.setState({ duration: 0.1 });
+    useSettingsStore.setState({ minWordDuration: 0.5 });
+    const line = createLine({
+      id: "l1",
+      text: "hello world",
+      words: [createWord({ text: "hello", begin: 0, end: 1 })],
+    });
+    useProjectStore.setState({ lines: [line] });
+    const screen = await render(
+      <LineRow line={line} lineIndex={0} duration={30} onUpdateWord={() => {}} onUpdateBgWord={() => {}} />,
+      { dndContext: true },
+    );
+
+    const dropZone = Array.from(screen.container.querySelectorAll("div")).find((d) => d.textContent?.trim() === "BG");
+    dropZone?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, clientX: 100 }));
+    expect(useProjectStore.getState().lines[0].backgroundWords).toBeUndefined();
+
+    useSettingsStore.setState({ minWordDuration: 0.05 });
+    dropZone?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, clientX: 100 }));
+    await expect.poll(() => useProjectStore.getState().lines[0].backgroundWords?.length).toBe(1);
   });
 });

--- a/src/views/timeline/line-row.tsx
+++ b/src/views/timeline/line-row.tsx
@@ -196,8 +196,8 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
                 const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
                 const time = (e.clientX - rect.left) / zoomPx;
                 const audioDuration = useAudioStore.getState().duration;
-                const wordDuration = useSettingsStore.getState().defaultWordDuration;
-                const slot = findInsertionSlot([], time, wordDuration, audioDuration);
+                const { defaultWordDuration, minWordDuration } = useSettingsStore.getState();
+                const slot = findInsertionSlot([], time, defaultWordDuration, audioDuration, minWordDuration);
                 if (!slot) return;
                 const newWord: WordTiming = {
                   text: displayText.slice(0, 60) || "...",
@@ -273,8 +273,8 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
               const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
               const time = (e.clientX - rect.left) / zoom;
               const audioDuration = useAudioStore.getState().duration;
-              const wordDuration = useSettingsStore.getState().defaultWordDuration;
-              const slot = findInsertionSlot([], time, wordDuration, audioDuration);
+              const { defaultWordDuration, minWordDuration } = useSettingsStore.getState();
+              const slot = findInsertionSlot([], time, defaultWordDuration, audioDuration, minWordDuration);
               if (!slot) return;
               const newWord: WordTiming = { text: "...", begin: slot.begin, end: slot.end };
               useProjectStore

--- a/src/views/timeline/paste-preview.tsx
+++ b/src/views/timeline/paste-preview.tsx
@@ -4,6 +4,7 @@ import { useModalStackStore } from "@/stores/modal-stack";
 import { useProjectStore } from "@/stores/project";
 import type { LineTemplate } from "@/domain/group/template";
 import type { LyricLine } from "@/domain/line/model";
+import { instanceIndicesOf } from "@/domain/instance/enumerate";
 import { boundsOverlap } from "@/domain/word/overlap";
 import { cn } from "@/utils/cn";
 import { applyPasteToLines } from "@/views/timeline/apply-paste-to-lines";
@@ -142,7 +143,7 @@ const PastePreview: React.FC<PastePreviewProps> = ({ clipboard, scrollContainerR
         if (match) {
           const group = useProjectStore.getState().groups.find((g) => g.id === match.groupId);
           const groupLabel = group?.label ?? "group";
-          const instanceCount = countInstances(lines, match.groupId);
+          const instanceCount = instanceIndicesOf(lines, match.groupId).length;
           const ok = await confirm({
             title: `Link as another ${groupLabel}?`,
             description: `These ${clipboard.candidateLines.length} lines look like a ${groupLabel} (matches ${instanceCount} instance${instanceCount === 1 ? "" : "s"}). Link as another instance, or paste as plain words?`,
@@ -261,14 +262,6 @@ const PastePreview: React.FC<PastePreviewProps> = ({ clipboard, scrollContainerR
 };
 
 // -- Helpers -------------------------------------------------------------------
-
-function countInstances(lines: LyricLine[], groupId: string): number {
-  const seen = new Set<number>();
-  for (const line of lines) {
-    if (line.groupId === groupId && line.instanceIdx !== undefined) seen.add(line.instanceIdx);
-  }
-  return seen.size;
-}
 
 function checkOverlaps(
   clipboard: ClipboardData,

--- a/src/views/timeline/timeline-context-menu.conform.browser.test.tsx
+++ b/src/views/timeline/timeline-context-menu.conform.browser.test.tsx
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
+import { ConfirmModalHost } from "@/ui/confirm-modal";
+import { createGroup, createLine, createWord } from "@/test/factories";
+import { render } from "@/test/render";
+import { TimelineContextMenu } from "@/views/timeline/timeline-context-menu";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+
+// -- Fixtures -----------------------------------------------------------------
+
+const DARK = "We were dancing in the dark";
+const MORNING = "Till the morning came";
+
+function seedProject() {
+  useProjectStore.setState({
+    groups: [createGroup({ id: "g1", label: "Chorus" })],
+    lines: [
+      createLine({
+        id: "c1",
+        text: DARK,
+        words: [createWord({ text: DARK, begin: 0, end: 2 })],
+        groupId: "g1",
+        instanceIdx: 0,
+        templateLineIdx: 0,
+      }),
+      createLine({
+        id: "c2",
+        text: MORNING,
+        words: [createWord({ text: MORNING, begin: 2.5, end: 4 })],
+        groupId: "g1",
+        instanceIdx: 0,
+        templateLineIdx: 1,
+      }),
+      createLine({
+        id: "l3",
+        text: "we were dancin in the dark",
+        words: [createWord({ text: "we were dancin in the dark", begin: 20, end: 22 })],
+      }),
+      createLine({
+        id: "l4",
+        text: "till mornin came",
+        words: [createWord({ text: "till mornin came", begin: 22.4, end: 24 })],
+      }),
+    ],
+  });
+}
+
+function seedSecondGroup() {
+  useProjectStore.setState({
+    groups: [createGroup({ id: "g1", label: "Chorus" }), createGroup({ id: "g2", label: "Bridge" })],
+    lines: [
+      ...useProjectStore.getState().lines,
+      createLine({
+        id: "b1",
+        text: "Hold on",
+        words: [createWord({ text: "Hold on", begin: 40, end: 41 })],
+        groupId: "g2",
+        instanceIdx: 0,
+        templateLineIdx: 0,
+      }),
+      createLine({
+        id: "b2",
+        text: "Just a while",
+        words: [createWord({ text: "Just a while", begin: 41, end: 42 })],
+        groupId: "g2",
+        instanceIdx: 0,
+        templateLineIdx: 1,
+      }),
+    ],
+  });
+}
+
+function openGutterMenu(lineIds: string[]) {
+  useTimelineStore.setState({
+    contextMenu: { x: 100, y: 100, target: { kind: "gutter", lineId: lineIds[0], lineIndex: 2 } },
+    selectedWords: lineIds.map((lineId, i) => ({ lineId, lineIndex: 2 + i, wordIndex: 0, type: "word" as const })),
+  });
+}
+
+function renderMenu() {
+  return render(
+    <>
+      <TimelineContextMenu />
+      <ConfirmModalHost />
+    </>,
+  );
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("TimelineContextMenu conform to group", () => {
+  beforeEach(() => {
+    seedProject();
+  });
+
+  it("offers the group when the selection length matches its template", async () => {
+    openGutterMenu(["l3", "l4"]);
+    const screen = await renderMenu();
+
+    await expect.element(screen.getByRole("button", { name: 'Conform to "Chorus"' })).toBeInTheDocument();
+  });
+
+  it("hides the action when the selection length differs from the template", async () => {
+    openGutterMenu(["l3"]);
+    const screen = await renderMenu();
+
+    await expect.element(screen.getByRole("button", { name: "Add line above" })).toBeInTheDocument();
+    await expect.element(screen.getByRole("button", { name: /Conform/ })).not.toBeInTheDocument();
+  });
+
+  it("hides the action when a selected line already belongs to a group", async () => {
+    useTimelineStore.setState({
+      contextMenu: { x: 100, y: 100, target: { kind: "gutter", lineId: "c2", lineIndex: 1 } },
+      selectedWords: [
+        { lineId: "c2", lineIndex: 1, wordIndex: 0, type: "word" },
+        { lineId: "l3", lineIndex: 2, wordIndex: 0, type: "word" },
+      ],
+    });
+    const screen = await renderMenu();
+
+    await expect.element(screen.getByRole("button", { name: "Add line above" })).toBeInTheDocument();
+    await expect.element(screen.getByRole("button", { name: /Conform/ })).not.toBeInTheDocument();
+  });
+
+  it("lists every matching group when more than one qualifies", async () => {
+    seedSecondGroup();
+    openGutterMenu(["l3", "l4"]);
+    const screen = await renderMenu();
+
+    await expect.element(screen.getByRole("button", { name: "Chorus", exact: true })).toBeInTheDocument();
+    await expect.element(screen.getByRole("button", { name: "Bridge", exact: true })).toBeInTheDocument();
+  });
+
+  it("conforms to the group picked from the list, not the first one", async () => {
+    seedSecondGroup();
+    openGutterMenu(["l3", "l4"]);
+    const screen = await renderMenu();
+
+    await screen.getByRole("button", { name: "Bridge", exact: true }).click();
+    await screen.getByRole("button", { name: "Conform", exact: true }).click();
+
+    await expect.poll(() => useProjectStore.getState().lines[2].groupId).toBe("g2");
+    const [, , third, fourth] = useProjectStore.getState().lines;
+    expect(third.text).toBe("Hold on");
+    expect(third.words?.[0].begin).toBe(20);
+    expect(fourth.text).toBe("Just a while");
+    expect(fourth.instanceIdx).toBe(1);
+  });
+
+  it("conforms the selection into a new instance once confirmed", async () => {
+    openGutterMenu(["l3", "l4"]);
+    const screen = await renderMenu();
+
+    await screen.getByRole("button", { name: 'Conform to "Chorus"' }).click();
+    await screen.getByRole("button", { name: "Conform", exact: true }).click();
+
+    await expect.poll(() => useProjectStore.getState().lines[2].groupId).toBe("g1");
+    const [, , third, fourth] = useProjectStore.getState().lines;
+    expect(third.instanceIdx).toBe(1);
+    expect(third.templateLineIdx).toBe(0);
+    expect(third.text).toBe(DARK);
+    expect(third.words?.[0].begin).toBe(20);
+    expect(fourth.instanceIdx).toBe(1);
+    expect(fourth.templateLineIdx).toBe(1);
+    expect(fourth.text).toBe(MORNING);
+    expect(fourth.words?.[0].begin).toBe(22.5);
+  });
+
+  it("restores the original lines on undo", async () => {
+    openGutterMenu(["l3", "l4"]);
+    const screen = await renderMenu();
+
+    await screen.getByRole("button", { name: 'Conform to "Chorus"' }).click();
+    await screen.getByRole("button", { name: "Conform", exact: true }).click();
+    await expect.poll(() => useProjectStore.getState().lines[2].groupId).toBe("g1");
+
+    useProjectStore.getState().undo();
+
+    const [, , third, fourth] = useProjectStore.getState().lines;
+    expect(third.groupId).toBeUndefined();
+    expect(third.text).toBe("we were dancin in the dark");
+    expect(third.words?.[0].begin).toBe(20);
+    expect(fourth.text).toBe("till mornin came");
+  });
+
+  it("skips the confirmation when the setting is off", async () => {
+    useSettingsStore.setState({ confirmConformToGroup: false });
+    openGutterMenu(["l3", "l4"]);
+    const screen = await renderMenu();
+
+    await screen.getByRole("button", { name: 'Conform to "Chorus"' }).click();
+
+    await expect.poll(() => useProjectStore.getState().lines[2].groupId).toBe("g1");
+    expect(document.querySelector("dialog")).toBeNull();
+  });
+
+  it("changes nothing when the confirmation is cancelled", async () => {
+    openGutterMenu(["l3", "l4"]);
+    const before = useProjectStore.getState().lines;
+    const screen = await renderMenu();
+
+    await screen.getByRole("button", { name: 'Conform to "Chorus"' }).click();
+    await screen.getByRole("button", { name: "Cancel" }).click();
+
+    await expect.poll(() => document.querySelector("dialog")).toBeNull();
+    expect(useProjectStore.getState().lines).toBe(before);
+  });
+
+  it("dismisses the menu on Escape without conforming", async () => {
+    openGutterMenu(["l3", "l4"]);
+    const before = useProjectStore.getState().lines;
+    await renderMenu();
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    await expect.poll(() => useTimelineStore.getState().contextMenu).toBeNull();
+    expect(useProjectStore.getState().lines).toBe(before);
+  });
+});

--- a/src/views/timeline/timeline-context-menu.tsx
+++ b/src/views/timeline/timeline-context-menu.tsx
@@ -11,7 +11,7 @@ import { useLineMenuActions } from "@/views/timeline/use-line-menu-actions";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { useWordMenuActions } from "@/views/timeline/use-word-menu-actions";
 import { IconCommand } from "@tabler/icons-react";
-import { flip, FloatingPortal, shift, useFloating } from "@floating-ui/react";
+import { flip, FloatingPortal, shift, size, useFloating } from "@floating-ui/react";
 import { useEffect, useLayoutEffect } from "react";
 
 function MenuItem({
@@ -57,7 +57,16 @@ const TimelineContextMenu: React.FC = () => {
 
   const { refs, floatingStyles } = useFloating({
     placement: "bottom-start",
-    middleware: [flip({ fallbackPlacements: ["top-start", "bottom-end", "top-end"] }), shift({ padding: 8 })],
+    middleware: [
+      flip({ fallbackPlacements: ["top-start", "bottom-end", "top-end"] }),
+      shift({ padding: 8 }),
+      size({
+        padding: 8,
+        apply: ({ availableHeight, elements }) => {
+          elements.floating.style.maxHeight = `${availableHeight}px`;
+        },
+      }),
+    ],
   });
 
   const agents = useProjectStore((s) => s.agents);
@@ -158,7 +167,7 @@ const TimelineContextMenu: React.FC = () => {
     <FloatingPortal>
       <div
         ref={refs.setFloating}
-        className="z-100 min-w-36 p-1 border shadow-2xl rounded-lg bg-composer-bg border-composer-border select-none"
+        className="z-100 min-w-36 p-1 border shadow-2xl rounded-lg bg-composer-bg border-composer-border select-none overflow-y-auto overscroll-contain"
         style={floatingStyles}
       >
         {target.kind === "word" && (

--- a/src/views/timeline/timeline-context-menu.tsx
+++ b/src/views/timeline/timeline-context-menu.tsx
@@ -49,6 +49,63 @@ function MenuDivider() {
   return <div className="my-1 border-t border-composer-border" />;
 }
 
+// -- Grouping section ---------------------------------------------------------
+
+type ContextMenuTargets = ReturnType<typeof useContextMenuTargets>;
+
+function GroupingMenuSection({
+  groupableSelection,
+  conformableSelection,
+  onCreateGroup,
+  onConform,
+}: {
+  groupableSelection: ContextMenuTargets["groupableSelection"];
+  conformableSelection: ContextMenuTargets["conformableSelection"];
+  onCreateGroup: () => void;
+  onConform: (groupId: string) => void;
+}) {
+  if (!groupableSelection && !conformableSelection) return null;
+  const soleOption = conformableSelection?.options.length === 1 ? conformableSelection.options[0] : null;
+
+  return (
+    <>
+      <MenuDivider />
+      {groupableSelection && (
+        <MenuItem
+          label={
+            groupableSelection.count > 1
+              ? `Group ${groupableSelection.count} lines${groupableSelection.addedFromGaps > 0 ? ` (incl. ${groupableSelection.addedFromGaps} gap)` : ""}`
+              : "Group this line"
+          }
+          shortcut={getEffectiveKeysArray("timeline.createGroup")}
+          onClick={onCreateGroup}
+        />
+      )}
+      {soleOption && (
+        <MenuItem label={`Conform to "${soleOption.group.label}"`} onClick={() => onConform(soleOption.group.id)} />
+      )}
+      {conformableSelection && !soleOption && (
+        <>
+          <p className="px-3 py-1 text-xs text-composer-text-muted">Conform to group</p>
+          <div className="flex flex-col gap-px">
+            {conformableSelection.options.map(({ group }) => (
+              <button
+                key={group.id}
+                type="button"
+                onClick={() => onConform(group.id)}
+                className="w-full text-left py-1 pl-2 pr-2.5 text-sm cursor-pointer rounded-md flex items-center gap-2 text-composer-text hover:bg-composer-button transition-colors"
+              >
+                <span className="size-2 rounded-full shrink-0" style={{ backgroundColor: group.color }} />
+                {group.label}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
 // -- Component ----------------------------------------------------------------
 
 const TimelineContextMenu: React.FC = () => {
@@ -77,6 +134,7 @@ const TimelineContextMenu: React.FC = () => {
     explicitToggleContext,
     gutterLineGroupInfo,
     groupableSelection,
+    conformableSelection,
     mergeInfo,
     groupedWordInfo,
     snapNeededInfo,
@@ -108,6 +166,7 @@ const TimelineContextMenu: React.FC = () => {
   const {
     handleJumpToGroupFromBanner,
     handleCreateGroupFromSelection,
+    handleConformToGroup,
     handleDeleteGroup,
     handleRenameStart,
     handleRecolorGroup,
@@ -216,20 +275,12 @@ const TimelineContextMenu: React.FC = () => {
                 />
               </>
             )}
-            {groupableSelection && (
-              <>
-                <MenuDivider />
-                <MenuItem
-                  label={
-                    groupableSelection.count > 1
-                      ? `Group ${groupableSelection.count} lines${groupableSelection.addedFromGaps > 0 ? ` (incl. ${groupableSelection.addedFromGaps} gap)` : ""}`
-                      : "Group this line"
-                  }
-                  shortcut={getEffectiveKeysArray("timeline.createGroup")}
-                  onClick={handleCreateGroupFromSelection}
-                />
-              </>
-            )}
+            <GroupingMenuSection
+              groupableSelection={groupableSelection}
+              conformableSelection={conformableSelection}
+              onCreateGroup={handleCreateGroupFromSelection}
+              onConform={handleConformToGroup}
+            />
             {explicitToggleContext && (
               <>
                 <MenuDivider />
@@ -262,20 +313,12 @@ const TimelineContextMenu: React.FC = () => {
           <>
             <MenuItem label="Add word here" shortcut={["Double Click"]} onClick={handleAddWordHere} />
             {placeLineHereInfo && <MenuItem label="Place line here" onClick={handlePlaceLineHere} />}
-            {groupableSelection && (
-              <>
-                <MenuDivider />
-                <MenuItem
-                  label={
-                    groupableSelection.count > 1
-                      ? `Group ${groupableSelection.count} lines${groupableSelection.addedFromGaps > 0 ? ` (incl. ${groupableSelection.addedFromGaps} gap)` : ""}`
-                      : "Group this line"
-                  }
-                  shortcut={getEffectiveKeysArray("timeline.createGroup")}
-                  onClick={handleCreateGroupFromSelection}
-                />
-              </>
-            )}
+            <GroupingMenuSection
+              groupableSelection={groupableSelection}
+              conformableSelection={conformableSelection}
+              onCreateGroup={handleCreateGroupFromSelection}
+              onConform={handleConformToGroup}
+            />
           </>
         )}
 
@@ -283,20 +326,12 @@ const TimelineContextMenu: React.FC = () => {
           <>
             <MenuItem label="Add line above" shortcut={["Shift", "N"]} onClick={() => handleAddLine("above")} />
             <MenuItem label="Add line below" shortcut={["N"]} onClick={() => handleAddLine("below")} />
-            {groupableSelection && (
-              <>
-                <MenuDivider />
-                <MenuItem
-                  label={
-                    groupableSelection.count > 1
-                      ? `Group ${groupableSelection.count} lines${groupableSelection.addedFromGaps > 0 ? ` (incl. ${groupableSelection.addedFromGaps} gap)` : ""}`
-                      : "Group this line"
-                  }
-                  shortcut={getEffectiveKeysArray("timeline.createGroup")}
-                  onClick={handleCreateGroupFromSelection}
-                />
-              </>
-            )}
+            <GroupingMenuSection
+              groupableSelection={groupableSelection}
+              conformableSelection={conformableSelection}
+              onCreateGroup={handleCreateGroupFromSelection}
+              onConform={handleConformToGroup}
+            />
             <MenuDivider />
             {agents.length > 1 && (
               <>
@@ -311,7 +346,7 @@ const TimelineContextMenu: React.FC = () => {
                         key={agent.id}
                         type="button"
                         onClick={() => handleAssignAgent(agent.id)}
-                        className={`w-full text-left px-2 py-1 text-sm cursor-pointer rounded-md flex items-center gap-2 transition-colors ${
+                        className={`w-full text-left py-1 pl-2 pr-2.5 text-sm cursor-pointer rounded-md flex items-center gap-2 transition-colors ${
                           isActive
                             ? "bg-composer-accent/15 text-composer-text"
                             : "text-composer-text hover:bg-composer-button"

--- a/src/views/timeline/timeline-info-panel.browser.test.tsx
+++ b/src/views/timeline/timeline-info-panel.browser.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { userEvent } from "vitest/browser";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
@@ -9,12 +8,6 @@ import { TimelineInfoPanel } from "@/views/timeline/timeline-info-panel";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 
 // -- Helpers ------------------------------------------------------------------
-
-function selectFirstWordOf(lineId: string): void {
-  useTimelineStore.setState({
-    selectedWords: [{ lineId, lineIndex: 0, wordIndex: 0, type: "word" }],
-  });
-}
 
 function selectWordAt(lineId: string, wordIndex: number): void {
   useTimelineStore.setState({
@@ -41,83 +34,6 @@ describe("TimelineInfoPanel", () => {
     useTimelineStore.setState({ selectedWords: [] });
     const screen = await render(<TimelineInfoPanel />);
     expect(screen.container.textContent?.trim() ?? "").toBe("");
-  });
-});
-
-describe("BackgroundTextEditor provenance", () => {
-  it("labels the background vocals input", async () => {
-    const line = createLine({
-      id: "l1",
-      text: "hello",
-      words: [createWord({ text: "hello", begin: 0, end: 1 })],
-    });
-    useProjectStore.setState({ lines: [line] });
-    selectFirstWordOf("l1");
-    const screen = await render(<TimelineInfoPanel />);
-
-    await screen.getByRole("button", { name: "Add BG" }).click();
-    await expect.element(screen.getByRole("textbox", { name: "Background vocals text" })).toBeInTheDocument();
-  });
-
-  it("stamps a manual provenance when adding background text", async () => {
-    const line = createLine({
-      id: "l1",
-      text: "hello",
-      words: [createWord({ text: "hello", begin: 0, end: 1 })],
-    });
-    useProjectStore.setState({ lines: [line] });
-    selectFirstWordOf("l1");
-    const screen = await render(<TimelineInfoPanel />);
-
-    await screen.getByRole("button", { name: "Add BG" }).click();
-    await screen.getByPlaceholder("Background vocals").fill("ooh");
-    await userEvent.keyboard("{Enter}");
-
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundText).toBe("ooh");
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
-  });
-
-  it("flips an extraction-sourced background to manual when edited", async () => {
-    const line = createLine({
-      id: "l1",
-      text: "hello",
-      words: [createWord({ text: "hello", begin: 0, end: 1 })],
-      backgroundText: "ooh",
-      backgroundTextSource: "extraction",
-    });
-    useProjectStore.setState({ lines: [line] });
-    selectFirstWordOf("l1");
-    const screen = await render(<TimelineInfoPanel />);
-
-    await screen.getByRole("button", { name: "BG: ooh" }).click();
-    await screen.getByPlaceholder("Background vocals").fill("aah");
-    await userEvent.keyboard("{Enter}");
-
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundText).toBe("aah");
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
-  });
-
-  it("clears all three background fields when the editor is emptied", async () => {
-    const line = createLine({
-      id: "l1",
-      text: "hello",
-      words: [createWord({ text: "hello", begin: 0, end: 1 })],
-      backgroundText: "ooh",
-      backgroundTextSource: "extraction",
-    });
-    useProjectStore.setState({
-      lines: [{ ...line, backgroundWords: [createWord({ text: "ooh", begin: 0, end: 1 })] }],
-    });
-    selectFirstWordOf("l1");
-    const screen = await render(<TimelineInfoPanel />);
-
-    await screen.getByRole("button", { name: "BG: ooh" }).click();
-    await screen.getByPlaceholder("Background vocals").fill("");
-    await userEvent.keyboard("{Enter}");
-
-    await expect.poll(() => useProjectStore.getState().lines[0].backgroundText).toBeUndefined();
-    expect(useProjectStore.getState().lines[0].backgroundWords).toBeUndefined();
-    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBeUndefined();
   });
 });
 

--- a/src/views/timeline/timeline-info-panel.browser.test.tsx
+++ b/src/views/timeline/timeline-info-panel.browser.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { userEvent } from "vitest/browser";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
 import { createLine, createWord } from "@/test/factories";
 import { render } from "@/test/render";
 import { TimelineInfoPanel } from "@/views/timeline/timeline-info-panel";
@@ -13,6 +14,24 @@ function selectFirstWordOf(lineId: string): void {
   useTimelineStore.setState({
     selectedWords: [{ lineId, lineIndex: 0, wordIndex: 0, type: "word" }],
   });
+}
+
+function selectWordAt(lineId: string, wordIndex: number): void {
+  useTimelineStore.setState({
+    selectedWords: [{ lineId, lineIndex: 0, wordIndex, type: "word" }],
+  });
+}
+
+function flushPairLine() {
+  return createLine({
+    id: "l1",
+    text: "hello world",
+    words: [createWord({ text: "hello ", begin: 0, end: 1 }), createWord({ text: "world", begin: 1, end: 2 })],
+  });
+}
+
+function currentWords() {
+  return useProjectStore.getState().lines[0].words ?? [];
 }
 
 // -- Tests --------------------------------------------------------------------
@@ -148,5 +167,89 @@ describe("TimelineInfoPanel bg word retiming provenance", () => {
 
     await expect.poll(() => useProjectStore.getState().lines[0].words?.[0].begin).toBeCloseTo(0.4);
     expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("extraction");
+  });
+});
+
+describe("TimelineInfoPanel cursor buttons · rolling edit", () => {
+  it("moves the previous word's end with Set Begin when rolling over a flush boundary", async () => {
+    useAudioStore.setState({ currentTime: 1.4, duration: 10 });
+    useProjectStore.setState({ lines: [flushPairLine()] });
+    useTimelineStore.setState({ rollingEditMode: true });
+    selectWordAt("l1", 1);
+    const screen = await render(<TimelineInfoPanel />);
+
+    await screen.getByRole("button", { name: /Set Begin/ }).click();
+
+    await expect.poll(() => currentWords()[1].begin).toBeCloseTo(1.4, 10);
+    expect(currentWords()[0].end).toBeCloseTo(1.4, 10);
+  });
+
+  it("moves the next word's begin with Set End when rolling over a flush boundary", async () => {
+    useAudioStore.setState({ currentTime: 1.4, duration: 10 });
+    useProjectStore.setState({ lines: [flushPairLine()] });
+    useTimelineStore.setState({ rollingEditMode: true });
+    selectWordAt("l1", 0);
+    const screen = await render(<TimelineInfoPanel />);
+
+    await screen.getByRole("button", { name: /Set End/ }).click();
+
+    await expect.poll(() => currentWords()[0].end).toBeCloseTo(1.4, 10);
+    expect(currentWords()[1].begin).toBeCloseTo(1.4, 10);
+  });
+
+  it("moves only the selected word when rolling edit is off", async () => {
+    useAudioStore.setState({ currentTime: 1.4, duration: 10 });
+    useProjectStore.setState({ lines: [flushPairLine()] });
+    useTimelineStore.setState({ rollingEditMode: false });
+    selectWordAt("l1", 1);
+    const screen = await render(<TimelineInfoPanel />);
+
+    await screen.getByRole("button", { name: /Set Begin/ }).click();
+
+    await expect.poll(() => currentWords()[1].begin).toBeCloseTo(1.4, 10);
+    expect(currentWords()[0].end).toBe(1);
+  });
+
+  it("records a rolling edit as a single undo entry", async () => {
+    useAudioStore.setState({ currentTime: 1.4, duration: 10 });
+    useProjectStore.setState({ lines: [flushPairLine()] });
+    useTimelineStore.setState({ rollingEditMode: true });
+    selectWordAt("l1", 1);
+    const screen = await render(<TimelineInfoPanel />);
+
+    await screen.getByRole("button", { name: /Set Begin/ }).click();
+    await expect.poll(() => currentWords()[0].end).toBeCloseTo(1.4, 10);
+    expect(useProjectStore.getState().history).toHaveLength(2);
+
+    useProjectStore.getState().undo();
+
+    expect(currentWords()[0].end).toBe(1);
+    expect(currentWords()[1].begin).toBe(1);
+  });
+
+  it("clamps Set Begin with the configured minimum word duration", async () => {
+    useSettingsStore.getState().set("minWordDuration", 0.2);
+    useAudioStore.setState({ currentTime: 99, duration: 10 });
+    useProjectStore.setState({ lines: [flushPairLine()] });
+    useTimelineStore.setState({ rollingEditMode: false });
+    selectWordAt("l1", 1);
+    const screen = await render(<TimelineInfoPanel />);
+
+    await screen.getByRole("button", { name: /Set Begin/ }).click();
+
+    await expect.poll(() => currentWords()[1].begin).toBeCloseTo(1.8, 10);
+  });
+
+  it("clamps Set End with the configured minimum word duration", async () => {
+    useSettingsStore.getState().set("minWordDuration", 0.2);
+    useAudioStore.setState({ currentTime: 0, duration: 10 });
+    useProjectStore.setState({ lines: [flushPairLine()] });
+    useTimelineStore.setState({ rollingEditMode: false });
+    selectWordAt("l1", 1);
+    const screen = await render(<TimelineInfoPanel />);
+
+    await screen.getByRole("button", { name: /Set End/ }).click();
+
+    await expect.poll(() => currentWords()[1].end).toBeCloseTo(1.2, 10);
   });
 });

--- a/src/views/timeline/timeline-info-panel.tsx
+++ b/src/views/timeline/timeline-info-panel.tsx
@@ -2,6 +2,7 @@ import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import { getAgentColor } from "@/domain/agent/colors";
+import { instanceIndicesOf } from "@/domain/instance/enumerate";
 import type { BoundaryEdge } from "@/domain/word/boundary";
 import { BackgroundTextEditor } from "@/views/timeline/background-text-editor";
 import { Button } from "@/ui/button";
@@ -47,9 +48,7 @@ const TimelineInfoPanel: React.FC = () => {
     const group = groups.find((g) => g.id === firstGroupId);
     if (!group) return null;
     const sameInstance = instanceKeys.size === 1;
-    const totalInstances = new Set(
-      rawLines.flatMap((l) => (l.groupId === firstGroupId && l.instanceIdx !== undefined ? [l.instanceIdx] : [])),
-    ).size;
+    const totalInstances = instanceIndicesOf(rawLines, firstGroupId).length;
     return {
       group,
       sameInstance,

--- a/src/views/timeline/timeline-info-panel.tsx
+++ b/src/views/timeline/timeline-info-panel.tsx
@@ -2,10 +2,9 @@ import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import { getAgentColor } from "@/domain/agent/colors";
-import { backgroundFields, CLEARED_BACKGROUND } from "@/domain/line/background";
 import type { BoundaryEdge } from "@/domain/word/boundary";
+import { BackgroundTextEditor } from "@/views/timeline/background-text-editor";
 import { Button } from "@/ui/button";
-import { createBgWordsFromLine } from "@/utils/sync-helpers";
 import { setBgWordBoundary } from "@/utils/timing/bg-word-timing";
 import { setWordBoundary } from "@/utils/timing/word-timing";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
@@ -13,64 +12,9 @@ import { isLineSynced } from "@/domain/line/predicates";
 import { getEffectiveLines } from "@/domain/line/effective-words";
 import { formatTime } from "@/views/timeline/utils";
 import { IconBracketsContainEnd, IconBracketsContainStart, IconLink } from "@tabler/icons-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 
 // -- Components ----------------------------------------------------------------
-
-const BackgroundTextEditor: React.FC<{ lineId: string; backgroundText?: string }> = ({ lineId, backgroundText }) => {
-  const [value, setValue] = useState(() => backgroundText ?? "");
-  const [isEditing, setIsEditing] = useState(false);
-  const focusOnMount = useCallback((el: HTMLInputElement | null) => {
-    el?.focus();
-  }, []);
-  const updateLineWithHistory = useProjectStore((s) => s.updateLineWithHistory);
-
-  const handleCommit = useCallback(() => {
-    const trimmed = value.trim() || undefined;
-    if (trimmed) {
-      const line = useProjectStore.getState().lines.find((l) => l.id === lineId);
-      const bgWords = line ? createBgWordsFromLine({ ...line, backgroundText: trimmed }) : null;
-      updateLineWithHistory(lineId, backgroundFields({ text: trimmed, words: bgWords ?? undefined, source: "manual" }));
-    } else {
-      updateLineWithHistory(lineId, CLEARED_BACKGROUND);
-    }
-    setIsEditing(false);
-  }, [lineId, value, updateLineWithHistory]);
-
-  if (!isEditing) {
-    return (
-      <button
-        type="button"
-        onClick={() => {
-          setValue(backgroundText ?? "");
-          setIsEditing(true);
-        }}
-        className="text-xs cursor-pointer text-composer-text-muted hover:text-composer-text px-1.5 py-0.5 rounded hover:bg-composer-button"
-        title="Edit background vocals"
-      >
-        {backgroundText ? `BG: ${backgroundText}` : "Add BG"}
-      </button>
-    );
-  }
-
-  return (
-    <input
-      ref={focusOnMount}
-      type="text"
-      aria-label="Background vocals text"
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      onBlur={handleCommit}
-      onKeyDown={(e) => {
-        e.stopPropagation();
-        if (e.key === "Enter") handleCommit();
-        if (e.key === "Escape") setIsEditing(false);
-      }}
-      placeholder="Background vocals"
-      className="w-32 px-1.5 py-0.5 text-xs border rounded bg-composer-input border-composer-border focus:outline-none focus:border-composer-accent"
-    />
-  );
-};
 
 const TimelineInfoPanel: React.FC = () => {
   const rawLines = useProjectStore((s) => s.lines);

--- a/src/views/timeline/timeline-info-panel.tsx
+++ b/src/views/timeline/timeline-info-panel.tsx
@@ -1,9 +1,13 @@
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
 import { getAgentColor } from "@/domain/agent/colors";
-import { backgroundFields, CLEARED_BACKGROUND, manualBackgroundWordEdit } from "@/domain/line/background";
+import { backgroundFields, CLEARED_BACKGROUND } from "@/domain/line/background";
+import type { BoundaryEdge } from "@/domain/word/boundary";
 import { Button } from "@/ui/button";
 import { createBgWordsFromLine } from "@/utils/sync-helpers";
+import { setBgWordBoundary } from "@/utils/timing/bg-word-timing";
+import { setWordBoundary } from "@/utils/timing/word-timing";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { isLineSynced } from "@/domain/line/predicates";
 import { getEffectiveLines } from "@/domain/line/effective-words";
@@ -162,63 +166,29 @@ const TimelineInfoPanel: React.FC = () => {
     return { count: selectedWords.length, wordCount, lineCount, begin: minBegin, end: maxEnd };
   }, [selectedWords, lines, rawLines]);
 
-  const handleSetBeginToCursor = useCallback(() => {
-    if (!selectedWord) return;
-    const line = lines[selectedWord.lineIndex];
-    if (!line) return;
+  const setSelectedWordBoundary = useCallback(
+    (edge: BoundaryEdge) => {
+      if (!selectedWord) return;
+      const audioEl = useAudioStore.getState().audioElement;
+      const currentTime = audioEl?.currentTime ?? useAudioStore.getState().currentTime;
+      const setBoundaryOp = selectedWord.type === "word" ? setWordBoundary : setBgWordBoundary;
+      setBoundaryOp({
+        lines,
+        lineIdx: selectedWord.lineIndex,
+        wordIdx: selectedWord.wordIndex,
+        edge,
+        time: currentTime,
+        minDuration: useSettingsStore.getState().minWordDuration,
+        duration,
+        rolling: useTimelineStore.getState().rollingEditMode,
+        updateLineWithHistory,
+      });
+    },
+    [selectedWord, lines, duration, updateLineWithHistory],
+  );
 
-    const wordsArray = selectedWord.type === "word" ? line.words : line.backgroundWords;
-    if (!wordsArray) return;
-
-    const audioEl = useAudioStore.getState().audioElement;
-    const currentTime = audioEl?.currentTime ?? useAudioStore.getState().currentTime;
-
-    const wordIndex = selectedWord.wordIndex;
-    const word = wordsArray[wordIndex];
-    if (!word) return;
-
-    const prevEnd = wordIndex > 0 ? wordsArray[wordIndex - 1].end : 0;
-    const maxBegin = word.end - 0.05;
-    const clampedBegin = Math.max(prevEnd, Math.min(maxBegin, Math.max(0, currentTime)));
-
-    const updatedWords = [...wordsArray];
-    updatedWords[wordIndex] = { ...word, begin: clampedBegin };
-
-    if (selectedWord.type === "word") {
-      updateLineWithHistory(line.id, { words: updatedWords }, { propagateToSiblings: false });
-    } else {
-      updateLineWithHistory(line.id, manualBackgroundWordEdit(updatedWords), { propagateToSiblings: false });
-    }
-  }, [selectedWord, lines, updateLineWithHistory]);
-
-  const handleSetEndToCursor = useCallback(() => {
-    if (!selectedWord) return;
-    const line = lines[selectedWord.lineIndex];
-    if (!line) return;
-
-    const wordsArray = selectedWord.type === "word" ? line.words : line.backgroundWords;
-    if (!wordsArray) return;
-
-    const audioEl = useAudioStore.getState().audioElement;
-    const currentTime = audioEl?.currentTime ?? useAudioStore.getState().currentTime;
-
-    const wordIndex = selectedWord.wordIndex;
-    const word = wordsArray[wordIndex];
-    if (!word) return;
-
-    const minEnd = word.begin + 0.05;
-    const nextBegin = wordIndex < wordsArray.length - 1 ? wordsArray[wordIndex + 1].begin : duration;
-    const clampedEnd = Math.min(nextBegin, Math.max(minEnd, Math.min(duration, currentTime)));
-
-    const updatedWords = [...wordsArray];
-    updatedWords[wordIndex] = { ...word, end: clampedEnd };
-
-    if (selectedWord.type === "word") {
-      updateLineWithHistory(line.id, { words: updatedWords }, { propagateToSiblings: false });
-    } else {
-      updateLineWithHistory(line.id, manualBackgroundWordEdit(updatedWords), { propagateToSiblings: false });
-    }
-  }, [selectedWord, lines, duration, updateLineWithHistory]);
+  const handleSetBeginToCursor = useCallback(() => setSelectedWordBoundary("begin"), [setSelectedWordBoundary]);
+  const handleSetEndToCursor = useCallback(() => setSelectedWordBoundary("end"), [setSelectedWordBoundary]);
 
   if (multiSelectionInfo) {
     const spanDuration = multiSelectionInfo.end - multiSelectionInfo.begin;

--- a/src/views/timeline/timeline-store.ts
+++ b/src/views/timeline/timeline-store.ts
@@ -186,3 +186,4 @@ const useTimelineStore = create<TimelineState & TimelineActions>((set, get) => {
 // -- Exports -------------------------------------------------------------------
 
 export { useTimelineStore, GUTTER_WIDTH, WAVEFORM_HEIGHT, MIN_ZOOM, MAX_ZOOM, DEFAULT_ROW_HEIGHT, ZOOM_STEP };
+export type { ContextMenuTarget };

--- a/src/views/timeline/use-context-menu-targets.ts
+++ b/src/views/timeline/use-context-menu-targets.ts
@@ -1,12 +1,29 @@
-import type { LyricLine } from "@/domain/line/model";
+import { instanceIndicesOf } from "@/domain/instance/enumerate";
 import { getEffectiveLines } from "@/domain/line/effective-words";
 import { isLineSynced } from "@/domain/line/predicates";
 import { contiguousSelectionRun } from "@/domain/selection/contiguous";
 import { hasIntraGroupGap } from "@/domain/word/syllable-groups";
 import { useProjectStore } from "@/stores/project";
-import { createGroupFromSelection, fillSelectionGaps } from "@/views/timeline/group-ops";
+import {
+  createGroupFromSelection,
+  fillSelectionGaps,
+  instanceToTemplate,
+  lineIdsAreContiguous,
+  selectionTouchesAnyGroup,
+} from "@/views/timeline/group-ops";
+import type { ContextMenuTarget } from "@/views/timeline/timeline-store";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { useMemo } from "react";
+
+// -- Selection ----------------------------------------------------------------
+
+// Auto-includes the right-clicked line for word/track/gutter targets so the user
+// can right-click a non-selected line and still act on it.
+function selectionLineIdsForTarget(target: ContextMenuTarget): Set<string> {
+  const ids = new Set<string>(useTimelineStore.getState().selectedWords.map((w) => w.lineId));
+  if (target.kind !== "group-banner") ids.add(target.lineId);
+  return ids;
+}
 
 // -- Hook ---------------------------------------------------------------------
 
@@ -49,21 +66,9 @@ function useContextMenuTargets() {
 
   const groupableSelection = useMemo(() => {
     if (!contextMenu) return null;
-    const target = contextMenu.target;
-    const selectedWords = useTimelineStore.getState().selectedWords;
-    const selectedLineIds = new Set<string>(selectedWords.map((w) => w.lineId));
-    // Auto-include the right-clicked line for word/track/gutter targets so the user can
-    // right-click on a non-selected line and still get "Group this line".
-    if (target.kind === "gutter" || target.kind === "track" || target.kind === "word") {
-      selectedLineIds.add(target.lineId);
-    }
+    const selectedLineIds = selectionLineIdsForTarget(contextMenu.target);
     if (selectedLineIds.size < 1) return null;
-    const rawLinesById = new Map<string, LyricLine>();
-    for (const l of rawLines) rawLinesById.set(l.id, l);
-    for (const id of selectedLineIds) {
-      const line = rawLinesById.get(id);
-      if (line?.groupId !== undefined) return null;
-    }
+    if (selectionTouchesAnyGroup(rawLines, selectedLineIds)) return null;
     const filled = fillSelectionGaps(rawLines, selectedLineIds);
     if (!filled) return null;
     const result = createGroupFromSelection(rawLines, filled.expanded, useProjectStore.getState().groups);
@@ -74,6 +79,23 @@ function useContextMenuTargets() {
       addedFromGaps: filled.addedCount,
       result,
     };
+  }, [contextMenu, rawLines]);
+
+  const conformableSelection = useMemo(() => {
+    if (!contextMenu) return null;
+    const selectedLineIds = selectionLineIdsForTarget(contextMenu.target);
+    if (selectedLineIds.size < 1) return null;
+    if (selectionTouchesAnyGroup(rawLines, selectedLineIds)) return null;
+    if (!lineIdsAreContiguous(rawLines, selectedLineIds)) return null;
+
+    const options = useProjectStore.getState().groups.flatMap((group) => {
+      const firstInstanceIdx = instanceIndicesOf(rawLines, group.id)[0];
+      if (firstInstanceIdx === undefined) return [];
+      const template = instanceToTemplate(rawLines, group.id, firstInstanceIdx);
+      return template.length === selectedLineIds.size ? [{ group, template }] : [];
+    });
+    if (options.length === 0) return null;
+    return { selectedLineIds, count: selectedLineIds.size, options };
   }, [contextMenu, rawLines]);
 
   const mergeInfo = useMemo(() => {
@@ -139,6 +161,7 @@ function useContextMenuTargets() {
     explicitToggleContext,
     gutterLineGroupInfo,
     groupableSelection,
+    conformableSelection,
     mergeInfo,
     groupedWordInfo,
     snapNeededInfo,

--- a/src/views/timeline/use-group-menu-actions.ts
+++ b/src/views/timeline/use-group-menu-actions.ts
@@ -1,4 +1,9 @@
+import { instanceIndicesOf } from "@/domain/instance/enumerate";
+import { useAudioStore } from "@/stores/audio";
+import { useConfirm } from "@/stores/confirm-store";
 import { useProjectStore } from "@/stores/project";
+import { showGroupActionToast } from "@/utils/group-toast";
+import { type ConformFailure, conformLinesToInstance } from "@/views/timeline/conform-lines-to-instance";
 import { deleteGroupWithConfirm } from "@/views/timeline/delete-group-with-confirm";
 import { scrollToInstanceHeader } from "@/views/timeline/scroll-helpers";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
@@ -10,13 +15,25 @@ import { toast } from "sonner";
 
 type ContextMenuTargets = ReturnType<typeof useContextMenuTargets>;
 
+// -- Constants ----------------------------------------------------------------
+
+const CONFORM_FAILURE_MESSAGE: Record<ConformFailure, string> = {
+  empty_selection: "Select the lines you want to conform first",
+  no_template: "That group has no lines to copy from",
+  already_grouped: "Some of those lines already belong to a group",
+  unknown_line: "Those lines are no longer in the project",
+  not_contiguous: "Select one unbroken run of lines",
+  length_mismatch: "Select exactly as many lines as the group has",
+};
+
 // -- Hook ---------------------------------------------------------------------
 
 function useGroupMenuActions(targets: ContextMenuTargets, clearContextMenu: () => void) {
-  const { groupableSelection } = targets;
+  const { groupableSelection, conformableSelection } = targets;
   const contextMenu = useTimelineStore((s) => s.contextMenu);
   const setRenamingGroupId = useTimelineStore((s) => s.setRenamingGroupId);
   const groups = useProjectStore((s) => s.groups);
+  const confirm = useConfirm();
 
   const handleJumpToGroupFromBanner = useCallback(() => {
     if (!contextMenu || contextMenu.target.kind !== "group-banner") return;
@@ -33,15 +50,54 @@ function useGroupMenuActions(targets: ContextMenuTargets, clearContextMenu: () =
     clearContextMenu();
   }, [groupableSelection, clearContextMenu]);
 
+  const handleConformToGroup = useCallback(
+    async (groupId: string) => {
+      if (!conformableSelection) return;
+      const option = conformableSelection.options.find((o) => o.group.id === groupId);
+      if (!option) return;
+      const { selectedLineIds, count } = conformableSelection;
+      clearContextMenu();
+
+      const ok = await confirm({
+        title: `Conform ${count} line${count === 1 ? "" : "s"} to "${option.group.label}"?`,
+        description: "Their current text, timing, agent and background vocals are replaced by the group's.",
+        confirmLabel: "Conform",
+        variant: "destructive",
+        settingsKey: "confirmConformToGroup",
+        recoverable: true,
+      });
+      if (!ok) return;
+
+      const projectState = useProjectStore.getState();
+      if (!projectState.groups.some((g) => g.id === groupId)) {
+        toast.error("That group no longer exists");
+        return;
+      }
+      const audioEl = useAudioStore.getState().audioElement;
+      const playheadTime = audioEl?.currentTime ?? useAudioStore.getState().currentTime;
+      const result = conformLinesToInstance({
+        lines: projectState.lines,
+        groupId,
+        template: option.template,
+        selectedLineIds,
+        playheadTime,
+      });
+      if (!result.ok || !result.updatedLines) {
+        toast.error(result.reason ? CONFORM_FAILURE_MESSAGE[result.reason] : "Could not conform those lines");
+        return;
+      }
+      useProjectStore.getState().setLinesWithHistory(result.updatedLines);
+      showGroupActionToast(`Conformed ${count} line${count === 1 ? "" : "s"} to "${option.group.label}"`);
+    },
+    [conformableSelection, confirm, clearContextMenu],
+  );
+
   const handleDeleteGroup = useCallback(async () => {
     if (!contextMenu || contextMenu.target.kind !== "group-banner") return;
     const { groupId } = contextMenu.target;
     const group = groups.find((g) => g.id === groupId);
     if (!group) return;
-    const projectLines = useProjectStore.getState().lines;
-    const instanceCount = new Set(
-      projectLines.flatMap((l) => (l.groupId === groupId && l.instanceIdx !== undefined ? [l.instanceIdx] : [])),
-    ).size;
+    const instanceCount = instanceIndicesOf(useProjectStore.getState().lines, groupId).length;
 
     clearContextMenu();
     await deleteGroupWithConfirm({ groupId, groupLabel: group.label, instanceCount });
@@ -66,6 +122,7 @@ function useGroupMenuActions(targets: ContextMenuTargets, clearContextMenu: () =
   return {
     handleJumpToGroupFromBanner,
     handleCreateGroupFromSelection,
+    handleConformToGroup,
     handleDeleteGroup,
     handleRenameStart,
     handleRecolorGroup,

--- a/src/views/timeline/use-instance-menu-actions.ts
+++ b/src/views/timeline/use-instance-menu-actions.ts
@@ -1,5 +1,5 @@
 import { instanceBounds } from "@/domain/instance/bounds";
-import { linesOfInstance } from "@/domain/instance/enumerate";
+import { instanceIndicesOf, linesOfInstance } from "@/domain/instance/enumerate";
 import type { WordSelection } from "@/domain/selection/model";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
@@ -94,11 +94,7 @@ function useInstanceMenuActions(clearContextMenu: () => void) {
       if (!contextMenu || contextMenu.target.kind !== "group-banner") return;
       const { groupId, instanceIdx } = contextMenu.target;
       const projectLines = useProjectStore.getState().lines;
-      const indices = new Set<number>();
-      for (const l of projectLines) {
-        if (l.groupId === groupId && l.instanceIdx !== undefined) indices.add(l.instanceIdx);
-      }
-      const sorted = Array.from(indices).sort((a, b) => a - b);
+      const sorted = instanceIndicesOf(projectLines, groupId);
       if (sorted.length < 2) return;
       const here = sorted.indexOf(instanceIdx);
       const next = sorted[(here + direction + sorted.length) % sorted.length];

--- a/src/views/timeline/use-timeline-keyboard.set-boundary.browser.test.tsx
+++ b/src/views/timeline/use-timeline-keyboard.set-boundary.browser.test.tsx
@@ -37,12 +37,32 @@ async function armTimeline(options: {
   await renderHook(() => useTimelineKeyboard(scrollContainerRef, [options.line], duration));
 }
 
+async function armPlayhead(options: {
+  lines: LyricLine[];
+  currentTime: number;
+  rolling: boolean;
+  duration?: number;
+}) {
+  const duration = options.duration ?? 10;
+  useAudioStore.setState({ currentTime: options.currentTime, duration });
+  useProjectStore.setState({ activeTab: "timeline", lines: options.lines });
+  useTimelineStore.setState({ rollingEditMode: options.rolling, selectedWords: [] });
+  const scrollContainerRef = createRef<HTMLDivElement | null>();
+  await renderHook(() =>
+    useTimelineKeyboard(
+      scrollContainerRef,
+      useProjectStore((state) => state.lines),
+      duration,
+    ),
+  );
+}
+
 function pressBoundaryKey(key: "[" | "]") {
   window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
 }
 
-function currentWords() {
-  return useProjectStore.getState().lines[0].words ?? [];
+function currentWords(lineIndex = 0) {
+  return useProjectStore.getState().lines[lineIndex].words ?? [];
 }
 
 // -- Tests --------------------------------------------------------------------
@@ -129,5 +149,97 @@ describe("useTimelineKeyboard · set boundary to playhead", () => {
     pressBoundaryKey("[");
 
     await expect.poll(() => currentWords()[1].begin).toBeCloseTo(1.8, 10);
+  });
+});
+
+describe("useTimelineKeyboard · set boundary from a gap", () => {
+  const gappedLine = () =>
+    createLine({
+      text: "done gave",
+      words: [
+        { text: "done ", begin: 1, end: 2 },
+        { text: "gave", begin: 3, end: 4 },
+      ],
+    });
+
+  it("pulls the next word's begin back to a playhead sitting in the gap", async () => {
+    await armPlayhead({ lines: [gappedLine()], currentTime: 2.5, rolling: false });
+
+    pressBoundaryKey("[");
+
+    await expect.poll(() => currentWords()[1].begin).toBeCloseTo(2.5, 10);
+    expect(currentWords()[0].end).toBe(2);
+  });
+
+  it("pushes the previous word's end forward to a playhead sitting in the gap", async () => {
+    await armPlayhead({ lines: [gappedLine()], currentTime: 2.5, rolling: false });
+
+    pressBoundaryKey("]");
+
+    await expect.poll(() => currentWords()[0].end).toBeCloseTo(2.5, 10);
+    expect(currentWords()[1].begin).toBe(3);
+  });
+
+  it("leaves the far side of the gap alone even with rolling on", async () => {
+    await armPlayhead({ lines: [gappedLine()], currentTime: 2.5, rolling: true });
+
+    pressBoundaryKey("[");
+
+    await expect.poll(() => currentWords()[1].begin).toBeCloseTo(2.5, 10);
+    expect(currentWords()[0].end).toBe(2);
+  });
+
+  it("reaches into the following line when the gap spans a line break", async () => {
+    const first = createLine({ text: "done", words: [{ text: "done", begin: 1, end: 2 }] });
+    const second = createLine({ text: "gave", words: [{ text: "gave", begin: 3, end: 4 }] });
+    await armPlayhead({ lines: [first, second], currentTime: 2.5, rolling: false });
+
+    pressBoundaryKey("[");
+
+    await expect.poll(() => currentWords(1)[0].begin).toBeCloseTo(2.5, 10);
+    expect(currentWords(0)[0].end).toBe(2);
+  });
+
+  it("closes the gap from both sides across two keystrokes", async () => {
+    await armPlayhead({ lines: [gappedLine()], currentTime: 2.5, rolling: false });
+
+    pressBoundaryKey("]");
+    await expect.poll(() => currentWords()[0].end).toBeCloseTo(2.5, 10);
+    pressBoundaryKey("[");
+
+    await expect.poll(() => currentWords()[1].begin).toBeCloseTo(2.5, 10);
+    expect(currentWords()[0].end).toBeCloseTo(2.5, 10);
+  });
+
+  it("stops reaching once the playhead lands on the begin it just pulled back", async () => {
+    await armPlayhead({ lines: [gappedLine()], currentTime: 2.5, rolling: false });
+
+    pressBoundaryKey("[");
+    await expect.poll(() => currentWords()[1].begin).toBeCloseTo(2.5, 10);
+    pressBoundaryKey("]");
+
+    const minDuration = useSettingsStore.getState().minWordDuration;
+    await expect.poll(() => currentWords()[1].end).toBeCloseTo(2.5 + minDuration, 10);
+    expect(currentWords()[0].end).toBe(2);
+  });
+
+  it("changes nothing when no word starts after the playhead", async () => {
+    await armPlayhead({ lines: [gappedLine()], currentTime: 8, rolling: false });
+
+    pressBoundaryKey("[");
+
+    await expect.poll(() => currentWords()[1].end).toBe(4);
+    expect(currentWords()[0]).toEqual({ text: "done ", begin: 1, end: 2 });
+    expect(currentWords()[1]).toEqual({ text: "gave", begin: 3, end: 4 });
+  });
+
+  it("changes nothing when no word ends before the playhead", async () => {
+    await armPlayhead({ lines: [gappedLine()], currentTime: 0.5, rolling: false });
+
+    pressBoundaryKey("]");
+
+    await expect.poll(() => currentWords()[0].begin).toBe(1);
+    expect(currentWords()[0]).toEqual({ text: "done ", begin: 1, end: 2 });
+    expect(currentWords()[1]).toEqual({ text: "gave", begin: 3, end: 4 });
   });
 });

--- a/src/views/timeline/use-timeline-keyboard.set-boundary.browser.test.tsx
+++ b/src/views/timeline/use-timeline-keyboard.set-boundary.browser.test.tsx
@@ -200,7 +200,7 @@ describe("useTimelineKeyboard · set boundary from a gap", () => {
     expect(currentWords(0)[0].end).toBe(2);
   });
 
-  it("closes the gap from both sides across two keystrokes", async () => {
+  it("closes the gap from both sides when the end edge goes first", async () => {
     await armPlayhead({ lines: [gappedLine()], currentTime: 2.5, rolling: false });
 
     pressBoundaryKey("]");
@@ -211,16 +211,24 @@ describe("useTimelineKeyboard · set boundary from a gap", () => {
     expect(currentWords()[0].end).toBeCloseTo(2.5, 10);
   });
 
-  it("stops reaching once the playhead lands on the begin it just pulled back", async () => {
+  it("closes the gap from both sides when the begin edge goes first", async () => {
     await armPlayhead({ lines: [gappedLine()], currentTime: 2.5, rolling: false });
 
     pressBoundaryKey("[");
     await expect.poll(() => currentWords()[1].begin).toBeCloseTo(2.5, 10);
     pressBoundaryKey("]");
 
-    const minDuration = useSettingsStore.getState().minWordDuration;
-    await expect.poll(() => currentWords()[1].end).toBeCloseTo(2.5 + minDuration, 10);
-    expect(currentWords()[0].end).toBe(2);
+    await expect.poll(() => currentWords()[0].end).toBeCloseTo(2.5, 10);
+    expect(currentWords()[1].end).toBe(4);
+  });
+
+  it("regression: leaves a word intact when the playhead rests on its begin", async () => {
+    await armPlayhead({ lines: [gappedLine()], currentTime: 3, rolling: false });
+
+    pressBoundaryKey("]");
+
+    await expect.poll(() => currentWords()[0].end).toBeCloseTo(3, 10);
+    expect(currentWords()[1]).toEqual({ text: "gave", begin: 3, end: 4 });
   });
 
   it("changes nothing when no word starts after the playhead", async () => {

--- a/src/views/timeline/use-timeline-keyboard.set-boundary.browser.test.tsx
+++ b/src/views/timeline/use-timeline-keyboard.set-boundary.browser.test.tsx
@@ -1,0 +1,133 @@
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { renderHook } from "vitest-browser-react";
+import type { LyricLine } from "@/domain/line/model";
+import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
+import { createLine } from "@/test/factories";
+import { useTimelineKeyboard } from "@/views/timeline/use-timeline-keyboard";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+
+// -- Helpers ------------------------------------------------------------------
+
+const FLUSH_WORDS = [
+  { text: "hello ", begin: 0, end: 1 },
+  { text: "world", begin: 1, end: 2 },
+];
+
+async function armTimeline(options: {
+  line: LyricLine;
+  wordIndex: number;
+  type?: "word" | "bg";
+  currentTime: number;
+  rolling: boolean;
+  duration?: number;
+}) {
+  const duration = options.duration ?? 10;
+  useAudioStore.setState({ currentTime: options.currentTime, duration });
+  useProjectStore.setState({ activeTab: "timeline", lines: [options.line] });
+  useTimelineStore.setState({
+    rollingEditMode: options.rolling,
+    selectedWords: [
+      { lineId: options.line.id, lineIndex: 0, wordIndex: options.wordIndex, type: options.type ?? "word" },
+    ],
+  });
+  const scrollContainerRef = createRef<HTMLDivElement | null>();
+  await renderHook(() => useTimelineKeyboard(scrollContainerRef, [options.line], duration));
+}
+
+function pressBoundaryKey(key: "[" | "]") {
+  window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+}
+
+function currentWords() {
+  return useProjectStore.getState().lines[0].words ?? [];
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("useTimelineKeyboard · set boundary to playhead", () => {
+  it("moves the previous word's end with the begin edge when rolling over a flush boundary", async () => {
+    await armTimeline({ line: createLine({ words: FLUSH_WORDS }), wordIndex: 1, currentTime: 1.4, rolling: true });
+
+    pressBoundaryKey("[");
+
+    await expect.poll(() => currentWords()[1].begin).toBeCloseTo(1.4, 10);
+    expect(currentWords()[0].end).toBeCloseTo(1.4, 10);
+  });
+
+  it("moves the next word's begin with the end edge when rolling over a flush boundary", async () => {
+    await armTimeline({ line: createLine({ words: FLUSH_WORDS }), wordIndex: 0, currentTime: 1.4, rolling: true });
+
+    pressBoundaryKey("]");
+
+    await expect.poll(() => currentWords()[0].end).toBeCloseTo(1.4, 10);
+    expect(currentWords()[1].begin).toBeCloseTo(1.4, 10);
+  });
+
+  it("moves only the selected word when rolling edit is off", async () => {
+    await armTimeline({ line: createLine({ words: FLUSH_WORDS }), wordIndex: 1, currentTime: 1.4, rolling: false });
+
+    pressBoundaryKey("[");
+
+    await expect.poll(() => currentWords()[1].begin).toBeCloseTo(1.4, 10);
+    expect(currentWords()[0].end).toBe(1);
+  });
+
+  it("records a rolling edit as a single undo entry", async () => {
+    await armTimeline({ line: createLine({ words: FLUSH_WORDS }), wordIndex: 1, currentTime: 1.4, rolling: true });
+
+    pressBoundaryKey("[");
+    await expect.poll(() => currentWords()[0].end).toBeCloseTo(1.4, 10);
+    expect(useProjectStore.getState().history).toHaveLength(2);
+
+    useProjectStore.getState().undo();
+
+    expect(currentWords()[0]).toEqual({ text: "hello ", begin: 0, end: 1 });
+    expect(currentWords()[1]).toEqual({ text: "world", begin: 1, end: 2 });
+  });
+
+  it("caps the last word's end at the audio duration", async () => {
+    await armTimeline({
+      line: createLine({ words: FLUSH_WORDS }),
+      wordIndex: 1,
+      currentTime: 99,
+      rolling: true,
+      duration: 1.5,
+    });
+
+    pressBoundaryKey("]");
+
+    await expect.poll(() => currentWords()[1].end).toBe(1.5);
+  });
+
+  it("rolls a flush background boundary and stamps the edit as manual", async () => {
+    const line = createLine({
+      text: "lead",
+      words: [{ text: "lead", begin: 0, end: 1 }],
+      backgroundText: "ooh aah",
+      backgroundWords: [
+        { text: "ooh ", begin: 1, end: 1.5 },
+        { text: "aah", begin: 1.5, end: 2 },
+      ],
+      backgroundTextSource: "extraction",
+    });
+    await armTimeline({ line, wordIndex: 1, type: "bg", currentTime: 1.7, rolling: true });
+
+    pressBoundaryKey("[");
+
+    await expect.poll(() => useProjectStore.getState().lines[0].backgroundWords?.[1].begin).toBeCloseTo(1.7, 10);
+    expect(useProjectStore.getState().lines[0].backgroundWords?.[0].end).toBeCloseTo(1.7, 10);
+    expect(useProjectStore.getState().lines[0].backgroundTextSource).toBe("manual");
+  });
+
+  it("threads the configured minimum word duration into the clamp", async () => {
+    useSettingsStore.getState().set("minWordDuration", 0.2);
+    await armTimeline({ line: createLine({ words: FLUSH_WORDS }), wordIndex: 1, currentTime: 99, rolling: false });
+
+    pressBoundaryKey("[");
+
+    await expect.poll(() => currentWords()[1].begin).toBeCloseTo(1.8, 10);
+  });
+});

--- a/src/views/timeline/use-timeline-keyboard.ts
+++ b/src/views/timeline/use-timeline-keyboard.ts
@@ -24,7 +24,7 @@ import { mergeWordText } from "@/utils/word-merge";
 import type { WordSelection } from "@/domain/selection/model";
 import { GUTTER_WIDTH, useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
 import { useTimelineClipboard } from "@/views/timeline/use-timeline-clipboard";
-import { findWordsAtTime, pickNextWordAtPlayhead } from "@/views/timeline/word-at-playhead";
+import { findBoundaryTarget, findWordsAtTime, pickNextWordAtPlayhead } from "@/views/timeline/word-at-playhead";
 import { instanceBounds } from "@/domain/instance/bounds";
 import { linesOfInstance } from "@/domain/instance/enumerate";
 import { isLinked } from "@/domain/instance/predicates";
@@ -34,7 +34,6 @@ import { centerTimeScrollLeft, revealTimeScrollLeft } from "@/views/timeline/coo
 import { effectiveBounds } from "@/domain/line/bounds";
 import {
   computeRowLayout,
-  findWordAtTime,
   getWordsInInstance,
   partitionNudgeSelections,
   shiftSelectionsTogether,
@@ -89,8 +88,11 @@ function useTimelineKeyboard(
       const { selectedWords, zoom, rowHeights, defaultRowHeight } = useTimelineStore.getState();
       const selectedWord = selectedWords[0] ?? null;
       const fromPlayhead = !selectedWord;
-      const targetWord = selectedWord ?? findWordAtTime(lines, currentTime);
-      if (!targetWord) return;
+      const targetWord = selectedWord ?? findBoundaryTarget(lines, currentTime, edge);
+      if (!targetWord) {
+        toast(edge === "begin" ? "No word starts after the playhead" : "No word ends before the playhead");
+        return;
+      }
 
       const line = lines[targetWord.lineIndex];
       if (!line) return;

--- a/src/views/timeline/use-timeline-keyboard.ts
+++ b/src/views/timeline/use-timeline-keyboard.ts
@@ -4,6 +4,8 @@ import { useProjectStore } from "@/stores/project";
 import type { LyricLine } from "@/domain/line/model";
 import { useSettingsStore } from "@/stores/settings";
 import { showGroupActionToast } from "@/utils/group-toast";
+import { setBgWordBoundary } from "@/utils/timing/bg-word-timing";
+import { setWordBoundary } from "@/utils/timing/word-timing";
 import { handleWordChangeWithDivergenceCheck } from "@/utils/word-divergence-flow";
 import { MOD_KEY } from "@/utils/platform";
 import { findMatchingShortcut } from "@/utils/shortcut-matcher";
@@ -153,26 +155,18 @@ function useTimelineKeyboard(
         }
       }
 
-      const updatedWords = [...wordsArray];
-
-      if (edge === "begin") {
-        const prevEnd = wordIndex > 0 ? wordsArray[wordIndex - 1].end : 0;
-        const maxBegin = word.end - useSettingsStore.getState().minWordDuration;
-        const clampedBegin = Math.max(prevEnd, Math.min(maxBegin, Math.max(0, currentTime)));
-        updatedWords[wordIndex] = { ...word, begin: clampedBegin };
-      } else {
-        const minEnd = word.begin + useSettingsStore.getState().minWordDuration;
-        const nextBegin = wordIndex < wordsArray.length - 1 ? wordsArray[wordIndex + 1].begin : duration;
-        const clampedEnd = Math.min(nextBegin, Math.max(minEnd, Math.min(duration, currentTime)));
-        updatedWords[wordIndex] = { ...word, end: clampedEnd };
-      }
-
-      const updateLineWithHistory = useProjectStore.getState().updateLineWithHistory;
-      if (targetWord.type === "word") {
-        updateLineWithHistory(line.id, { words: updatedWords }, { propagateToSiblings: false });
-      } else {
-        updateLineWithHistory(line.id, manualBackgroundWordEdit(updatedWords), { propagateToSiblings: false });
-      }
+      const setBoundaryOp = targetWord.type === "word" ? setWordBoundary : setBgWordBoundary;
+      setBoundaryOp({
+        lines,
+        lineIdx: targetWord.lineIndex,
+        wordIdx: wordIndex,
+        edge,
+        time: currentTime,
+        minDuration: useSettingsStore.getState().minWordDuration,
+        duration,
+        rolling: useTimelineStore.getState().rollingEditMode,
+        updateLineWithHistory: useProjectStore.getState().updateLineWithHistory,
+      });
     },
     [lines, duration, scrollContainerRef],
   );

--- a/src/views/timeline/use-timeline-keyboard.ts
+++ b/src/views/timeline/use-timeline-keyboard.ts
@@ -1,3 +1,4 @@
+import { instanceIndicesOf } from "@/domain/instance/enumerate";
 import { useAudioStore } from "@/stores/audio";
 import { isAnyModalOpen } from "@/stores/modal-stack";
 import { useProjectStore } from "@/stores/project";
@@ -64,14 +65,6 @@ function currentInstanceFromSelection(
   }
   if (groupId === null || instanceIdx === null) return null;
   return { groupId, instanceIdx };
-}
-
-function listInstancesOfGroup(lines: LyricLine[], groupId: string): number[] {
-  const set = new Set<number>();
-  for (const line of lines) {
-    if (line.groupId === groupId && line.instanceIdx !== undefined) set.add(line.instanceIdx);
-  }
-  return Array.from(set).sort((a, b) => a - b);
 }
 
 // -- Constants -----------------------------------------------------------------
@@ -576,7 +569,7 @@ function useTimelineKeyboard(
             toast.error("Select words inside one instance first");
             break;
           }
-          const all = listInstancesOfGroup(projectLines, inst.groupId);
+          const all = instanceIndicesOf(projectLines, inst.groupId);
           if (all.length < 2) {
             toast.error("This group has only one instance");
             break;
@@ -613,7 +606,7 @@ function useTimelineKeyboard(
           const group = useProjectStore.getState().groups.find((g) => g.id === inst.groupId);
           if (!group) break;
           e.preventDefault();
-          const instanceCount = listInstancesOfGroup(projectLines, inst.groupId).length;
+          const instanceCount = instanceIndicesOf(projectLines, inst.groupId).length;
           void deleteGroupWithConfirm({ groupId: inst.groupId, groupLabel: group.label, instanceCount });
           break;
         }

--- a/src/views/timeline/use-word-menu-actions.ts
+++ b/src/views/timeline/use-word-menu-actions.ts
@@ -86,9 +86,9 @@ function useWordMenuActions(targets: ContextMenuTargets, clearContextMenu: () =>
     const line = lines.find((l) => l.id === lineId);
     if (!line) return;
 
-    const wordDuration = useSettingsStore.getState().defaultWordDuration;
+    const { defaultWordDuration, minWordDuration } = useSettingsStore.getState();
     const existingWords = type === "word" ? line.words : line.backgroundWords;
-    const slot = findInsertionSlot(existingWords ?? [], time, wordDuration, duration);
+    const slot = findInsertionSlot(existingWords ?? [], time, defaultWordDuration, duration, minWordDuration);
     if (!slot) {
       clearContextMenu();
       return;

--- a/src/views/timeline/utils.ts
+++ b/src/views/timeline/utils.ts
@@ -4,12 +4,10 @@ import { manualBackgroundWordEdit } from "@/domain/line/background";
 import { getEffectiveLines } from "@/domain/line/effective-words";
 import { isLineSynced, isWordSynced } from "@/domain/line/predicates";
 import type { LyricLine } from "@/domain/line/model";
-import type { WordSelection } from "@/domain/selection/model";
 import type { WordTiming } from "@/domain/word/timing";
 import { formatTime as formatTimeBase } from "@/utils/format-time";
 import { expandSelectionToGroupmates } from "@/domain/word/syllable-groups";
 import { distributeWordsInLine } from "@/utils/sync-helpers";
-import { findWordsAtTime } from "@/views/timeline/word-at-playhead";
 
 // -- Functions -----------------------------------------------------------------
 
@@ -34,10 +32,6 @@ function distributeLinesTiming<T extends { id: string; text: string }>(
 }
 
 const formatTime = (seconds: number) => formatTimeBase(seconds, 2);
-
-function findWordAtTime(lines: LyricLine[], time: number): WordSelection | null {
-  return findWordsAtTime(lines, time)[0] ?? null;
-}
 
 interface GroupHeaderRow {
   kind: "group-header";
@@ -427,7 +421,6 @@ export {
   distributeWordsInLine,
   distributeLinesTiming,
   formatTime,
-  findWordAtTime,
   getEffectiveRows,
   getWordsInInstance,
   computeRowLayout,

--- a/src/views/timeline/word-at-playhead.test.ts
+++ b/src/views/timeline/word-at-playhead.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createLine } from "@/test/factories";
 import type { WordSelection } from "@/domain/selection/model";
-import { findWordsAtTime, pickNextWordAtPlayhead } from "@/views/timeline/word-at-playhead";
+import { findBoundaryTarget, findWordsAtTime, pickNextWordAtPlayhead } from "@/views/timeline/word-at-playhead";
 
 describe("findWordsAtTime", () => {
   it("returns empty when nothing overlaps the time", () => {
@@ -68,5 +68,164 @@ describe("pickNextWordAtPlayhead", () => {
   it("falls back to the first match when the selection is not among the matches", () => {
     const outsider: WordSelection = { lineId: "line-9", lineIndex: 8, wordIndex: 3, type: "word" };
     expect(pickNextWordAtPlayhead([matchA, matchB, matchC], [outsider])).toEqual(matchA);
+  });
+});
+
+describe("findBoundaryTarget", () => {
+  const gappedLine = () =>
+    createLine({
+      id: "gapped",
+      text: "done gave",
+      words: [
+        { text: "done ", begin: 1, end: 2 },
+        { text: "gave", begin: 3, end: 4 },
+      ],
+    });
+
+  it("prefers the word under the playhead over any neighbour, on both edges", () => {
+    const lines = [gappedLine()];
+    const inside = { lineId: "gapped", lineIndex: 0, wordIndex: 0, type: "word" as const };
+    expect(findBoundaryTarget(lines, 1.5, "begin")).toEqual(inside);
+    expect(findBoundaryTarget(lines, 1.5, "end")).toEqual(inside);
+  });
+
+  it("reaches forward to the word starting after the playhead on the begin edge", () => {
+    expect(findBoundaryTarget([gappedLine()], 2.5, "begin")).toEqual({
+      lineId: "gapped",
+      lineIndex: 0,
+      wordIndex: 1,
+      type: "word",
+    });
+  });
+
+  it("reaches back to the word ending before the playhead on the end edge", () => {
+    expect(findBoundaryTarget([gappedLine()], 2.5, "end")).toEqual({
+      lineId: "gapped",
+      lineIndex: 0,
+      wordIndex: 0,
+      type: "word",
+    });
+  });
+
+  it("picks the nearest word in time rather than the earliest line", () => {
+    const far = createLine({ id: "far", words: [{ text: "far", begin: 9, end: 10 }] });
+    const near = createLine({ id: "near", words: [{ text: "near", begin: 5, end: 6 }] });
+    expect(findBoundaryTarget([far, near], 4, "begin")).toEqual({
+      lineId: "near",
+      lineIndex: 1,
+      wordIndex: 0,
+      type: "word",
+    });
+  });
+
+  it("lets a background word win when it is the nearest across the gap", () => {
+    const line = createLine({
+      id: "mixed",
+      text: "lead",
+      words: [{ text: "lead", begin: 6, end: 7 }],
+      backgroundText: "ooh",
+      backgroundWords: [{ text: "ooh", begin: 5, end: 5.5 }],
+    });
+    expect(findBoundaryTarget([line], 4, "begin")).toEqual({
+      lineId: "mixed",
+      lineIndex: 0,
+      wordIndex: 0,
+      type: "bg",
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns null for an empty timeline on both edges", () => {
+      expect(findBoundaryTarget([], 1, "begin")).toBeNull();
+      expect(findBoundaryTarget([], 1, "end")).toBeNull();
+    });
+
+    it("ignores lines that carry no timed words", () => {
+      const untimed = createLine({ id: "untimed", text: "no timing" });
+      expect(findBoundaryTarget([untimed], 1, "begin")).toBeNull();
+      expect(findBoundaryTarget([untimed], 1, "end")).toBeNull();
+    });
+
+    it("has nothing to pull back when the playhead sits past every word", () => {
+      const lines = [gappedLine()];
+      expect(findBoundaryTarget(lines, 8, "begin")).toBeNull();
+      expect(findBoundaryTarget(lines, 8, "end")).toEqual({
+        lineId: "gapped",
+        lineIndex: 0,
+        wordIndex: 1,
+        type: "word",
+      });
+    });
+
+    it("has nothing to push forward when the playhead sits before every word", () => {
+      const lines = [gappedLine()];
+      expect(findBoundaryTarget(lines, 0.5, "end")).toBeNull();
+      expect(findBoundaryTarget(lines, 0.5, "begin")).toEqual({
+        lineId: "gapped",
+        lineIndex: 0,
+        wordIndex: 0,
+        type: "word",
+      });
+    });
+
+    it("treats a playhead resting exactly on a word's end as outside that word", () => {
+      const lines = [gappedLine()];
+      expect(findBoundaryTarget(lines, 2, "end")).toEqual({
+        lineId: "gapped",
+        lineIndex: 0,
+        wordIndex: 0,
+        type: "word",
+      });
+      expect(findBoundaryTarget(lines, 2, "begin")).toEqual({
+        lineId: "gapped",
+        lineIndex: 0,
+        wordIndex: 1,
+        type: "word",
+      });
+    });
+
+    it("treats a playhead resting exactly on a word's begin as inside that word", () => {
+      expect(findBoundaryTarget([gappedLine()], 3, "begin")).toEqual({
+        lineId: "gapped",
+        lineIndex: 0,
+        wordIndex: 1,
+        type: "word",
+      });
+    });
+  });
+
+  describe("invariants", () => {
+    it("breaks a tie on equal distance by scan order", () => {
+      const first = createLine({ id: "first", words: [{ text: "a", begin: 3, end: 4 }] });
+      const second = createLine({ id: "second", words: [{ text: "b", begin: 3, end: 4 }] });
+      expect(findBoundaryTarget([first, second], 2, "begin")).toEqual({
+        lineId: "first",
+        lineIndex: 0,
+        wordIndex: 0,
+        type: "word",
+      });
+    });
+
+    it("never reaches across a word that already lies between the playhead and the candidate", () => {
+      const line = createLine({
+        id: "three",
+        text: "a b c",
+        words: [
+          { text: "a ", begin: 0, end: 1 },
+          { text: "b ", begin: 2, end: 3 },
+          { text: "c", begin: 4, end: 5 },
+        ],
+      });
+      expect(findBoundaryTarget([line], 1.5, "begin")?.wordIndex).toBe(1);
+      expect(findBoundaryTarget([line], 3.5, "end")?.wordIndex).toBe(1);
+    });
+
+    it("leaves the input lines untouched", () => {
+      const lines = [gappedLine()];
+      const snapshot = structuredClone(lines);
+      findBoundaryTarget(lines, 2.5, "begin");
+      findBoundaryTarget(lines, 2.5, "end");
+      expect(lines).toEqual(snapshot);
+    });
   });
 });

--- a/src/views/timeline/word-at-playhead.test.ts
+++ b/src/views/timeline/word-at-playhead.test.ts
@@ -184,13 +184,35 @@ describe("findBoundaryTarget", () => {
       });
     });
 
-    it("treats a playhead resting exactly on a word's begin as inside that word", () => {
+    it("keeps the begin edge on the word the playhead starts", () => {
       expect(findBoundaryTarget([gappedLine()], 3, "begin")).toEqual({
         lineId: "gapped",
         lineIndex: 0,
         wordIndex: 1,
         type: "word",
       });
+    });
+
+    it("sends the end edge back a word when the playhead rests on a word's begin", () => {
+      expect(findBoundaryTarget([gappedLine()], 3, "end")).toEqual({
+        lineId: "gapped",
+        lineIndex: 0,
+        wordIndex: 0,
+        type: "word",
+      });
+    });
+
+    it("hands each edge its own side of a flush seam", () => {
+      const flush = createLine({
+        id: "flush",
+        text: "a b",
+        words: [
+          { text: "a ", begin: 1, end: 2 },
+          { text: "b", begin: 2, end: 3 },
+        ],
+      });
+      expect(findBoundaryTarget([flush], 2, "end")?.wordIndex).toBe(0);
+      expect(findBoundaryTarget([flush], 2, "begin")?.wordIndex).toBe(1);
     });
   });
 
@@ -218,6 +240,17 @@ describe("findBoundaryTarget", () => {
       });
       expect(findBoundaryTarget([line], 1.5, "begin")?.wordIndex).toBe(1);
       expect(findBoundaryTarget([line], 3.5, "end")?.wordIndex).toBe(1);
+    });
+
+    it("prefers a word spanning the playhead over one that merely ends on it", () => {
+      const ending = createLine({ id: "ending", words: [{ text: "x", begin: 1, end: 2 }] });
+      const spanning = createLine({ id: "spanning", words: [{ text: "y", begin: 1.5, end: 2.5 }] });
+      expect(findBoundaryTarget([ending, spanning], 2, "end")).toEqual({
+        lineId: "spanning",
+        lineIndex: 1,
+        wordIndex: 0,
+        type: "word",
+      });
     });
 
     it("leaves the input lines untouched", () => {

--- a/src/views/timeline/word-at-playhead.ts
+++ b/src/views/timeline/word-at-playhead.ts
@@ -1,6 +1,8 @@
 import type { LyricLine } from "@/domain/line/model";
 import type { WordSelection } from "@/domain/selection/model";
 import { sameWordSelection } from "@/domain/selection/identity";
+import type { BoundaryEdge } from "@/domain/word/boundary";
+import type { WordTiming } from "@/domain/word/timing";
 
 // -- Functions -----------------------------------------------------------------
 
@@ -38,6 +40,51 @@ function pickNextWordAtPlayhead(matches: WordSelection[], selectedWords: WordSel
   return matches[0];
 }
 
+function nearestInTrack(
+  words: readonly WordTiming[] | undefined,
+  time: number,
+  edge: BoundaryEdge,
+): { wordIndex: number; distance: number } | null {
+  if (!words) return null;
+  let nearestIndex = -1;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+  for (let wordIndex = 0; wordIndex < words.length; wordIndex++) {
+    const word = words[wordIndex];
+    const reachable = edge === "begin" ? word.begin > time : word.end <= time;
+    if (!reachable) continue;
+    const distance = edge === "begin" ? word.begin - time : time - word.end;
+    if (distance >= nearestDistance) continue;
+    nearestDistance = distance;
+    nearestIndex = wordIndex;
+  }
+  return nearestIndex === -1 ? null : { wordIndex: nearestIndex, distance: nearestDistance };
+}
+
+function findWordAcrossGap(lines: LyricLine[], time: number, edge: BoundaryEdge): WordSelection | null {
+  let nearest: WordSelection | null = null;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
+    const main = nearestInTrack(line.words, time, edge);
+    if (main && main.distance < nearestDistance) {
+      nearestDistance = main.distance;
+      nearest = { lineId: line.id, lineIndex, wordIndex: main.wordIndex, type: "word" };
+    }
+    const background = nearestInTrack(line.backgroundWords, time, edge);
+    if (background && background.distance < nearestDistance) {
+      nearestDistance = background.distance;
+      nearest = { lineId: line.id, lineIndex, wordIndex: background.wordIndex, type: "bg" };
+    }
+  }
+  return nearest;
+}
+
+// Containment resolves first, so anything the gap search still sees lies wholly on one
+// side of the playhead and can be ranked by plain distance.
+function findBoundaryTarget(lines: LyricLine[], time: number, edge: BoundaryEdge): WordSelection | null {
+  return findWordsAtTime(lines, time)[0] ?? findWordAcrossGap(lines, time, edge);
+}
+
 // -- Exports -------------------------------------------------------------------
 
-export { findWordsAtTime, pickNextWordAtPlayhead };
+export { findBoundaryTarget, findWordsAtTime, pickNextWordAtPlayhead };

--- a/src/views/timeline/word-at-playhead.ts
+++ b/src/views/timeline/word-at-playhead.ts
@@ -79,10 +79,29 @@ function findWordAcrossGap(lines: LyricLine[], time: number, edge: BoundaryEdge)
   return nearest;
 }
 
+// The end edge will not claim a word the playhead has only just entered, since setting
+// that word's end back to its own begin just collapses it to the minimum duration. It
+// falls through to the gap search and lands on the word before instead.
+function containsForEdge(word: WordTiming, time: number, edge: BoundaryEdge): boolean {
+  const startedBefore = edge === "begin" ? time >= word.begin : time > word.begin;
+  return startedBefore && time < word.end;
+}
+
+function findContainingWord(lines: LyricLine[], time: number, edge: BoundaryEdge): WordSelection | null {
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
+    const mainIndex = line.words?.findIndex((word) => containsForEdge(word, time, edge)) ?? -1;
+    if (mainIndex !== -1) return { lineId: line.id, lineIndex, wordIndex: mainIndex, type: "word" };
+    const bgIndex = line.backgroundWords?.findIndex((word) => containsForEdge(word, time, edge)) ?? -1;
+    if (bgIndex !== -1) return { lineId: line.id, lineIndex, wordIndex: bgIndex, type: "bg" };
+  }
+  return null;
+}
+
 // Containment resolves first, so anything the gap search still sees lies wholly on one
 // side of the playhead and can be ranked by plain distance.
 function findBoundaryTarget(lines: LyricLine[], time: number, edge: BoundaryEdge): WordSelection | null {
-  return findWordsAtTime(lines, time)[0] ?? findWordAcrossGap(lines, time, edge);
+  return findContainingWord(lines, time, edge) ?? findWordAcrossGap(lines, time, edge);
 }
 
 // -- Exports -------------------------------------------------------------------

--- a/src/views/timeline/word-track.boundary-clamp.browser.test.tsx
+++ b/src/views/timeline/word-track.boundary-clamp.browser.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { WordTiming } from "@/domain/word/timing";
+import { useProjectStore } from "@/stores/project";
+import { createLine, createWord } from "@/test/factories";
+import { render } from "@/test/render";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+import { WordTrack } from "@/views/timeline/word-track";
+
+// -- Helpers ------------------------------------------------------------------
+
+interface ResizeCall {
+  index: number;
+  updates: Partial<WordTiming>;
+  adjacentIndex?: number;
+  adjacentUpdates?: Partial<WordTiming>;
+}
+
+const GESTURE_START_X = 200;
+
+// A flush pair whose combined span is shorter than twice the minimum word
+// duration, so no boundary position can satisfy both words' floors.
+const TIGHT_PAIR = [createWord({ text: "a ", begin: 0.99, end: 1 }), createWord({ text: "b", begin: 1, end: 1.02 })];
+const ROOMY_PAIR = [createWord({ text: "a ", begin: 0, end: 1 }), createWord({ text: "b", begin: 1, end: 2 })];
+
+async function renderResizableTrack(words: WordTiming[], options: { rolling?: boolean; duration?: number } = {}) {
+  const { rolling = true, duration = 3 } = options;
+  const calls: ResizeCall[] = [];
+  useTimelineStore.setState({ rollingEditMode: rolling, zoom: 100 });
+  const line = createLine({ words });
+  useProjectStore.setState({ lines: [line] });
+  const screen = await render(
+    <WordTrack
+      lineId={line.id}
+      lineIndex={0}
+      words={words}
+      color="#a3c9ff"
+      trackType="word"
+      duration={duration}
+      height={32}
+      onUpdateWord={(index, updates, adjacentIndex, adjacentUpdates) =>
+        calls.push({ index, updates, adjacentIndex, adjacentUpdates })
+      }
+    />,
+    { dndContext: true },
+  );
+  return { blocks: Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]")), calls };
+}
+
+function dragEdgeBy(block: HTMLElement, edge: "left" | "right", offsetPx: number) {
+  const handle = block.querySelector<HTMLElement>(`[data-edge="${edge}"]`);
+  if (!handle) throw new Error(`word block has no ${edge} edge handle`);
+  handle.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0, clientX: GESTURE_START_X }));
+  document.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX: GESTURE_START_X + offsetPx }));
+  document.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+}
+
+// -- Tests --------------------------------------------------------------------
+
+// The clamp arithmetic itself lives in domain/word/boundary.test.ts. These cover
+// the inputs only the drag gesture can supply.
+describe("WordTrack boundary drag inputs", () => {
+  describe("regressions", () => {
+    it("regression: does not invert either word when dragging the left edge of a tight flush pair", async () => {
+      const { blocks, calls } = await renderResizableTrack(TIGHT_PAIR);
+
+      dragEdgeBy(blocks[1], "left", 30);
+
+      await expect.poll(() => calls.length).toBe(1);
+      expect(calls[0].adjacentIndex).toBe(0);
+      const boundary = calls[0].updates.begin ?? Number.NaN;
+      expect(boundary).toBeLessThanOrEqual(TIGHT_PAIR[1].end);
+      expect(boundary).toBeGreaterThanOrEqual(TIGHT_PAIR[0].begin);
+      expect(calls[0].adjacentUpdates?.end).toBe(boundary);
+    });
+
+    it("regression: does not invert the last word when the audio ends before it begins", async () => {
+      const { blocks, calls } = await renderResizableTrack(ROOMY_PAIR, { duration: 0.5 });
+
+      dragEdgeBy(blocks[1], "right", -30);
+
+      await expect.poll(() => calls.length).toBe(1);
+      expect(calls[0].adjacentIndex).toBeUndefined();
+      expect(calls[0].updates.end ?? Number.NaN).toBeGreaterThanOrEqual(ROOMY_PAIR[1].begin);
+    });
+  });
+});

--- a/src/views/timeline/word-track.boundary-clamp.browser.test.tsx
+++ b/src/views/timeline/word-track.boundary-clamp.browser.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { WordTiming } from "@/domain/word/timing";
 import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
 import { createLine, createWord } from "@/test/factories";
 import { render } from "@/test/render";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
@@ -21,6 +22,7 @@ const GESTURE_START_X = 200;
 // duration, so no boundary position can satisfy both words' floors.
 const TIGHT_PAIR = [createWord({ text: "a ", begin: 0.99, end: 1 }), createWord({ text: "b", begin: 1, end: 1.02 })];
 const ROOMY_PAIR = [createWord({ text: "a ", begin: 0, end: 1 }), createWord({ text: "b", begin: 1, end: 2 })];
+const GAPPED_PAIR = [createWord({ text: "a ", begin: 0, end: 1 }), createWord({ text: "b", begin: 1.5, end: 2.5 })];
 
 async function renderResizableTrack(words: WordTiming[], options: { rolling?: boolean; duration?: number } = {}) {
   const { rolling = true, duration = 3 } = options;
@@ -81,6 +83,30 @@ describe("WordTrack boundary drag inputs", () => {
       await expect.poll(() => calls.length).toBe(1);
       expect(calls[0].adjacentIndex).toBeUndefined();
       expect(calls[0].updates.end ?? Number.NaN).toBeGreaterThanOrEqual(ROOMY_PAIR[1].begin);
+    });
+  });
+
+  describe("minimum word duration setting", () => {
+    it("clamps a conjoined drag with the configured minimum", async () => {
+      useSettingsStore.getState().set("minWordDuration", 0.2);
+      const { blocks, calls } = await renderResizableTrack(ROOMY_PAIR);
+
+      dragEdgeBy(blocks[1], "left", 300);
+
+      await expect.poll(() => calls.length).toBe(1);
+      expect(calls[0].updates.begin).toBeCloseTo(1.8, 10);
+      expect(calls[0].adjacentUpdates?.end).toBeCloseTo(1.8, 10);
+    });
+
+    it("clamps an independent right-edge drag with the configured minimum", async () => {
+      useSettingsStore.getState().set("minWordDuration", 0.2);
+      const { blocks, calls } = await renderResizableTrack(GAPPED_PAIR);
+
+      dragEdgeBy(blocks[0], "right", -300);
+
+      await expect.poll(() => calls.length).toBe(1);
+      expect(calls[0].adjacentIndex).toBeUndefined();
+      expect(calls[0].updates.end).toBeCloseTo(0.2, 10);
     });
   });
 });

--- a/src/views/timeline/word-track.browser.test.tsx
+++ b/src/views/timeline/word-track.browser.test.tsx
@@ -1,19 +1,26 @@
 import { describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
 import { WordTrack } from "@/views/timeline/word-track";
 import type { WordTiming } from "@/domain/word/timing";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
+import { applyWordPatch } from "@/utils/word-patch";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { createLine, createWord } from "@/test/factories";
 import { render } from "@/test/render";
 
-type UpdateWord = (index: number, updates: object, adjacentIndex?: number, adjacentUpdates?: object) => void;
+type UpdateWord = (
+  index: number,
+  updates: Partial<WordTiming>,
+  adjacentIndex?: number,
+  adjacentUpdates?: Partial<WordTiming>,
+) => void;
 
 async function renderTrack(words: WordTiming[], onUpdateWord: UpdateWord = () => {}) {
   const line = createLine({ words });
   useProjectStore.setState({ lines: [line] });
-  return render(
+  const screen = await render(
     <WordTrack
       lineId={line.id}
       lineIndex={0}
@@ -26,6 +33,7 @@ async function renderTrack(words: WordTiming[], onUpdateWord: UpdateWord = () =>
     />,
     { dndContext: true },
   );
+  return { screen, line };
 }
 
 function dragRightEdge(block: HTMLElement, opts: { altKey?: boolean } = {}) {
@@ -43,7 +51,74 @@ function dragRightEdgeBy(block: HTMLElement, offsetPx: number) {
   document.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
 }
 
+const commitToStore: UpdateWord = (index, updates, adjacentIndex, adjacentUpdates) => {
+  const line = useProjectStore.getState().lines[0];
+  if (!line.words) return;
+  const patched = applyWordPatch(
+    line.words,
+    index,
+    updates,
+    adjacentIndex !== undefined && adjacentUpdates ? { index: adjacentIndex, updates: adjacentUpdates } : undefined,
+  );
+  if (!patched) return;
+  useProjectStore.getState().updateLineWithHistory(line.id, { words: patched }, { propagateToSiblings: false });
+};
+
+async function renderTrackWritingToStore(words: WordTiming[]) {
+  const rendered = await renderTrack(words, commitToStore);
+  // Browser tests load no stylesheet, so the Tailwind-sized edges have no box for Playwright to click.
+  for (const el of rendered.screen.container.querySelectorAll<HTMLElement>("[data-edge]")) {
+    el.style.width = "8px";
+    el.style.height = "16px";
+  }
+  return rendered;
+}
+
+function edgeOf(block: HTMLElement, edge: "left" | "right"): HTMLElement {
+  return block.querySelector(`[data-edge="${edge}"]`) as HTMLElement;
+}
+
+const GESTURE_START_X = 200;
+
+function pressEdge(block: HTMLElement, edge: "left" | "right"): HTMLElement {
+  const el = edgeOf(block, edge);
+  const clientX = GESTURE_START_X;
+  el.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, clientX, clientY: 0 }));
+  el.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0, clientX, clientY: 0 }));
+  return el;
+}
+
+function movePointer(move: { dx: number; dy: number }) {
+  const clientX = GESTURE_START_X + move.dx;
+  document.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX, clientY: move.dy }));
+}
+
+function releasePointer(el: HTMLElement, move: { dx: number; dy: number }) {
+  const clientX = GESTURE_START_X + move.dx;
+  document.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, clientX, clientY: move.dy }));
+  el.dispatchEvent(new MouseEvent("click", { bubbles: true, button: 0, clientX, clientY: move.dy }));
+}
+
+function pressEdgeMoveAndClick(
+  block: HTMLElement,
+  edge: "left" | "right",
+  ...moves: Array<{ dx: number; dy: number }>
+) {
+  const el = pressEdge(block, edge);
+  let last = { dx: 0, dy: 0 };
+  for (const move of moves) {
+    movePointer(move);
+    last = move;
+  }
+  releasePointer(el, last);
+}
+
 const WORDS = [createWord({ text: "hello ", begin: 0, end: 1 }), createWord({ text: "world", begin: 1, end: 2 })];
+
+const GAPPED_WORDS = [
+  createWord({ text: "hello ", begin: 0, end: 1 }),
+  createWord({ text: "world", begin: 1.2, end: 2 }),
+];
 
 const SYLLABLE_GROUP_WORDS = [
   createWord({ text: "hello ", begin: 0, end: 1 }),
@@ -187,7 +262,7 @@ describe("WordTrack", () => {
       createWord({ text: "ev", begin: 0, end: 0.5, syllableGroupId: "g" }),
       createWord({ text: "er", begin: 0.8, end: 1.3, syllableGroupId: "g" }),
     ];
-    const screen = await renderTrack(words);
+    const { screen } = await renderTrack(words);
     const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
     expect(blocks[0].style.borderRightStyle).toBe("dashed");
     expect(blocks[1].style.borderLeftStyle).toBe("dashed");
@@ -199,7 +274,7 @@ describe("WordTrack", () => {
       createWord({ text: "ev", begin: 0, end: 0.5, syllableGroupId: "g" }),
       createWord({ text: "er", begin: 0.5, end: 1, syllableGroupId: "g" }),
     ];
-    const screen = await renderTrack(words, (index, _u, adjacentIndex) => calls.push({ index, adjacentIndex }));
+    const { screen } = await renderTrack(words, (index, _u, adjacentIndex) => calls.push({ index, adjacentIndex }));
     const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
     dragRightEdge(blocks[0]);
     expect(calls).toHaveLength(1);
@@ -212,7 +287,7 @@ describe("WordTrack", () => {
       createWord({ text: "ev", begin: 0, end: 0.5, syllableGroupId: "g" }),
       createWord({ text: "er", begin: 0.8, end: 1.3, syllableGroupId: "g" }),
     ];
-    const screen = await renderTrack(words, (index, _u, adjacentIndex) => calls.push({ index, adjacentIndex }));
+    const { screen } = await renderTrack(words, (index, _u, adjacentIndex) => calls.push({ index, adjacentIndex }));
     const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
     dragRightEdge(blocks[0]);
     expect(calls).toHaveLength(1);
@@ -225,7 +300,7 @@ describe("WordTrack", () => {
       createWord({ text: "ev", begin: 0, end: 0.5, syllableGroupId: "g" }),
       createWord({ text: "er", begin: 0.8, end: 1.3, syllableGroupId: "g" }),
     ];
-    const screen = await renderTrack(words, (index, _u, adjacentIndex) => calls.push({ index, adjacentIndex }));
+    const { screen } = await renderTrack(words, (index, _u, adjacentIndex) => calls.push({ index, adjacentIndex }));
     const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
     dragRightEdge(blocks[0], { altKey: true });
     expect(calls).toHaveLength(1);
@@ -240,7 +315,7 @@ describe("WordTrack", () => {
       createWord({ text: "er", begin: 1.2, end: 1.6, syllableGroupId: "g" }),
       createWord({ text: "y", begin: 1.6, end: 2, syllableGroupId: "g" }),
     ];
-    const screen = await renderTrack(words, (index, updates, adjacentIndex) =>
+    const { screen } = await renderTrack(words, (index, updates, adjacentIndex) =>
       calls.push({ index, updates, adjacentIndex }),
     );
     const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
@@ -263,7 +338,7 @@ describe("WordTrack", () => {
       adjacentUpdates?: { begin?: number; end?: number };
     }> = [];
     const words = [createWord({ text: "a ", begin: 1, end: 1.5 }), createWord({ text: "b", begin: 1.5, end: 2 })];
-    const screen = await renderTrack(words, (index, updates, adjacentIndex, adjacentUpdates) =>
+    const { screen } = await renderTrack(words, (index, updates, adjacentIndex, adjacentUpdates) =>
       calls.push({ index, updates, adjacentIndex, adjacentUpdates }),
     );
     const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
@@ -287,7 +362,7 @@ describe("WordTrack", () => {
     useTimelineStore.setState({ rollingEditMode: true, zoom: 100 });
     const calls: Array<{ index: number; adjacentIndex?: number }> = [];
     const words = [createWord({ text: "a ", begin: 1, end: 1.5 }), createWord({ text: "b", begin: 1.5, end: 2 })];
-    const screen = await renderTrack(words, (index, _u, adjacentIndex) => calls.push({ index, adjacentIndex }));
+    const { screen } = await renderTrack(words, (index, _u, adjacentIndex) => calls.push({ index, adjacentIndex }));
     const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
 
     const edge = blocks[0].querySelector('[data-edge="right"]') as HTMLElement;
@@ -324,7 +399,7 @@ describe("WordTrack", () => {
   it("adds a word on double-click and spaces the seam before it", async () => {
     useAudioStore.setState({ duration: 3 });
     useTimelineStore.setState({ zoom: 100 });
-    const screen = await renderTrack(WORDS);
+    const { screen } = await renderTrack(WORDS);
     const track = screen.container.querySelector(".relative") as HTMLElement;
     const rect = track.getBoundingClientRect();
 
@@ -334,5 +409,130 @@ describe("WordTrack", () => {
 
     await expect.poll(() => useProjectStore.getState().lines[0].words?.length).toBe(3);
     expect(useProjectStore.getState().lines[0].words?.map((w) => w.text)).toEqual(["hello ", "world ", "..."]);
+  });
+
+  describe("boundary click (issue #165)", () => {
+    it("selects the word when its left edge is clicked without dragging", async () => {
+      useTimelineStore.setState({ zoom: 100 });
+      const { screen, line } = await renderTrackWritingToStore(GAPPED_WORDS);
+      const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
+
+      await userEvent.click(edgeOf(blocks[1], "left"));
+
+      await expect.poll(() => useTimelineStore.getState().selectedWords).toHaveLength(1);
+      expect(useTimelineStore.getState().selectedWords[0]).toEqual({
+        lineId: line.id,
+        lineIndex: 0,
+        wordIndex: 1,
+        type: "word",
+      });
+    });
+
+    it("selects the word when its right edge is clicked without dragging", async () => {
+      useTimelineStore.setState({ zoom: 100 });
+      const { screen, line } = await renderTrackWritingToStore(GAPPED_WORDS);
+      const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
+
+      await userEvent.click(edgeOf(blocks[0], "right"));
+
+      await expect.poll(() => useTimelineStore.getState().selectedWords).toHaveLength(1);
+      expect(useTimelineStore.getState().selectedWords[0]).toEqual({
+        lineId: line.id,
+        lineIndex: 0,
+        wordIndex: 0,
+        type: "word",
+      });
+    });
+
+    it("does not push an undo entry when a boundary is clicked without dragging", async () => {
+      useTimelineStore.setState({ zoom: 100 });
+      const { screen } = await renderTrackWritingToStore(GAPPED_WORDS);
+      const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
+      const historyBefore = useProjectStore.getState().history.length;
+
+      await userEvent.click(edgeOf(blocks[1], "left"));
+
+      expect(useProjectStore.getState().history).toHaveLength(historyBefore);
+      expect(useProjectStore.getState().lines[0].words?.[1].begin).toBe(1.2);
+    });
+
+    it("selects the word when the pointer jitters vertically without moving sideways", async () => {
+      useTimelineStore.setState({ zoom: 100 });
+      const { screen, line } = await renderTrackWritingToStore(GAPPED_WORDS);
+      const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
+
+      pressEdgeMoveAndClick(blocks[1], "left", { dx: 0, dy: 40 });
+
+      await expect.poll(() => useTimelineStore.getState().selectedWords).toHaveLength(1);
+      expect(useTimelineStore.getState().selectedWords[0]).toEqual({
+        lineId: line.id,
+        lineIndex: 0,
+        wordIndex: 1,
+        type: "word",
+      });
+      expect(useProjectStore.getState().lines[0].words?.[1].begin).toBe(1.2);
+      expect(useProjectStore.getState().history).toHaveLength(0);
+    });
+
+    it("selects the word when the press drifts a single pixel sideways", async () => {
+      useTimelineStore.setState({ zoom: 100 });
+      const { screen, line } = await renderTrackWritingToStore(GAPPED_WORDS);
+      const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
+
+      pressEdgeMoveAndClick(blocks[1], "left", { dx: 1, dy: 0 });
+
+      await expect.poll(() => useTimelineStore.getState().selectedWords).toHaveLength(1);
+      expect(useTimelineStore.getState().selectedWords[0]).toEqual({
+        lineId: line.id,
+        lineIndex: 0,
+        wordIndex: 1,
+        type: "word",
+      });
+      expect(useProjectStore.getState().lines[0].words?.[1].begin).toBe(1.2);
+      expect(useProjectStore.getState().history).toHaveLength(0);
+    });
+
+    it("holds the block still below the drag threshold and moves it above", async () => {
+      useTimelineStore.setState({ zoom: 100 });
+      const { screen } = await renderTrackWritingToStore(GAPPED_WORDS);
+      const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
+      const el = pressEdge(blocks[1], "left");
+
+      movePointer({ dx: 2, dy: 0 });
+      await expect.poll(() => blocks[1].style.left).toBe("120px");
+
+      movePointer({ dx: 30, dy: 0 });
+      await expect.poll(() => blocks[1].style.left).toBe("150px");
+
+      releasePointer(el, { dx: 30, dy: 0 });
+    });
+
+    it("commits nothing when a drag returns to where it started", async () => {
+      useTimelineStore.setState({ zoom: 100 });
+      const { screen } = await renderTrackWritingToStore(GAPPED_WORDS);
+      const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
+
+      pressEdgeMoveAndClick(blocks[1], "left", { dx: 30, dy: 0 }, { dx: 0, dy: 0 });
+
+      expect(useProjectStore.getState().lines[0].words?.[1].begin).toBe(1.2);
+      expect(useProjectStore.getState().lines[0].words?.[1].end).toBe(2);
+      expect(useProjectStore.getState().history).toHaveLength(0);
+      expect(useProjectStore.getState().isDirty).toBe(false);
+    });
+
+    it("leaves selection empty and commits the new timing after a real drag", async () => {
+      useTimelineStore.setState({ zoom: 100 });
+      const { screen } = await renderTrackWritingToStore(GAPPED_WORDS);
+      const blocks = Array.from(screen.container.querySelectorAll<HTMLElement>("[data-word-block]"));
+
+      pressEdgeMoveAndClick(blocks[1], "left", { dx: 30, dy: 0 });
+
+      await expect.poll(() => useProjectStore.getState().lines[0].words?.[1].begin).not.toBe(1.2);
+      const movedBegin = useProjectStore.getState().lines[0].words?.[1].begin;
+      expect(movedBegin).toBeGreaterThan(1.4);
+      expect(movedBegin).toBeLessThan(1.6);
+      expect(useTimelineStore.getState().selectedWords).toHaveLength(0);
+      expect(useProjectStore.getState().history.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -46,10 +46,6 @@ interface DragState {
   adjacentEnd?: number;
 }
 
-// -- Constants -----------------------------------------------------------------
-
-const MIN_WORD_DURATION = 0.05;
-
 // -- Helpers -------------------------------------------------------------------
 
 function resizeChangedTiming(initial: DragState, final: DragState, words: WordTiming[]): boolean {
@@ -124,6 +120,7 @@ const WordTrack: React.FC<WordTrackProps> = ({
       setDragState(initialState);
 
       const rollingEdit = useTimelineStore.getState().rollingEditMode;
+      const minWordDuration = useSettingsStore.getState().minWordDuration;
       const boundaryEdge: BoundaryEdge = edge === "left" ? "begin" : "end";
 
       setResizing(true);
@@ -178,7 +175,7 @@ const WordTrack: React.FC<WordTrackProps> = ({
           wordIndex,
           edge: boundaryEdge,
           time: edgeAtStart + (rawDeltaPx + snapShiftPx) / zoom,
-          minDuration: MIN_WORD_DURATION,
+          minDuration: minWordDuration,
           rollNeighbour: adjacentWordIndex !== null,
           duration,
         });

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -4,7 +4,7 @@ import { useAudioStore } from "@/stores/audio";
 import type { WordTiming } from "@/domain/word/timing";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
-import { type BoundaryEdge, clampBoundaryTime, isBoundaryFlush } from "@/domain/word/boundary";
+import { type BoundaryEdge, clampBoundaryTime, shouldRollNeighbour } from "@/domain/word/boundary";
 import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
 import { boundsOverlap } from "@/domain/word/overlap";
 import { computeSyllableGroups, getSyllablePositions } from "@/domain/word/syllable-groups";
@@ -143,29 +143,22 @@ const WordTrack: React.FC<WordTrackProps> = ({
         },
       });
 
-      const isSyllableBoundary = (idx: number, side: "left" | "right"): boolean => {
-        const pos = syllablePositions[idx];
-        if (side === "right") return pos === "first" || pos === "middle";
-        return pos === "middle" || pos === "last";
-      };
-
       const handleMouseMove = (e: PointerEvent) => {
         if (Math.abs(e.clientX - startX) >= DRAG_THRESHOLD_PX) draggedRef.current = true;
         lastPointerRef.current = { clientX: e.clientX, clientY: e.clientY };
         if (!draggedRef.current) return;
         const originalWord = words[wordIndex];
         const rawDeltaPx = e.clientX - startX;
-        const altHeld = e.altKey;
-        const conjoinedByDefault =
-          (rollingEdit || isSyllableBoundary(wordIndex, edge)) && isBoundaryFlush(words, wordIndex, boundaryEdge);
-        const conjoined = altHeld ? !conjoinedByDefault : conjoinedByDefault;
+        const conjoined = shouldRollNeighbour({
+          words,
+          wordIndex,
+          edge: boundaryEdge,
+          rollingEdit,
+          syllablePositions,
+          altHeld: e.altKey,
+        });
 
-        const adjacentWordIndex =
-          conjoined && edge === "left" && wordIndex > 0
-            ? wordIndex - 1
-            : conjoined && edge === "right" && wordIndex < words.length - 1
-              ? wordIndex + 1
-              : null;
+        const adjacentWordIndex = conjoined ? (edge === "left" ? wordIndex - 1 : wordIndex + 1) : null;
         conjoinedRef.current = { active: adjacentWordIndex !== null, adjacentWordIndex };
 
         const edgeAtStart = edge === "left" ? originalWord.begin : originalWord.end;
@@ -243,13 +236,15 @@ const WordTrack: React.FC<WordTrackProps> = ({
     [words, zoom, duration, onUpdateWord, syllablePositions, snap, lineId, trackType],
   );
 
-  const isBoundaryConjoined = (boundaryIndex: number): boolean => {
-    if (boundaryIndex < 0 || boundaryIndex >= words.length - 1) return false;
-    const pos = syllablePositions[boundaryIndex];
-    const isSyllable = pos === "first" || pos === "middle";
-    const conjoinedByDefault = (rollingEditMode || isSyllable) && isBoundaryFlush(words, boundaryIndex, "end");
-    return altPressed ? !conjoinedByDefault : conjoinedByDefault;
-  };
+  const isBoundaryConjoined = (boundaryIndex: number): boolean =>
+    shouldRollNeighbour({
+      words,
+      wordIndex: boundaryIndex,
+      edge: "end",
+      rollingEdit: rollingEditMode,
+      syllablePositions,
+      altHeld: altPressed,
+    });
 
   const hasSelection = selectedWords.length > 0;
 

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -8,6 +8,7 @@ import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
 import { boundsOverlap } from "@/domain/word/overlap";
 import { computeSyllableGroups, getSyllablePositions } from "@/domain/word/syllable-groups";
 import { findInsertionSlot } from "@/utils/word-spaces";
+import { DRAG_THRESHOLD_PX } from "@/views/timeline/drag-threshold";
 import { resizeGestureSelfIds } from "@/views/timeline/resize-self-ids";
 import { selfKey } from "@/views/timeline/snap";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
@@ -48,6 +49,15 @@ interface DragState {
 
 const MIN_WORD_DURATION = 0.05;
 
+// -- Helpers -------------------------------------------------------------------
+
+function resizeChangedTiming(initial: DragState, final: DragState, words: WordTiming[]): boolean {
+  if (final.begin !== initial.begin || final.end !== initial.end) return true;
+  if (final.adjacentWordIndex === undefined) return false;
+  const adjacent = words[final.adjacentWordIndex];
+  return final.adjacentBegin !== adjacent.begin || final.adjacentEnd !== adjacent.end;
+}
+
 // -- Component -----------------------------------------------------------------
 
 const WordTrack: React.FC<WordTrackProps> = ({
@@ -76,6 +86,7 @@ const WordTrack: React.FC<WordTrackProps> = ({
   const [resizing, setResizing] = useState(false);
   const dragStateRef = useRef<DragState | null>(null);
   const justResizedRef = useRef(false);
+  const draggedRef = useRef(false);
   const cleanupRef = useRef<(() => void) | null>(null);
   const lastPointerRef = useRef<{ clientX: number; clientY: number } | null>(null);
   const conjoinedRef = useRef<{ active: boolean; adjacentWordIndex: number | null }>({
@@ -116,6 +127,7 @@ const WordTrack: React.FC<WordTrackProps> = ({
       setResizing(true);
       lastPointerRef.current = { clientX: startX, clientY: 0 };
       conjoinedRef.current = { active: false, adjacentWordIndex: null };
+      draggedRef.current = false;
       snap.beginGesture({
         selfIds: resizeGestureSelfIds(lineId, wordIndex, edge, words.length, trackType),
         leaderKey: selfKey(lineId, wordIndex, trackType),
@@ -144,7 +156,9 @@ const WordTrack: React.FC<WordTrackProps> = ({
       };
 
       const handleMouseMove = (e: PointerEvent) => {
+        if (Math.abs(e.clientX - startX) >= DRAG_THRESHOLD_PX) draggedRef.current = true;
         lastPointerRef.current = { clientX: e.clientX, clientY: e.clientY };
+        if (!draggedRef.current) return;
         const originalWord = words[wordIndex];
         const rawDeltaPx = e.clientX - startX;
         const altHeld = e.altKey;
@@ -223,14 +237,18 @@ const WordTrack: React.FC<WordTrackProps> = ({
         snap.endGesture();
 
         const finalState = dragStateRef.current;
+        const dragged = draggedRef.current;
         dragStateRef.current = null;
         setDragState(null);
-        justResizedRef.current = true;
-        requestAnimationFrame(() => {
-          justResizedRef.current = false;
-        });
 
-        if (finalState) {
+        if (dragged) {
+          justResizedRef.current = true;
+          requestAnimationFrame(() => {
+            justResizedRef.current = false;
+          });
+        }
+
+        if (dragged && finalState && resizeChangedTiming(initialState, finalState, words)) {
           if (finalState.adjacentWordIndex !== undefined) {
             const mainUpdate = edge === "left" ? { begin: finalState.begin } : { end: finalState.end };
             const adjUpdate = edge === "left" ? { end: finalState.adjacentEnd! } : { begin: finalState.adjacentBegin! };

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -329,8 +329,8 @@ const WordTrack: React.FC<WordTrackProps> = ({
     const time = clickX / zoom;
 
     const audioDuration = useAudioStore.getState().duration;
-    const wordDuration = useSettingsStore.getState().defaultWordDuration;
-    const slot = findInsertionSlot(words, time, wordDuration, audioDuration);
+    const { defaultWordDuration, minWordDuration } = useSettingsStore.getState();
+    const slot = findInsertionSlot(words, time, defaultWordDuration, audioDuration, minWordDuration);
     if (!slot) return;
 
     const newWord: WordTiming = { text: "... ", begin: slot.begin, end: slot.end };

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -4,6 +4,7 @@ import { useAudioStore } from "@/stores/audio";
 import type { WordTiming } from "@/domain/word/timing";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
+import { type BoundaryEdge, clampBoundaryTime, isBoundaryFlush } from "@/domain/word/boundary";
 import { mergeWordsIntoTrack } from "@/domain/word/merge-track";
 import { boundsOverlap } from "@/domain/word/overlap";
 import { computeSyllableGroups, getSyllablePositions } from "@/domain/word/syllable-groups";
@@ -123,6 +124,7 @@ const WordTrack: React.FC<WordTrackProps> = ({
       setDragState(initialState);
 
       const rollingEdit = useTimelineStore.getState().rollingEditMode;
+      const boundaryEdge: BoundaryEdge = edge === "left" ? "begin" : "end";
 
       setResizing(true);
       lastPointerRef.current = { clientX: startX, clientY: 0 };
@@ -150,11 +152,6 @@ const WordTrack: React.FC<WordTrackProps> = ({
         return pos === "middle" || pos === "last";
       };
 
-      const boundaryHasGap = (idx: number, side: "left" | "right"): boolean => {
-        if (side === "right") return idx < words.length - 1 && words[idx].end < words[idx + 1].begin;
-        return idx > 0 && words[idx - 1].end < words[idx].begin;
-      };
-
       const handleMouseMove = (e: PointerEvent) => {
         if (Math.abs(e.clientX - startX) >= DRAG_THRESHOLD_PX) draggedRef.current = true;
         lastPointerRef.current = { clientX: e.clientX, clientY: e.clientY };
@@ -163,7 +160,7 @@ const WordTrack: React.FC<WordTrackProps> = ({
         const rawDeltaPx = e.clientX - startX;
         const altHeld = e.altKey;
         const conjoinedByDefault =
-          (rollingEdit || isSyllableBoundary(wordIndex, edge)) && !boundaryHasGap(wordIndex, edge);
+          (rollingEdit || isSyllableBoundary(wordIndex, edge)) && isBoundaryFlush(words, wordIndex, boundaryEdge);
         const conjoined = altHeld ? !conjoinedByDefault : conjoinedByDefault;
 
         const adjacentWordIndex =
@@ -172,61 +169,32 @@ const WordTrack: React.FC<WordTrackProps> = ({
             : conjoined && edge === "right" && wordIndex < words.length - 1
               ? wordIndex + 1
               : null;
-        conjoinedRef.current = { active: conjoined && adjacentWordIndex !== null, adjacentWordIndex };
+        conjoinedRef.current = { active: adjacentWordIndex !== null, adjacentWordIndex };
 
-        const edgesAtStart = edge === "left" ? [originalWord.begin] : [originalWord.end];
-        const snapShiftPx = snap.computeShiftPx(rawDeltaPx, edgesAtStart);
-        const deltaTime = (rawDeltaPx + snapShiftPx) / zoom;
+        const edgeAtStart = edge === "left" ? originalWord.begin : originalWord.end;
+        const snapShiftPx = snap.computeShiftPx(rawDeltaPx, [edgeAtStart]);
+        const clamped = clampBoundaryTime({
+          words,
+          wordIndex,
+          edge: boundaryEdge,
+          time: edgeAtStart + (rawDeltaPx + snapShiftPx) / zoom,
+          minDuration: MIN_WORD_DURATION,
+          rollNeighbour: adjacentWordIndex !== null,
+          duration,
+        });
 
-        let newState: DragState;
-
-        if (edge === "left") {
-          if (conjoined && wordIndex > 0) {
-            const prevWord = words[wordIndex - 1];
-            const newBoundary = originalWord.begin + deltaTime;
-            const min = prevWord.begin + MIN_WORD_DURATION;
-            const max = originalWord.end - MIN_WORD_DURATION;
-            const clamped = Math.max(min, Math.min(max, Math.max(0, newBoundary)));
-            newState = {
-              wordIndex,
-              edge,
-              begin: clamped,
-              end: originalWord.end,
-              adjacentWordIndex: wordIndex - 1,
-              adjacentBegin: prevWord.begin,
-              adjacentEnd: clamped,
-            };
-          } else {
-            const newBegin = originalWord.begin + deltaTime;
-            const maxBegin = originalWord.end - MIN_WORD_DURATION;
-            const prevEnd = wordIndex > 0 ? words[wordIndex - 1].end : 0;
-            const clampedBegin = Math.max(prevEnd, Math.min(maxBegin, Math.max(0, newBegin)));
-            newState = { wordIndex, edge, begin: clampedBegin, end: originalWord.end };
-          }
-        } else {
-          if (conjoined && wordIndex < words.length - 1) {
-            const nextWord = words[wordIndex + 1];
-            const newBoundary = originalWord.end + deltaTime;
-            const min = originalWord.begin + MIN_WORD_DURATION;
-            const max = nextWord.end - MIN_WORD_DURATION;
-            const clamped = Math.max(min, Math.min(max, Math.min(duration, newBoundary)));
-            newState = {
-              wordIndex,
-              edge,
-              begin: originalWord.begin,
-              end: clamped,
-              adjacentWordIndex: wordIndex + 1,
-              adjacentBegin: clamped,
-              adjacentEnd: nextWord.end,
-            };
-          } else {
-            const newEnd = originalWord.end + deltaTime;
-            const minEnd = originalWord.begin + MIN_WORD_DURATION;
-            const nextBegin = wordIndex < words.length - 1 ? words[wordIndex + 1].begin : duration;
-            const clampedEnd = Math.min(nextBegin, Math.max(minEnd, Math.min(duration, newEnd)));
-            newState = { wordIndex, edge, begin: originalWord.begin, end: clampedEnd };
-          }
-        }
+        const adjacent =
+          adjacentWordIndex === null
+            ? null
+            : {
+                adjacentWordIndex,
+                adjacentBegin: edge === "left" ? words[adjacentWordIndex].begin : clamped,
+                adjacentEnd: edge === "left" ? clamped : words[adjacentWordIndex].end,
+              };
+        const newState: DragState =
+          edge === "left"
+            ? { wordIndex, edge, begin: clamped, end: originalWord.end, ...adjacent }
+            : { wordIndex, edge, begin: originalWord.begin, end: clamped, ...adjacent };
 
         dragStateRef.current = newState;
         setDragState(newState);
@@ -282,8 +250,7 @@ const WordTrack: React.FC<WordTrackProps> = ({
     if (boundaryIndex < 0 || boundaryIndex >= words.length - 1) return false;
     const pos = syllablePositions[boundaryIndex];
     const isSyllable = pos === "first" || pos === "middle";
-    const hasGap = words[boundaryIndex].end < words[boundaryIndex + 1].begin;
-    const conjoinedByDefault = (rollingEditMode || isSyllable) && !hasGap;
+    const conjoinedByDefault = (rollingEditMode || isSyllable) && isBoundaryFlush(words, boundaryIndex, "end");
     return altPressed ? !conjoinedByDefault : conjoinedByDefault;
   };
 


### PR DESCRIPTION
## Overview

Closes #165, closes #166, closes #167 and closes #168. Fixing the boundary click turned up three more bugs in the same drag path where a word could end up with its begin past its end, so those are in here too. The two boundary keys were also dead whenever the playhead sat in a gap with nothing selected, so they now reach for the nearest word on the side they'd move. The `en` in `xml:lang` was a lie whenever nobody set a language, and Better Lyrics reads that attribute to decide whether to romanize or translate, so it's omitted now when unset and there's a Language field on Export. Only part a of #167 is built: the second half wanted a matcher over ungrouped lines, which the suggestions engine already covers.
