### PR TITLE
fix: theme share code compatibility, guide prerendering and help reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.38.0",
+  "version": "1.38.1",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -8,6 +8,21 @@ import { TOUR_SEEN_KEY } from "@/tour/use-tour";
 
 const bridgeSectionVisible = () => document.querySelector('[data-testid="bridge-section"]') !== null;
 
+const helpButton = () => document.querySelector('button[title^="Keyboard shortcuts"]') as HTMLButtonElement;
+
+const HELP_NAV_LABELS = ["Getting Started", "Best practices", "Exporting", "Timeline"];
+
+const helpNav = () => [...(document.querySelector("dialog")?.querySelectorAll("button") ?? [])];
+
+const helpNavButton = (label: string) => helpNav().find((b) => b.textContent?.trim() === label) as HTMLButtonElement;
+
+const activeHelpSection = () =>
+  helpNav()
+    .find((b) => b.classList.contains("bg-composer-button") && HELP_NAV_LABELS.includes(b.textContent?.trim() ?? ""))
+    ?.textContent?.trim() ?? "";
+
+const helpModalOpen = () => document.querySelector("[data-help-content]") !== null;
+
 describe("App", () => {
   it("renders the app header and tab bar", async () => {
     useProjectStore.setState({ activeTab: "import" });
@@ -41,5 +56,26 @@ describe("App", () => {
     useUIStore.getState().openSettings();
     await expect.poll(() => document.querySelector("dialog") !== null).toBe(true);
     expect(bridgeSectionVisible()).toBe(false);
+  });
+
+  it("regression: reopening help resets the section instead of restoring the last one viewed", async () => {
+    allowConsole(/cannot be a descendant of/);
+    allowConsole(/cannot contain a nested/);
+    localStorage.setItem(TOUR_SEEN_KEY, "true");
+    await render(<App />);
+
+    helpButton().click();
+    await expect.poll(helpModalOpen).toBe(true);
+    expect(activeHelpSection()).toBe("Getting Started");
+
+    helpNavButton("Exporting").click();
+    await expect.poll(activeHelpSection).toBe("Exporting");
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await expect.poll(helpModalOpen).toBe(false);
+
+    helpButton().click();
+    await expect.poll(helpModalOpen).toBe(true);
+    expect(activeHelpSection()).toBe("Getting Started");
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,12 @@ const AppContent: React.FC = () => {
   return (
     <div className="flex flex-col h-screen bg-composer-bg text-composer-text">
       <AppHeader onSettingsOpen={() => openSettings()} onHelpOpen={() => openHelp()} onTourStart={resumeOrStartTour} />
-      <HelpModal key={helpSection} isOpen={helpOpen} initialSection={helpSection} onClose={() => setHelpOpen(false)} />
+      <HelpModal
+        key={helpOpen ? `help-${helpSection ?? "default"}` : "help-closed"}
+        isOpen={helpOpen}
+        initialSection={helpSection}
+        onClose={() => setHelpOpen(false)}
+      />
       <SettingsModal
         key={settingsOpen ? "settings-open" : "settings-closed"}
         isOpen={settingsOpen}

--- a/src/best-practices/examples.browser.test.tsx
+++ b/src/best-practices/examples.browser.test.tsx
@@ -1,15 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { LyricSample, SyllableSample, TimingSample } from "@/best-practices/examples";
+import { LyricSample, SyllableSample } from "@/best-practices/examples";
+import { comesBefore } from "@/test/dom-order";
 import { render } from "@/test/render";
 
 // -- Helpers -------------------------------------------------------------------
 
 function countOccurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
-}
-
-function comesBefore(first: Element, second: Element): boolean {
-  return Boolean(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING);
 }
 
 // -- Lyric sample --------------------------------------------------------------
@@ -184,159 +181,5 @@ describe("SyllableSample invariants", () => {
   it("keeps the parts in the order they are given", async () => {
     const screen = await render(<SyllableSample parts={["hel", "lo"]} caption="" />);
     expect(screen.container.textContent).toBe("hel|lo");
-  });
-});
-
-// -- Timing sample -------------------------------------------------------------
-
-describe("TimingSample", () => {
-  it("renders a labelled block for each word", async () => {
-    const screen = await render(
-      <TimingSample
-        caption="Kept"
-        cells={[
-          { kind: "word", label: "I" },
-          { kind: "word", label: "can't" },
-        ]}
-      />,
-    );
-    await expect.element(screen.getByText("I")).toBeInTheDocument();
-    await expect.element(screen.getByText("can't")).toBeInTheDocument();
-    await expect.element(screen.getByText("Kept")).toBeInTheDocument();
-  });
-
-  it("groups cells into a paragraph box when a group is given", async () => {
-    const screen = await render(
-      <TimingSample
-        caption="One paragraph"
-        cells={[
-          {
-            kind: "group",
-            cells: [
-              { kind: "word", label: "verse line" },
-              { kind: "gap", width: "sm" },
-            ],
-          },
-        ]}
-      />,
-    );
-    await expect.element(screen.getByText("verse line")).toBeInTheDocument();
-  });
-
-  it("renders a highlighted block with its label intact", async () => {
-    const screen = await render(
-      <TimingSample caption="Held" cells={[{ kind: "word", label: "stop", highlighted: true }]} />,
-    );
-    await expect.element(screen.getByText("stop")).toBeInTheDocument();
-  });
-
-  it("renders a wide block with its label intact", async () => {
-    const screen = await render(
-      <TimingSample caption="Stretched" cells={[{ kind: "word", label: "verse line", wide: true }]} />,
-    );
-    await expect.element(screen.getByText("verse line")).toBeInTheDocument();
-  });
-});
-
-describe("TimingSample edge cases", () => {
-  it("renders the caption alone for an empty cell list", async () => {
-    const screen = await render(<TimingSample caption="Nothing timed" cells={[]} />);
-    expect(screen.container.textContent).toBe("Nothing timed");
-  });
-
-  it("renders a gap on both sides of a grouped word", async () => {
-    const screen = await render(
-      <TimingSample
-        caption="Isolated paragraph"
-        cells={[
-          { kind: "gap", width: "lg" },
-          { kind: "group", cells: [{ kind: "word", label: "yeah!" }] },
-          { kind: "gap", width: "lg" },
-        ]}
-      />,
-    );
-    await expect.element(screen.getByText("yeah!")).toBeInTheDocument();
-    expect(screen.container.textContent).toBe("yeah!Isolated paragraph");
-  });
-
-  it("renders nested groups down to the innermost label", async () => {
-    const screen = await render(
-      <TimingSample
-        caption="Nested"
-        cells={[
-          {
-            kind: "group",
-            cells: [
-              { kind: "group", cells: [{ kind: "word", label: "inner" }] },
-              { kind: "word", label: "outer" },
-            ],
-          },
-        ]}
-      />,
-    );
-    await expect.element(screen.getByText("inner")).toBeInTheDocument();
-    await expect.element(screen.getByText("outer")).toBeInTheDocument();
-  });
-
-  it("renders an empty group without dropping the rest of the strip", async () => {
-    const screen = await render(
-      <TimingSample
-        caption="Empty paragraph"
-        cells={[
-          { kind: "group", cells: [] },
-          { kind: "word", label: "after" },
-        ]}
-      />,
-    );
-    await expect.element(screen.getByText("after")).toBeInTheDocument();
-  });
-
-  it("renders repeated identical labels once each", async () => {
-    const screen = await render(
-      <TimingSample
-        caption="Doubled"
-        cells={[
-          { kind: "word", label: "la" },
-          { kind: "word", label: "la" },
-        ]}
-      />,
-    );
-    expect(countOccurrences(screen.container.textContent ?? "", "la")).toBe(2);
-  });
-});
-
-describe("TimingSample invariants", () => {
-  it("contributes no text for gap cells", async () => {
-    const screen = await render(
-      <TimingSample
-        caption="Breath"
-        cells={[
-          { kind: "word", label: "stop" },
-          { kind: "gap", width: "lg" },
-          { kind: "word", label: "think" },
-        ]}
-      />,
-    );
-    expect(screen.container.textContent).toBe("stopthinkBreath");
-  });
-
-  it("places the caption after the strip", async () => {
-    const screen = await render(<TimingSample caption="Kept" cells={[{ kind: "word", label: "I" }]} />);
-    const block = screen.getByText("I").element();
-    const caption = screen.getByText("Kept").element();
-    expect(comesBefore(block, caption)).toBe(true);
-  });
-
-  it("keeps cells in the order they are given", async () => {
-    const screen = await render(
-      <TimingSample
-        caption=""
-        cells={[
-          { kind: "word", label: "think" },
-          { kind: "word", label: "ing" },
-        ]}
-      />,
-    );
-    expect(screen.container.textContent).toBe("thinking");
   });
 });

--- a/src/best-practices/examples.timing.browser.test.tsx
+++ b/src/best-practices/examples.timing.browser.test.tsx
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { TimingSample } from "@/best-practices/examples";
+import { comesBefore } from "@/test/dom-order";
+import { render } from "@/test/render";
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe("TimingSample", () => {
+  it("renders a labelled block for each word", async () => {
+    const screen = await render(
+      <TimingSample
+        caption="Kept"
+        cells={[
+          { kind: "word", label: "I" },
+          { kind: "word", label: "can't" },
+        ]}
+      />,
+    );
+    await expect.element(screen.getByText("I")).toBeInTheDocument();
+    await expect.element(screen.getByText("can't")).toBeInTheDocument();
+    await expect.element(screen.getByText("Kept")).toBeInTheDocument();
+  });
+
+  it("groups cells into a paragraph box when a group is given", async () => {
+    const screen = await render(
+      <TimingSample
+        caption="One paragraph"
+        cells={[
+          {
+            kind: "group",
+            cells: [
+              { kind: "word", label: "verse line" },
+              { kind: "gap", width: "sm" },
+            ],
+          },
+        ]}
+      />,
+    );
+    await expect.element(screen.getByText("verse line")).toBeInTheDocument();
+  });
+
+  it("renders a highlighted block with its label intact", async () => {
+    const screen = await render(
+      <TimingSample caption="Held" cells={[{ kind: "word", label: "stop", highlighted: true }]} />,
+    );
+    await expect.element(screen.getByText("stop")).toBeInTheDocument();
+  });
+
+  it("renders a wide block with its label intact", async () => {
+    const screen = await render(
+      <TimingSample caption="Stretched" cells={[{ kind: "word", label: "verse line", wide: true }]} />,
+    );
+    await expect.element(screen.getByText("verse line")).toBeInTheDocument();
+  });
+});
+
+describe("TimingSample edge cases", () => {
+  it("renders the caption alone for an empty cell list", async () => {
+    const screen = await render(<TimingSample caption="Nothing timed" cells={[]} />);
+    expect(screen.container.textContent).toBe("Nothing timed");
+  });
+
+  it("renders a gap on both sides of a grouped word", async () => {
+    const screen = await render(
+      <TimingSample
+        caption="Isolated paragraph"
+        cells={[
+          { kind: "gap", width: "lg" },
+          { kind: "group", cells: [{ kind: "word", label: "yeah!" }] },
+          { kind: "gap", width: "lg" },
+        ]}
+      />,
+    );
+    await expect.element(screen.getByText("yeah!")).toBeInTheDocument();
+    expect(screen.container.textContent).toBe("yeah!Isolated paragraph");
+  });
+
+  it("renders nested groups down to the innermost label", async () => {
+    const screen = await render(
+      <TimingSample
+        caption="Nested"
+        cells={[
+          {
+            kind: "group",
+            cells: [
+              { kind: "group", cells: [{ kind: "word", label: "inner" }] },
+              { kind: "word", label: "outer" },
+            ],
+          },
+        ]}
+      />,
+    );
+    await expect.element(screen.getByText("inner")).toBeInTheDocument();
+    await expect.element(screen.getByText("outer")).toBeInTheDocument();
+  });
+
+  it("renders an empty group without dropping the rest of the strip", async () => {
+    const screen = await render(
+      <TimingSample
+        caption="Empty paragraph"
+        cells={[
+          { kind: "group", cells: [] },
+          { kind: "word", label: "after" },
+        ]}
+      />,
+    );
+    await expect.element(screen.getByText("after")).toBeInTheDocument();
+  });
+
+  it("renders repeated identical labels once each", async () => {
+    const screen = await render(
+      <TimingSample
+        caption="Doubled"
+        cells={[
+          { kind: "word", label: "la" },
+          { kind: "word", label: "la" },
+        ]}
+      />,
+    );
+    expect(countOccurrences(screen.container.textContent ?? "", "la")).toBe(2);
+  });
+});
+
+describe("TimingSample invariants", () => {
+  it("contributes no text for gap cells", async () => {
+    const screen = await render(
+      <TimingSample
+        caption="Breath"
+        cells={[
+          { kind: "word", label: "stop" },
+          { kind: "gap", width: "lg" },
+          { kind: "word", label: "think" },
+        ]}
+      />,
+    );
+    expect(screen.container.textContent).toBe("stopthinkBreath");
+  });
+
+  it("places the caption after the strip", async () => {
+    const screen = await render(<TimingSample caption="Kept" cells={[{ kind: "word", label: "I" }]} />);
+    const block = screen.getByText("I").element();
+    const caption = screen.getByText("Kept").element();
+    expect(comesBefore(block, caption)).toBe(true);
+  });
+
+  it("keeps cells in the order they are given", async () => {
+    const screen = await render(
+      <TimingSample
+        caption=""
+        cells={[
+          { kind: "word", label: "think" },
+          { kind: "word", label: "ing" },
+        ]}
+      />,
+    );
+    expect(screen.container.textContent).toBe("thinking");
+  });
+});

--- a/src/best-practices/model.ts
+++ b/src/best-practices/model.ts
@@ -21,4 +21,4 @@ interface RuleGroup {
 
 // -- Exports -------------------------------------------------------------------
 
-export type { Rule, RuleExample, RuleGroup };
+export type { Rule, RuleGroup };

--- a/src/best-practices/rule-card.browser.test.tsx
+++ b/src/best-practices/rule-card.browser.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { LyricSample } from "@/best-practices/examples";
 import type { Rule } from "@/best-practices/model";
 import { RuleCard } from "@/best-practices/rule-card";
+import { comesBefore } from "@/test/dom-order";
 import { render } from "@/test/render";
 
 // -- Fixtures ------------------------------------------------------------------
@@ -38,10 +39,6 @@ const WITH_ASIDE_AND_EXAMPLE: Rule = {
 };
 
 // -- Helpers -------------------------------------------------------------------
-
-function comesBefore(first: Element, second: Element): boolean {
-  return Boolean(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING);
-}
 
 function exampleKinds(container: Element): (string | null)[] {
   return Array.from(container.querySelectorAll("[data-example-kind]")).map((row) =>

--- a/src/domain/theme/code.test.ts
+++ b/src/domain/theme/code.test.ts
@@ -2,12 +2,71 @@
  * @vitest-environment node
  */
 import { describe, expect, it } from "vitest";
-import { decodeThemeCode, encodeThemeCode } from "./code";
+import { decodeThemeCode, encodeThemeCode, SEED_CODE_ORDER } from "./code";
 import { type Theme, SEED_TOKENS } from "./model";
 import { PRESETS } from "./presets";
 
 let counter = 0;
 const makeId = () => `test-id-${counter++}`;
+
+// The Default preset's share code as emitted by Composer 1.37.x, before the
+// positive/negative seeds existed. Any wire-order change breaks this fixture.
+const LEGACY_DEFAULT_CODE =
+  "ctm1:dark:Default:28292c,1a1a1c,3e3e41,ffffff,aaaaaa,696b77,818cf8,d4a5a5,5865f2,b45555,ffe5e5,f5a623,ff7a85,737476,ffd66b,4fd6c0";
+
+describe("wire format compatibility", () => {
+  it("regression: a 1.37.x share code still maps every seed to the token it was written for", () => {
+    const decoded = decodeThemeCode(LEGACY_DEFAULT_CODE, makeId);
+    expect(decoded.tokens.bg).toBe("#28292c");
+    expect(decoded.tokens.explicit).toBe("#ff7a85");
+    expect(decoded.tokens.wave).toBe("#737476");
+    expect(decoded.tokens.snap).toBe("#ffd66b");
+    expect(decoded.tokens.onset).toBe("#4fd6c0");
+  });
+
+  it("regression: seeds added after 1.37.x stay unset when decoding a legacy code", () => {
+    const decoded = decodeThemeCode(LEGACY_DEFAULT_CODE, makeId);
+    expect(decoded.tokens.positive).toBeUndefined();
+    expect(decoded.tokens.negative).toBeUndefined();
+  });
+
+  it("pins the first sixteen wire slots to the 1.37.x order", () => {
+    expect(SEED_CODE_ORDER.slice(0, 16)).toEqual([
+      "bg",
+      "bg-dark",
+      "bg-elevated",
+      "text",
+      "text-tertiary",
+      "text-faint",
+      "accent",
+      "accent-warm",
+      "link",
+      "error",
+      "error-text",
+      "warning",
+      "explicit",
+      "wave",
+      "snap",
+      "onset",
+    ]);
+  });
+
+  it("covers every seed token, so no seed is unshareable", () => {
+    expect([...SEED_CODE_ORDER].sort()).toEqual([...SEED_TOKENS].sort());
+  });
+
+  it("has no duplicate slots", () => {
+    expect(new Set(SEED_CODE_ORDER).size).toBe(SEED_CODE_ORDER.length);
+  });
+
+  it("encodes into the wire order, not the display order", () => {
+    const code = encodeThemeCode(PRESETS[0]);
+    const hexes = code.split(":")[3].split(",");
+    SEED_CODE_ORDER.forEach((key, index) => {
+      expect(`#${hexes[index]}`.toLowerCase()).toBe(PRESETS[0].tokens[key]?.toLowerCase());
+    });
+  });
+});
 
 describe("encodeThemeCode", () => {
   it("emits the ctm1 envelope with scheme, encoded name, and seed hexes", () => {
@@ -143,36 +202,36 @@ describe("edge cases", () => {
 
   it("only maps as many seeds as are present in the code", () => {
     const decoded = decodeThemeCode("ctm1:dark:Partial:280000,1a1a1c", makeId);
-    expect(decoded.tokens[SEED_TOKENS[0]]).toBe("#280000");
-    expect(decoded.tokens[SEED_TOKENS[1]]).toBe("#1a1a1c");
-    expect(decoded.tokens[SEED_TOKENS[2]]).toBeUndefined();
+    expect(decoded.tokens[SEED_CODE_ORDER[0]]).toBe("#280000");
+    expect(decoded.tokens[SEED_CODE_ORDER[1]]).toBe("#1a1a1c");
+    expect(decoded.tokens[SEED_CODE_ORDER[2]]).toBeUndefined();
   });
 });
 
 describe("invalid hex seeds are skipped, not assigned", () => {
   it("drops a non-hex seed value", () => {
     const decoded = decodeThemeCode("ctm1:dark:Bad:zzzzzz", makeId);
-    expect(decoded.tokens[SEED_TOKENS[0]]).toBeUndefined();
+    expect(decoded.tokens[SEED_CODE_ORDER[0]]).toBeUndefined();
   });
 
   it("keeps valid seeds and drops only the invalid ones", () => {
     const decoded = decodeThemeCode("ctm1:dark:Mixed:280000,zzzzzz,1a1a1c", makeId);
-    expect(decoded.tokens[SEED_TOKENS[0]]).toBe("#280000");
-    expect(decoded.tokens[SEED_TOKENS[1]]).toBeUndefined();
-    expect(decoded.tokens[SEED_TOKENS[2]]).toBe("#1a1a1c");
+    expect(decoded.tokens[SEED_CODE_ORDER[0]]).toBe("#280000");
+    expect(decoded.tokens[SEED_CODE_ORDER[1]]).toBeUndefined();
+    expect(decoded.tokens[SEED_CODE_ORDER[2]]).toBe("#1a1a1c");
   });
 
   it("skips empty inter-comma slots", () => {
     const decoded = decodeThemeCode("ctm1:dark:Gaps:280000,,1a1a1c", makeId);
-    expect(decoded.tokens[SEED_TOKENS[0]]).toBe("#280000");
-    expect(decoded.tokens[SEED_TOKENS[1]]).toBeUndefined();
-    expect(decoded.tokens[SEED_TOKENS[2]]).toBe("#1a1a1c");
+    expect(decoded.tokens[SEED_CODE_ORDER[0]]).toBe("#280000");
+    expect(decoded.tokens[SEED_CODE_ORDER[1]]).toBeUndefined();
+    expect(decoded.tokens[SEED_CODE_ORDER[2]]).toBe("#1a1a1c");
   });
 
   it("drops wrong-length hex values", () => {
     const decoded = decodeThemeCode("ctm1:dark:Short:2800,1a1a1c", makeId);
-    expect(decoded.tokens[SEED_TOKENS[0]]).toBeUndefined();
-    expect(decoded.tokens[SEED_TOKENS[1]]).toBe("#1a1a1c");
+    expect(decoded.tokens[SEED_CODE_ORDER[0]]).toBeUndefined();
+    expect(decoded.tokens[SEED_CODE_ORDER[1]]).toBe("#1a1a1c");
   });
 
   it("does not let CSS-injection-shaped payloads through", () => {

--- a/src/domain/theme/code.ts
+++ b/src/domain/theme/code.ts
@@ -1,16 +1,40 @@
 // -- Share codes ---------------------------------------------------------------
 // A compact, copy-pasteable representation of a theme's seeds. Format:
 //   ctm1:<scheme>:<encodeURIComponent(name)>:<seedHex,seedHex,...>
-// Seed order follows SEED_TOKENS; hexes are stored without the leading #.
+// Seed order follows SEED_CODE_ORDER; hexes are stored without the leading #.
 
 import { isHexColor } from "@/domain/theme/color";
-import { SEED_TOKENS, type Theme } from "@/domain/theme/model";
+import type { Theme, TokenKey } from "@/domain/theme/model";
+
+// Slot index IS the ctm1 wire format. Never reorder or remove an entry: codes
+// already in the wild decode positionally against this list. New seeds append
+// to the end, where older builds simply ignore them.
+const SEED_CODE_ORDER: TokenKey[] = [
+  "bg",
+  "bg-dark",
+  "bg-elevated",
+  "text",
+  "text-tertiary",
+  "text-faint",
+  "accent",
+  "accent-warm",
+  "link",
+  "error",
+  "error-text",
+  "warning",
+  "explicit",
+  "wave",
+  "snap",
+  "onset",
+  "positive",
+  "negative",
+];
 
 const CODE_PATTERN = /^ctm1:(dark|light):([^:]*):(.+)$/;
 const DEFAULT_IMPORT_NAME = "Imported theme";
 
 function encodeThemeCode(theme: Theme): string {
-  const seeds = SEED_TOKENS.map((key) => (theme.tokens[key] ?? "").replace("#", "")).join(",");
+  const seeds = SEED_CODE_ORDER.map((key) => (theme.tokens[key] ?? "").replace("#", "")).join(",");
   return `ctm1:${theme.scheme}:${encodeURIComponent(theme.name)}:${seeds}`;
 }
 
@@ -23,7 +47,7 @@ function decodeThemeCode(code: string, makeId: () => string): Theme {
   const name = match[2] ? decodeURIComponent(match[2]) : DEFAULT_IMPORT_NAME;
   const hexes = match[3].split(",");
   const tokens: Theme["tokens"] = {};
-  SEED_TOKENS.forEach((key, index) => {
+  SEED_CODE_ORDER.forEach((key, index) => {
     const hex = hexes[index];
     if (!hex) return;
     const candidate = `#${hex.replace("#", "")}`;
@@ -41,4 +65,4 @@ function decodeThemeCode(code: string, makeId: () => string): Theme {
   };
 }
 
-export { encodeThemeCode, decodeThemeCode };
+export { encodeThemeCode, decodeThemeCode, SEED_CODE_ORDER };

--- a/src/pages/guides/guide-page.tsx
+++ b/src/pages/guides/guide-page.tsx
@@ -8,6 +8,7 @@ import MultiAgentDuetsContent from "@/pages/guides/content/multi-agent-lyrics-du
 import TtmlFileFormatSpecContent from "@/pages/guides/content/ttml-file-format-spec";
 import TtmlVsLrcContent from "@/pages/guides/content/ttml-vs-lrc";
 import WhatIsTtmlContent from "@/pages/guides/content/what-is-ttml";
+import type { GuideSlug } from "@/pages/guides/slugs";
 import { Navigate, useParams } from "react-router-dom";
 
 interface GuideEntry {
@@ -18,7 +19,7 @@ interface GuideEntry {
   Content: React.FC;
 }
 
-const GUIDE_ENTRIES: Record<string, GuideEntry> = {
+const GUIDE_ENTRIES: Record<GuideSlug, GuideEntry> = {
   "what-is-ttml": {
     title: "What is TTML?",
     description:
@@ -118,9 +119,13 @@ const GUIDE_ENTRIES: Record<string, GuideEntry> = {
   },
 };
 
+function isGuideSlug(value: string): value is GuideSlug {
+  return value in GUIDE_ENTRIES;
+}
+
 const GuidePage: React.FC = () => {
   const { slug } = useParams<{ slug: string }>();
-  const entry = slug ? GUIDE_ENTRIES[slug] : undefined;
+  const entry = slug && isGuideSlug(slug) ? GUIDE_ENTRIES[slug] : undefined;
 
   if (!slug || !entry) {
     return <Navigate to="/guides" replace />;
@@ -135,4 +140,5 @@ const GuidePage: React.FC = () => {
   );
 };
 
+export { GUIDE_ENTRIES };
 export default GuidePage;

--- a/src/pages/guides/guides-index.tsx
+++ b/src/pages/guides/guides-index.tsx
@@ -1,3 +1,4 @@
+import type { GuideSlug } from "@/pages/guides/slugs";
 import { LandingLayout } from "@/pages/landing/landing-layout";
 import { BetterLyricsPromo } from "@/pages/landing/sections/better-lyrics-promo";
 import { PageHead } from "@/seo/page-head";
@@ -6,7 +7,7 @@ import { IconArrowRight } from "@tabler/icons-react";
 import { Link } from "react-router-dom";
 
 interface GuideListing {
-  slug: string;
+  slug: GuideSlug;
   title: string;
   description: string;
 }

--- a/src/pages/guides/slugs.test.ts
+++ b/src/pages/guides/slugs.test.ts
@@ -1,0 +1,41 @@
+import { GUIDE_ENTRIES } from "@/pages/guides/guide-page";
+import { GUIDES } from "@/pages/guides/guides-index";
+import { GUIDE_SLUGS } from "@/pages/guides/slugs";
+import { routes } from "@/router";
+import { describe, expect, it } from "vitest";
+
+const sorted = (values: readonly string[]) => [...values].sort();
+
+describe("guide slug registry", () => {
+  it("regression: every guide with a page entry is prerendered", () => {
+    expect(sorted(Object.keys(GUIDE_ENTRIES))).toEqual(sorted(GUIDE_SLUGS));
+  });
+
+  it("regression: every guide listed on the index is prerendered", () => {
+    expect(sorted(GUIDES.map((guide) => guide.slug))).toEqual(sorted(GUIDE_SLUGS));
+  });
+
+  it("emits one static path per slug from the router", () => {
+    const guideRoute = routes.find((route) => route.path === "/guides/:slug");
+    expect(guideRoute?.getStaticPaths?.()).toEqual(GUIDE_SLUGS.map((slug) => `/guides/${slug}`));
+  });
+
+  it("invariant: slugs are unique", () => {
+    expect(new Set(GUIDE_SLUGS).size).toBe(GUIDE_SLUGS.length);
+  });
+
+  it("invariant: slugs are URL-safe and lowercase", () => {
+    for (const slug of GUIDE_SLUGS) {
+      expect(slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+  });
+
+  it("invariant: every related link points at a real guide", () => {
+    for (const entry of Object.values(GUIDE_ENTRIES)) {
+      for (const related of entry.related) {
+        if (!related.path.startsWith("/guides/")) continue;
+        expect(GUIDE_SLUGS).toContain(related.path.slice("/guides/".length));
+      }
+    }
+  });
+});

--- a/src/pages/guides/slugs.ts
+++ b/src/pages/guides/slugs.ts
@@ -1,0 +1,22 @@
+// -- Guide slugs ---------------------------------------------------------------
+// The single owner of which guides exist. The router prerenders exactly this
+// list, so a slug missing here ships as a client-only route that 404s on a cold
+// visit. Kept free of component imports so the router can read it without
+// pulling guide content into the entry bundle.
+
+const GUIDE_SLUGS = [
+  "what-is-ttml",
+  "ttml-vs-lrc",
+  "ttml-file-format-spec",
+  "how-to-make-apple-music-synced-lyrics",
+  "karaoke-style-lyrics-guide",
+  "background-vocals-in-ttml",
+  "multi-agent-lyrics-duets",
+  "lrc-to-ttml-conversion-guide",
+  "lyric-best-practices",
+] as const;
+
+type GuideSlug = (typeof GUIDE_SLUGS)[number];
+
+export { GUIDE_SLUGS };
+export type { GuideSlug };

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,16 +1,6 @@
 import { ErrorFallback } from "@/pages/error-fallback";
+import { GUIDE_SLUGS } from "@/pages/guides/slugs";
 import type { RouteRecord } from "vite-react-ssg";
-
-const GUIDE_SLUGS = [
-  "what-is-ttml",
-  "ttml-vs-lrc",
-  "ttml-file-format-spec",
-  "how-to-make-apple-music-synced-lyrics",
-  "karaoke-style-lyrics-guide",
-  "background-vocals-in-ttml",
-  "multi-agent-lyrics-duets",
-  "lrc-to-ttml-conversion-guide",
-] as const;
 
 const errorElement = <ErrorFallback />;
 

--- a/src/stores/settings.migration.test.ts
+++ b/src/stores/settings.migration.test.ts
@@ -1,0 +1,62 @@
+import { DEFAULTS, migrateSettingsForTest, useSettingsStore } from "@/stores/settings";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// A settings blob as written by 1.37.x: every key is present, so an
+// `=== undefined` migration guard never fires for any of them.
+function legacyBlob(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { ...DEFAULTS, preserveBracketsOnExtraction: false, defaultZoom: 140, ...overrides };
+}
+
+async function rehydrateAt(version: number, state: Record<string, unknown>): Promise<void> {
+  window.localStorage.setItem("composer-settings", JSON.stringify({ state, version }));
+  await useSettingsStore.persist.rehydrate();
+}
+
+beforeEach(() => {
+  window.localStorage.removeItem("composer-settings");
+  useSettingsStore.setState({ ...DEFAULTS });
+});
+
+describe("preserveBracketsOnExtraction migration", () => {
+  it("regression: an inherited false from a pre-1.38 blob is lifted to the new default", async () => {
+    await rehydrateAt(5, legacyBlob());
+    expect(useSettingsStore.getState().preserveBracketsOnExtraction).toBe(true);
+  });
+
+  it("regression: the fix reaches an existing user, not just a fresh profile", async () => {
+    const migrated = migrateSettingsForTest(legacyBlob(), 5) as { preserveBracketsOnExtraction: boolean };
+    expect(migrated.preserveBracketsOnExtraction).toBe(true);
+  });
+
+  it("leaves a choice made after the flip alone", async () => {
+    await rehydrateAt(6, legacyBlob({ preserveBracketsOnExtraction: false }));
+    expect(useSettingsStore.getState().preserveBracketsOnExtraction).toBe(false);
+  });
+
+  it("is idempotent across a second rehydrate at the current version", async () => {
+    await rehydrateAt(5, legacyBlob());
+    const first = useSettingsStore.getState().preserveBracketsOnExtraction;
+    await rehydrateAt(6, { ...legacyBlob(), preserveBracketsOnExtraction: first });
+    expect(useSettingsStore.getState().preserveBracketsOnExtraction).toBe(true);
+  });
+
+  it("preserves unrelated persisted settings while migrating", async () => {
+    await rehydrateAt(5, legacyBlob({ defaultZoom: 200 }));
+    expect(useSettingsStore.getState().defaultZoom).toBe(200);
+    expect(useSettingsStore.getState().preserveBracketsOnExtraction).toBe(true);
+  });
+
+  it("edge case: tolerates a blob missing the key entirely", () => {
+    const { preserveBracketsOnExtraction: _omitted, ...blob } = legacyBlob();
+    const migrated = migrateSettingsForTest(blob, 5) as { preserveBracketsOnExtraction: boolean };
+    expect(migrated.preserveBracketsOnExtraction).toBe(true);
+  });
+
+  it("edge case: tolerates a null persisted state", () => {
+    expect(migrateSettingsForTest(null, 5)).toBeNull();
+  });
+
+  it("invariant: a fresh profile already gets the new default", () => {
+    expect(DEFAULTS.preserveBracketsOnExtraction).toBe(true);
+  });
+});

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -158,7 +158,7 @@ const BUILTIN_COBALT_INSTANCE: CobaltInstance = {
   url: "https://cobalt.boidu.dev",
 };
 
-const SETTINGS_PERSIST_VERSION = 5;
+const SETTINGS_PERSIST_VERSION = 6;
 
 function migrateSettings(persistedState: unknown, version: number): unknown {
   if (!persistedState || typeof persistedState !== "object") return persistedState;
@@ -172,6 +172,9 @@ function migrateSettings(persistedState: unknown, version: number): unknown {
   if (next.vocalOnsetSnap === undefined) next.vocalOnsetSnap = true;
   if (next.snapPlayheadToPoints === undefined) next.snapPlayheadToPoints = true;
   if (next.redoPreroll === undefined) next.redoPreroll = 1.5;
+  // The key predates the default flip, so every old blob carries an explicit
+  // false that a plain undefined guard would never reach.
+  if (version < 6) next.preserveBracketsOnExtraction = true;
   return next;
 }
 

--- a/src/stores/theme.test.ts
+++ b/src/stores/theme.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { encodeThemeCode } from "@/domain/theme/code";
+import { deriveTheme } from "@/domain/theme/derive";
+import { DARK_NEGATIVE, DARK_POSITIVE, LIGHT_NEGATIVE, LIGHT_POSITIVE } from "@/domain/theme/mark-constants";
 import type { Theme } from "@/domain/theme/model";
 import { initTheme, useThemeStore } from "@/stores/theme";
 
@@ -171,12 +173,81 @@ describe("theme store · initTheme", () => {
   });
 });
 
-describe("theme store · persistence", () => {
-  it("round-trips activeThemeId and customThemes and re-applies on rehydrate", async () => {
-    const custom = makeCustom({ id: "persisted", tokens: { accent: "#fafbfc" } });
+describe("theme store · mark token migration", () => {
+  async function rehydrateV1(customThemes: Theme[]): Promise<Theme[]> {
     window.localStorage.setItem(
       "composer-theme",
-      JSON.stringify({ state: { activeThemeId: "persisted", customThemes: [custom] }, version: 1 }),
+      JSON.stringify({ state: { activeThemeId: "default", customThemes }, version: 1 }),
+    );
+    await useThemeStore.persist.rehydrate();
+    return useThemeStore.getState().customThemes;
+  }
+
+  it("regression: backfills the dark mark tokens a pre-1.38 custom theme never stored", async () => {
+    const [migrated] = await rehydrateV1([makeCustom({ scheme: "dark", tokens: { accent: "#123456" } })]);
+    expect(migrated.tokens.positive).toBe(DARK_POSITIVE);
+    expect(migrated.tokens.negative).toBe(DARK_NEGATIVE);
+  });
+
+  it("regression: backfills the light mark tokens for a light custom theme", async () => {
+    const [migrated] = await rehydrateV1([makeCustom({ scheme: "light", tokens: { accent: "#123456" } })]);
+    expect(migrated.tokens.positive).toBe(LIGHT_POSITIVE);
+    expect(migrated.tokens.negative).toBe(LIGHT_NEGATIVE);
+  });
+
+  it("never resolves a migrated mark token to the missing-seed magenta", async () => {
+    const [migrated] = await rehydrateV1([makeCustom({ tokens: { accent: "#123456" } })]);
+    const resolved = deriveTheme(migrated);
+    expect(resolved.positive).not.toBe("#ff00ff");
+    expect(resolved.negative).not.toBe("#ff00ff");
+  });
+
+  it("leaves an explicitly chosen mark token alone", async () => {
+    const [migrated] = await rehydrateV1([makeCustom({ tokens: { positive: "#00ff00", negative: "#ff0000" } })]);
+    expect(migrated.tokens.positive).toBe("#00ff00");
+    expect(migrated.tokens.negative).toBe("#ff0000");
+  });
+
+  it("preserves every other token on the migrated theme", async () => {
+    const [migrated] = await rehydrateV1([makeCustom({ tokens: { accent: "#123456", bg: "#000000" } })]);
+    expect(migrated.tokens.accent).toBe("#123456");
+    expect(migrated.tokens.bg).toBe("#000000");
+    expect(migrated.name).toBe("My Theme");
+    expect(migrated.kind).toBe("custom");
+  });
+
+  it("migrates every custom theme, not just the first", async () => {
+    const migrated = await rehydrateV1([
+      makeCustom({ id: "a", scheme: "dark" }),
+      makeCustom({ id: "b", scheme: "light" }),
+    ]);
+    expect(migrated.map((t) => t.tokens.positive)).toEqual([DARK_POSITIVE, LIGHT_POSITIVE]);
+  });
+
+  it("edge case: survives an empty custom theme list", async () => {
+    expect(await rehydrateV1([])).toEqual([]);
+  });
+
+  it("is idempotent, so a v2 payload passes through untouched", async () => {
+    const custom = makeCustom({ tokens: { accent: "#123456", positive: "#00ff00", negative: "#ff0000" } });
+    window.localStorage.setItem(
+      "composer-theme",
+      JSON.stringify({ state: { activeThemeId: "default", customThemes: [custom] }, version: 2 }),
+    );
+    await useThemeStore.persist.rehydrate();
+    expect(useThemeStore.getState().customThemes).toEqual([custom]);
+  });
+});
+
+describe("theme store · persistence", () => {
+  it("round-trips activeThemeId and customThemes and re-applies on rehydrate", async () => {
+    const custom = makeCustom({
+      id: "persisted",
+      tokens: { accent: "#fafbfc", positive: DARK_POSITIVE, negative: DARK_NEGATIVE },
+    });
+    window.localStorage.setItem(
+      "composer-theme",
+      JSON.stringify({ state: { activeThemeId: "persisted", customThemes: [custom] }, version: 2 }),
     );
     document.documentElement.style.removeProperty(ACCENT_VAR);
     await useThemeStore.persist.rehydrate();

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { decodeThemeCode } from "@/domain/theme/code";
 import { deriveTheme } from "@/domain/theme/derive";
+import { DARK_NEGATIVE, DARK_POSITIVE, LIGHT_NEGATIVE, LIGHT_POSITIVE } from "@/domain/theme/mark-constants";
 import type { Theme, ThemeId } from "@/domain/theme/model";
 import { DEFAULT_PRESET_ID, PRESET_BY_ID } from "@/domain/theme/presets";
 import { applyResolvedTheme } from "@/utils/theme/apply";
@@ -35,6 +36,31 @@ function makeRandomId(): string {
 
 function applyTheme(theme: Theme): void {
   applyResolvedTheme(deriveTheme(theme), theme.scheme);
+}
+
+// -- Migration ----------------------------------------------------------------
+
+const THEME_PERSIST_VERSION = 2;
+
+const MARK_DEFAULTS = {
+  dark: { positive: DARK_POSITIVE, negative: DARK_NEGATIVE },
+  light: { positive: LIGHT_POSITIVE, negative: LIGHT_NEGATIVE },
+};
+
+// v2 added the positive/negative seeds. Themes saved before then have no value
+// for either, and deriveTheme resolves a missing seed to magenta.
+function migrateTheme(persistedState: unknown, version: number): unknown {
+  if (version >= THEME_PERSIST_VERSION) return persistedState;
+  if (!persistedState || typeof persistedState !== "object") return persistedState;
+  const state = persistedState as Partial<ThemeState>;
+  if (!Array.isArray(state.customThemes)) return state;
+  return {
+    ...state,
+    customThemes: state.customThemes.map((theme) => ({
+      ...theme,
+      tokens: { ...MARK_DEFAULTS[theme.scheme === "light" ? "light" : "dark"], ...theme.tokens },
+    })),
+  };
 }
 
 // -- Store --------------------------------------------------------------------
@@ -82,7 +108,8 @@ const useThemeStore = create<ThemeState & ThemeActions>()(
     }),
     {
       name: "composer-theme",
-      version: 1,
+      version: THEME_PERSIST_VERSION,
+      migrate: migrateTheme,
       onRehydrateStorage: () => (state) => {
         if (state) state.setActiveTheme(state.activeThemeId);
       },

--- a/src/test/copy-guards.ts
+++ b/src/test/copy-guards.ts
@@ -24,4 +24,4 @@ function expectCleanRuleCopy(group: RuleGroup) {
 
 // -- Exports -------------------------------------------------------------------
 
-export { expectCleanRuleCopy, FORBIDDEN_PUNCTUATION };
+export { expectCleanRuleCopy };

--- a/src/test/dom-order.ts
+++ b/src/test/dom-order.ts
@@ -1,0 +1,8 @@
+// -- Document order assertions -------------------------------------------------
+// Shared so tests that assert "X renders before Y" agree on what that means.
+
+function comesBefore(first: Element, second: Element): boolean {
+  return Boolean(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING);
+}
+
+export { comesBefore };

--- a/src/ui/help-sections/best-practices.browser.test.tsx
+++ b/src/ui/help-sections/best-practices.browser.test.tsx
@@ -2,6 +2,7 @@ import { cdp, userEvent } from "vitest/browser";
 import { describe, expect, it } from "vitest";
 import { groupAnchorId } from "@/best-practices/anchors";
 import { BEST_PRACTICE_GROUPS } from "@/best-practices/groups";
+import { comesBefore } from "@/test/dom-order";
 import { render } from "@/test/render";
 import { HelpSectionContent } from "@/ui/help-sections";
 import { BestPracticesSection } from "@/ui/help-sections/best-practices";
@@ -9,10 +10,6 @@ import { BestPracticesSection } from "@/ui/help-sections/best-practices";
 // -- Helpers -------------------------------------------------------------------
 
 type Screen = Awaited<ReturnType<typeof render>>;
-
-function comesBefore(first: Element, second: Element): boolean {
-  return Boolean(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING);
-}
 
 function chipLabels(container: Element): (string | null)[] {
   return Array.from(container.querySelectorAll("li button")).map((chip) => chip.textContent);


### PR DESCRIPTION
## Overview

Follow-up on #172. The two theme seeds it added landed in the middle of the token list, which shifted every slot in the share-code format, so codes copied from an older build imported with the wrong waveform color and magenta snap markers. Pinned the slot order so it can't drift again and backfilled the new mark colors onto themes people had already saved. The guide never made it into the prerender list either, so its URL 404'd on a cold visit. The slug list owns that now and a mismatch fails typecheck. Also migrated the bracket-preservation default so it reaches existing installs, and help now reopens on the section you asked for instead of the last one you read.
