### PR TITLE
perf: stop rendering when the app is idle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.38.1",
+  "version": "1.38.2",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { App } from "@/App";
+import { subscribeFrame } from "@/lib/frame-loop";
 import { useProjectStore } from "@/stores/project";
 import { useUIStore } from "@/stores/ui";
 import { allowConsole } from "@/test/console-guard";
+import { settleFrames } from "@/test/frame-steps";
 import { render } from "@/test/render";
 import { TOUR_SEEN_KEY } from "@/tour/use-tour";
 
@@ -77,5 +79,22 @@ describe("App", () => {
     helpButton().click();
     await expect.poll(helpModalOpen).toBe(true);
     expect(activeHelpSection()).toBe("Getting Started");
+  });
+
+  it("wires the frame loop so a store write wakes it", async () => {
+    localStorage.setItem(TOUR_SEEN_KEY, "true");
+    await render(<App />);
+
+    let frames = 0;
+    const unsubscribe = subscribeFrame(() => {
+      frames += 1;
+    });
+    await settleFrames(() => frames);
+    frames = 0;
+    useProjectStore.setState({ activeTab: "edit" });
+    await settleFrames(() => frames);
+    unsubscribe();
+
+    expect(frames).toBeGreaterThan(0);
   });
 });

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -88,7 +88,7 @@ describe("App", () => {
     let frames = 0;
     const unsubscribe = subscribeFrame(() => {
       frames += 1;
-    });
+    }, "app-wiring-probe");
     await settleFrames(() => frames);
     frames = 0;
     useProjectStore.setState({ activeTab: "edit" });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { usePanicRecovery } from "@/hooks/usePanicRecovery";
 import { usePersistence } from "@/hooks/usePersistence";
 import { useResolveYouTubeTunnel } from "@/hooks/useResolveYouTubeTunnel";
 import { useVocalOnsetSnapPoints } from "@/hooks/useVocalOnsetSnapPoints";
+import { wireFrameLoop } from "@/lib/frame-loop-wiring";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useUIStore } from "@/stores/ui";
@@ -70,6 +71,8 @@ const AppContent: React.FC = () => {
     const timer = setTimeout(() => startTourRef.current(), 500);
     return () => clearTimeout(timer);
   }, [shouldShowTour]);
+
+  useEffect(() => wireFrameLoop(), []);
 
   usePersistence();
   useImportFromHash();

--- a/src/hooks/use-frame-loop.browser.test.tsx
+++ b/src/hooks/use-frame-loop.browser.test.tsx
@@ -18,7 +18,7 @@ const IDLE_FRAMES = TAIL_FRAMES + 4;
 // -- Components ---------------------------------------------------------------
 
 const FrameProbe: React.FC<FrameProbeProps> = ({ onFrame, enabled }) => {
-  useFrameLoop(onFrame, enabled);
+  useFrameLoop(onFrame, "frame-probe", enabled);
   return null;
 };
 

--- a/src/hooks/use-frame-loop.browser.test.tsx
+++ b/src/hooks/use-frame-loop.browser.test.tsx
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { useFrameLoop } from "@/hooks/use-frame-loop";
+import { TAIL_FRAMES, wake } from "@/lib/frame-loop";
+import { settleFrames, stepFrames } from "@/test/frame-steps";
+import { render } from "@/test/render";
+
+// -- Interfaces ---------------------------------------------------------------
+
+interface FrameProbeProps {
+  onFrame: () => void;
+  enabled?: boolean;
+}
+
+// -- Constants ----------------------------------------------------------------
+
+const IDLE_FRAMES = TAIL_FRAMES + 4;
+
+// -- Components ---------------------------------------------------------------
+
+const FrameProbe: React.FC<FrameProbeProps> = ({ onFrame, enabled }) => {
+  useFrameLoop(onFrame, enabled);
+  return null;
+};
+
+// -- Tests --------------------------------------------------------------------
+
+describe("useFrameLoop", () => {
+  it("runs the callback while enabled", async () => {
+    let calls = 0;
+    await render(
+      <FrameProbe
+        onFrame={() => {
+          calls += 1;
+        }}
+      />,
+    );
+    await settleFrames(() => calls);
+    expect(calls).toBeGreaterThan(0);
+  });
+
+  it("uses the latest callback without resubscribing", async () => {
+    let firstCalls = 0;
+    let secondCalls = 0;
+    const screen = await render(
+      <FrameProbe
+        onFrame={() => {
+          firstCalls += 1;
+        }}
+      />,
+    );
+    await settleFrames(() => firstCalls);
+    expect(firstCalls).toBeGreaterThan(0);
+
+    const callsBeforeSwap = firstCalls;
+    await screen.rerender(
+      <FrameProbe
+        onFrame={() => {
+          secondCalls += 1;
+        }}
+      />,
+    );
+    await stepFrames(IDLE_FRAMES);
+    expect(secondCalls).toBe(0);
+
+    wake();
+    await settleFrames(() => secondCalls);
+    expect(secondCalls).toBeGreaterThan(0);
+    expect(firstCalls).toBe(callsBeforeSwap);
+  });
+
+  it("never subscribes while disabled", async () => {
+    let calls = 0;
+    await render(
+      <FrameProbe
+        enabled={false}
+        onFrame={() => {
+          calls += 1;
+        }}
+      />,
+    );
+    wake();
+    await stepFrames(IDLE_FRAMES);
+    expect(calls).toBe(0);
+  });
+
+  it("subscribes and unsubscribes as enabled toggles", async () => {
+    let calls = 0;
+    const onFrame = () => {
+      calls += 1;
+    };
+    const screen = await render(<FrameProbe enabled={false} onFrame={onFrame} />);
+    wake();
+    await stepFrames(IDLE_FRAMES);
+    expect(calls).toBe(0);
+
+    await screen.rerender(<FrameProbe enabled={true} onFrame={onFrame} />);
+    await settleFrames(() => calls);
+    expect(calls).toBeGreaterThan(0);
+
+    await screen.rerender(<FrameProbe enabled={false} onFrame={onFrame} />);
+    const callsWhileDisabled = calls;
+    wake();
+    await stepFrames(IDLE_FRAMES);
+    expect(calls).toBe(callsWhileDisabled);
+  });
+
+  it("unsubscribes on unmount", async () => {
+    let calls = 0;
+    const screen = await render(
+      <FrameProbe
+        onFrame={() => {
+          calls += 1;
+        }}
+      />,
+    );
+    await settleFrames(() => calls);
+    expect(calls).toBeGreaterThan(0);
+
+    await screen.unmount();
+    const callsAtUnmount = calls;
+    wake();
+    await stepFrames(IDLE_FRAMES);
+    expect(calls).toBe(callsAtUnmount);
+  });
+});

--- a/src/hooks/use-frame-loop.ts
+++ b/src/hooks/use-frame-loop.ts
@@ -3,14 +3,14 @@ import { useEffect, useRef } from "react";
 
 // -- Hook ---------------------------------------------------------------------
 
-function useFrameLoop(callback: FrameCallback, enabled = true): void {
+function useFrameLoop(callback: FrameCallback, label: string, enabled = true): void {
   const callbackRef = useRef(callback);
   callbackRef.current = callback;
 
   useEffect(() => {
     if (!enabled) return;
-    return subscribeFrame((now) => callbackRef.current(now));
-  }, [enabled]);
+    return subscribeFrame((now) => callbackRef.current(now), label);
+  }, [enabled, label]);
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/src/hooks/use-frame-loop.ts
+++ b/src/hooks/use-frame-loop.ts
@@ -1,0 +1,18 @@
+import { type FrameCallback, subscribeFrame } from "@/lib/frame-loop";
+import { useEffect, useRef } from "react";
+
+// -- Hook ---------------------------------------------------------------------
+
+function useFrameLoop(callback: FrameCallback, enabled = true): void {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  useEffect(() => {
+    if (!enabled) return;
+    return subscribeFrame((now) => callbackRef.current(now));
+  }, [enabled]);
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { useFrameLoop };

--- a/src/hooks/use-frame-loop.ts
+++ b/src/hooks/use-frame-loop.ts
@@ -5,7 +5,11 @@ import { useEffect, useRef } from "react";
 
 function useFrameLoop(callback: FrameCallback, label: string, enabled = true): void {
   const callbackRef = useRef(callback);
-  callbackRef.current = callback;
+
+  // Assigned in an effect, never during render: React may replay or discard a render.
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
 
   useEffect(() => {
     if (!enabled) return;

--- a/src/hooks/use-renderer-audio-sync.browser.test.tsx
+++ b/src/hooks/use-renderer-audio-sync.browser.test.tsx
@@ -3,21 +3,28 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useRendererAudioSync } from "@/hooks/use-renderer-audio-sync";
 import { wireFrameLoop } from "@/lib/frame-loop-wiring";
 import { useAudioStore } from "@/stores/audio";
+import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
+import { settleFrames } from "@/test/frame-steps";
 import { render } from "@/test/render";
 
 // -- Harness -------------------------------------------------------------------
 
 const SyncedElement: React.FC = () => {
   const elementRef = useRef<HTMLDivElement>(null);
-  useRendererAudioSync(elementRef, (element, audio) => {
-    element.dataset.time = String(audio.currentTime);
-    element.dataset.paused = String(audio.paused);
-    element.dataset.rate = String(audio.playbackRate);
-  });
+  useRendererAudioSync(
+    elementRef,
+    (element, audio) => {
+      element.dataset.time = String(audio.currentTime);
+      element.dataset.paused = String(audio.paused);
+      element.dataset.rate = String(audio.playbackRate);
+    },
+    "synced-element",
+  );
   return <div ref={elementRef} data-test="synced" />;
 };
 
 let disposeWiring: (() => void) | null = null;
+let probe: FrameProbe;
 
 function attachAudio(): HTMLAudioElement {
   const audioElement = document.createElement("audio");
@@ -33,9 +40,11 @@ function syncedElement(root: HTMLElement): HTMLElement {
 
 beforeEach(() => {
   disposeWiring = wireFrameLoop();
+  probe = createFrameProbe();
 });
 
 afterEach(() => {
+  probe.dispose();
   disposeWiring?.();
   disposeWiring = null;
 });
@@ -99,5 +108,17 @@ describe("useRendererAudioSync", () => {
     const screen = await render(<SyncedElement />);
 
     expect(syncedElement(screen.container).dataset.time).toBeUndefined();
+  });
+
+  describe("invariants", () => {
+    it("regression #174: stops running frames once the audio is paused and idle", async () => {
+      attachAudio();
+      const screen = await render(<SyncedElement />);
+      await expect.poll(() => syncedElement(screen.container).dataset.time).toBe("0");
+      await probe.quiesce();
+
+      await settleFrames(probe.count);
+      expect(probe.count()).toBe(0);
+    });
   });
 });

--- a/src/hooks/use-renderer-audio-sync.browser.test.tsx
+++ b/src/hooks/use-renderer-audio-sync.browser.test.tsx
@@ -1,0 +1,103 @@
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useRendererAudioSync } from "@/hooks/use-renderer-audio-sync";
+import { wireFrameLoop } from "@/lib/frame-loop-wiring";
+import { useAudioStore } from "@/stores/audio";
+import { render } from "@/test/render";
+
+// -- Harness -------------------------------------------------------------------
+
+const SyncedElement: React.FC = () => {
+  const elementRef = useRef<HTMLDivElement>(null);
+  useRendererAudioSync(elementRef, (element, audio) => {
+    element.dataset.time = String(audio.currentTime);
+    element.dataset.paused = String(audio.paused);
+    element.dataset.rate = String(audio.playbackRate);
+  });
+  return <div ref={elementRef} data-test="synced" />;
+};
+
+let disposeWiring: (() => void) | null = null;
+
+function attachAudio(): HTMLAudioElement {
+  const audioElement = document.createElement("audio");
+  useAudioStore.getState().registerAudioElement(audioElement);
+  return audioElement;
+}
+
+function syncedElement(root: HTMLElement): HTMLElement {
+  const element = root.querySelector<HTMLElement>("[data-test='synced']");
+  if (!element) throw new Error("synced element missing");
+  return element;
+}
+
+beforeEach(() => {
+  disposeWiring = wireFrameLoop();
+});
+
+afterEach(() => {
+  disposeWiring?.();
+  disposeWiring = null;
+});
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("useRendererAudioSync", () => {
+  it("applies the audio clock on mount", async () => {
+    const audioElement = attachAudio();
+    audioElement.currentTime = 4;
+    const screen = await render(<SyncedElement />);
+
+    await expect.poll(() => syncedElement(screen.container).dataset.time).toBe("4");
+  });
+
+  it("keeps applying the clock while the audio plays", async () => {
+    const audioElement = attachAudio();
+    const screen = await render(<SyncedElement />);
+    await expect.poll(() => syncedElement(screen.container).dataset.time).toBe("0");
+
+    useAudioStore.getState().setIsPlaying(true);
+    audioElement.currentTime = 9;
+
+    await expect.poll(() => syncedElement(screen.container).dataset.time).toBe("9");
+  });
+
+  it("applies a scrub while the audio stays paused", async () => {
+    attachAudio();
+    const screen = await render(<SyncedElement />);
+    await expect.poll(() => syncedElement(screen.container).dataset.time).toBe("0");
+
+    useAudioStore.getState().seekTo(21);
+
+    await expect.poll(() => syncedElement(screen.container).dataset.time).toBe("21");
+    expect(syncedElement(screen.container).dataset.paused).toBe("true");
+  });
+
+  it("applies a playback rate change", async () => {
+    const audioElement = attachAudio();
+    const screen = await render(<SyncedElement />);
+    await expect.poll(() => syncedElement(screen.container).dataset.rate).toBe("1");
+
+    audioElement.playbackRate = 2;
+
+    await expect.poll(() => syncedElement(screen.container).dataset.rate).toBe("2");
+  });
+
+  it("follows the audio element the engine registers next", async () => {
+    attachAudio();
+    const screen = await render(<SyncedElement />);
+    await expect.poll(() => syncedElement(screen.container).dataset.time).toBe("0");
+
+    const replacement = document.createElement("audio");
+    replacement.currentTime = 17;
+    useAudioStore.getState().registerAudioElement(replacement);
+
+    await expect.poll(() => syncedElement(screen.container).dataset.time).toBe("17");
+  });
+
+  it("applies nothing while no audio element is registered", async () => {
+    const screen = await render(<SyncedElement />);
+
+    expect(syncedElement(screen.container).dataset.time).toBeUndefined();
+  });
+});

--- a/src/hooks/use-renderer-audio-sync.ts
+++ b/src/hooks/use-renderer-audio-sync.ts
@@ -1,28 +1,21 @@
+import { useFrameLoop } from "@/hooks/use-frame-loop";
 import { useAudioStore } from "@/stores/audio";
-import { type RefObject, useEffect, useRef } from "react";
+import type { RefObject } from "react";
 
 // -- Hook ---------------------------------------------------------------------
 
 function useRendererAudioSync<T extends HTMLElement>(
   elementRef: RefObject<T | null>,
   apply: (element: T, audio: HTMLAudioElement) => void,
+  label: string,
 ): void {
-  const applyRef = useRef(apply);
-  applyRef.current = apply;
-
-  useEffect(() => {
-    let frameId: number;
-    const tick = () => {
-      const element = elementRef.current;
-      // Re-read the audio element from the store each frame so the loop keeps
-      // tracking it after the audio engine tears down and recreates it.
-      const audio = useAudioStore.getState().audioElement;
-      if (element && audio) applyRef.current(element, audio);
-      frameId = requestAnimationFrame(tick);
-    };
-    frameId = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(frameId);
-  }, [elementRef]);
+  useFrameLoop(() => {
+    const element = elementRef.current;
+    // Re-read the audio element from the store each frame so the loop keeps
+    // tracking it after the audio engine tears down and recreates it.
+    const audio = useAudioStore.getState().audioElement;
+    if (element && audio) apply(element, audio);
+  }, label);
 }
 
 // -- Exports ------------------------------------------------------------------

--- a/src/index.css
+++ b/src/index.css
@@ -221,6 +221,10 @@ braccato-lyrics .blyrics-container {
     -webkit-mask-size: 50vw 100%;
     mask-repeat: repeat;
     -webkit-mask-repeat: repeat;
+  }
+
+  /* Gated: Blink cannot composite mask-position, so an always-on sweep repaints every frame at opacity 0. */
+  &[data-sweeping]::before {
     animation: waveform-loading-sweep 1.8s linear infinite;
   }
 }

--- a/src/lib/frame-loop-wiring.browser.test.ts
+++ b/src/lib/frame-loop-wiring.browser.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AUDIO_WAKE_EVENTS, wireFrameLoop } from "@/lib/frame-loop-wiring";
+import { subscribeFrame, TAIL_FRAMES } from "@/lib/frame-loop";
+import { useAudioStore } from "@/stores/audio";
+import { useAuthStore } from "@/stores/auth";
+import { useConfirmStore } from "@/stores/confirm-store";
+import { useDivergenceStore } from "@/stores/divergence-store";
+import { useImportModalStore } from "@/stores/import-modal-store";
+import { useModalStackStore } from "@/stores/modal-stack";
+import { useProjectStore } from "@/stores/project";
+import { useSeparationStore } from "@/stores/separation";
+import { useSettingsStore } from "@/stores/settings";
+import { useShortcutBindingsStore } from "@/stores/shortcut-bindings";
+import { useThemeStore } from "@/stores/theme";
+import { useUIStore } from "@/stores/ui";
+import { createAudioFile } from "@/test/audio-fixtures";
+import { settleFrames, stepFrames } from "@/test/frame-steps";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+
+// -- Constants ----------------------------------------------------------------
+
+const LIVE_FRAMES = TAIL_FRAMES + 6;
+
+const WIRED_STORE_WRITES: Array<[string, () => void]> = [
+  ["audio", () => useAudioStore.getState().setCurrentTime(1)],
+  ["auth", () => useAuthStore.getState().setJwt("frame-loop", Date.now() + 60_000)],
+  ["confirm", () => useConfirmStore.setState({ isOpen: true })],
+  ["divergence", () => useDivergenceStore.setState({ isOpen: true })],
+  ["import modal", () => useImportModalStore.getState().open()],
+  ["modal stack", () => useModalStackStore.getState().push()],
+  ["project", () => useProjectStore.setState({ activeTab: "edit" })],
+  ["separation", () => useSeparationStore.setState({ modelCached: true })],
+  ["settings", () => useSettingsStore.setState({ defaultZoom: 120 })],
+  ["shortcut bindings", () => useShortcutBindingsStore.setState({ overrides: {} })],
+  ["theme", () => useThemeStore.setState({ customThemes: [] })],
+  ["ui", () => useUIStore.getState().openSettings()],
+  ["timeline", () => useTimelineStore.setState({ scrollLeft: 42 })],
+];
+
+// -- Harness ------------------------------------------------------------------
+
+let disposeWiring: (() => void) | null = null;
+let unsubscribeProbe: (() => void) | null = null;
+let frames = 0;
+
+function attachAudioElement(): HTMLAudioElement {
+  const audioElement = document.createElement("audio");
+  useAudioStore.getState().registerAudioElement(audioElement);
+  return audioElement;
+}
+
+async function quiesce(): Promise<void> {
+  await settleFrames(() => frames);
+  frames = 0;
+}
+
+async function wokeAfter(trigger: () => void): Promise<boolean> {
+  await quiesce();
+  trigger();
+  await settleFrames(() => frames);
+  return frames > 0;
+}
+
+beforeEach(() => {
+  frames = 0;
+  disposeWiring = wireFrameLoop();
+  unsubscribeProbe = subscribeFrame(() => {
+    frames += 1;
+  });
+});
+
+afterEach(() => {
+  unsubscribeProbe?.();
+  disposeWiring?.();
+  unsubscribeProbe = null;
+  disposeWiring = null;
+});
+
+// -- Tests --------------------------------------------------------------------
+
+describe("wireFrameLoop", () => {
+  describe("store wakes", () => {
+    for (const [storeName, write] of WIRED_STORE_WRITES) {
+      it(`wakes the loop on a ${storeName} store write`, async () => {
+        expect(await wokeAfter(write)).toBe(true);
+      });
+    }
+  });
+
+  describe("audio element", () => {
+    for (const eventType of AUDIO_WAKE_EVENTS) {
+      it(`wakes the loop on the audio ${eventType} event`, async () => {
+        const audioElement = attachAudioElement();
+        expect(await wokeAfter(() => audioElement.dispatchEvent(new Event(eventType)))).toBe(true);
+      });
+    }
+
+    it("stops listening to the previous element after a rebind", async () => {
+      const replaced = attachAudioElement();
+      const current = attachAudioElement();
+      expect(await wokeAfter(() => replaced.dispatchEvent(new Event("play")))).toBe(false);
+      expect(await wokeAfter(() => current.dispatchEvent(new Event("play")))).toBe(true);
+    });
+
+    it("fires loadstart when a stem switch assigns a new src", async () => {
+      const audioElement = attachAudioElement();
+      const observed: string[] = [];
+      audioElement.addEventListener("loadstart", () => observed.push("loadstart"));
+      audioElement.src = URL.createObjectURL(createAudioFile());
+      await expect.poll(() => observed).toContain("loadstart");
+    });
+
+    it("wakes the loop when a stem switch assigns a new src", async () => {
+      const audioElement = attachAudioElement();
+      const woke = await wokeAfter(() => {
+        audioElement.src = URL.createObjectURL(createAudioFile());
+      });
+      expect(woke).toBe(true);
+    });
+  });
+
+  describe("playing frame source", () => {
+    it("keeps the loop live while isPlaying is true", async () => {
+      await quiesce();
+      useAudioStore.getState().setIsPlaying(true);
+      await stepFrames(LIVE_FRAMES);
+      expect(frames).toBeGreaterThan(TAIL_FRAMES);
+      useAudioStore.getState().setIsPlaying(false);
+      await settleFrames(() => frames);
+    });
+
+    it("lets the loop quiesce once isPlaying goes false", async () => {
+      useAudioStore.getState().setIsPlaying(true);
+      await stepFrames(LIVE_FRAMES);
+      useAudioStore.getState().setIsPlaying(false);
+      const settled = await settleFrames(() => frames);
+      await stepFrames(30);
+      expect(frames).toBe(settled);
+    });
+
+    it("seeds the playing frame source when wiring starts during playback", async () => {
+      disposeWiring?.();
+      useAudioStore.setState({ isPlaying: true });
+      disposeWiring = wireFrameLoop();
+      frames = 0;
+      await stepFrames(LIVE_FRAMES);
+      expect(frames).toBeGreaterThan(TAIL_FRAMES);
+      useAudioStore.getState().setIsPlaying(false);
+      await settleFrames(() => frames);
+    });
+  });
+
+  describe("document visibility", () => {
+    it("wakes the loop when the document becomes visible", async () => {
+      expect(document.hidden).toBe(false);
+      expect(await wokeAfter(() => document.dispatchEvent(new Event("visibilitychange")))).toBe(true);
+    });
+  });
+
+  describe("disposal", () => {
+    it("removes every wake source", async () => {
+      const audioElement = attachAudioElement();
+      await quiesce();
+      disposeWiring?.();
+      disposeWiring = null;
+
+      expect(await wokeAfter(() => useProjectStore.setState({ activeTab: "edit" }))).toBe(false);
+      expect(await wokeAfter(() => audioElement.dispatchEvent(new Event("play")))).toBe(false);
+      expect(await wokeAfter(() => document.dispatchEvent(new Event("visibilitychange")))).toBe(false);
+    });
+
+    it("clears the playing frame source so the loop can quiesce", async () => {
+      useAudioStore.getState().setIsPlaying(true);
+      await stepFrames(LIVE_FRAMES);
+      disposeWiring?.();
+      disposeWiring = null;
+      const settled = await settleFrames(() => frames);
+      await stepFrames(30);
+      expect(frames).toBe(settled);
+    });
+  });
+
+  describe("regressions", () => {
+    it("regression #174: with no writes and no events the loop quiesces within TAIL_FRAMES + 2 frames", async () => {
+      await quiesce();
+      const audioElement = attachAudioElement();
+      audioElement.dispatchEvent(new Event("pause"));
+      frames = 0;
+      const total = await settleFrames(() => frames);
+      expect(total).toBeGreaterThan(0);
+      expect(total).toBeLessThanOrEqual(TAIL_FRAMES + 2);
+    });
+  });
+});

--- a/src/lib/frame-loop-wiring.browser.test.ts
+++ b/src/lib/frame-loop-wiring.browser.test.ts
@@ -66,7 +66,7 @@ beforeEach(() => {
   disposeWiring = wireFrameLoop();
   unsubscribeProbe = subscribeFrame(() => {
     frames += 1;
-  });
+  }, "wiring-probe");
 });
 
 afterEach(() => {
@@ -177,6 +177,51 @@ describe("wireFrameLoop", () => {
       const settled = await settleFrames(() => frames);
       await stepFrames(30);
       expect(frames).toBe(settled);
+    });
+  });
+
+  describe("re-entrancy", () => {
+    it("keeps the surviving wiring bound when an earlier wiring is disposed", async () => {
+      const audioElement = attachAudioElement();
+      const disposeSecond = wireFrameLoop();
+      disposeWiring?.();
+      disposeWiring = disposeSecond;
+
+      expect(await wokeAfter(() => audioElement.dispatchEvent(new Event("play")))).toBe(true);
+      expect(await wokeAfter(() => useProjectStore.setState({ activeTab: "edit" }))).toBe(true);
+    });
+
+    it("keeps the playing hold alive when an earlier wiring is disposed mid-playback", async () => {
+      const disposeSecond = wireFrameLoop();
+      useAudioStore.getState().setIsPlaying(true);
+      disposeWiring?.();
+      disposeWiring = disposeSecond;
+
+      frames = 0;
+      await stepFrames(LIVE_FRAMES);
+      expect(frames).toBeGreaterThan(TAIL_FRAMES);
+
+      useAudioStore.getState().setIsPlaying(false);
+      await settleFrames(() => frames);
+    });
+  });
+
+  describe("invariants", () => {
+    it("a frame callback that writes to a store keeps the loop awake forever", async () => {
+      await quiesce();
+      let writes = 0;
+      const unsubscribeWriter = subscribeFrame(() => {
+        writes += 1;
+        useTimelineStore.setState({ scrollLeft: writes });
+      }, "store-writer");
+
+      await stepFrames(30);
+      const midpoint = writes;
+      await stepFrames(30);
+
+      expect(writes).toBeGreaterThan(midpoint + 20);
+      unsubscribeWriter();
+      await settleFrames(() => frames);
     });
   });
 

--- a/src/lib/frame-loop-wiring.browser.test.ts
+++ b/src/lib/frame-loop-wiring.browser.test.ts
@@ -14,6 +14,7 @@ import { useShortcutBindingsStore } from "@/stores/shortcut-bindings";
 import { useThemeStore } from "@/stores/theme";
 import { useUIStore } from "@/stores/ui";
 import { createAudioFile } from "@/test/audio-fixtures";
+import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
 import { settleFrames, stepFrames } from "@/test/frame-steps";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 
@@ -40,8 +41,7 @@ const WIRED_STORE_WRITES: Array<[string, () => void]> = [
 // -- Harness ------------------------------------------------------------------
 
 let disposeWiring: (() => void) | null = null;
-let unsubscribeProbe: (() => void) | null = null;
-let frames = 0;
+let probe: FrameProbe;
 
 function attachAudioElement(): HTMLAudioElement {
   const audioElement = document.createElement("audio");
@@ -49,30 +49,14 @@ function attachAudioElement(): HTMLAudioElement {
   return audioElement;
 }
 
-async function quiesce(): Promise<void> {
-  await settleFrames(() => frames);
-  frames = 0;
-}
-
-async function wokeAfter(trigger: () => void): Promise<boolean> {
-  await quiesce();
-  trigger();
-  await settleFrames(() => frames);
-  return frames > 0;
-}
-
 beforeEach(() => {
-  frames = 0;
   disposeWiring = wireFrameLoop();
-  unsubscribeProbe = subscribeFrame(() => {
-    frames += 1;
-  }, "wiring-probe");
+  probe = createFrameProbe();
 });
 
 afterEach(() => {
-  unsubscribeProbe?.();
+  probe.dispose();
   disposeWiring?.();
-  unsubscribeProbe = null;
   disposeWiring = null;
 });
 
@@ -82,7 +66,7 @@ describe("wireFrameLoop", () => {
   describe("store wakes", () => {
     for (const [storeName, write] of WIRED_STORE_WRITES) {
       it(`wakes the loop on a ${storeName} store write`, async () => {
-        expect(await wokeAfter(write)).toBe(true);
+        expect(await probe.wokeAfter(write)).toBe(true);
       });
     }
   });
@@ -91,15 +75,15 @@ describe("wireFrameLoop", () => {
     for (const eventType of AUDIO_WAKE_EVENTS) {
       it(`wakes the loop on the audio ${eventType} event`, async () => {
         const audioElement = attachAudioElement();
-        expect(await wokeAfter(() => audioElement.dispatchEvent(new Event(eventType)))).toBe(true);
+        expect(await probe.wokeAfter(() => audioElement.dispatchEvent(new Event(eventType)))).toBe(true);
       });
     }
 
     it("stops listening to the previous element after a rebind", async () => {
       const replaced = attachAudioElement();
       const current = attachAudioElement();
-      expect(await wokeAfter(() => replaced.dispatchEvent(new Event("play")))).toBe(false);
-      expect(await wokeAfter(() => current.dispatchEvent(new Event("play")))).toBe(true);
+      expect(await probe.wokeAfter(() => replaced.dispatchEvent(new Event("play")))).toBe(false);
+      expect(await probe.wokeAfter(() => current.dispatchEvent(new Event("play")))).toBe(true);
     });
 
     it("fires loadstart when a stem switch assigns a new src", async () => {
@@ -112,7 +96,7 @@ describe("wireFrameLoop", () => {
 
     it("wakes the loop when a stem switch assigns a new src", async () => {
       const audioElement = attachAudioElement();
-      const woke = await wokeAfter(() => {
+      const woke = await probe.wokeAfter(() => {
         audioElement.src = URL.createObjectURL(createAudioFile());
       });
       expect(woke).toBe(true);
@@ -121,52 +105,52 @@ describe("wireFrameLoop", () => {
 
   describe("playing frame source", () => {
     it("keeps the loop live while isPlaying is true", async () => {
-      await quiesce();
+      await probe.quiesce();
       useAudioStore.getState().setIsPlaying(true);
       await stepFrames(LIVE_FRAMES);
-      expect(frames).toBeGreaterThan(TAIL_FRAMES);
+      expect(probe.count()).toBeGreaterThan(TAIL_FRAMES);
       useAudioStore.getState().setIsPlaying(false);
-      await settleFrames(() => frames);
+      await settleFrames(probe.count);
     });
 
     it("lets the loop quiesce once isPlaying goes false", async () => {
       useAudioStore.getState().setIsPlaying(true);
       await stepFrames(LIVE_FRAMES);
       useAudioStore.getState().setIsPlaying(false);
-      const settled = await settleFrames(() => frames);
+      const settled = await settleFrames(probe.count);
       await stepFrames(30);
-      expect(frames).toBe(settled);
+      expect(probe.count()).toBe(settled);
     });
 
     it("seeds the playing frame source when wiring starts during playback", async () => {
       disposeWiring?.();
       useAudioStore.setState({ isPlaying: true });
       disposeWiring = wireFrameLoop();
-      frames = 0;
+      const baseline = probe.count();
       await stepFrames(LIVE_FRAMES);
-      expect(frames).toBeGreaterThan(TAIL_FRAMES);
+      expect(probe.count() - baseline).toBeGreaterThan(TAIL_FRAMES);
       useAudioStore.getState().setIsPlaying(false);
-      await settleFrames(() => frames);
+      await settleFrames(probe.count);
     });
   });
 
   describe("document visibility", () => {
     it("wakes the loop when the document becomes visible", async () => {
       expect(document.hidden).toBe(false);
-      expect(await wokeAfter(() => document.dispatchEvent(new Event("visibilitychange")))).toBe(true);
+      expect(await probe.wokeAfter(() => document.dispatchEvent(new Event("visibilitychange")))).toBe(true);
     });
   });
 
   describe("disposal", () => {
     it("removes every wake source", async () => {
       const audioElement = attachAudioElement();
-      await quiesce();
+      await probe.quiesce();
       disposeWiring?.();
       disposeWiring = null;
 
-      expect(await wokeAfter(() => useProjectStore.setState({ activeTab: "edit" }))).toBe(false);
-      expect(await wokeAfter(() => audioElement.dispatchEvent(new Event("play")))).toBe(false);
-      expect(await wokeAfter(() => document.dispatchEvent(new Event("visibilitychange")))).toBe(false);
+      expect(await probe.wokeAfter(() => useProjectStore.setState({ activeTab: "edit" }))).toBe(false);
+      expect(await probe.wokeAfter(() => audioElement.dispatchEvent(new Event("play")))).toBe(false);
+      expect(await probe.wokeAfter(() => document.dispatchEvent(new Event("visibilitychange")))).toBe(false);
     });
 
     it("clears the playing frame source so the loop can quiesce", async () => {
@@ -174,9 +158,9 @@ describe("wireFrameLoop", () => {
       await stepFrames(LIVE_FRAMES);
       disposeWiring?.();
       disposeWiring = null;
-      const settled = await settleFrames(() => frames);
+      const settled = await settleFrames(probe.count);
       await stepFrames(30);
-      expect(frames).toBe(settled);
+      expect(probe.count()).toBe(settled);
     });
   });
 
@@ -187,8 +171,8 @@ describe("wireFrameLoop", () => {
       disposeWiring?.();
       disposeWiring = disposeSecond;
 
-      expect(await wokeAfter(() => audioElement.dispatchEvent(new Event("play")))).toBe(true);
-      expect(await wokeAfter(() => useProjectStore.setState({ activeTab: "edit" }))).toBe(true);
+      expect(await probe.wokeAfter(() => audioElement.dispatchEvent(new Event("play")))).toBe(true);
+      expect(await probe.wokeAfter(() => useProjectStore.setState({ activeTab: "edit" }))).toBe(true);
     });
 
     it("keeps the playing hold alive when an earlier wiring is disposed mid-playback", async () => {
@@ -197,18 +181,18 @@ describe("wireFrameLoop", () => {
       disposeWiring?.();
       disposeWiring = disposeSecond;
 
-      frames = 0;
+      const baseline = probe.count();
       await stepFrames(LIVE_FRAMES);
-      expect(frames).toBeGreaterThan(TAIL_FRAMES);
+      expect(probe.count() - baseline).toBeGreaterThan(TAIL_FRAMES);
 
       useAudioStore.getState().setIsPlaying(false);
-      await settleFrames(() => frames);
+      await settleFrames(probe.count);
     });
   });
 
   describe("invariants", () => {
     it("a frame callback that writes to a store keeps the loop awake forever", async () => {
-      await quiesce();
+      await probe.quiesce();
       let writes = 0;
       const unsubscribeWriter = subscribeFrame(() => {
         writes += 1;
@@ -221,17 +205,16 @@ describe("wireFrameLoop", () => {
 
       expect(writes).toBeGreaterThan(midpoint + 20);
       unsubscribeWriter();
-      await settleFrames(() => frames);
+      await settleFrames(probe.count);
     });
   });
 
   describe("regressions", () => {
     it("regression #174: with no writes and no events the loop quiesces within TAIL_FRAMES + 2 frames", async () => {
-      await quiesce();
       const audioElement = attachAudioElement();
+      await probe.quiesce();
       audioElement.dispatchEvent(new Event("pause"));
-      frames = 0;
-      const total = await settleFrames(() => frames);
+      const total = await settleFrames(probe.count);
       expect(total).toBeGreaterThan(0);
       expect(total).toBeLessThanOrEqual(TAIL_FRAMES + 2);
     });

--- a/src/lib/frame-loop-wiring.test.ts
+++ b/src/lib/frame-loop-wiring.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { subscribeFrame, TAIL_FRAMES } from "@/lib/frame-loop";
+import { wireFrameLoop } from "@/lib/frame-loop-wiring";
+import { useProjectStore } from "@/stores/project";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+
+// Exercises the wiring against the real frame-loop singleton and real stores.
+// The audio-element paths need real media events and live in the browser test.
+
+// -- Constants ----------------------------------------------------------------
+
+const FRAME_MS = 16;
+
+// -- Harness ------------------------------------------------------------------
+
+let frames = 0;
+let unsubscribeProbe: (() => void) | null = null;
+const disposers: Array<() => void> = [];
+
+function advanceFrames(count: number): void {
+  vi.advanceTimersByTime(FRAME_MS * count);
+}
+
+function wire(): () => void {
+  const dispose = wireFrameLoop();
+  disposers.push(dispose);
+  return dispose;
+}
+
+function settleThenReset(): void {
+  advanceFrames(TAIL_FRAMES + 1);
+  frames = 0;
+}
+
+function framesAfter(trigger: () => void): number {
+  settleThenReset();
+  trigger();
+  advanceFrames(TAIL_FRAMES + 1);
+  return frames;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  frames = 0;
+  unsubscribeProbe = subscribeFrame(() => {
+    frames += 1;
+  }, "wiring-probe");
+});
+
+afterEach(() => {
+  for (const dispose of disposers.splice(0)) dispose();
+  unsubscribeProbe?.();
+  unsubscribeProbe = null;
+  vi.useRealTimers();
+});
+
+// -- Tests --------------------------------------------------------------------
+
+describe("wireFrameLoop store subscriptions", () => {
+  describe("happy path", () => {
+    it("wakes the loop on a store write", () => {
+      wire();
+      expect(framesAfter(() => useProjectStore.setState({ activeTab: "edit" }))).toBeGreaterThan(0);
+    });
+
+    it("stops waking once disposed", () => {
+      const dispose = wire();
+      dispose();
+      expect(framesAfter(() => useProjectStore.setState({ activeTab: "sync" }))).toBe(0);
+    });
+  });
+
+  describe("re-entrancy", () => {
+    it("regression: disposing one wiring leaves another wiring's store subscriptions intact", () => {
+      const disposeFirst = wire();
+      wire();
+      disposeFirst();
+      expect(framesAfter(() => useProjectStore.setState({ activeTab: "edit" }))).toBeGreaterThan(0);
+      expect(framesAfter(() => useTimelineStore.setState({ scrollLeft: 21 }))).toBeGreaterThan(0);
+    });
+
+    it("stops waking only once every wiring is disposed", () => {
+      const disposeFirst = wire();
+      const disposeSecond = wire();
+      disposeFirst();
+      disposeSecond();
+      expect(framesAfter(() => useProjectStore.setState({ activeTab: "export" }))).toBe(0);
+    });
+
+    it("tolerates the same wiring being disposed twice", () => {
+      const disposeFirst = wire();
+      wire();
+      disposeFirst();
+      disposeFirst();
+      expect(framesAfter(() => useProjectStore.setState({ activeTab: "edit" }))).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/lib/frame-loop-wiring.ts
+++ b/src/lib/frame-loop-wiring.ts
@@ -43,18 +43,18 @@ function wireFrameLoop(): () => void {
   let boundAudioElement: HTMLAudioElement | null = null;
   let releasePlayingHold: (() => void) | null = null;
 
-  // Fresh identity per wiring: addEventListener dedupes a shared reference, so one
-  // disposer would silently unbind every other wiring.
-  const wakeFromAudio = () => wake();
+  // Fresh identity per wiring: Zustand listener sets and addEventListener both dedupe a
+  // shared reference, so one disposer would silently unbind every other wiring.
+  const wakeFromThisWiring = () => wake();
 
   const bindAudioElement = (element: HTMLAudioElement | null) => {
     if (boundAudioElement === element) return;
     if (boundAudioElement) {
-      for (const eventType of AUDIO_WAKE_EVENTS) boundAudioElement.removeEventListener(eventType, wakeFromAudio);
+      for (const eventType of AUDIO_WAKE_EVENTS) boundAudioElement.removeEventListener(eventType, wakeFromThisWiring);
     }
     boundAudioElement = element;
     if (boundAudioElement) {
-      for (const eventType of AUDIO_WAKE_EVENTS) boundAudioElement.addEventListener(eventType, wakeFromAudio);
+      for (const eventType of AUDIO_WAKE_EVENTS) boundAudioElement.addEventListener(eventType, wakeFromThisWiring);
     }
   };
 
@@ -80,18 +80,18 @@ function wireFrameLoop(): () => void {
 
   const unsubscribes = [
     useAudioStore.subscribe(syncAudio),
-    useAuthStore.subscribe(wake),
-    useConfirmStore.subscribe(wake),
-    useDivergenceStore.subscribe(wake),
-    useImportModalStore.subscribe(wake),
-    useModalStackStore.subscribe(wake),
-    useProjectStore.subscribe(wake),
-    useSeparationStore.subscribe(wake),
-    useSettingsStore.subscribe(wake),
-    useShortcutBindingsStore.subscribe(wake),
-    useThemeStore.subscribe(wake),
-    useUIStore.subscribe(wake),
-    useTimelineStore.subscribe(wake),
+    useAuthStore.subscribe(wakeFromThisWiring),
+    useConfirmStore.subscribe(wakeFromThisWiring),
+    useDivergenceStore.subscribe(wakeFromThisWiring),
+    useImportModalStore.subscribe(wakeFromThisWiring),
+    useModalStackStore.subscribe(wakeFromThisWiring),
+    useProjectStore.subscribe(wakeFromThisWiring),
+    useSeparationStore.subscribe(wakeFromThisWiring),
+    useSettingsStore.subscribe(wakeFromThisWiring),
+    useShortcutBindingsStore.subscribe(wakeFromThisWiring),
+    useThemeStore.subscribe(wakeFromThisWiring),
+    useUIStore.subscribe(wakeFromThisWiring),
+    useTimelineStore.subscribe(wakeFromThisWiring),
   ];
 
   document.addEventListener("visibilitychange", wakeWhenVisible);

--- a/src/lib/frame-loop-wiring.ts
+++ b/src/lib/frame-loop-wiring.ts
@@ -107,4 +107,4 @@ function wireFrameLoop(): () => void {
 
 // -- Exports ------------------------------------------------------------------
 
-export { AUDIO_WAKE_EVENTS, PLAYING_HOLD_LABEL, wireFrameLoop };
+export { AUDIO_WAKE_EVENTS, wireFrameLoop };

--- a/src/lib/frame-loop-wiring.ts
+++ b/src/lib/frame-loop-wiring.ts
@@ -1,4 +1,4 @@
-import { setFrameSource, wake } from "@/lib/frame-loop";
+import { holdFrames, wake } from "@/lib/frame-loop";
 import { useAudioStore } from "@/stores/audio";
 import { useAuthStore } from "@/stores/auth";
 import { useConfirmStore } from "@/stores/confirm-store";
@@ -22,7 +22,7 @@ interface AudioFrameInputs {
 
 // -- Constants ----------------------------------------------------------------
 
-const PLAYING_FRAME_SOURCE = "playing";
+const PLAYING_HOLD_LABEL = "playing";
 
 const AUDIO_WAKE_EVENTS = [
   "play",
@@ -41,20 +41,35 @@ const AUDIO_WAKE_EVENTS = [
 
 function wireFrameLoop(): () => void {
   let boundAudioElement: HTMLAudioElement | null = null;
+  let releasePlayingHold: (() => void) | null = null;
+
+  // Fresh identity per wiring: addEventListener dedupes a shared reference, so one
+  // disposer would silently unbind every other wiring.
+  const wakeFromAudio = () => wake();
 
   const bindAudioElement = (element: HTMLAudioElement | null) => {
     if (boundAudioElement === element) return;
     if (boundAudioElement) {
-      for (const eventType of AUDIO_WAKE_EVENTS) boundAudioElement.removeEventListener(eventType, wake);
+      for (const eventType of AUDIO_WAKE_EVENTS) boundAudioElement.removeEventListener(eventType, wakeFromAudio);
     }
     boundAudioElement = element;
     if (boundAudioElement) {
-      for (const eventType of AUDIO_WAKE_EVENTS) boundAudioElement.addEventListener(eventType, wake);
+      for (const eventType of AUDIO_WAKE_EVENTS) boundAudioElement.addEventListener(eventType, wakeFromAudio);
     }
   };
 
+  const syncPlayingHold = (isPlaying: boolean) => {
+    if (isPlaying === (releasePlayingHold !== null)) return;
+    if (isPlaying) {
+      releasePlayingHold = holdFrames(PLAYING_HOLD_LABEL);
+      return;
+    }
+    releasePlayingHold?.();
+    releasePlayingHold = null;
+  };
+
   const syncAudio = (state: AudioFrameInputs) => {
-    setFrameSource(PLAYING_FRAME_SOURCE, state.isPlaying);
+    syncPlayingHold(state.isPlaying);
     bindAudioElement(state.audioElement);
     wake();
   };
@@ -86,10 +101,10 @@ function wireFrameLoop(): () => void {
     for (const unsubscribe of unsubscribes) unsubscribe();
     document.removeEventListener("visibilitychange", wakeWhenVisible);
     bindAudioElement(null);
-    setFrameSource(PLAYING_FRAME_SOURCE, false);
+    syncPlayingHold(false);
   };
 }
 
 // -- Exports ------------------------------------------------------------------
 
-export { AUDIO_WAKE_EVENTS, wireFrameLoop };
+export { AUDIO_WAKE_EVENTS, PLAYING_HOLD_LABEL, wireFrameLoop };

--- a/src/lib/frame-loop-wiring.ts
+++ b/src/lib/frame-loop-wiring.ts
@@ -1,0 +1,95 @@
+import { setFrameSource, wake } from "@/lib/frame-loop";
+import { useAudioStore } from "@/stores/audio";
+import { useAuthStore } from "@/stores/auth";
+import { useConfirmStore } from "@/stores/confirm-store";
+import { useDivergenceStore } from "@/stores/divergence-store";
+import { useImportModalStore } from "@/stores/import-modal-store";
+import { useModalStackStore } from "@/stores/modal-stack";
+import { useProjectStore } from "@/stores/project";
+import { useSeparationStore } from "@/stores/separation";
+import { useSettingsStore } from "@/stores/settings";
+import { useShortcutBindingsStore } from "@/stores/shortcut-bindings";
+import { useThemeStore } from "@/stores/theme";
+import { useUIStore } from "@/stores/ui";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+
+// -- Interfaces ---------------------------------------------------------------
+
+interface AudioFrameInputs {
+  isPlaying: boolean;
+  audioElement: HTMLAudioElement | null;
+}
+
+// -- Constants ----------------------------------------------------------------
+
+const PLAYING_FRAME_SOURCE = "playing";
+
+const AUDIO_WAKE_EVENTS = [
+  "play",
+  "playing",
+  "pause",
+  "seeking",
+  "seeked",
+  "ratechange",
+  "durationchange",
+  "loadedmetadata",
+  "loadstart",
+  "emptied",
+] as const;
+
+// -- Wiring -------------------------------------------------------------------
+
+function wireFrameLoop(): () => void {
+  let boundAudioElement: HTMLAudioElement | null = null;
+
+  const bindAudioElement = (element: HTMLAudioElement | null) => {
+    if (boundAudioElement === element) return;
+    if (boundAudioElement) {
+      for (const eventType of AUDIO_WAKE_EVENTS) boundAudioElement.removeEventListener(eventType, wake);
+    }
+    boundAudioElement = element;
+    if (boundAudioElement) {
+      for (const eventType of AUDIO_WAKE_EVENTS) boundAudioElement.addEventListener(eventType, wake);
+    }
+  };
+
+  const syncAudio = (state: AudioFrameInputs) => {
+    setFrameSource(PLAYING_FRAME_SOURCE, state.isPlaying);
+    bindAudioElement(state.audioElement);
+    wake();
+  };
+
+  const wakeWhenVisible = () => {
+    if (!document.hidden) wake();
+  };
+
+  const unsubscribes = [
+    useAudioStore.subscribe(syncAudio),
+    useAuthStore.subscribe(wake),
+    useConfirmStore.subscribe(wake),
+    useDivergenceStore.subscribe(wake),
+    useImportModalStore.subscribe(wake),
+    useModalStackStore.subscribe(wake),
+    useProjectStore.subscribe(wake),
+    useSeparationStore.subscribe(wake),
+    useSettingsStore.subscribe(wake),
+    useShortcutBindingsStore.subscribe(wake),
+    useThemeStore.subscribe(wake),
+    useUIStore.subscribe(wake),
+    useTimelineStore.subscribe(wake),
+  ];
+
+  document.addEventListener("visibilitychange", wakeWhenVisible);
+  syncAudio(useAudioStore.getState());
+
+  return () => {
+    for (const unsubscribe of unsubscribes) unsubscribe();
+    document.removeEventListener("visibilitychange", wakeWhenVisible);
+    bindAudioElement(null);
+    setFrameSource(PLAYING_FRAME_SOURCE, false);
+  };
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { AUDIO_WAKE_EVENTS, wireFrameLoop };

--- a/src/lib/frame-loop.holds.test.ts
+++ b/src/lib/frame-loop.holds.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { advanceFrames, type FrameLoopModule, loadFrameLoop } from "@/test/frame-loop-harness";
+
+// -- Harness ------------------------------------------------------------------
+
+let subscribeFrame: FrameLoopModule["subscribeFrame"];
+let holdFrames: FrameLoopModule["holdFrames"];
+let tailFrames: number;
+let calls = 0;
+let unsubscribe: (() => void) | null = null;
+
+function framesUntilQuiet(): number {
+  advanceFrames(tailFrames);
+  const settled = calls;
+  advanceFrames(200);
+  return calls - settled;
+}
+
+beforeEach(async () => {
+  const frameLoop = await loadFrameLoop();
+  subscribeFrame = frameLoop.subscribeFrame;
+  holdFrames = frameLoop.holdFrames;
+  tailFrames = frameLoop.TAIL_FRAMES;
+  calls = 0;
+  unsubscribe = subscribeFrame(() => {
+    calls += 1;
+  }, "probe");
+});
+
+afterEach(() => {
+  unsubscribe?.();
+  unsubscribe = null;
+  vi.useRealTimers();
+});
+
+// -- Tests --------------------------------------------------------------------
+
+describe("holdFrames", () => {
+  describe("happy path", () => {
+    it("keeps the loop running for as long as the hold is held", () => {
+      const release = holdFrames("marquee-scroll");
+      advanceFrames(600);
+      expect(calls).toBe(600);
+      release();
+    });
+
+    it("lets the loop quiesce after the tail once released", () => {
+      const release = holdFrames("marquee-scroll");
+      advanceFrames(10);
+      release();
+      expect(framesUntilQuiet()).toBe(0);
+    });
+  });
+
+  describe("reference counting", () => {
+    it("keeps the loop alive while a second holder of the same label remains", () => {
+      const releaseFirst = holdFrames("drag");
+      const releaseSecond = holdFrames("drag");
+      advanceFrames(10);
+      releaseFirst();
+      advanceFrames(30);
+      expect(calls).toBe(40);
+      releaseSecond();
+      expect(framesUntilQuiet()).toBe(0);
+    });
+
+    it("keeps the loop alive while a holder of a different label remains", () => {
+      const releasePlaying = holdFrames("playing");
+      const releaseScroll = holdFrames("marquee-scroll");
+      advanceFrames(10);
+      releasePlaying();
+      advanceFrames(30);
+      expect(calls).toBe(40);
+      releaseScroll();
+      expect(framesUntilQuiet()).toBe(0);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("treats a repeated release of the same handle as a no-op", () => {
+      const releaseFirst = holdFrames("drag");
+      const releaseSecond = holdFrames("drag");
+      releaseFirst();
+      releaseFirst();
+      releaseFirst();
+      advanceFrames(30);
+      expect(calls).toBe(30);
+      releaseSecond();
+      expect(framesUntilQuiet()).toBe(0);
+    });
+
+    it("re-arms the tail on release so callbacks can settle", () => {
+      const release = holdFrames("drag");
+      advanceFrames(10);
+      const heldCalls = calls;
+      release();
+      advanceFrames(tailFrames);
+      expect(calls).toBe(heldCalls + tailFrames);
+    });
+
+    it("keeps at most one frame pending when many holds are acquired at once", () => {
+      const releases = ["a", "b", "c"].map((label) => holdFrames(label));
+      expect(vi.getTimerCount()).toBe(1);
+      advanceFrames(1);
+      expect(vi.getTimerCount()).toBe(1);
+      for (const release of releases) release();
+    });
+
+    it("can be re-acquired under the same label after a full release", () => {
+      holdFrames("drag")();
+      expect(framesUntilQuiet()).toBe(0);
+      const release = holdFrames("drag");
+      advanceFrames(50);
+      expect(calls).toBeGreaterThan(tailFrames);
+      release();
+    });
+  });
+
+  describe("invariants", () => {
+    it("never lets a stale release from one holder drop another holder's hold", () => {
+      const releaseStale = holdFrames("shared");
+      releaseStale();
+      const releaseLive = holdFrames("shared");
+      releaseStale();
+      advanceFrames(50);
+      expect(calls).toBe(50);
+      releaseLive();
+      expect(framesUntilQuiet()).toBe(0);
+    });
+  });
+
+  describe("regressions", () => {
+    it("regression #174: an unreleased hold is the only thing that can pin the loop", () => {
+      const release = holdFrames("marquee-scroll");
+      advanceFrames(1000);
+      expect(calls).toBe(1000);
+      release();
+      expect(framesUntilQuiet()).toBe(0);
+    });
+  });
+});

--- a/src/lib/frame-loop.isolation.test.ts
+++ b/src/lib/frame-loop.isolation.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { advanceFrames, type FrameLoopModule, loadFrameLoop } from "@/test/frame-loop-harness";
+
+// -- Harness ------------------------------------------------------------------
+
+let subscribeFrame: FrameLoopModule["subscribeFrame"];
+let holdFrames: FrameLoopModule["holdFrames"];
+let wake: FrameLoopModule["wake"];
+let tailFrames: number;
+let errorSpy: ReturnType<typeof silenceConsoleError>;
+
+function silenceConsoleError() {
+  return vi.spyOn(console, "error").mockImplementation(() => {});
+}
+
+function loggedMessages(): string[] {
+  return errorSpy.mock.calls.map((args) => String(args[0]));
+}
+
+function messagesMatching(pattern: RegExp): string[] {
+  return loggedMessages().filter((message) => pattern.test(message));
+}
+
+beforeEach(async () => {
+  const frameLoop = await loadFrameLoop();
+  subscribeFrame = frameLoop.subscribeFrame;
+  holdFrames = frameLoop.holdFrames;
+  wake = frameLoop.wake;
+  tailFrames = frameLoop.TAIL_FRAMES;
+  errorSpy = silenceConsoleError();
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+  vi.useRealTimers();
+});
+
+// -- Tests --------------------------------------------------------------------
+
+describe("frame-loop subscriber isolation", () => {
+  describe("containment", () => {
+    it("runs a later-ordered subscriber after an earlier one throws", () => {
+      let laterCalls = 0;
+      const unsubscribeThrower = subscribeFrame(() => {
+        throw new Error("playhead ref went away");
+      }, "playhead");
+      const unsubscribeLater = subscribeFrame(() => {
+        laterCalls += 1;
+      }, "preview-sidebar");
+
+      advanceFrames(1);
+
+      expect(laterCalls).toBe(1);
+      unsubscribeThrower();
+      unsubscribeLater();
+    });
+
+    it("runs an earlier-ordered subscriber before a later one throws", () => {
+      let earlierCalls = 0;
+      const unsubscribeEarlier = subscribeFrame(() => {
+        earlierCalls += 1;
+      }, "snap-markers");
+      const unsubscribeThrower = subscribeFrame(() => {
+        throw new Error("boom");
+      }, "playhead");
+
+      advanceFrames(1);
+
+      expect(earlierCalls).toBe(1);
+      unsubscribeEarlier();
+      unsubscribeThrower();
+    });
+
+    it("hands every subscriber the same timestamp in a frame where one throws", () => {
+      const timestamps: number[] = [];
+      const unsubscribeFirst = subscribeFrame((now) => timestamps.push(now), "first");
+      const unsubscribeThrower = subscribeFrame(() => {
+        throw new Error("boom");
+      }, "thrower");
+      const unsubscribeLast = subscribeFrame((now) => timestamps.push(now), "last");
+
+      advanceFrames(1);
+
+      expect(timestamps).toHaveLength(2);
+      expect(timestamps[0]).toBe(timestamps[1]);
+      unsubscribeFirst();
+      unsubscribeThrower();
+      unsubscribeLast();
+    });
+
+    it("lets a sibling unsubscribe and wake in a frame where another throws", () => {
+      let survivorCalls = 0;
+      const unsubscribeThrower = subscribeFrame(() => {
+        throw new Error("boom");
+      }, "thrower");
+      let unsubscribeDoomed: (() => void) | null = null;
+      const unsubscribeSurvivor = subscribeFrame(() => {
+        survivorCalls += 1;
+        unsubscribeDoomed?.();
+        wake();
+      }, "survivor");
+      let doomedCalls = 0;
+      unsubscribeDoomed = subscribeFrame(() => {
+        doomedCalls += 1;
+      }, "doomed");
+
+      advanceFrames(1);
+
+      expect(survivorCalls).toBe(1);
+      expect(doomedCalls).toBe(0);
+      unsubscribeThrower();
+      unsubscribeSurvivor();
+    });
+  });
+
+  describe("the loop survives a thrower", () => {
+    it("completes the full tail while a subscriber throws every frame", () => {
+      let survivorCalls = 0;
+      const unsubscribeThrower = subscribeFrame(() => {
+        throw new Error("boom");
+      }, "thrower");
+      const unsubscribeSurvivor = subscribeFrame(() => {
+        survivorCalls += 1;
+      }, "survivor");
+
+      advanceFrames(100);
+
+      expect(survivorCalls).toBe(tailFrames);
+      unsubscribeThrower();
+      unsubscribeSurvivor();
+    });
+
+    it("keeps running every frame under a hold while a subscriber throws", () => {
+      let survivorCalls = 0;
+      const unsubscribeThrower = subscribeFrame(() => {
+        throw new Error("boom");
+      }, "thrower");
+      const unsubscribeSurvivor = subscribeFrame(() => {
+        survivorCalls += 1;
+      }, "survivor");
+      const release = holdFrames("playing");
+
+      advanceFrames(50);
+
+      expect(survivorCalls).toBe(50);
+      release();
+      unsubscribeThrower();
+      unsubscribeSurvivor();
+    });
+
+    it("queues the next frame before any callback runs", () => {
+      let pendingDuringFrame = -1;
+      const release = holdFrames("playing");
+      const unsubscribe = subscribeFrame(() => {
+        pendingDuringFrame = vi.getTimerCount();
+      }, "probe");
+
+      advanceFrames(1);
+
+      expect(pendingDuringFrame).toBe(1);
+      release();
+      unsubscribe();
+    });
+
+    it("leaves the next frame queued even when reporting a failure throws", () => {
+      errorSpy.mockImplementation(() => {
+        throw new Error("console instrumentation exploded");
+      });
+      const release = holdFrames("playing");
+      const unsubscribe = subscribeFrame(() => {
+        throw new Error("boom");
+      }, "thrower");
+
+      expect(() => advanceFrames(1)).toThrow(/console instrumentation exploded/);
+
+      expect(vi.getTimerCount()).toBe(1);
+      release();
+      unsubscribe();
+    });
+
+    it("quiesces after the tail even though a subscriber threw", () => {
+      const unsubscribeThrower = subscribeFrame(() => {
+        throw new Error("boom");
+      }, "thrower");
+      const probe = { calls: 0 };
+      const unsubscribeProbe = subscribeFrame(() => {
+        probe.calls += 1;
+      }, "probe");
+
+      advanceFrames(tailFrames);
+      expect(vi.getTimerCount()).toBe(0);
+      advanceFrames(500);
+      expect(probe.calls).toBe(tailFrames);
+
+      unsubscribeThrower();
+      unsubscribeProbe();
+    });
+  });
+
+  describe("logging", () => {
+    it("names the failing subscriber", () => {
+      const unsubscribe = subscribeFrame(() => {
+        throw new Error("boom");
+      }, "timeline-playhead");
+
+      advanceFrames(1);
+
+      expect(messagesMatching(/frame callback/)).toEqual([
+        expect.stringContaining('frame callback "timeline-playhead" failed'),
+      ]);
+      unsubscribe();
+    });
+
+    it("logs once rather than once per frame while a subscriber throws every frame", () => {
+      const unsubscribeThrower = subscribeFrame(() => {
+        throw new Error("boom");
+      }, "thrower");
+      const release = holdFrames("playing");
+
+      advanceFrames(300);
+
+      expect(messagesMatching(/frame callback/)).toHaveLength(1);
+      release();
+      unsubscribeThrower();
+    });
+
+    it("logs again when a subscriber recovers and then breaks a second time", () => {
+      let shouldThrow = true;
+      const unsubscribe = subscribeFrame(() => {
+        if (shouldThrow) throw new Error("boom");
+      }, "flaky");
+      const release = holdFrames("playing");
+
+      advanceFrames(5);
+      expect(messagesMatching(/frame callback/)).toHaveLength(1);
+
+      shouldThrow = false;
+      advanceFrames(5);
+      expect(messagesMatching(/frame callback/)).toHaveLength(1);
+
+      shouldThrow = true;
+      advanceFrames(5);
+      expect(messagesMatching(/frame callback/)).toHaveLength(2);
+
+      release();
+      unsubscribe();
+    });
+
+    it("keeps each subscriber's failure independent", () => {
+      const unsubscribeFirst = subscribeFrame(() => {
+        throw new Error("boom");
+      }, "first-broken");
+      const unsubscribeSecond = subscribeFrame(() => {
+        throw new Error("boom");
+      }, "second-broken");
+      const release = holdFrames("playing");
+
+      advanceFrames(100);
+
+      expect(messagesMatching(/frame callback/)).toEqual([
+        expect.stringContaining('"first-broken"'),
+        expect.stringContaining('"second-broken"'),
+      ]);
+      release();
+      unsubscribeFirst();
+      unsubscribeSecond();
+    });
+  });
+});
+
+describe("frame-loop runaway diagnostics", () => {
+  it("reports once when a subscriber wakes the loop every frame with no hold", () => {
+    const unsubscribe = subscribeFrame(() => wake(), "store-writer");
+
+    advanceFrames(3000);
+
+    expect(messagesMatching(/never idled/)).toHaveLength(1);
+    expect(messagesMatching(/never idled/)[0]).toContain("store-writer");
+    unsubscribe();
+  });
+
+  it("stays silent across many separate short tails", () => {
+    const unsubscribe = subscribeFrame(() => {}, "quiet");
+
+    for (let cycle = 0; cycle < 500; cycle++) {
+      wake();
+      advanceFrames(tailFrames + 2);
+    }
+
+    expect(messagesMatching(/never idled/)).toEqual([]);
+    unsubscribe();
+  });
+
+  it("stays silent while a hold legitimately keeps the loop awake and wakes keep arriving", () => {
+    const unsubscribe = subscribeFrame(() => {}, "playhead");
+    const release = holdFrames("playing");
+
+    for (let beat = 0; beat < 200; beat++) {
+      wake();
+      advanceFrames(15);
+    }
+
+    expect(loggedMessages()).toEqual([]);
+    release();
+    unsubscribe();
+  });
+
+  it("reports an unreleased hold by label once nothing is waking the loop", () => {
+    const unsubscribe = subscribeFrame(() => {}, "playhead");
+    const release = holdFrames("marquee-scroll");
+
+    advanceFrames(3000);
+
+    expect(messagesMatching(/held/)).toHaveLength(1);
+    expect(messagesMatching(/held/)[0]).toContain("marquee-scroll");
+    release();
+    unsubscribe();
+  });
+});

--- a/src/lib/frame-loop.test.ts
+++ b/src/lib/frame-loop.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// -- Types --------------------------------------------------------------------
+
+type FrameLoop = typeof import("@/lib/frame-loop");
+
+// -- Constants ----------------------------------------------------------------
+
+const FRAME_MS = 16;
+
+// -- Harness ------------------------------------------------------------------
+
+let subscribeFrame: FrameLoop["subscribeFrame"];
+let setFrameSource: FrameLoop["setFrameSource"];
+let wake: FrameLoop["wake"];
+let nextFrame: FrameLoop["nextFrame"];
+let cancelNextFrame: FrameLoop["cancelNextFrame"];
+let tailFrames: number;
+
+function advanceFrames(count: number): void {
+  vi.advanceTimersByTime(FRAME_MS * count);
+}
+
+function countingSubscriber(): { calls: () => number; subscribe: () => () => void } {
+  let calls = 0;
+  return {
+    calls: () => calls,
+    subscribe: () =>
+      subscribeFrame(() => {
+        calls += 1;
+      }),
+  };
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.useFakeTimers();
+  const frameLoop = await import("@/lib/frame-loop");
+  subscribeFrame = frameLoop.subscribeFrame;
+  setFrameSource = frameLoop.setFrameSource;
+  wake = frameLoop.wake;
+  nextFrame = frameLoop.nextFrame;
+  cancelNextFrame = frameLoop.cancelNextFrame;
+  tailFrames = frameLoop.TAIL_FRAMES;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// -- Tests --------------------------------------------------------------------
+
+describe("frame-loop", () => {
+  describe("happy path", () => {
+    it("runs a subscriber on the next frame", () => {
+      const probe = countingSubscriber();
+      const unsubscribe = probe.subscribe();
+      expect(probe.calls()).toBe(0);
+      advanceFrames(1);
+      expect(probe.calls()).toBe(1);
+      unsubscribe();
+    });
+
+    it("runs every frame while a live source is set", () => {
+      const probe = countingSubscriber();
+      const unsubscribe = probe.subscribe();
+      setFrameSource("playing", true);
+      advanceFrames(40);
+      expect(probe.calls()).toBe(40);
+      setFrameSource("playing", false);
+      unsubscribe();
+    });
+
+    it("stops after the tail once the last live source is cleared", () => {
+      const probe = countingSubscriber();
+      const unsubscribe = probe.subscribe();
+      setFrameSource("playing", true);
+      advanceFrames(10);
+      setFrameSource("playing", false);
+      advanceFrames(tailFrames);
+      const stopped = probe.calls();
+      advanceFrames(100);
+      expect(probe.calls()).toBe(stopped);
+      unsubscribe();
+    });
+  });
+
+  describe("tail behaviour", () => {
+    it("runs exactly TAIL_FRAMES frames after a wake with no live source", () => {
+      const probe = countingSubscriber();
+      const unsubscribe = probe.subscribe();
+      advanceFrames(100);
+      expect(probe.calls()).toBe(tailFrames);
+      unsubscribe();
+    });
+
+    it("re-arms the full tail when a second wake arrives mid-tail", () => {
+      const probe = countingSubscriber();
+      const unsubscribe = probe.subscribe();
+      advanceFrames(1);
+      wake();
+      advanceFrames(100);
+      expect(probe.calls()).toBe(1 + tailFrames);
+      unsubscribe();
+    });
+
+    it("re-arms the full tail when a subscriber wakes from inside a frame", () => {
+      let calls = 0;
+      const unsubscribe = subscribeFrame(() => {
+        calls += 1;
+        if (calls === 1) wake();
+      });
+      advanceFrames(100);
+      expect(calls).toBe(1 + tailFrames);
+      unsubscribe();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("schedules nothing when waking with zero subscribers", () => {
+      wake();
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("cancels the pending frame when the last subscriber leaves", () => {
+      const probe = countingSubscriber();
+      const unsubscribe = probe.subscribe();
+      expect(vi.getTimerCount()).toBe(1);
+      unsubscribe();
+      expect(vi.getTimerCount()).toBe(0);
+      advanceFrames(100);
+      expect(probe.calls()).toBe(0);
+    });
+
+    it("does not skip a sibling when one subscriber unsubscribes mid-frame", () => {
+      let firstCalls = 0;
+      let removedCalls = 0;
+      let lastCalls = 0;
+      let unsubscribeRemoved: (() => void) | null = null;
+      const unsubscribeFirst = subscribeFrame(() => {
+        firstCalls += 1;
+        unsubscribeRemoved?.();
+      });
+      unsubscribeRemoved = subscribeFrame(() => {
+        removedCalls += 1;
+      });
+      const unsubscribeLast = subscribeFrame(() => {
+        lastCalls += 1;
+      });
+      advanceFrames(1);
+      expect(firstCalls).toBe(1);
+      expect(removedCalls).toBe(0);
+      expect(lastCalls).toBe(1);
+      unsubscribeFirst();
+      unsubscribeLast();
+    });
+
+    it("runs a subscriber added during a frame in that same frame", () => {
+      let addedCalls = 0;
+      let unsubscribeAdded: (() => void) | null = null;
+      const unsubscribeFirst = subscribeFrame(() => {
+        unsubscribeAdded ??= subscribeFrame(() => {
+          addedCalls += 1;
+        });
+      });
+      advanceFrames(1);
+      expect(addedCalls).toBe(1);
+      unsubscribeFirst();
+      unsubscribeAdded?.();
+    });
+
+    it("treats a repeated setFrameSource value as a no-op", () => {
+      const probe = countingSubscriber();
+      const unsubscribe = probe.subscribe();
+      setFrameSource("scrubbing", true);
+      setFrameSource("scrubbing", true);
+      advanceFrames(30);
+      expect(probe.calls()).toBe(30);
+      setFrameSource("scrubbing", false);
+      advanceFrames(tailFrames);
+      const stopped = probe.calls();
+      advanceFrames(100);
+      expect(probe.calls()).toBe(stopped);
+      unsubscribe();
+    });
+
+    it("does not re-arm the tail when clearing a source that was never set", () => {
+      const probe = countingSubscriber();
+      const unsubscribe = probe.subscribe();
+      advanceFrames(100);
+      expect(probe.calls()).toBe(tailFrames);
+      setFrameSource("never-set", false);
+      advanceFrames(100);
+      expect(probe.calls()).toBe(tailFrames);
+      unsubscribe();
+    });
+
+    it("keeps running until every live source is cleared", () => {
+      const probe = countingSubscriber();
+      const unsubscribe = probe.subscribe();
+      setFrameSource("playing", true);
+      setFrameSource("scrubbing", true);
+      advanceFrames(10);
+      setFrameSource("playing", false);
+      advanceFrames(20);
+      expect(probe.calls()).toBe(30);
+      setFrameSource("scrubbing", false);
+      advanceFrames(tailFrames);
+      const stopped = probe.calls();
+      advanceFrames(100);
+      expect(probe.calls()).toBe(stopped);
+      unsubscribe();
+    });
+
+    it("cancels a one-shot frame handed to cancelNextFrame", () => {
+      let calls = 0;
+      const handle = nextFrame(() => {
+        calls += 1;
+      });
+      cancelNextFrame(handle);
+      advanceFrames(10);
+      expect(calls).toBe(0);
+    });
+  });
+
+  describe("invariants", () => {
+    it("keeps at most one frame pending however many wakes arrive", () => {
+      const probe = countingSubscriber();
+      const unsubscribe = probe.subscribe();
+      wake();
+      wake();
+      wake();
+      setFrameSource("playing", true);
+      expect(vi.getTimerCount()).toBe(1);
+      advanceFrames(1);
+      expect(vi.getTimerCount()).toBe(1);
+      setFrameSource("playing", false);
+      unsubscribe();
+    });
+
+    it("quiesces fully: no frame callbacks across 100 idle frames", () => {
+      const probe = countingSubscriber();
+      const unsubscribe = probe.subscribe();
+      advanceFrames(tailFrames);
+      expect(vi.getTimerCount()).toBe(0);
+      advanceFrames(100);
+      expect(probe.calls()).toBe(tailFrames);
+      unsubscribe();
+    });
+
+    it("quiesces after the same tail regardless of subscriber order", () => {
+      const counts = [0, 0, 0];
+      const subscribers = counts.map((_unused, index) => () => {
+        counts[index] += 1;
+      });
+      const forward = subscribers.map((callback) => subscribeFrame(callback));
+      advanceFrames(100);
+      expect(counts).toEqual([tailFrames, tailFrames, tailFrames]);
+      for (const unsubscribe of forward) unsubscribe();
+
+      counts[0] = 0;
+      counts[1] = 0;
+      counts[2] = 0;
+      const reversed = subscribers.toReversed().map((callback) => subscribeFrame(callback));
+      advanceFrames(100);
+      expect(counts).toEqual([tailFrames, tailFrames, tailFrames]);
+      for (const unsubscribe of reversed) unsubscribe();
+    });
+
+    it("hands every subscriber the same timestamp within one frame", () => {
+      const timestamps: number[] = [];
+      const unsubscribeFirst = subscribeFrame((now) => timestamps.push(now));
+      const unsubscribeSecond = subscribeFrame((now) => timestamps.push(now));
+      advanceFrames(1);
+      expect(timestamps).toHaveLength(2);
+      expect(timestamps[0]).toBe(timestamps[1]);
+      unsubscribeFirst();
+      unsubscribeSecond();
+    });
+  });
+
+  describe("regressions", () => {
+    it("regression #174: does not schedule a frame when idle with no live source", () => {
+      const probe = countingSubscriber();
+      const unsubscribe = probe.subscribe();
+      advanceFrames(tailFrames);
+      expect(vi.getTimerCount()).toBe(0);
+      advanceFrames(60 * 60);
+      expect(probe.calls()).toBe(tailFrames);
+      expect(vi.getTimerCount()).toBe(0);
+      unsubscribe();
+    });
+  });
+});

--- a/src/lib/frame-loop.test.ts
+++ b/src/lib/frame-loop.test.ts
@@ -157,16 +157,20 @@ describe("frame-loop", () => {
 
     it("runs a subscriber added during a frame in that same frame", () => {
       let addedCalls = 0;
-      let unsubscribeAdded: (() => void) | null = null;
-      const unsubscribeFirst = subscribeFrame(() => {
-        unsubscribeAdded ??= subscribeFrame(() => {
-          addedCalls += 1;
-        });
-      });
+      const unsubscribes: Array<() => void> = [];
+      unsubscribes.push(
+        subscribeFrame(() => {
+          if (unsubscribes.length > 1) return;
+          unsubscribes.push(
+            subscribeFrame(() => {
+              addedCalls += 1;
+            }),
+          );
+        }),
+      );
       advanceFrames(1);
       expect(addedCalls).toBe(1);
-      unsubscribeFirst();
-      unsubscribeAdded?.();
+      for (const unsubscribe of unsubscribes) unsubscribe();
     });
 
     it("treats a repeated setFrameSource value as a no-op", () => {

--- a/src/lib/frame-loop.test.ts
+++ b/src/lib/frame-loop.test.ts
@@ -1,43 +1,30 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-// -- Types --------------------------------------------------------------------
-
-type FrameLoop = typeof import("@/lib/frame-loop");
-
-// -- Constants ----------------------------------------------------------------
-
-const FRAME_MS = 16;
+import { advanceFrames, type FrameLoopModule, loadFrameLoop } from "@/test/frame-loop-harness";
 
 // -- Harness ------------------------------------------------------------------
 
-let subscribeFrame: FrameLoop["subscribeFrame"];
-let setFrameSource: FrameLoop["setFrameSource"];
-let wake: FrameLoop["wake"];
-let nextFrame: FrameLoop["nextFrame"];
-let cancelNextFrame: FrameLoop["cancelNextFrame"];
+let subscribeFrame: FrameLoopModule["subscribeFrame"];
+let holdFrames: FrameLoopModule["holdFrames"];
+let wake: FrameLoopModule["wake"];
+let nextFrame: FrameLoopModule["nextFrame"];
+let cancelNextFrame: FrameLoopModule["cancelNextFrame"];
 let tailFrames: number;
 
-function advanceFrames(count: number): void {
-  vi.advanceTimersByTime(FRAME_MS * count);
-}
-
-function countingSubscriber(): { calls: () => number; subscribe: () => () => void } {
+function countingSubscriber(label = "probe"): { calls: () => number; subscribe: () => () => void } {
   let calls = 0;
   return {
     calls: () => calls,
     subscribe: () =>
       subscribeFrame(() => {
         calls += 1;
-      }),
+      }, label),
   };
 }
 
 beforeEach(async () => {
-  vi.resetModules();
-  vi.useFakeTimers();
-  const frameLoop = await import("@/lib/frame-loop");
+  const frameLoop = await loadFrameLoop();
   subscribeFrame = frameLoop.subscribeFrame;
-  setFrameSource = frameLoop.setFrameSource;
+  holdFrames = frameLoop.holdFrames;
   wake = frameLoop.wake;
   nextFrame = frameLoop.nextFrame;
   cancelNextFrame = frameLoop.cancelNextFrame;
@@ -61,22 +48,22 @@ describe("frame-loop", () => {
       unsubscribe();
     });
 
-    it("runs every frame while a live source is set", () => {
+    it("runs every frame while a hold is held", () => {
       const probe = countingSubscriber();
       const unsubscribe = probe.subscribe();
-      setFrameSource("playing", true);
+      const release = holdFrames("playing");
       advanceFrames(40);
       expect(probe.calls()).toBe(40);
-      setFrameSource("playing", false);
+      release();
       unsubscribe();
     });
 
-    it("stops after the tail once the last live source is cleared", () => {
+    it("stops after the tail once the last hold is released", () => {
       const probe = countingSubscriber();
       const unsubscribe = probe.subscribe();
-      setFrameSource("playing", true);
+      const release = holdFrames("playing");
       advanceFrames(10);
-      setFrameSource("playing", false);
+      release();
       advanceFrames(tailFrames);
       const stopped = probe.calls();
       advanceFrames(100);
@@ -86,7 +73,7 @@ describe("frame-loop", () => {
   });
 
   describe("tail behaviour", () => {
-    it("runs exactly TAIL_FRAMES frames after a wake with no live source", () => {
+    it("runs exactly TAIL_FRAMES frames after a wake with no hold", () => {
       const probe = countingSubscriber();
       const unsubscribe = probe.subscribe();
       advanceFrames(100);
@@ -109,7 +96,7 @@ describe("frame-loop", () => {
       const unsubscribe = subscribeFrame(() => {
         calls += 1;
         if (calls === 1) wake();
-      });
+      }, "waker");
       advanceFrames(100);
       expect(calls).toBe(1 + tailFrames);
       unsubscribe();
@@ -140,13 +127,13 @@ describe("frame-loop", () => {
       const unsubscribeFirst = subscribeFrame(() => {
         firstCalls += 1;
         unsubscribeRemoved?.();
-      });
+      }, "first");
       unsubscribeRemoved = subscribeFrame(() => {
         removedCalls += 1;
-      });
+      }, "removed");
       const unsubscribeLast = subscribeFrame(() => {
         lastCalls += 1;
-      });
+      }, "last");
       advanceFrames(1);
       expect(firstCalls).toBe(1);
       expect(removedCalls).toBe(0);
@@ -164,56 +151,28 @@ describe("frame-loop", () => {
           unsubscribes.push(
             subscribeFrame(() => {
               addedCalls += 1;
-            }),
+            }, "added"),
           );
-        }),
+        }, "adder"),
       );
       advanceFrames(1);
       expect(addedCalls).toBe(1);
       for (const unsubscribe of unsubscribes) unsubscribe();
     });
 
-    it("treats a repeated setFrameSource value as a no-op", () => {
-      const probe = countingSubscriber();
-      const unsubscribe = probe.subscribe();
-      setFrameSource("scrubbing", true);
-      setFrameSource("scrubbing", true);
-      advanceFrames(30);
-      expect(probe.calls()).toBe(30);
-      setFrameSource("scrubbing", false);
-      advanceFrames(tailFrames);
-      const stopped = probe.calls();
-      advanceFrames(100);
-      expect(probe.calls()).toBe(stopped);
-      unsubscribe();
-    });
-
-    it("does not re-arm the tail when clearing a source that was never set", () => {
-      const probe = countingSubscriber();
-      const unsubscribe = probe.subscribe();
-      advanceFrames(100);
-      expect(probe.calls()).toBe(tailFrames);
-      setFrameSource("never-set", false);
-      advanceFrames(100);
-      expect(probe.calls()).toBe(tailFrames);
-      unsubscribe();
-    });
-
-    it("keeps running until every live source is cleared", () => {
-      const probe = countingSubscriber();
-      const unsubscribe = probe.subscribe();
-      setFrameSource("playing", true);
-      setFrameSource("scrubbing", true);
-      advanceFrames(10);
-      setFrameSource("playing", false);
-      advanceFrames(20);
-      expect(probe.calls()).toBe(30);
-      setFrameSource("scrubbing", false);
-      advanceFrames(tailFrames);
-      const stopped = probe.calls();
-      advanceFrames(100);
-      expect(probe.calls()).toBe(stopped);
-      unsubscribe();
+    it("keeps the same callback subscribed twice as two independent subscriptions", () => {
+      let calls = 0;
+      const callback = () => {
+        calls += 1;
+      };
+      const unsubscribeFirst = subscribeFrame(callback, "twin-a");
+      const unsubscribeSecond = subscribeFrame(callback, "twin-b");
+      advanceFrames(1);
+      expect(calls).toBe(2);
+      unsubscribeFirst();
+      advanceFrames(1);
+      expect(calls).toBe(3);
+      unsubscribeSecond();
     });
 
     it("cancels a one-shot frame handed to cancelNextFrame", () => {
@@ -234,11 +193,11 @@ describe("frame-loop", () => {
       wake();
       wake();
       wake();
-      setFrameSource("playing", true);
+      const release = holdFrames("playing");
       expect(vi.getTimerCount()).toBe(1);
       advanceFrames(1);
       expect(vi.getTimerCount()).toBe(1);
-      setFrameSource("playing", false);
+      release();
       unsubscribe();
     });
 
@@ -257,7 +216,7 @@ describe("frame-loop", () => {
       const subscribers = counts.map((_unused, index) => () => {
         counts[index] += 1;
       });
-      const forward = subscribers.map((callback) => subscribeFrame(callback));
+      const forward = subscribers.map((callback, index) => subscribeFrame(callback, `ordered-${index}`));
       advanceFrames(100);
       expect(counts).toEqual([tailFrames, tailFrames, tailFrames]);
       for (const unsubscribe of forward) unsubscribe();
@@ -265,7 +224,7 @@ describe("frame-loop", () => {
       counts[0] = 0;
       counts[1] = 0;
       counts[2] = 0;
-      const reversed = subscribers.toReversed().map((callback) => subscribeFrame(callback));
+      const reversed = subscribers.toReversed().map((callback, index) => subscribeFrame(callback, `reversed-${index}`));
       advanceFrames(100);
       expect(counts).toEqual([tailFrames, tailFrames, tailFrames]);
       for (const unsubscribe of reversed) unsubscribe();
@@ -273,8 +232,8 @@ describe("frame-loop", () => {
 
     it("hands every subscriber the same timestamp within one frame", () => {
       const timestamps: number[] = [];
-      const unsubscribeFirst = subscribeFrame((now) => timestamps.push(now));
-      const unsubscribeSecond = subscribeFrame((now) => timestamps.push(now));
+      const unsubscribeFirst = subscribeFrame((now) => timestamps.push(now), "stamp-a");
+      const unsubscribeSecond = subscribeFrame((now) => timestamps.push(now), "stamp-b");
       advanceFrames(1);
       expect(timestamps).toHaveLength(2);
       expect(timestamps[0]).toBe(timestamps[1]);
@@ -284,7 +243,7 @@ describe("frame-loop", () => {
   });
 
   describe("regressions", () => {
-    it("regression #174: does not schedule a frame when idle with no live source", () => {
+    it("regression #174: does not schedule a frame when idle with no hold", () => {
       const probe = countingSubscriber();
       const unsubscribe = probe.subscribe();
       advanceFrames(tailFrames);

--- a/src/lib/frame-loop.ts
+++ b/src/lib/frame-loop.ts
@@ -2,16 +2,60 @@
 
 type FrameCallback = (now: number) => void;
 
+interface FrameSubscriber {
+  callback: FrameCallback;
+  label: string;
+  failing: boolean;
+}
+
 // -- Constants ----------------------------------------------------------------
 
+const LOG_PREFIX = "[FrameLoop]";
+
+// 3 frames covers a React commit landing a DOM write on the frame after the store notify.
 const TAIL_FRAMES = 3;
+
+const RUNAWAY_WAKE_FRAMES = 600;
+const STALE_HOLD_FRAMES = 600;
 
 // -- State --------------------------------------------------------------------
 
-const subscribers = new Set<FrameCallback>();
-const liveSources = new Set<string>();
+const subscribers = new Set<FrameSubscriber>();
+const holds = new Map<string, number>();
 let tailFrames = 0;
 let rafId: number | null = null;
+let unheldFrameRun = 0;
+let framesSinceWake = 0;
+let hasReportedRunawayWakes = false;
+let hasReportedStaleHold = false;
+
+// -- Diagnostics --------------------------------------------------------------
+
+function subscriberLabels(): string[] {
+  return [...subscribers].map((subscriber) => subscriber.label);
+}
+
+function reportRunawayFrames(rescheduling: boolean): void {
+  if (!rescheduling) {
+    unheldFrameRun = 0;
+    return;
+  }
+  if (holds.size > 0) {
+    unheldFrameRun = 0;
+    if (framesSinceWake < STALE_HOLD_FRAMES || hasReportedStaleHold) return;
+    hasReportedStaleHold = true;
+    console.error(
+      `${LOG_PREFIX} loop held for ${framesSinceWake} frames with nothing waking it; unreleased hold: ${[...holds.keys()].join(", ")}`,
+    );
+    return;
+  }
+  unheldFrameRun += 1;
+  if (unheldFrameRun < RUNAWAY_WAKE_FRAMES || hasReportedRunawayWakes) return;
+  hasReportedRunawayWakes = true;
+  console.error(
+    `${LOG_PREFIX} loop never idled across ${unheldFrameRun} frames with no hold held; a frame callback is probably writing to a store every frame. Subscribers: ${subscriberLabels().join(", ")}`,
+  );
+}
 
 // -- Scheduler ----------------------------------------------------------------
 
@@ -20,31 +64,55 @@ function schedule(): void {
   rafId = window.requestAnimationFrame(pump);
 }
 
+function runSubscriber(subscriber: FrameSubscriber, now: number): void {
+  try {
+    subscriber.callback(now);
+    subscriber.failing = false;
+  } catch (error) {
+    if (subscriber.failing) return;
+    subscriber.failing = true;
+    console.error(`${LOG_PREFIX} frame callback "${subscriber.label}" failed`, error);
+  }
+}
+
 function pump(now: number): void {
   rafId = null;
-  if (liveSources.size > 0) tailFrames = TAIL_FRAMES;
+  framesSinceWake += 1;
+  if (holds.size > 0) tailFrames = TAIL_FRAMES;
   else tailFrames -= 1;
-  for (const callback of subscribers) callback(now);
-  if (tailFrames > 0) schedule();
+  const rescheduling = tailFrames > 0;
+  // Queued before any callback runs, so nothing a subscriber does can stop the loop.
+  if (rescheduling) schedule();
+  for (const subscriber of subscribers) runSubscriber(subscriber, now);
+  if (import.meta.env.DEV) reportRunawayFrames(rescheduling);
 }
 
 function wake(): void {
   tailFrames = TAIL_FRAMES;
+  framesSinceWake = 0;
   schedule();
 }
 
-function setFrameSource(name: string, live: boolean): void {
-  if (live === liveSources.has(name)) return;
-  if (live) liveSources.add(name);
-  else liveSources.delete(name);
+function holdFrames(label: string): () => void {
+  holds.set(label, (holds.get(label) ?? 0) + 1);
   wake();
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    const remaining = (holds.get(label) ?? 1) - 1;
+    if (remaining > 0) holds.set(label, remaining);
+    else holds.delete(label);
+    wake();
+  };
 }
 
-function subscribeFrame(callback: FrameCallback): () => void {
-  subscribers.add(callback);
+function subscribeFrame(callback: FrameCallback, label: string): () => void {
+  const subscriber: FrameSubscriber = { callback, label, failing: false };
+  subscribers.add(subscriber);
   wake();
   return () => {
-    subscribers.delete(callback);
+    subscribers.delete(subscriber);
     if (subscribers.size === 0 && rafId !== null) {
       window.cancelAnimationFrame(rafId);
       rafId = null;
@@ -62,5 +130,5 @@ function cancelNextFrame(handle: number): void {
 
 // -- Exports ------------------------------------------------------------------
 
-export { TAIL_FRAMES, cancelNextFrame, nextFrame, setFrameSource, subscribeFrame, wake };
+export { TAIL_FRAMES, cancelNextFrame, holdFrames, nextFrame, subscribeFrame, wake };
 export type { FrameCallback };

--- a/src/lib/frame-loop.ts
+++ b/src/lib/frame-loop.ts
@@ -1,0 +1,66 @@
+// -- Types --------------------------------------------------------------------
+
+type FrameCallback = (now: number) => void;
+
+// -- Constants ----------------------------------------------------------------
+
+const TAIL_FRAMES = 3;
+
+// -- State --------------------------------------------------------------------
+
+const subscribers = new Set<FrameCallback>();
+const liveSources = new Set<string>();
+let tailFrames = 0;
+let rafId: number | null = null;
+
+// -- Scheduler ----------------------------------------------------------------
+
+function schedule(): void {
+  if (rafId !== null || subscribers.size === 0) return;
+  rafId = window.requestAnimationFrame(pump);
+}
+
+function pump(now: number): void {
+  rafId = null;
+  if (liveSources.size > 0) tailFrames = TAIL_FRAMES;
+  else tailFrames -= 1;
+  for (const callback of subscribers) callback(now);
+  if (tailFrames > 0) schedule();
+}
+
+function wake(): void {
+  tailFrames = TAIL_FRAMES;
+  schedule();
+}
+
+function setFrameSource(name: string, live: boolean): void {
+  if (live === liveSources.has(name)) return;
+  if (live) liveSources.add(name);
+  else liveSources.delete(name);
+  wake();
+}
+
+function subscribeFrame(callback: FrameCallback): () => void {
+  subscribers.add(callback);
+  wake();
+  return () => {
+    subscribers.delete(callback);
+    if (subscribers.size === 0 && rafId !== null) {
+      window.cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  };
+}
+
+function nextFrame(callback: FrameCallback): number {
+  return window.requestAnimationFrame(callback);
+}
+
+function cancelNextFrame(handle: number): void {
+  window.cancelAnimationFrame(handle);
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { TAIL_FRAMES, cancelNextFrame, nextFrame, setFrameSource, subscribeFrame, wake };
+export type { FrameCallback };

--- a/src/test/browser-css.ts
+++ b/src/test/browser-css.ts
@@ -1,0 +1,50 @@
+import indexCss from "@/index.css?raw";
+
+// The browser project has no Tailwind plugin, so a rule a test needs to observe has to be lifted
+// out of the real src/index.css and installed by hand.
+
+// -- Constants -----------------------------------------------------------------
+
+const WAVEFORM_SWEEP_ANIMATION = "waveform-loading-sweep";
+const WAVEFORM_DOTS_UTILITY = "waveform-loading-dots";
+
+// Without these the timeline's layers all stack in flow, which pushes the rows past
+// react-virtuoso's viewport and leaves it with nothing to render.
+const POSITION_UTILITIES_CSS = ".relative{position:relative}.absolute{position:absolute}.sticky{position:sticky;top:0}";
+
+// -- Helpers -------------------------------------------------------------------
+
+function extractCssBlock(header: RegExp): string {
+  const match = header.exec(indexCss);
+  if (!match) throw new Error(`no CSS block matching ${header} in src/index.css`);
+  const bodyStart = match.index + match[0].length;
+  let depth = 1;
+  for (let i = bodyStart; i < indexCss.length; i++) {
+    if (indexCss[i] === "{") depth++;
+    else if (indexCss[i] === "}" && --depth === 0) return indexCss.slice(bodyStart, i);
+  }
+  throw new Error(`unbalanced CSS block matching ${header} in src/index.css`);
+}
+
+function utilityRule(name: string): string {
+  return `.${name} {${extractCssBlock(new RegExp(`@utility\\s+${name}\\s*\\{`))}}`;
+}
+
+function keyframesRule(name: string): string {
+  return `@keyframes ${name} {${extractCssBlock(new RegExp(`@keyframes\\s+${name}\\s*\\{`))}}`;
+}
+
+function installStyleSheet(css: string): HTMLStyleElement {
+  const style = document.createElement("style");
+  style.textContent = css;
+  document.head.appendChild(style);
+  return style;
+}
+
+// -- Rules ---------------------------------------------------------------------
+
+const WAVEFORM_SWEEP_CSS = [utilityRule(WAVEFORM_DOTS_UTILITY), keyframesRule(WAVEFORM_SWEEP_ANIMATION)].join("\n");
+
+// -- Exports -------------------------------------------------------------------
+
+export { installStyleSheet, POSITION_UTILITIES_CSS, WAVEFORM_SWEEP_ANIMATION, WAVEFORM_SWEEP_CSS };

--- a/src/test/compositor-safe-animations.test.ts
+++ b/src/test/compositor-safe-animations.test.ts
@@ -25,7 +25,6 @@ interface CssDeclaration {
 }
 
 interface CssBlock {
-  prelude: string;
   chain: string[];
   keyframesName: string | null;
   declarations: CssDeclaration[];
@@ -101,7 +100,6 @@ function parseBlocks(source: string): CssBlock[] {
       const prelude = buffer.trim();
       const named = KEYFRAMES_PRELUDE.exec(prelude);
       const block: CssBlock = {
-        prelude,
         chain: [...(parent?.chain ?? []), prelude],
         keyframesName: named ? named[1].toLowerCase() : (parent?.keyframesName ?? null),
         declarations: [],

--- a/src/test/compositor-safe-animations.test.ts
+++ b/src/test/compositor-safe-animations.test.ts
@@ -1,0 +1,204 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// CI guard for compositor-safe animation. Blink can run transform, opacity and
+// filter on the compositor thread; everything else forces a style recalc and a
+// main-thread paint on every single frame. An infinite animation of an
+// uncompositable property therefore burns the main thread forever, even when the
+// element is fully transparent or scrolled out of view (issue #174).
+//
+// `prefers-reduced-motion` is not a mitigation. Measured over CDP emulation it
+// removes the paint cost and leaves the frame cost unchanged, so this guard
+// deliberately ignores the global `animation-iteration-count: 1` override.
+//
+// Animations behind a state gate (an attribute selector or a state pseudo-class)
+// run only while that state is on, so they are bounded by the interaction that
+// turns them on and are out of scope here. Ungated ones run forever.
+
+// -- Types --------------------------------------------------------------------
+
+interface CssDeclaration {
+  property: string;
+  value: string;
+}
+
+interface CssBlock {
+  prelude: string;
+  chain: string[];
+  keyframesName: string | null;
+  declarations: CssDeclaration[];
+}
+
+interface InfiniteAnimation {
+  keyframesName: string;
+  animatedProperties: string[];
+}
+
+// -- Constants ----------------------------------------------------------------
+
+const SRC_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const COMPOSITABLE = new Set(["transform", "translate", "rotate", "scale", "opacity", "filter", "backdrop-filter"]);
+const KEYFRAMES_PRELUDE = /^@(?:-\w+-)?keyframes\s+(\S+)/;
+const STATE_GATE = /\[[^\]]+\]|:(?:hover|focus|focus-visible|focus-within|active|checked|disabled|target)\b/;
+const VENDOR_PREFIX = /^-\w+-/;
+
+// -- Stylesheet parsing -------------------------------------------------------
+
+function* walkStylesheets(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "node_modules" || entry === "dist" || entry === ".git") continue;
+      yield* walkStylesheets(full);
+      continue;
+    }
+    if (entry.endsWith(".css")) yield full;
+  }
+}
+
+function toDeclaration(raw: string): CssDeclaration | null {
+  const text = raw.trim();
+  const colon = text.indexOf(":");
+  if (colon <= 0) return null;
+  return {
+    property: text.slice(0, colon).trim().toLowerCase(),
+    value: text
+      .slice(colon + 1)
+      .trim()
+      .toLowerCase(),
+  };
+}
+
+function parseBlocks(source: string): CssBlock[] {
+  const blocks: CssBlock[] = [];
+  const open: CssBlock[] = [];
+  let buffer = "";
+  let parenDepth = 0;
+  let quote: string | null = null;
+
+  for (const char of source.replace(/\/\*[\s\S]*?\*\//g, "")) {
+    if (quote) {
+      buffer += char;
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      buffer += char;
+      continue;
+    }
+    if (char === "(") parenDepth += 1;
+    if (char === ")") parenDepth -= 1;
+    if (parenDepth > 0 || (char !== "{" && char !== "}" && char !== ";")) {
+      buffer += char;
+      continue;
+    }
+
+    const parent = open[open.length - 1];
+    if (char === "{") {
+      const prelude = buffer.trim();
+      const named = KEYFRAMES_PRELUDE.exec(prelude);
+      const block: CssBlock = {
+        prelude,
+        chain: [...(parent?.chain ?? []), prelude],
+        keyframesName: named ? named[1].toLowerCase() : (parent?.keyframesName ?? null),
+        declarations: [],
+      };
+      open.push(block);
+      blocks.push(block);
+    } else {
+      const declaration = toDeclaration(buffer);
+      if (declaration && parent) parent.declarations.push(declaration);
+      if (char === "}") open.pop();
+    }
+    buffer = "";
+  }
+
+  return blocks;
+}
+
+function allBlocks(): CssBlock[] {
+  return [...walkStylesheets(SRC_ROOT)].flatMap((file) => parseBlocks(readFileSync(file, "utf8")));
+}
+
+// -- Analysis -----------------------------------------------------------------
+
+function keyframesProperties(blocks: CssBlock[]): Map<string, Set<string>> {
+  const byName = new Map<string, Set<string>>();
+  for (const block of blocks) {
+    if (!block.keyframesName) continue;
+    const properties = byName.get(block.keyframesName) ?? new Set<string>();
+    for (const declaration of block.declarations) {
+      if (declaration.property.startsWith("animation")) continue;
+      properties.add(declaration.property.replace(VENDOR_PREFIX, ""));
+    }
+    byName.set(block.keyframesName, properties);
+  }
+  return byName;
+}
+
+function referencedNames(value: string, known: Map<string, Set<string>>): string[] {
+  return value.split(/[\s,]+/).filter((token) => known.has(token));
+}
+
+function infiniteNamesIn(block: CssBlock, known: Map<string, Set<string>>): string[] {
+  const countIsInfinite = block.declarations.some(
+    (declaration) => declaration.property === "animation-iteration-count" && declaration.value.includes("infinite"),
+  );
+  const names = new Set<string>();
+
+  for (const declaration of block.declarations) {
+    if (declaration.property === "animation" && (countIsInfinite || declaration.value.includes("infinite"))) {
+      for (const name of referencedNames(declaration.value, known)) names.add(name);
+    }
+    if (declaration.property === "animation-name" && countIsInfinite) {
+      for (const name of referencedNames(declaration.value, known)) names.add(name);
+    }
+  }
+
+  return [...names];
+}
+
+function infiniteAnimations(requireUngated: boolean): InfiniteAnimation[] {
+  const blocks = allBlocks();
+  const known = keyframesProperties(blocks);
+  const found = new Map<string, InfiniteAnimation>();
+
+  for (const block of blocks) {
+    if (requireUngated && block.chain.some((prelude) => STATE_GATE.test(prelude))) continue;
+    for (const keyframesName of infiniteNamesIn(block, known)) {
+      found.set(keyframesName, { keyframesName, animatedProperties: [...(known.get(keyframesName) ?? [])] });
+    }
+  }
+
+  return [...found.values()];
+}
+
+function describeOffender({ keyframesName, animatedProperties }: InfiniteAnimation): string {
+  return [
+    `@keyframes ${keyframesName} runs infinitely and animates: ${animatedProperties.join(", ")}.`,
+    "Only transform / opacity / filter can run on the compositor. Anything else forces",
+    "a style recalc and a main-thread paint every frame, forever, even when the element",
+    "is invisible. See issue #174.",
+  ].join("\n");
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("compositor safe animations", () => {
+  it("resolves the keyframes behind an infinite animation, reduced-motion override notwithstanding", () => {
+    const resolved = infiniteAnimations(false);
+    expect(resolved.length).toBeGreaterThan(0);
+    for (const animation of resolved) expect(animation.animatedProperties.length).toBeGreaterThan(0);
+  });
+
+  it("runs every always-on infinite animation on the compositor", () => {
+    const offenders = infiniteAnimations(true)
+      .filter((animation) => animation.animatedProperties.some((property) => !COMPOSITABLE.has(property)))
+      .map(describeOffender);
+
+    expect(offenders.join("\n\n")).toBe("");
+  });
+});

--- a/src/test/frame-loop-harness.ts
+++ b/src/test/frame-loop-harness.ts
@@ -1,0 +1,26 @@
+import { vi } from "vitest";
+
+// -- Types --------------------------------------------------------------------
+
+type FrameLoopModule = typeof import("@/lib/frame-loop");
+
+// -- Constants ----------------------------------------------------------------
+
+const FRAME_MS = 16;
+
+// -- Helpers ------------------------------------------------------------------
+
+async function loadFrameLoop(): Promise<FrameLoopModule> {
+  vi.resetModules();
+  vi.useFakeTimers();
+  return import("@/lib/frame-loop");
+}
+
+function advanceFrames(count: number): void {
+  vi.advanceTimersByTime(FRAME_MS * count);
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { advanceFrames, loadFrameLoop };
+export type { FrameLoopModule };

--- a/src/test/frame-loop-ownership.test.ts
+++ b/src/test/frame-loop-ownership.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// CI guard for frame ownership. A raw `requestAnimationFrame` loop reschedules
+// itself forever, so it keeps the main thread busy long after the app goes idle
+// (issue #174). `src/lib/frame-loop.ts` is the single scheduler: it runs only
+// while something holds it awake, names every subscriber for diagnostics, and
+// fault-isolates callbacks. It is therefore the only file allowed to touch the
+// platform API.
+//
+// There is no allowlist. A file that trips this guard has not been migrated
+// yet; migrate it rather than exempting it.
+
+// -- Constants ----------------------------------------------------------------
+
+const SRC_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const FRAME_LOOP_OWNER = "lib/frame-loop.ts";
+const RAW_FRAME_CALL = /\b(request|cancel)AnimationFrame\b/;
+
+// -- Helpers ------------------------------------------------------------------
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "node_modules" || entry === "dist" || entry === ".git") continue;
+      yield* walk(full);
+      continue;
+    }
+    if (entry.endsWith(".ts") || entry.endsWith(".tsx")) yield full;
+  }
+}
+
+function isTestFile(relPath: string): boolean {
+  return relPath.endsWith(".test.ts") || relPath.endsWith(".test.tsx") || relPath.endsWith(".browser.test.tsx");
+}
+
+function describeOffender(relPath: string, lineNumber: number, call: string): string {
+  return [
+    `src/${relPath}:${lineNumber} calls ${call} directly.`,
+    "Frame scheduling has one owner: src/lib/frame-loop.ts.",
+    "  Repeating work each frame -> useFrameLoop(callback, label, enabled)",
+    "  A single deferred frame    -> nextFrame(callback)",
+    "  Continuous frames during a drag -> holdFrames(label), release on every exit path",
+    "A raw loop never stops when the app is idle. See issue #174.",
+  ].join("\n");
+}
+
+function rawFrameCallers(exemptOwner: boolean): string[] {
+  const offenders: string[] = [];
+
+  for (const file of walk(SRC_ROOT)) {
+    const relPath = relative(SRC_ROOT, file).replace(/\\/g, "/");
+    if (isTestFile(relPath)) continue;
+    if (exemptOwner && relPath === FRAME_LOOP_OWNER) continue;
+
+    readFileSync(file, "utf8")
+      .split("\n")
+      .forEach((line, index) => {
+        const match = RAW_FRAME_CALL.exec(line);
+        if (match) offenders.push(describeOffender(relPath, index + 1, `${match[1]}AnimationFrame`));
+      });
+  }
+
+  return offenders;
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("frame loop ownership", () => {
+  it("detects raw animation frame calls, so the guard cannot silently pass", () => {
+    expect(rawFrameCallers(false).join("\n\n")).toContain(`src/${FRAME_LOOP_OWNER}`);
+  });
+
+  it("routes every animation frame in src through src/lib/frame-loop.ts", () => {
+    expect(rawFrameCallers(true).join("\n\n")).toBe("");
+  });
+});

--- a/src/test/frame-loop-wiring-complete.test.ts
+++ b/src/test/frame-loop-wiring-complete.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// CI guard for wake completeness. `wireFrameLoop` gates every animation frame in
+// the app, so a Zustand store it does not subscribe to produces a surface that
+// never repaints until something unrelated wakes the loop. Enumerating the
+// stores from disk is what stops that from being a silent omission.
+
+// -- Constants ----------------------------------------------------------------
+
+const SRC_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const WIRING_PATH = join(SRC_ROOT, "lib", "frame-loop-wiring.ts");
+const STORE_DECLARATION = /\bconst (use[A-Za-z]*Store) = create[<(]/g;
+
+// -- Helpers ------------------------------------------------------------------
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      yield* walk(full);
+      continue;
+    }
+    if (entry.endsWith(".ts") && !entry.includes(".test.")) yield full;
+  }
+}
+
+function declaredStoreHooks(): string[] {
+  const found = new Set<string>();
+  for (const file of walk(SRC_ROOT)) {
+    const source = readFileSync(file, "utf8");
+    for (const match of source.matchAll(STORE_DECLARATION)) found.add(match[1]);
+  }
+  return [...found].toSorted();
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("frame loop wake completeness", () => {
+  it("finds the app's Zustand stores on disk", () => {
+    expect(declaredStoreHooks().length).toBeGreaterThan(10);
+  });
+
+  it("subscribes wireFrameLoop to every Zustand store in the app", () => {
+    const wiring = readFileSync(WIRING_PATH, "utf8");
+    const unwired = declaredStoreHooks().filter((storeHook) => !wiring.includes(`${storeHook}.subscribe(`));
+    expect(unwired).toEqual([]);
+  });
+});

--- a/src/test/frame-probe.ts
+++ b/src/test/frame-probe.ts
@@ -1,0 +1,44 @@
+import { subscribeFrame } from "@/lib/frame-loop";
+import { settleFrames } from "@/test/frame-steps";
+
+// -- Interfaces ---------------------------------------------------------------
+
+interface FrameProbe {
+  count: () => number;
+  quiesce: () => Promise<void>;
+  wokeAfter: (trigger: () => void) => Promise<boolean>;
+  dispose: () => void;
+}
+
+// -- Helpers ------------------------------------------------------------------
+
+function createFrameProbe(): FrameProbe {
+  let frames = 0;
+  const unsubscribe = subscribeFrame(() => {
+    frames += 1;
+  });
+
+  const count = () => frames;
+
+  const quiesce = async () => {
+    await settleFrames(count);
+    frames = 0;
+  };
+
+  return {
+    count,
+    quiesce,
+    wokeAfter: async (trigger) => {
+      await quiesce();
+      trigger();
+      await settleFrames(count);
+      return frames > 0;
+    },
+    dispose: unsubscribe,
+  };
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { createFrameProbe };
+export type { FrameProbe };

--- a/src/test/frame-probe.ts
+++ b/src/test/frame-probe.ts
@@ -16,7 +16,7 @@ function createFrameProbe(): FrameProbe {
   let frames = 0;
   const unsubscribe = subscribeFrame(() => {
     frames += 1;
-  });
+  }, "frame-probe");
 
   const count = () => frames;
 

--- a/src/test/frame-steps.ts
+++ b/src/test/frame-steps.ts
@@ -36,4 +36,4 @@ async function settleFrames(readFrameCount: () => number): Promise<number> {
 
 // -- Exports ------------------------------------------------------------------
 
-export { QUIET_FRAMES, settleFrames, stepFrame, stepFrames };
+export { settleFrames, stepFrames };

--- a/src/test/frame-steps.ts
+++ b/src/test/frame-steps.ts
@@ -1,0 +1,39 @@
+import { nextFrame } from "@/lib/frame-loop";
+
+// -- Constants ----------------------------------------------------------------
+
+const QUIET_FRAMES = 6;
+const MAX_SETTLE_FRAMES = 300;
+
+// -- Helpers ------------------------------------------------------------------
+
+function stepFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    nextFrame(() => resolve());
+  });
+}
+
+async function stepFrames(count: number): Promise<void> {
+  for (let stepped = 0; stepped < count; stepped++) await stepFrame();
+}
+
+async function settleFrames(readFrameCount: () => number): Promise<number> {
+  let quietFrames = 0;
+  let lastCount = readFrameCount();
+  for (let stepped = 0; stepped < MAX_SETTLE_FRAMES; stepped++) {
+    await stepFrame();
+    const currentCount = readFrameCount();
+    if (currentCount !== lastCount) {
+      quietFrames = 0;
+      lastCount = currentCount;
+      continue;
+    }
+    quietFrames += 1;
+    if (quietFrames >= QUIET_FRAMES) return lastCount;
+  }
+  throw new Error(`frame loop did not quiesce within ${MAX_SETTLE_FRAMES} frames`);
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { QUIET_FRAMES, settleFrames, stepFrame, stepFrames };

--- a/src/utils/animationVariants.ts
+++ b/src/utils/animationVariants.ts
@@ -23,6 +23,20 @@ const slideUpVariants: Variants = {
   exit: { opacity: 0, y: 8 },
 };
 
+// The x holds the centring a `left-1/2` element would take from `-translate-x-1/2`, which motion
+// overwrites the moment it owns the transform.
+const centeredSlideUpVariants: Variants = {
+  hidden: { opacity: 0, x: "-50%", y: 8 },
+  visible: { opacity: 1, x: "-50%", y: 0 },
+  exit: { opacity: 0, x: "-50%", y: 8 },
+};
+
+const centeredFadeVariants: Variants = {
+  hidden: { opacity: 0, x: "-50%" },
+  visible: { opacity: 1, x: "-50%" },
+  exit: { opacity: 0, x: "-50%" },
+};
+
 // -- Sync Carousel (vertical, direction-aware, instant) ----------------------
 
 const syncCarouselTransition: Transition = {
@@ -117,6 +131,8 @@ const accordionVariants: Variants = {
 export {
   springSnappy,
   slideUpVariants,
+  centeredSlideUpVariants,
+  centeredFadeVariants,
   syncCarouselTransition,
   syncPulseVariants,
   buildGroupPingVariants,

--- a/src/views/preview/am-lyrics-renderer.browser.test.tsx
+++ b/src/views/preview/am-lyrics-renderer.browser.test.tsx
@@ -1,4 +1,5 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { wireFrameLoop } from "@/lib/frame-loop-wiring";
 import { useAudioStore } from "@/stores/audio";
 import { addGlobalAllowedConsolePattern } from "@/test/console-guard";
 import { render } from "@/test/render";
@@ -32,6 +33,17 @@ function firstLyricLine(el: Element): HTMLElement | null {
   return el.shadowRoot?.querySelector<HTMLElement>(".lyrics-line:not(.lyrics-gap)") ?? null;
 }
 
+let disposeWiring: (() => void) | null = null;
+
+beforeEach(() => {
+  disposeWiring = wireFrameLoop();
+});
+
+afterEach(() => {
+  disposeWiring?.();
+  disposeWiring = null;
+});
+
 // -- Tests --------------------------------------------------------------------
 
 describe("AmLyricsRenderer", () => {
@@ -49,7 +61,7 @@ describe("AmLyricsRenderer", () => {
     const el = await waitForAmLyrics(screen.container);
     await waitForLyrics(el);
 
-    audio.currentTime = 14;
+    useAudioStore.getState().seekTo(14);
     await expect.poll(() => activeLineText(el)).toContain("second line");
   });
 
@@ -63,11 +75,27 @@ describe("AmLyricsRenderer", () => {
     const el = await waitForAmLyrics(screen.container);
     await waitForLyrics(el);
 
-    audio.currentTime = 14;
+    useAudioStore.getState().seekTo(14);
     await expect.poll(() => activeLineText(el)).toContain("second line");
 
-    audio.currentTime = 26;
+    useAudioStore.getState().seekTo(26);
     await expect.poll(() => activeLineText(el)).toContain("third line");
+  });
+
+  it("keeps following the clock while the timeline is scrubbed paused", async () => {
+    useAudioStore.setState({ audioElement: new Audio(), isPlaying: false });
+
+    const screen = await render(
+      <AmLyricsRenderer ttmlString={buildSyncedTtml()} durationSeconds={SONG_DURATION_SECONDS} />,
+    );
+    const el = await waitForAmLyrics(screen.container);
+    await waitForLyrics(el);
+
+    useAudioStore.getState().seekTo(26);
+    await expect.poll(() => activeLineText(el)).toContain("third line");
+
+    useAudioStore.getState().seekTo(4);
+    await expect.poll(() => activeLineText(el)).toContain("first line");
   });
 
   it("tracks a newly registered audio element", async () => {
@@ -80,7 +108,7 @@ describe("AmLyricsRenderer", () => {
     const el = await waitForAmLyrics(screen.container);
     await waitForLyrics(el);
 
-    firstAudio.currentTime = 14;
+    useAudioStore.getState().seekTo(14);
     await expect.poll(() => activeLineText(el)).toContain("second line");
 
     const replacementAudio = new Audio();

--- a/src/views/preview/am-lyrics-renderer.tsx
+++ b/src/views/preview/am-lyrics-renderer.tsx
@@ -1,4 +1,5 @@
 import { useRendererAudioSync } from "@/hooks/use-renderer-audio-sync";
+import { wake } from "@/lib/frame-loop";
 import { useAudioStore } from "@/stores/audio";
 import type { AmLyrics as AmLyricsElement } from "@uimaxbai/am-lyrics";
 import { useEffect, useRef, useState } from "react";
@@ -64,6 +65,9 @@ const AmLyricsRenderer: React.FC<AmLyricsRendererProps> = ({ ttmlString, duratio
 
     container.appendChild(el);
     elementRef.current = el;
+    // The element arrives once the registration import resolves, long after the
+    // mount wake expired, so the first frame that can address it has to be asked for.
+    wake();
 
     const injectHideStyle = () => {
       if (!el.shadowRoot) return;
@@ -96,9 +100,13 @@ const AmLyricsRenderer: React.FC<AmLyricsRendererProps> = ({ ttmlString, duratio
     el.songDurationMs = durationSeconds * 1000;
   }, [durationSeconds]);
 
-  useRendererAudioSync(elementRef, (el, audio) => {
-    el.currentTime = audio.currentTime * 1000;
-  });
+  useRendererAudioSync(
+    elementRef,
+    (el, audio) => {
+      el.currentTime = audio.currentTime * 1000;
+    },
+    "am-lyrics-renderer",
+  );
 
   return <div ref={containerRef} className="flex flex-col flex-1 min-h-0" />;
 };

--- a/src/views/preview/braccato-renderer.browser.test.tsx
+++ b/src/views/preview/braccato-renderer.browser.test.tsx
@@ -340,7 +340,7 @@ describe("BraccatoRenderer invariants", () => {
     expect(probe.count()).toBe(0);
   });
 
-  it("regression #174: quiesces again once the reader is scrolled back", async () => {
+  it("regression #174: quiesces again once the reader is scrolled back and playback stops", async () => {
     const audio = new Audio();
     audio.currentTime = 14;
     useAudioStore.setState({ audioElement: audio, isPlaying: false });
@@ -354,6 +354,9 @@ describe("BraccatoRenderer invariants", () => {
 
     await screen.getByRole("button", { name: "Resume autoscroll" }).click();
     await expect.element(screen.getByRole("button", { name: "Resume autoscroll" })).not.toBeInTheDocument();
+
+    expect(useAudioStore.getState().isPlaying).toBe(true);
+    useAudioStore.getState().setIsPlaying(false);
     await probe.quiesce();
 
     await settleFrames(probe.count);
@@ -439,7 +442,17 @@ describe("BraccatoRenderer regressions", () => {
     topmostAtCentre(button)?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     await stepFrames(QUIET_FRAMES_AFTER_CLICK);
+    expect(useAudioStore.getState().currentTime).toBe(0);
+    await expect.element(screen.getByRole("button", { name: "Resume autoscroll" })).not.toBeInTheDocument();
+  });
+
+  it("regression: resuming autoscroll from the affordance starts playback again", async () => {
+    const { screen } = await showResumeAffordance();
     expect(useAudioStore.getState().isPlaying).toBe(false);
+
+    await screen.getByRole("button", { name: "Resume autoscroll" }).click();
+
+    await expect.poll(() => useAudioStore.getState().isPlaying).toBe(true);
     await expect.element(screen.getByRole("button", { name: "Resume autoscroll" })).not.toBeInTheDocument();
   });
 

--- a/src/views/preview/braccato-renderer.browser.test.tsx
+++ b/src/views/preview/braccato-renderer.browser.test.tsx
@@ -1,12 +1,39 @@
 import type { BraccatoLyricsElement } from "@braccato/core/element";
+import braccatoLyricsCss from "@braccato/core/styles/lyrics.css?raw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { wireFrameLoop } from "@/lib/frame-loop-wiring";
 import { useAudioStore } from "@/stores/audio";
+import { installStyleSheet, POSITION_UTILITIES_CSS } from "@/test/browser-css";
 import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
-import { settleFrames } from "@/test/frame-steps";
+import { settleFrames, stepFrames } from "@/test/frame-steps";
 import { render } from "@/test/render";
 import { buildBackgroundVocalTtml, buildSyncedTtml } from "@/test/ttml-fixtures";
 import { BraccatoRenderer } from "@/views/preview/braccato-renderer";
+
+// -- Constants -----------------------------------------------------------------
+
+// The browser project has no Tailwind plugin, so the utilities that float the affordance over the
+// lyrics are installed by hand next to braccato's own `.blyrics-container` rule, which carries the
+// z-index: 1 the affordance has to clear, and next to the scroller rule from src/index.css.
+const RESUME_AFFORDANCE_LAYOUT_CSS = [
+  braccatoLyricsCss,
+  POSITION_UTILITIES_CSS,
+  "braccato-lyrics{display:block;overflow-y:auto}",
+  ".flex{display:flex}",
+  ".flex-col{flex-direction:column}",
+  ".flex-1{flex:1 1 0%}",
+  ".min-h-0{min-height:0}",
+  ".bottom-6{bottom:1.5rem}",
+  ".left-1\\/2{left:50%}",
+  ".-translate-x-1\\/2{translate:-50% 0}",
+  ".z-10{z-index:10}",
+].join("\n");
+
+// PreviewPanel hands the renderer a bounded flex column; without one the lyrics run past the
+// viewport and the affordance lands where elementFromPoint cannot see it.
+const PREVIEW_PANEL_CSS = "display:flex;flex-direction:column;height:600px";
+
+const QUIET_FRAMES_AFTER_CLICK = 6;
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -351,5 +378,59 @@ describe("BraccatoRenderer invariants", () => {
 
     useAudioStore.getState().seekTo(5);
     await expect.poll(() => el.currentTime).toBe(5);
+  });
+});
+
+// -- Regressions ---------------------------------------------------------------
+
+describe("BraccatoRenderer regressions", () => {
+  let layoutStyles: HTMLStyleElement | null = null;
+
+  beforeEach(() => {
+    layoutStyles = installStyleSheet(RESUME_AFFORDANCE_LAYOUT_CSS);
+  });
+
+  afterEach(() => {
+    layoutStyles?.remove();
+    layoutStyles = null;
+  });
+
+  type ResumeAffordance = { screen: Awaited<ReturnType<typeof render>>; button: HTMLElement };
+
+  async function showResumeAffordance(): Promise<ResumeAffordance> {
+    const audio = new Audio();
+    audio.currentTime = 14;
+    useAudioStore.setState({ audioElement: audio, isPlaying: false });
+
+    const screen = await render(<BraccatoRenderer ttmlString={buildSyncedTtml()} />);
+    screen.container.style.cssText = PREVIEW_PANEL_CSS;
+    const el = getBraccatoElement(screen.container);
+    await waitForLyrics(el);
+
+    for (let i = 0; i < 5; i++) el.dispatchEvent(new Event("scroll"));
+    const affordance = screen.getByRole("button", { name: "Resume autoscroll" });
+    await expect.element(affordance).toBeInTheDocument();
+    return { screen, button: affordance.element() as HTMLElement };
+  }
+
+  function topmostAtCentre(element: HTMLElement): Element | null {
+    const rect = element.getBoundingClientRect();
+    return document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+  }
+
+  it("regression: the resume affordance is the topmost element at its own centre", async () => {
+    const { button } = await showResumeAffordance();
+
+    expect(topmostAtCentre(button)?.closest("button")).toBe(button);
+  });
+
+  it("regression: a pointer at the resume affordance resumes autoscroll rather than seeking the line beneath", async () => {
+    const { screen, button } = await showResumeAffordance();
+
+    topmostAtCentre(button)?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await stepFrames(QUIET_FRAMES_AFTER_CLICK);
+    expect(useAudioStore.getState().isPlaying).toBe(false);
+    await expect.element(screen.getByRole("button", { name: "Resume autoscroll" })).not.toBeInTheDocument();
   });
 });

--- a/src/views/preview/braccato-renderer.browser.test.tsx
+++ b/src/views/preview/braccato-renderer.browser.test.tsx
@@ -2,6 +2,8 @@ import type { BraccatoLyricsElement } from "@braccato/core/element";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { wireFrameLoop } from "@/lib/frame-loop-wiring";
 import { useAudioStore } from "@/stores/audio";
+import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
+import { settleFrames } from "@/test/frame-steps";
 import { render } from "@/test/render";
 import { buildBackgroundVocalTtml, buildSyncedTtml } from "@/test/ttml-fixtures";
 import { BraccatoRenderer } from "@/views/preview/braccato-renderer";
@@ -27,12 +29,15 @@ function lineTexts(el: BraccatoLyricsElement): string[] {
 }
 
 let disposeWiring: (() => void) | null = null;
+let probe: FrameProbe;
 
 beforeEach(() => {
   disposeWiring = wireFrameLoop();
+  probe = createFrameProbe();
 });
 
 afterEach(() => {
+  probe.dispose();
   disposeWiring?.();
   disposeWiring = null;
   for (const el of document.querySelectorAll("#composer-audio")) {
@@ -288,6 +293,37 @@ describe("BraccatoRenderer edge cases", () => {
 // -- Invariants ---------------------------------------------------------------
 
 describe("BraccatoRenderer invariants", () => {
+  it("regression #174: stops running frames once the audio is paused and idle", async () => {
+    useAudioStore.setState({ audioElement: new Audio(), isPlaying: false });
+
+    const screen = await render(<BraccatoRenderer ttmlString={buildSyncedTtml()} />);
+    await waitForLyrics(getBraccatoElement(screen.container));
+    await probe.quiesce();
+
+    await settleFrames(probe.count);
+    expect(probe.count()).toBe(0);
+  });
+
+  it("regression #174: quiesces again once the reader is scrolled back", async () => {
+    const audio = new Audio();
+    audio.currentTime = 14;
+    useAudioStore.setState({ audioElement: audio, isPlaying: false });
+
+    const screen = await render(<BraccatoRenderer ttmlString={buildSyncedTtml()} />);
+    const el = getBraccatoElement(screen.container);
+    await waitForLyrics(el);
+
+    for (let i = 0; i < 5; i++) el.dispatchEvent(new Event("scroll"));
+    await expect.element(screen.getByRole("button", { name: "Resume autoscroll" })).toBeInTheDocument();
+
+    await screen.getByRole("button", { name: "Resume autoscroll" }).click();
+    await expect.element(screen.getByRole("button", { name: "Resume autoscroll" })).not.toBeInTheDocument();
+    await probe.quiesce();
+
+    await settleFrames(probe.count);
+    expect(probe.count()).toBe(0);
+  });
+
   it("updates lyrics in place rather than recreating the element", async () => {
     useAudioStore.setState({ audioElement: new Audio() });
 

--- a/src/views/preview/braccato-renderer.browser.test.tsx
+++ b/src/views/preview/braccato-renderer.browser.test.tsx
@@ -1,5 +1,6 @@
 import type { BraccatoLyricsElement } from "@braccato/core/element";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { wireFrameLoop } from "@/lib/frame-loop-wiring";
 import { useAudioStore } from "@/stores/audio";
 import { render } from "@/test/render";
 import { buildBackgroundVocalTtml, buildSyncedTtml } from "@/test/ttml-fixtures";
@@ -25,7 +26,15 @@ function lineTexts(el: BraccatoLyricsElement): string[] {
   return [...el.querySelectorAll(".blyrics--line")].map((line) => line.textContent ?? "");
 }
 
+let disposeWiring: (() => void) | null = null;
+
+beforeEach(() => {
+  disposeWiring = wireFrameLoop();
+});
+
 afterEach(() => {
+  disposeWiring?.();
+  disposeWiring = null;
   for (const el of document.querySelectorAll("#composer-audio")) {
     el.remove();
   }
@@ -56,8 +65,24 @@ describe("BraccatoRenderer", () => {
     await waitForLyrics(el);
     await expect.poll(() => activeLineText(el)).toContain("second line");
 
-    audio.currentTime = 26;
+    useAudioStore.getState().seekTo(26);
     await expect.poll(() => activeLineText(el)).toContain("third line");
+  });
+
+  it("keeps following the clock while the timeline is scrubbed paused", async () => {
+    const audio = new Audio();
+    useAudioStore.setState({ audioElement: audio, isPlaying: false });
+
+    const screen = await render(<BraccatoRenderer ttmlString={buildSyncedTtml()} />);
+    const el = getBraccatoElement(screen.container);
+    await waitForLyrics(el);
+
+    useAudioStore.getState().seekTo(26);
+    await expect.poll(() => el.currentTime).toBe(26);
+
+    useAudioStore.getState().seekTo(4);
+    await expect.poll(() => el.currentTime).toBe(4);
+    expect(el.playing).toBe(false);
   });
 
   it("tracks a newly registered audio element", async () => {
@@ -288,7 +313,7 @@ describe("BraccatoRenderer invariants", () => {
 
     await screen.rerender(<BraccatoRenderer ttmlString={buildBackgroundVocalTtml()} />);
 
-    audio.currentTime = 5;
+    useAudioStore.getState().seekTo(5);
     await expect.poll(() => el.currentTime).toBe(5);
   });
 });

--- a/src/views/preview/braccato-renderer.browser.test.tsx
+++ b/src/views/preview/braccato-renderer.browser.test.tsx
@@ -433,4 +433,14 @@ describe("BraccatoRenderer regressions", () => {
     expect(useAudioStore.getState().isPlaying).toBe(false);
     await expect.element(screen.getByRole("button", { name: "Resume autoscroll" })).not.toBeInTheDocument();
   });
+
+  it("regression: clicking a line while scrolled away seeks and takes the reader back", async () => {
+    const { screen } = await showResumeAffordance();
+    const el = getBraccatoElement(screen.container);
+
+    el.querySelector<HTMLElement>(".blyrics--line")?.click();
+
+    await expect.poll(() => useAudioStore.getState().currentTime).toBe(2);
+    await expect.element(screen.getByRole("button", { name: "Resume autoscroll" })).not.toBeInTheDocument();
+  });
 });

--- a/src/views/preview/braccato-renderer.browser.test.tsx
+++ b/src/views/preview/braccato-renderer.browser.test.tsx
@@ -13,20 +13,25 @@ import { BraccatoRenderer } from "@/views/preview/braccato-renderer";
 // -- Constants -----------------------------------------------------------------
 
 // The browser project has no Tailwind plugin, so the utilities that float the affordance over the
-// lyrics are installed by hand next to braccato's own `.blyrics-container` rule, which carries the
-// z-index: 1 the affordance has to clear, and next to the scroller rule from src/index.css.
+// lyrics are installed by hand. Motion owns the affordance transform, so without the absolute box to
+// shrink-wrap it the centring `-50%` would drag it half the page width off screen.
+const AFFORDANCE_POSITION_CSS = [
+  POSITION_UTILITIES_CSS,
+  ".bottom-6{bottom:1.5rem}",
+  ".left-1\\/2{left:50%}",
+  ".z-10{z-index:10}",
+].join("\n");
+
+// Braccato's own `.blyrics-container` rule carries the z-index: 1 the affordance has to clear, and
+// the scroller rule comes from src/index.css.
 const RESUME_AFFORDANCE_LAYOUT_CSS = [
   braccatoLyricsCss,
-  POSITION_UTILITIES_CSS,
+  AFFORDANCE_POSITION_CSS,
   "braccato-lyrics{display:block;overflow-y:auto}",
   ".flex{display:flex}",
   ".flex-col{flex-direction:column}",
   ".flex-1{flex:1 1 0%}",
   ".min-h-0{min-height:0}",
-  ".bottom-6{bottom:1.5rem}",
-  ".left-1\\/2{left:50%}",
-  ".-translate-x-1\\/2{translate:-50% 0}",
-  ".z-10{z-index:10}",
 ].join("\n");
 
 // PreviewPanel hands the renderer a bounded flex column; without one the lyrics run past the
@@ -57,14 +62,18 @@ function lineTexts(el: BraccatoLyricsElement): string[] {
 
 let disposeWiring: (() => void) | null = null;
 let probe: FrameProbe;
+let positionStyles: HTMLStyleElement | null = null;
 
 beforeEach(() => {
   disposeWiring = wireFrameLoop();
   probe = createFrameProbe();
+  positionStyles = installStyleSheet(AFFORDANCE_POSITION_CSS);
 });
 
 afterEach(() => {
   probe.dispose();
+  positionStyles?.remove();
+  positionStyles = null;
   disposeWiring?.();
   disposeWiring = null;
   for (const el of document.querySelectorAll("#composer-audio")) {

--- a/src/views/preview/braccato-renderer.resume-wake.browser.test.tsx
+++ b/src/views/preview/braccato-renderer.resume-wake.browser.test.tsx
@@ -1,0 +1,195 @@
+import type { BraccatoLyricsElement } from "@braccato/core/element";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { wireFrameLoop } from "@/lib/frame-loop-wiring";
+import { useAudioStore } from "@/stores/audio";
+import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
+import { settleFrames, stepFrames } from "@/test/frame-steps";
+import { render } from "@/test/render";
+import { buildSyncedTtml } from "@/test/ttml-fixtures";
+import { BraccatoRenderer, RESUME_AFFORDANCE_WAKE_MS } from "@/views/preview/braccato-renderer";
+
+// -- Constants -----------------------------------------------------------------
+
+const ACTIVE_LYRIC_TIME_S = 14;
+const SCROLL_EVENTS = 5;
+const IDLE_FRAMES = 30;
+const SECOND_SCROLL_AT_MS = 1000;
+
+// -- Harness -------------------------------------------------------------------
+
+let disposeWiring: (() => void) | null = null;
+let probe: FrameProbe;
+
+function braccatoElement(container: Element): BraccatoLyricsElement {
+  const el = container.querySelector("braccato-lyrics");
+  if (!el) throw new Error("braccato-lyrics element not rendered");
+  return el as BraccatoLyricsElement;
+}
+
+async function waitForLyrics(el: BraccatoLyricsElement): Promise<void> {
+  await expect.poll(() => el.querySelectorAll(".blyrics--line").length).toBeGreaterThan(0);
+}
+
+function resumeButton(container: Element): HTMLButtonElement | null {
+  return [...container.querySelectorAll("button")].find((b) => b.textContent?.includes("Resume autoscroll")) ?? null;
+}
+
+function scrollAway(el: BraccatoLyricsElement): void {
+  // Braccato swallows the scrolls it performed itself one at a time, so a real one has to outlast them.
+  for (let i = 0; i < SCROLL_EVENTS; i++) el.dispatchEvent(new Event("scroll"));
+}
+
+async function renderPausedPreview() {
+  const audio = new Audio();
+  audio.currentTime = ACTIVE_LYRIC_TIME_S;
+  useAudioStore.setState({ audioElement: audio, isPlaying: false });
+
+  const screen = await render(<BraccatoRenderer ttmlString={buildSyncedTtml()} />);
+  const el = braccatoElement(screen.container);
+  await waitForLyrics(el);
+  return { screen, el };
+}
+
+// Braccato's resume deadline is 25 s of wall clock. Faking setTimeout and Date is the only way
+// to cross it in a test; animation frames stay real, so the frames the wake schedules are real.
+function useFakeClock(): void {
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+}
+
+beforeEach(() => {
+  disposeWiring = wireFrameLoop();
+  probe = createFrameProbe();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  probe.dispose();
+  disposeWiring?.();
+  disposeWiring = null;
+  for (const el of document.querySelectorAll("#composer-audio")) el.remove();
+});
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("BraccatoRenderer resume affordance while paused", () => {
+  it("clears the affordance on braccato's own deadline, with the loop asleep in between", async () => {
+    const { screen, el } = await renderPausedPreview();
+    useFakeClock();
+
+    const timersBefore = vi.getTimerCount();
+    scrollAway(el);
+    expect(vi.getTimerCount()).toBe(timersBefore + 1);
+    await settleFrames(probe.count);
+    expect(resumeButton(screen.container)).not.toBeNull();
+
+    const quietBaseline = probe.count();
+    await stepFrames(IDLE_FRAMES);
+    expect(probe.count()).toBe(quietBaseline);
+
+    vi.advanceTimersByTime(RESUME_AFFORDANCE_WAKE_MS);
+    await settleFrames(probe.count);
+    expect(probe.count()).toBeGreaterThan(quietBaseline);
+    expect(resumeButton(screen.container)).toBeNull();
+
+    vi.useRealTimers();
+    await expect.element(screen.getByRole("button", { name: "Resume autoscroll" })).not.toBeInTheDocument();
+  });
+
+  it("costs a handful of frames rather than the whole wait", async () => {
+    const { screen, el } = await renderPausedPreview();
+    useFakeClock();
+
+    scrollAway(el);
+    await settleFrames(probe.count);
+    const quietBaseline = probe.count();
+
+    vi.advanceTimersByTime(RESUME_AFFORDANCE_WAKE_MS);
+    const woken = (await settleFrames(probe.count)) - quietBaseline;
+
+    expect(woken).toBeGreaterThan(0);
+    expect(woken).toBeLessThan(IDLE_FRAMES);
+    expect(resumeButton(screen.container)).toBeNull();
+  });
+
+  describe("edge cases", () => {
+    it("re-arms on a second scroll rather than stacking the first wake", async () => {
+      const { screen, el } = await renderPausedPreview();
+      useFakeClock();
+
+      const timersBefore = vi.getTimerCount();
+      scrollAway(el);
+      vi.advanceTimersByTime(SECOND_SCROLL_AT_MS);
+      scrollAway(el);
+      expect(vi.getTimerCount()).toBe(timersBefore + 1);
+      await settleFrames(probe.count);
+      const quietBaseline = probe.count();
+
+      // Past the wake the first scroll asked for, short of the one the second scroll asked for.
+      vi.advanceTimersByTime(RESUME_AFFORDANCE_WAKE_MS - SECOND_SCROLL_AT_MS / 2);
+      await stepFrames(IDLE_FRAMES);
+      expect(probe.count()).toBe(quietBaseline);
+      expect(resumeButton(screen.container)).not.toBeNull();
+
+      vi.advanceTimersByTime(SECOND_SCROLL_AT_MS);
+      await settleFrames(probe.count);
+      expect(resumeButton(screen.container)).toBeNull();
+    });
+
+    it("arms no wake while the song is playing, the playing hold already covering it", async () => {
+      const audio = new Audio();
+      audio.currentTime = ACTIVE_LYRIC_TIME_S;
+      useAudioStore.setState({ audioElement: audio, isPlaying: true });
+
+      const screen = await render(<BraccatoRenderer ttmlString={buildSyncedTtml()} />);
+      const el = braccatoElement(screen.container);
+      await waitForLyrics(el);
+      useFakeClock();
+
+      const timersBefore = vi.getTimerCount();
+      scrollAway(el);
+      expect(vi.getTimerCount()).toBe(timersBefore);
+      await stepFrames(IDLE_FRAMES);
+      expect(resumeButton(screen.container)).not.toBeNull();
+
+      vi.advanceTimersByTime(RESUME_AFFORDANCE_WAKE_MS);
+      await stepFrames(IDLE_FRAMES);
+
+      expect(resumeButton(screen.container)).toBeNull();
+    });
+  });
+
+  describe("invariants", () => {
+    it("leaves no pending wake behind when the reader resumes by hand", async () => {
+      const { screen, el } = await renderPausedPreview();
+      useFakeClock();
+
+      scrollAway(el);
+      await settleFrames(probe.count);
+      resumeButton(screen.container)?.click();
+      await settleFrames(probe.count);
+      expect(resumeButton(screen.container)).toBeNull();
+
+      const quietBaseline = probe.count();
+      vi.advanceTimersByTime(RESUME_AFFORDANCE_WAKE_MS * 2);
+      await stepFrames(IDLE_FRAMES);
+
+      expect(probe.count()).toBe(quietBaseline);
+    });
+
+    it("leaves no pending wake behind when the preview unmounts", async () => {
+      const { screen, el } = await renderPausedPreview();
+      useFakeClock();
+
+      scrollAway(el);
+      await settleFrames(probe.count);
+      screen.unmount();
+      await settleFrames(probe.count);
+
+      const quietBaseline = probe.count();
+      vi.advanceTimersByTime(RESUME_AFFORDANCE_WAKE_MS * 2);
+      await stepFrames(IDLE_FRAMES);
+
+      expect(probe.count()).toBe(quietBaseline);
+    });
+  });
+});

--- a/src/views/preview/braccato-renderer.resume-wake.browser.test.tsx
+++ b/src/views/preview/braccato-renderer.resume-wake.browser.test.tsx
@@ -195,6 +195,8 @@ describe("BraccatoRenderer resume affordance", () => {
       scrollAway(el);
       await settleFrames(probe.count);
       resumeButton(screen.container)?.click();
+      expect(useAudioStore.getState().isPlaying).toBe(true);
+      useAudioStore.setState({ isPlaying: false });
       await settleFrames(probe.count);
       expect(resumeButton(screen.container)).toBeNull();
 

--- a/src/views/preview/braccato-renderer.resume-wake.browser.test.tsx
+++ b/src/views/preview/braccato-renderer.resume-wake.browser.test.tsx
@@ -80,7 +80,7 @@ afterEach(() => {
 
 // -- Tests ---------------------------------------------------------------------
 
-describe("BraccatoRenderer resume affordance while paused", () => {
+describe("BraccatoRenderer resume affordance", () => {
   it("clears the affordance on braccato's own deadline, with the loop asleep in between", async () => {
     const { screen, el } = await renderPausedPreview();
     useFakeClock();

--- a/src/views/preview/braccato-renderer.resume-wake.browser.test.tsx
+++ b/src/views/preview/braccato-renderer.resume-wake.browser.test.tsx
@@ -14,6 +14,7 @@ const ACTIVE_LYRIC_TIME_S = 14;
 const SCROLL_EVENTS = 5;
 const IDLE_FRAMES = 30;
 const SECOND_SCROLL_AT_MS = 1000;
+const PAUSE_AFTER_SCROLL_MS = 1000;
 
 // -- Harness -------------------------------------------------------------------
 
@@ -39,15 +40,23 @@ function scrollAway(el: BraccatoLyricsElement): void {
   for (let i = 0; i < SCROLL_EVENTS; i++) el.dispatchEvent(new Event("scroll"));
 }
 
-async function renderPausedPreview() {
+async function renderPreview(isPlaying: boolean) {
   const audio = new Audio();
   audio.currentTime = ACTIVE_LYRIC_TIME_S;
-  useAudioStore.setState({ audioElement: audio, isPlaying: false });
+  useAudioStore.setState({ audioElement: audio, isPlaying });
 
   const screen = await render(<BraccatoRenderer ttmlString={buildSyncedTtml()} />);
   const el = braccatoElement(screen.container);
   await waitForLyrics(el);
   return { screen, el };
+}
+
+async function renderPausedPreview() {
+  return renderPreview(false);
+}
+
+async function renderPlayingPreview() {
+  return renderPreview(true);
 }
 
 // Braccato's resume deadline is 25 s of wall clock. Faking setTimeout and Date is the only way
@@ -135,19 +144,13 @@ describe("BraccatoRenderer resume affordance while paused", () => {
       expect(resumeButton(screen.container)).toBeNull();
     });
 
-    it("arms no wake while the song is playing, the playing hold already covering it", async () => {
-      const audio = new Audio();
-      audio.currentTime = ACTIVE_LYRIC_TIME_S;
-      useAudioStore.setState({ audioElement: audio, isPlaying: true });
-
-      const screen = await render(<BraccatoRenderer ttmlString={buildSyncedTtml()} />);
-      const el = braccatoElement(screen.container);
-      await waitForLyrics(el);
+    it("arms the wake while the song is playing too", async () => {
+      const { screen, el } = await renderPlayingPreview();
       useFakeClock();
 
       const timersBefore = vi.getTimerCount();
       scrollAway(el);
-      expect(vi.getTimerCount()).toBe(timersBefore);
+      expect(vi.getTimerCount()).toBe(timersBefore + 1);
       await stepFrames(IDLE_FRAMES);
       expect(resumeButton(screen.container)).not.toBeNull();
 
@@ -155,6 +158,32 @@ describe("BraccatoRenderer resume affordance while paused", () => {
       await stepFrames(IDLE_FRAMES);
 
       expect(resumeButton(screen.container)).toBeNull();
+    });
+  });
+
+  describe("regressions", () => {
+    it("regression: clears the affordance when the reader scrolls while playing and then pauses", async () => {
+      const { screen, el } = await renderPlayingPreview();
+      useFakeClock();
+
+      scrollAway(el);
+      await stepFrames(IDLE_FRAMES);
+      expect(resumeButton(screen.container)).not.toBeNull();
+
+      vi.advanceTimersByTime(PAUSE_AFTER_SCROLL_MS);
+      useAudioStore.setState({ isPlaying: false });
+      await settleFrames(probe.count);
+      expect(resumeButton(screen.container)).not.toBeNull();
+
+      const quietBaseline = probe.count();
+      await stepFrames(IDLE_FRAMES);
+      expect(probe.count()).toBe(quietBaseline);
+
+      vi.advanceTimersByTime(RESUME_AFFORDANCE_WAKE_MS);
+      await settleFrames(probe.count);
+
+      expect(resumeButton(screen.container)).toBeNull();
+      expect(probe.count()).toBeGreaterThan(quietBaseline);
     });
   });
 

--- a/src/views/preview/braccato-renderer.tsx
+++ b/src/views/preview/braccato-renderer.tsx
@@ -18,6 +18,10 @@ interface BraccatoRendererProps {
 
 const LOG_PREFIX = "[BraccatoRenderer]";
 
+// Mirrors braccato's unexported USER_SCROLL_RESUME_DELAY_MS (25000); the margin lands the wake
+// on the far side of its deadline instead of racing it.
+const RESUME_AFFORDANCE_WAKE_MS = 25_500;
+
 // -- Element registration -----------------------------------------------------
 
 // Must stay dynamic: registering evaluates `class ... extends HTMLElement`, which
@@ -40,10 +44,6 @@ function handleBraccatoLineClick(e: Event): void {
   audio.setIsPlaying(true);
 }
 
-function handleBraccatoScroll(e: Event): void {
-  (e.currentTarget as BraccatoLyricsElement).renderer?.noteUserScroll();
-}
-
 // -- Component ----------------------------------------------------------------
 
 const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
@@ -52,28 +52,55 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
   const latestLyricsRef = useRef(lyrics);
   const appliedPlaybackRateRef = useRef(1);
   const [isAutoscrollPaused, setIsAutoscrollPaused] = useState(false);
+  const resumeWakeRef = useRef<number | null>(null);
 
-  const setElement = useCallback((el: BraccatoLyricsElement | null) => {
-    elementRef.current = el;
-    if (!el) return;
-    el.theme = braccatoTheme;
-    el.host = { setResumeAffordanceVisible: setIsAutoscrollPaused };
-    el.lyrics = latestLyricsRef.current;
-    el.addEventListener("braccato:line-click", handleBraccatoLineClick);
-    el.addEventListener("scroll", handleBraccatoScroll, { passive: true });
-    return () => {
-      el.removeEventListener("braccato:line-click", handleBraccatoLineClick);
-      el.removeEventListener("scroll", handleBraccatoScroll);
-      elementRef.current = null;
-    };
+  const clearResumeWake = useCallback(() => {
+    if (resumeWakeRef.current === null) return;
+    window.clearTimeout(resumeWakeRef.current);
+    resumeWakeRef.current = null;
   }, []);
 
+  const handleScroll = useCallback(
+    (e: Event) => {
+      (e.currentTarget as BraccatoLyricsElement).renderer?.noteUserScroll();
+      // A playing song already holds the loop awake, so only a paused reader needs the wake that
+      // hands braccato the tick it hides the affordance on.
+      if (useAudioStore.getState().isPlaying) return;
+      clearResumeWake();
+      resumeWakeRef.current = window.setTimeout(() => {
+        resumeWakeRef.current = null;
+        wake();
+      }, RESUME_AFFORDANCE_WAKE_MS);
+    },
+    [clearResumeWake],
+  );
+
+  const setElement = useCallback(
+    (el: BraccatoLyricsElement | null) => {
+      elementRef.current = el;
+      if (!el) return;
+      el.theme = braccatoTheme;
+      el.host = { setResumeAffordanceVisible: setIsAutoscrollPaused };
+      el.lyrics = latestLyricsRef.current;
+      el.addEventListener("braccato:line-click", handleBraccatoLineClick);
+      el.addEventListener("scroll", handleScroll, { passive: true });
+      return () => {
+        el.removeEventListener("braccato:line-click", handleBraccatoLineClick);
+        el.removeEventListener("scroll", handleScroll);
+        clearResumeWake();
+        elementRef.current = null;
+      };
+    },
+    [handleScroll, clearResumeWake],
+  );
+
   const resumeAutoscroll = useCallback(() => {
+    clearResumeWake();
     elementRef.current?.renderer?.resumeAutoscroll();
     // Braccato clears the affordance and scrolls back on its next tick, which this
     // component drives, so a paused reader would otherwise see nothing happen.
     wake();
-  }, []);
+  }, [clearResumeWake]);
 
   useEffect(() => {
     // The element upgrades once the registration import resolves, long after the mount
@@ -125,4 +152,4 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
 
 // -- Exports ------------------------------------------------------------------
 
-export { BraccatoRenderer };
+export { BraccatoRenderer, RESUME_AFFORDANCE_WAKE_MS };

--- a/src/views/preview/braccato-renderer.tsx
+++ b/src/views/preview/braccato-renderer.tsx
@@ -68,6 +68,7 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
   const resumeAutoscroll = useCallback(() => {
     clearResumeWake();
     elementRef.current?.renderer?.resumeAutoscroll();
+    useAudioStore.getState().setIsPlaying(true);
     // Braccato clears the affordance and scrolls back on its next tick, which this
     // component drives, so a paused reader would otherwise see nothing happen.
     wake();
@@ -77,9 +78,7 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
     (e: Event) => {
       const detail = (e as CustomEvent<LineClickDetail>).detail;
       if (detail?.timeS == null) return;
-      const audio = useAudioStore.getState();
-      audio.seekTo(detail.timeS);
-      audio.setIsPlaying(true);
+      useAudioStore.getState().seekTo(detail.timeS);
       resumeAutoscroll();
     },
     [resumeAutoscroll],

--- a/src/views/preview/braccato-renderer.tsx
+++ b/src/views/preview/braccato-renderer.tsx
@@ -137,7 +137,7 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
           variant="secondary"
           hasIcon
           onClick={resumeAutoscroll}
-          className="absolute bottom-6 left-1/2 -translate-x-1/2 shadow-2xl"
+          className="absolute bottom-6 left-1/2 z-10 -translate-x-1/2 shadow-2xl"
         >
           <IconArrowDown className="size-4" />
           Resume autoscroll

--- a/src/views/preview/braccato-renderer.tsx
+++ b/src/views/preview/braccato-renderer.tsx
@@ -3,6 +3,7 @@ import { TTMLParser } from "@braccato/parsers";
 import { IconArrowDown } from "@tabler/icons-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRendererAudioSync } from "@/hooks/use-renderer-audio-sync";
+import { wake } from "@/lib/frame-loop";
 import { useAudioStore } from "@/stores/audio";
 import { Button } from "@/ui/button";
 import braccatoTheme from "@/views/preview/braccato-theme.css?raw";
@@ -69,10 +70,15 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
 
   const resumeAutoscroll = useCallback(() => {
     elementRef.current?.renderer?.resumeAutoscroll();
+    // Braccato clears the affordance and scrolls back on its next tick, which this
+    // component drives, so a paused reader would otherwise see nothing happen.
+    wake();
   }, []);
 
   useEffect(() => {
-    void ensureRegistered();
+    // The element upgrades once the registration import resolves, long after the mount
+    // wake expired, so the first frame that can address its accessors has to be asked for.
+    void ensureRegistered().then(wake);
   }, []);
 
   useEffect(() => {
@@ -83,17 +89,21 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
 
   // Binding `source` would make braccato own the clock, and it only polls during
   // playback, freezing the preview whenever the timeline is scrubbed paused.
-  useRendererAudioSync(elementRef, (el, audio) => {
-    // Without the rate the word sweeps run on the wall clock and stutter at any
-    // speed but 1x. Tracked here rather than read back off the element, which has
-    // no properties to read until the registration import lands.
-    if (appliedPlaybackRateRef.current !== audio.playbackRate) {
-      appliedPlaybackRateRef.current = audio.playbackRate;
-      el.tickOptions = { playbackRate: audio.playbackRate };
-    }
-    el.currentTime = audio.currentTime;
-    el.playing = !audio.paused;
-  });
+  useRendererAudioSync(
+    elementRef,
+    (el, audio) => {
+      // Without the rate the word sweeps run on the wall clock and stutter at any
+      // speed but 1x. Tracked here rather than read back off the element, which has
+      // no properties to read until the registration import lands.
+      if (appliedPlaybackRateRef.current !== audio.playbackRate) {
+        appliedPlaybackRateRef.current = audio.playbackRate;
+        el.tickOptions = { playbackRate: audio.playbackRate };
+      }
+      el.currentTime = audio.currentTime;
+      el.playing = !audio.paused;
+    },
+    "braccato-renderer",
+  );
 
   return (
     <div className="relative flex flex-col flex-1 min-h-0">

--- a/src/views/preview/braccato-renderer.tsx
+++ b/src/views/preview/braccato-renderer.tsx
@@ -63,9 +63,6 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
   const handleScroll = useCallback(
     (e: Event) => {
       (e.currentTarget as BraccatoLyricsElement).renderer?.noteUserScroll();
-      // A playing song already holds the loop awake, so only a paused reader needs the wake that
-      // hands braccato the tick it hides the affordance on.
-      if (useAudioStore.getState().isPlaying) return;
       clearResumeWake();
       resumeWakeRef.current = window.setTimeout(() => {
         resumeWakeRef.current = null;

--- a/src/views/preview/braccato-renderer.tsx
+++ b/src/views/preview/braccato-renderer.tsx
@@ -34,16 +34,6 @@ function ensureRegistered(): Promise<unknown> {
   return registerPromise;
 }
 
-// -- Helpers ------------------------------------------------------------------
-
-function handleBraccatoLineClick(e: Event): void {
-  const detail = (e as CustomEvent<LineClickDetail>).detail;
-  if (detail?.timeS == null) return;
-  const audio = useAudioStore.getState();
-  audio.seekTo(detail.timeS);
-  audio.setIsPlaying(true);
-}
-
 // -- Component ----------------------------------------------------------------
 
 const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
@@ -72,25 +62,6 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
     [clearResumeWake],
   );
 
-  const setElement = useCallback(
-    (el: BraccatoLyricsElement | null) => {
-      elementRef.current = el;
-      if (!el) return;
-      el.theme = braccatoTheme;
-      el.host = { setResumeAffordanceVisible: setIsAutoscrollPaused };
-      el.lyrics = latestLyricsRef.current;
-      el.addEventListener("braccato:line-click", handleBraccatoLineClick);
-      el.addEventListener("scroll", handleScroll, { passive: true });
-      return () => {
-        el.removeEventListener("braccato:line-click", handleBraccatoLineClick);
-        el.removeEventListener("scroll", handleScroll);
-        clearResumeWake();
-        elementRef.current = null;
-      };
-    },
-    [handleScroll, clearResumeWake],
-  );
-
   const resumeAutoscroll = useCallback(() => {
     clearResumeWake();
     elementRef.current?.renderer?.resumeAutoscroll();
@@ -98,6 +69,37 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
     // component drives, so a paused reader would otherwise see nothing happen.
     wake();
   }, [clearResumeWake]);
+
+  const handleLineClick = useCallback(
+    (e: Event) => {
+      const detail = (e as CustomEvent<LineClickDetail>).detail;
+      if (detail?.timeS == null) return;
+      const audio = useAudioStore.getState();
+      audio.seekTo(detail.timeS);
+      audio.setIsPlaying(true);
+      resumeAutoscroll();
+    },
+    [resumeAutoscroll],
+  );
+
+  const setElement = useCallback(
+    (el: BraccatoLyricsElement | null) => {
+      elementRef.current = el;
+      if (!el) return;
+      el.theme = braccatoTheme;
+      el.host = { setResumeAffordanceVisible: setIsAutoscrollPaused };
+      el.lyrics = latestLyricsRef.current;
+      el.addEventListener("braccato:line-click", handleLineClick);
+      el.addEventListener("scroll", handleScroll, { passive: true });
+      return () => {
+        el.removeEventListener("braccato:line-click", handleLineClick);
+        el.removeEventListener("scroll", handleScroll);
+        clearResumeWake();
+        elementRef.current = null;
+      };
+    },
+    [handleScroll, handleLineClick, clearResumeWake],
+  );
 
   useEffect(() => {
     // The element upgrades once the registration import resolves, long after the mount

--- a/src/views/preview/braccato-renderer.tsx
+++ b/src/views/preview/braccato-renderer.tsx
@@ -84,24 +84,25 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
     [resumeAutoscroll],
   );
 
-  const setElement = useCallback(
-    (el: BraccatoLyricsElement | null) => {
-      elementRef.current = el;
-      if (!el) return;
-      el.theme = braccatoTheme;
-      el.host = { setResumeAffordanceVisible: setIsAutoscrollPaused };
-      el.lyrics = latestLyricsRef.current;
-      el.addEventListener("braccato:line-click", handleLineClick);
-      el.addEventListener("scroll", handleScroll, { passive: true });
-      return () => {
-        el.removeEventListener("braccato:line-click", handleLineClick);
-        el.removeEventListener("scroll", handleScroll);
-        clearResumeWake();
-        elementRef.current = null;
-      };
-    },
-    [handleScroll, handleLineClick, clearResumeWake],
-  );
+  const setElement = useCallback((el: BraccatoLyricsElement | null) => {
+    elementRef.current = el;
+    if (!el) return;
+    el.theme = braccatoTheme;
+    el.host = { setResumeAffordanceVisible: setIsAutoscrollPaused };
+    el.lyrics = latestLyricsRef.current;
+  }, []);
+
+  useEffect(() => {
+    const el = elementRef.current;
+    if (!el) return;
+    el.addEventListener("braccato:line-click", handleLineClick);
+    el.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      el.removeEventListener("braccato:line-click", handleLineClick);
+      el.removeEventListener("scroll", handleScroll);
+      clearResumeWake();
+    };
+  }, [handleLineClick, handleScroll, clearResumeWake]);
 
   useEffect(() => {
     // The element upgrades once the registration import resolves, long after the mount

--- a/src/views/preview/braccato-renderer.tsx
+++ b/src/views/preview/braccato-renderer.tsx
@@ -1,11 +1,13 @@
 import type { BraccatoLyricsElement, LineClickDetail } from "@braccato/core/element";
 import { TTMLParser } from "@braccato/parsers";
 import { IconArrowDown } from "@tabler/icons-react";
+import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRendererAudioSync } from "@/hooks/use-renderer-audio-sync";
 import { wake } from "@/lib/frame-loop";
 import { useAudioStore } from "@/stores/audio";
 import { Button } from "@/ui/button";
+import { centeredFadeVariants, centeredSlideUpVariants, springSnappy } from "@/utils/animationVariants";
 import braccatoTheme from "@/views/preview/braccato-theme.css?raw";
 
 // -- Interfaces ---------------------------------------------------------------
@@ -43,6 +45,7 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
   const appliedPlaybackRateRef = useRef(1);
   const [isAutoscrollPaused, setIsAutoscrollPaused] = useState(false);
   const resumeWakeRef = useRef<number | null>(null);
+  const reducedMotion = useReducedMotion();
 
   const clearResumeWake = useCallback(() => {
     if (resumeWakeRef.current === null) return;
@@ -134,17 +137,24 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
   return (
     <div className="relative flex flex-col flex-1 min-h-0">
       <braccato-lyrics ref={setElement} className="block flex-1 mx-auto w-full max-w-3xl px-6" />
-      {isAutoscrollPaused ? (
-        <Button
-          variant="secondary"
-          hasIcon
-          onClick={resumeAutoscroll}
-          className="absolute bottom-6 left-1/2 z-10 -translate-x-1/2 shadow-2xl backdrop-blur-md"
-        >
-          <IconArrowDown className="size-4" />
-          Resume autoscroll
-        </Button>
-      ) : null}
+      <AnimatePresence>
+        {isAutoscrollPaused ? (
+          <m.div
+            key="resume-autoscroll"
+            variants={reducedMotion ? centeredFadeVariants : centeredSlideUpVariants}
+            initial="hidden"
+            animate="visible"
+            exit="exit"
+            transition={springSnappy}
+            className="absolute bottom-6 left-1/2 z-10"
+          >
+            <Button variant="secondary" hasIcon onClick={resumeAutoscroll} className="shadow-2xl backdrop-blur-md">
+              <IconArrowDown className="size-4" />
+              Resume autoscroll
+            </Button>
+          </m.div>
+        ) : null}
+      </AnimatePresence>
     </div>
   );
 };

--- a/src/views/preview/braccato-renderer.tsx
+++ b/src/views/preview/braccato-renderer.tsx
@@ -137,7 +137,7 @@ const BraccatoRenderer: React.FC<BraccatoRendererProps> = ({ ttmlString }) => {
           variant="secondary"
           hasIcon
           onClick={resumeAutoscroll}
-          className="absolute bottom-6 left-1/2 z-10 -translate-x-1/2 shadow-2xl"
+          className="absolute bottom-6 left-1/2 z-10 -translate-x-1/2 shadow-2xl backdrop-blur-md"
         >
           <IconArrowDown className="size-4" />
           Resume autoscroll

--- a/src/views/sync/sync-panel.frame-loop.browser.test.tsx
+++ b/src/views/sync/sync-panel.frame-loop.browser.test.tsx
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { wireFrameLoop } from "@/lib/frame-loop-wiring";
+import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
+import { createAudioFile } from "@/test/audio-fixtures";
+import { createLine } from "@/test/factories";
+import { render } from "@/test/render";
+import { SyncPanel } from "@/views/sync/sync-panel";
+
+// -- Harness -------------------------------------------------------------------
+
+let disposeWiring: (() => void) | null = null;
+
+function seedEditableProject(): HTMLAudioElement {
+  const audioElement = document.createElement("audio");
+  useAudioStore.setState({ source: { type: "file", file: createAudioFile() }, duration: 10, currentTime: 0 });
+  useAudioStore.getState().registerAudioElement(audioElement);
+  useProjectStore.setState({
+    granularity: "word",
+    lines: [
+      createLine({
+        text: "Hello world",
+        words: [
+          { text: "Hello ", begin: 1, end: 3 },
+          { text: "world", begin: 3, end: 5 },
+        ],
+      }),
+    ],
+  });
+  return audioElement;
+}
+
+function wordProgress(root: HTMLElement, begin: number): string | undefined {
+  return root.querySelector<HTMLElement>(`[data-word-begin='${begin}']`)?.style.width;
+}
+
+beforeEach(() => {
+  disposeWiring = wireFrameLoop();
+});
+
+afterEach(() => {
+  disposeWiring?.();
+  disposeWiring = null;
+});
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("SyncPanel on the frame loop", () => {
+  it("widens the word progress while the audio plays in edit mode", async () => {
+    const audioElement = seedEditableProject();
+    const screen = await render(<SyncPanel />);
+    await screen.getByRole("button", { name: "Edit" }).click();
+    await expect.poll(() => wordProgress(screen.container, 1)).toBe("0%");
+
+    useAudioStore.getState().setIsPlaying(true);
+    audioElement.currentTime = 2;
+
+    await expect.poll(() => wordProgress(screen.container, 1)).toBe("50%");
+  });
+
+  it("widens the word progress after a seek while paused in edit mode", async () => {
+    seedEditableProject();
+    const screen = await render(<SyncPanel />);
+    await screen.getByRole("button", { name: "Edit" }).click();
+    await expect.poll(() => wordProgress(screen.container, 1)).toBe("0%");
+
+    useAudioStore.getState().seekTo(4);
+
+    await expect.poll(() => wordProgress(screen.container, 3)).toBe("50%");
+    expect(wordProgress(screen.container, 1)).toBe("100%");
+  });
+
+  it("resumes widening after edit mode is left and entered again", async () => {
+    seedEditableProject();
+    const screen = await render(<SyncPanel />);
+    await screen.getByRole("button", { name: "Edit" }).click();
+    useAudioStore.getState().seekTo(4);
+    await expect.poll(() => wordProgress(screen.container, 3)).toBe("50%");
+
+    await screen.getByRole("button", { name: "Done" }).click();
+    await expect.poll(() => wordProgress(screen.container, 3)).toBeUndefined();
+
+    useAudioStore.getState().seekTo(2);
+    await screen.getByRole("button", { name: "Edit" }).click();
+
+    await expect.poll(() => wordProgress(screen.container, 1)).toBe("50%");
+  });
+});

--- a/src/views/sync/sync-panel.frame-loop.browser.test.tsx
+++ b/src/views/sync/sync-panel.frame-loop.browser.test.tsx
@@ -4,12 +4,15 @@ import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { createAudioFile } from "@/test/audio-fixtures";
 import { createLine } from "@/test/factories";
+import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
+import { settleFrames } from "@/test/frame-steps";
 import { render } from "@/test/render";
 import { SyncPanel } from "@/views/sync/sync-panel";
 
 // -- Harness -------------------------------------------------------------------
 
 let disposeWiring: (() => void) | null = null;
+let probe: FrameProbe;
 
 function seedEditableProject(): HTMLAudioElement {
   const audioElement = document.createElement("audio");
@@ -36,9 +39,11 @@ function wordProgress(root: HTMLElement, begin: number): string | undefined {
 
 beforeEach(() => {
   disposeWiring = wireFrameLoop();
+  probe = createFrameProbe();
 });
 
 afterEach(() => {
+  probe.dispose();
   disposeWiring?.();
   disposeWiring = null;
 });
@@ -84,5 +89,27 @@ describe("SyncPanel on the frame loop", () => {
     await screen.getByRole("button", { name: "Edit" }).click();
 
     await expect.poll(() => wordProgress(screen.container, 1)).toBe("50%");
+  });
+
+  describe("invariants", () => {
+    it("regression #174: stops running frames once edit mode settles while paused", async () => {
+      seedEditableProject();
+      const screen = await render(<SyncPanel />);
+      await screen.getByRole("button", { name: "Edit" }).click();
+      await expect.poll(() => wordProgress(screen.container, 1)).toBe("0%");
+      await probe.quiesce();
+
+      await settleFrames(probe.count);
+      expect(probe.count()).toBe(0);
+    });
+
+    it("regression #174: stops running frames while edit mode is off", async () => {
+      seedEditableProject();
+      await render(<SyncPanel />);
+      await probe.quiesce();
+
+      await settleFrames(probe.count);
+      expect(probe.count()).toBe(0);
+    });
   });
 });

--- a/src/views/sync/sync-panel.tsx
+++ b/src/views/sync/sync-panel.tsx
@@ -1,3 +1,4 @@
+import { useFrameLoop } from "@/hooks/use-frame-loop";
 import { useSyncHandlers } from "@/hooks/useSyncHandlers";
 import { useAudioStore } from "@/stores/audio";
 import { isAnyModalOpen } from "@/stores/modal-stack";
@@ -74,7 +75,6 @@ const SyncPanel: React.FC = () => {
   const [isHolding, setIsHolding] = useState(false);
   const [rippleTarget, setRippleTarget] = useState<RippleTarget | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const rafRef = useRef<number | null>(null);
   const heldKeyCodeRef = useRef<string | null>(null);
   const holdPointerIdRef = useRef<number | null>(null);
 
@@ -149,19 +149,11 @@ const SyncPanel: React.FC = () => {
     }
   }, [lines, updateLine]);
 
-  // RAF animation loop for smooth word progress updates (reads audioElement.currentTime directly)
-  useEffect(() => {
-    if (!editMode) {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
-      return;
-    }
-
-    const update = () => {
+  // Smooth word progress updates (reads audioElement.currentTime directly)
+  useFrameLoop(
+    () => {
       const container = scrollContainerRef.current;
-      if (!container) {
-        rafRef.current = requestAnimationFrame(update);
-        return;
-      }
+      if (!container) return;
 
       const audioEl = useAudioStore.getState().audioElement;
       const time = audioEl?.currentTime ?? useAudioStore.getState().currentTime;
@@ -185,15 +177,10 @@ const SyncPanel: React.FC = () => {
 
         el.style.width = `${progress * 100}%`;
       }
-
-      rafRef.current = requestAnimationFrame(update);
-    };
-
-    rafRef.current = requestAnimationFrame(update);
-    return () => {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
-    };
-  }, [editMode]);
+    },
+    "sync-panel",
+    editMode,
+  );
 
   const totalWords = useMemo(() => getTotalWords(lines), [lines]);
   const syncedWords = useMemo(() => getSyncedWordCount(lines), [lines]);

--- a/src/views/sync/timing-display.frame-loop.browser.test.tsx
+++ b/src/views/sync/timing-display.frame-loop.browser.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { wireFrameLoop } from "@/lib/frame-loop-wiring";
+import { useAudioStore } from "@/stores/audio";
+import { render } from "@/test/render";
+import { formatTimeMs } from "@/utils/sync-helpers";
+import { TimingDisplay } from "@/views/sync/timing-display";
+
+// -- Harness -------------------------------------------------------------------
+
+let disposeWiring: (() => void) | null = null;
+
+function attachAudio(): HTMLAudioElement {
+  const audioElement = document.createElement("audio");
+  useAudioStore.getState().registerAudioElement(audioElement);
+  return audioElement;
+}
+
+beforeEach(() => {
+  disposeWiring = wireFrameLoop();
+});
+
+afterEach(() => {
+  disposeWiring?.();
+  disposeWiring = null;
+});
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("TimingDisplay on the frame loop", () => {
+  it("tracks the audio element clock while playing", async () => {
+    const audioElement = attachAudio();
+    const screen = await render(<TimingDisplay />);
+    await expect.poll(() => screen.container.textContent).toContain(formatTimeMs(0));
+
+    useAudioStore.getState().setIsPlaying(true);
+    audioElement.currentTime = 12.5;
+
+    await expect.poll(() => screen.container.textContent).toContain(formatTimeMs(12.5));
+  });
+
+  it("tracks a seek while paused", async () => {
+    attachAudio();
+    const screen = await render(<TimingDisplay />);
+    await expect.poll(() => screen.container.textContent).toContain(formatTimeMs(0));
+
+    useAudioStore.getState().seekTo(7.25);
+
+    await expect.poll(() => screen.container.textContent).toContain(formatTimeMs(7.25));
+  });
+
+  it("falls back to the stored time when no audio element is registered", async () => {
+    useAudioStore.setState({ currentTime: 3.5 });
+    const screen = await render(<TimingDisplay />);
+
+    await expect.poll(() => screen.container.textContent).toContain(formatTimeMs(3.5));
+  });
+});

--- a/src/views/sync/timing-display.frame-loop.browser.test.tsx
+++ b/src/views/sync/timing-display.frame-loop.browser.test.tsx
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { wireFrameLoop } from "@/lib/frame-loop-wiring";
 import { useAudioStore } from "@/stores/audio";
+import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
+import { settleFrames } from "@/test/frame-steps";
 import { render } from "@/test/render";
 import { formatTimeMs } from "@/utils/sync-helpers";
 import { TimingDisplay } from "@/views/sync/timing-display";
@@ -8,6 +10,7 @@ import { TimingDisplay } from "@/views/sync/timing-display";
 // -- Harness -------------------------------------------------------------------
 
 let disposeWiring: (() => void) | null = null;
+let probe: FrameProbe;
 
 function attachAudio(): HTMLAudioElement {
   const audioElement = document.createElement("audio");
@@ -17,9 +20,11 @@ function attachAudio(): HTMLAudioElement {
 
 beforeEach(() => {
   disposeWiring = wireFrameLoop();
+  probe = createFrameProbe();
 });
 
 afterEach(() => {
+  probe.dispose();
   disposeWiring?.();
   disposeWiring = null;
 });
@@ -53,5 +58,17 @@ describe("TimingDisplay on the frame loop", () => {
     const screen = await render(<TimingDisplay />);
 
     await expect.poll(() => screen.container.textContent).toContain(formatTimeMs(3.5));
+  });
+
+  describe("invariants", () => {
+    it("regression #174: stops running frames once the audio is paused and idle", async () => {
+      attachAudio();
+      const screen = await render(<TimingDisplay />);
+      await expect.poll(() => screen.container.textContent).toContain(formatTimeMs(0));
+      await probe.quiesce();
+
+      await settleFrames(probe.count);
+      expect(probe.count()).toBe(0);
+    });
   });
 });

--- a/src/views/sync/timing-display.tsx
+++ b/src/views/sync/timing-display.tsx
@@ -1,6 +1,7 @@
+import { useFrameLoop } from "@/hooks/use-frame-loop";
 import { useAudioStore } from "@/stores/audio";
 import { formatTimeMs } from "@/utils/sync-helpers";
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 // -- Interfaces ---------------------------------------------------------------
 
@@ -12,25 +13,15 @@ interface TimingDisplayProps {
 
 const TimingDisplay: React.FC<TimingDisplayProps> = ({ lastSyncedTime }) => {
   const currentTimeRef = useRef<HTMLDivElement>(null);
-  const rafRef = useRef<number | null>(null);
 
-  // RAF loop for real-time current time display
-  useEffect(() => {
-    const update = () => {
-      const el = currentTimeRef.current;
-      if (el) {
-        const audioEl = useAudioStore.getState().audioElement;
-        const time = audioEl?.currentTime ?? useAudioStore.getState().currentTime;
-        el.textContent = formatTimeMs(time);
-      }
-      rafRef.current = requestAnimationFrame(update);
-    };
-
-    rafRef.current = requestAnimationFrame(update);
-    return () => {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
-    };
-  }, []);
+  useFrameLoop(() => {
+    const el = currentTimeRef.current;
+    if (el) {
+      const audioEl = useAudioStore.getState().audioElement;
+      const time = audioEl?.currentTime ?? useAudioStore.getState().currentTime;
+      el.textContent = formatTimeMs(time);
+    }
+  }, "timing-display");
 
   return (
     <div className="flex items-center justify-center gap-8 font-mono text-sm select-text tabular-nums">

--- a/src/views/timeline/playhead-drag.frame-loop.browser.test.ts
+++ b/src/views/timeline/playhead-drag.frame-loop.browser.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
+import { settleFrames, stepFrames } from "@/test/frame-steps";
+import { createPlayheadDrag, type PlayheadDragConfig } from "@/views/timeline/playhead-drag";
+
+// -- Constants -----------------------------------------------------------------
+
+const VIEWPORT_WIDTH = 400;
+const VIEWPORT_HEIGHT = 300;
+const CONTENT_WIDTH = 6000;
+const CONTENT_HEIGHT = 100;
+const RELEASE_FRAMES = 6;
+const IDLE_FRAMES = 30;
+
+// -- Harness -------------------------------------------------------------------
+
+function buildScrollContainer(): HTMLDivElement {
+  const container = document.createElement("div");
+  container.dataset.test = "scroll-container";
+  container.style.position = "absolute";
+  container.style.top = "0";
+  container.style.left = "0";
+  container.style.width = `${VIEWPORT_WIDTH}px`;
+  container.style.height = `${VIEWPORT_HEIGHT}px`;
+  container.style.overflow = "auto";
+
+  const content = document.createElement("div");
+  content.style.width = `${CONTENT_WIDTH}px`;
+  content.style.height = `${CONTENT_HEIGHT}px`;
+  container.appendChild(content);
+
+  document.body.appendChild(container);
+  return container;
+}
+
+function makeConfig(container: HTMLDivElement): PlayheadDragConfig {
+  return {
+    getContainerRect: () => container.getBoundingClientRect(),
+    getScrollContainer: () => container,
+    getDuration: () => 60,
+    getZoom: () => 50,
+    getStoreScrollLeft: () => container.scrollLeft,
+    getCurrentTime: () => 1,
+    setIsPlaying: () => undefined,
+    setDraggingPlayhead: () => undefined,
+    setDragTime: () => undefined,
+    seekTo: () => undefined,
+    snapTime: (time) => time,
+  };
+}
+
+function rightEdgeX(container: HTMLDivElement): number {
+  return container.getBoundingClientRect().right - 5;
+}
+
+function pressAt(drag: ReturnType<typeof createPlayheadDrag>, clientX: number): void {
+  drag.onMouseDown({ button: 0, clientX, preventDefault: () => undefined } as unknown as React.MouseEvent);
+}
+
+function releaseAt(clientX: number): void {
+  document.dispatchEvent(new MouseEvent("mouseup", { clientX, bubbles: true }));
+}
+
+let container: HTMLDivElement;
+let drag: ReturnType<typeof createPlayheadDrag>;
+let probe: FrameProbe;
+
+beforeEach(() => {
+  container = buildScrollContainer();
+  drag = createPlayheadDrag(makeConfig(container));
+  probe = createFrameProbe();
+});
+
+afterEach(() => {
+  drag.dispose();
+  probe.dispose();
+  container.remove();
+});
+
+async function pressAtEdgeAndScroll(): Promise<void> {
+  pressAt(drag, rightEdgeX(container));
+  await expect.poll(() => container.scrollLeft).toBeGreaterThan(0);
+}
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("playhead drag edge scroll", () => {
+  it("scrolls the container while the pointer sits in the right edge zone", async () => {
+    await pressAtEdgeAndScroll();
+  });
+
+  it("keeps scrolling while the pointer is held still at the edge", async () => {
+    await pressAtEdgeAndScroll();
+
+    const before = container.scrollLeft;
+    await stepFrames(IDLE_FRAMES);
+    expect(container.scrollLeft).toBeGreaterThan(before);
+  });
+
+  it("stops scrolling once the drag is released", async () => {
+    await pressAtEdgeAndScroll();
+
+    releaseAt(rightEdgeX(container));
+    await stepFrames(RELEASE_FRAMES);
+    const parked = container.scrollLeft;
+
+    await stepFrames(IDLE_FRAMES);
+    expect(container.scrollLeft).toBe(parked);
+  });
+
+  describe("regressions", () => {
+    it("regression #174: the hold is released when the drag is disposed mid-drag", async () => {
+      await pressAtEdgeAndScroll();
+
+      drag.dispose();
+      await stepFrames(RELEASE_FRAMES);
+      const parked = container.scrollLeft;
+
+      const settled = await settleFrames(probe.count);
+      await stepFrames(IDLE_FRAMES);
+      expect(probe.count()).toBe(settled);
+      expect(container.scrollLeft).toBe(parked);
+    });
+
+    it("regression #174: the loop quiesces after the drag ends", async () => {
+      await pressAtEdgeAndScroll();
+
+      releaseAt(rightEdgeX(container));
+      const settled = await settleFrames(probe.count);
+      await stepFrames(IDLE_FRAMES);
+      expect(probe.count()).toBe(settled);
+    });
+
+    it("regression #174: disposing twice mid-drag quiesces the loop and a later drag still scrolls", async () => {
+      await pressAtEdgeAndScroll();
+
+      drag.dispose();
+      drag.dispose();
+      await settleFrames(probe.count);
+
+      const resumedFrom = container.scrollLeft;
+      pressAt(drag, rightEdgeX(container));
+      await expect.poll(() => container.scrollLeft).toBeGreaterThan(resumedFrom);
+
+      releaseAt(rightEdgeX(container));
+      const settled = await settleFrames(probe.count);
+      await stepFrames(IDLE_FRAMES);
+      expect(probe.count()).toBe(settled);
+    });
+
+    it("regression #174: restarting a drag before releasing it leaves no stale hold", async () => {
+      await pressAtEdgeAndScroll();
+      pressAt(drag, rightEdgeX(container));
+
+      const resumedFrom = container.scrollLeft;
+      await expect.poll(() => container.scrollLeft).toBeGreaterThan(resumedFrom);
+
+      releaseAt(rightEdgeX(container));
+      const settled = await settleFrames(probe.count);
+      await stepFrames(IDLE_FRAMES);
+      expect(probe.count()).toBe(settled);
+    });
+  });
+});

--- a/src/views/timeline/playhead-drag.ts
+++ b/src/views/timeline/playhead-drag.ts
@@ -1,5 +1,6 @@
 import { scrubPreview } from "@/audio/scrub-preview";
 import { computeScrubVelocity, DEFAULT_SCRUB_OPTS, type ScrubSample } from "@/audio/scrub-velocity";
+import { holdFrames, subscribeFrame } from "@/lib/frame-loop";
 import { computeEdgeScrollVelocity } from "@/views/timeline/edge-scroll";
 import { GUTTER_WIDTH } from "@/views/timeline/timeline-store";
 
@@ -28,6 +29,7 @@ interface PlayheadDrag {
 
 const EDGE_SCROLL_ZONE = 60;
 const EDGE_SCROLL_MAX_SPEED = 22;
+const EDGE_SCROLL_LABEL = "playhead-edge-scroll";
 
 // -- Functions -----------------------------------------------------------------
 
@@ -53,9 +55,11 @@ function createPlayheadDrag(config: PlayheadDragConfig): PlayheadDrag {
 
     let pointerX = e.clientX;
     let metaHeld = e.metaKey;
-    let edgeScrollRaf: number | null = null;
     let prevSample: ScrubSample | null = null;
+    let unsubscribeEdgeScroll: (() => void) | null = null;
     const controller = new AbortController();
+    // Edge auto-scroll must keep running while the pointer is held still at the edge.
+    const releaseEdgeScrollFrames = holdFrames(EDGE_SCROLL_LABEL);
 
     const tickScrubPreview = (time: number): void => {
       const curr: ScrubSample = { time, wallClockMs: performance.now() };
@@ -65,7 +69,6 @@ function createPlayheadDrag(config: PlayheadDragConfig): PlayheadDrag {
     };
 
     const tickEdgeScroll = (): void => {
-      edgeScrollRaf = requestAnimationFrame(tickEdgeScroll);
       const container = config.getScrollContainer();
       if (!container) return;
       const rect = container.getBoundingClientRect();
@@ -99,10 +102,9 @@ function createPlayheadDrag(config: PlayheadDragConfig): PlayheadDrag {
     };
 
     const cleanup = (): void => {
-      if (edgeScrollRaf !== null) {
-        cancelAnimationFrame(edgeScrollRaf);
-        edgeScrollRaf = null;
-      }
+      unsubscribeEdgeScroll?.();
+      unsubscribeEdgeScroll = null;
+      releaseEdgeScrollFrames();
       controller.abort();
       scrubPreview.stop();
       activeCleanup = null;
@@ -118,7 +120,7 @@ function createPlayheadDrag(config: PlayheadDragConfig): PlayheadDrag {
     activeCleanup = cleanup;
     document.addEventListener("mousemove", handleMouseMove, { signal: controller.signal });
     document.addEventListener("mouseup", handleMouseUp, { signal: controller.signal });
-    tickEdgeScroll();
+    unsubscribeEdgeScroll = subscribeFrame(tickEdgeScroll, EDGE_SCROLL_LABEL);
   };
 
   const dispose = (): void => {

--- a/src/views/timeline/snap-markers-overlay.frame-loop.browser.test.tsx
+++ b/src/views/timeline/snap-markers-overlay.frame-loop.browser.test.tsx
@@ -1,0 +1,150 @@
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { subscribeFrame } from "@/lib/frame-loop";
+import { useProjectStore } from "@/stores/project";
+import { useSettingsStore } from "@/stores/settings";
+import { snapPoints } from "@/test/factories";
+import { settleFrames } from "@/test/frame-steps";
+import { render } from "@/test/render";
+import { SnapMarkersOverlay } from "@/views/timeline/snap-markers-overlay";
+import { GUTTER_WIDTH, useTimelineStore } from "@/views/timeline/timeline-store";
+import { useTimelineFrameWake } from "@/views/timeline/use-timeline-frame-wake";
+
+// -- Interfaces ----------------------------------------------------------------
+
+interface HarnessProps {
+  wakeSources?: boolean;
+}
+
+// -- Constants -----------------------------------------------------------------
+
+const VIEWPORT_WIDTH = 600;
+const VIEWPORT_HEIGHT = 200;
+const CONTENT_WIDTH = 3000;
+const CONTENT_HEIGHT = 400;
+
+// -- Harness -------------------------------------------------------------------
+
+const Harness: React.FC<HarnessProps> = ({ wakeSources = true }) => {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  useTimelineFrameWake(scrollContainerRef, hostRef, wakeSources);
+  return (
+    <div ref={hostRef} style={{ position: "relative", width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT }}>
+      <div
+        ref={scrollContainerRef}
+        data-test="scroll-container"
+        style={{ position: "absolute", inset: 0, overflow: "auto" }}
+      >
+        <div style={{ width: CONTENT_WIDTH, height: CONTENT_HEIGHT }} />
+      </div>
+      <SnapMarkersOverlay scrollContainerRef={scrollContainerRef} />
+    </div>
+  );
+};
+
+let unsubscribeProbe: (() => void) | null = null;
+let frames = 0;
+
+function seedNothingToShow(): void {
+  useSettingsStore.setState({ vocalOnsetSnap: false });
+  useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [], markerMode: false });
+  useProjectStore.setState({ customSnapPoints: [] });
+}
+
+function layerOf(root: HTMLElement): HTMLElement | null {
+  return root.querySelector<HTMLElement>("[data-snap-markers-layer]");
+}
+
+function scrollContainerOf(root: HTMLElement): HTMLDivElement {
+  const container = root.querySelector<HTMLDivElement>("[data-test='scroll-container']");
+  if (!container) throw new Error("scroll container missing");
+  return container;
+}
+
+function transformAt(scrollLeft: number): string {
+  return `translate3d(${GUTTER_WIDTH - scrollLeft}px, 0px, 0px)`;
+}
+
+async function quiesce(): Promise<void> {
+  await settleFrames(() => frames);
+  frames = 0;
+}
+
+beforeEach(() => {
+  frames = 0;
+  unsubscribeProbe = subscribeFrame(() => {
+    frames += 1;
+  });
+});
+
+afterEach(() => {
+  unsubscribeProbe?.();
+  unsubscribeProbe = null;
+});
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("SnapMarkersOverlay on the frame loop", () => {
+  it("keeps the layer transform in sync with horizontal scroll", async () => {
+    useSettingsStore.setState({ vocalOnsetSnap: true });
+    useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [1, 2], markerMode: false });
+
+    const screen = await render(<Harness />);
+    const container = scrollContainerOf(screen.container);
+    await expect.poll(() => layerOf(screen.container)?.style.transform).toBe(transformAt(0));
+
+    container.scrollLeft = 240;
+    await expect.poll(() => layerOf(screen.container)?.style.transform).toBe(transformAt(240));
+  });
+
+  it("applies the transform once marker mode turns the overlay on", async () => {
+    seedNothingToShow();
+
+    const screen = await render(<Harness />);
+    expect(layerOf(screen.container)).toBeNull();
+
+    const container = scrollContainerOf(screen.container);
+    container.scrollLeft = 120;
+    useTimelineStore.setState({ markerMode: true });
+
+    await expect.poll(() => layerOf(screen.container)?.style.transform).toBe(transformAt(120));
+  });
+
+  it("stops updating the layer once the overlay is turned off", async () => {
+    useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [], markerMode: true });
+    useProjectStore.setState({ customSnapPoints: [] });
+    useSettingsStore.setState({ vocalOnsetSnap: false });
+
+    const screen = await render(<Harness />);
+    await expect.poll(() => layerOf(screen.container)?.style.transform).toBe(transformAt(0));
+
+    useTimelineStore.setState({ markerMode: false });
+    await expect.poll(() => layerOf(screen.container)).toBeNull();
+  });
+
+  describe("invariants", () => {
+    it("regression #174: never subscribes while there is nothing to show", async () => {
+      seedNothingToShow();
+      await quiesce();
+
+      await render(<Harness wakeSources={false} />);
+
+      await settleFrames(() => frames);
+      expect(frames).toBe(0);
+    });
+
+    it("regression #174: stops running frames once the overlay settles", async () => {
+      useSettingsStore.setState({ vocalOnsetSnap: true });
+      useTimelineStore.setState({ zoom: 100, scrollLeft: 0, vocalOnsetSnapPoints: [1, 2], markerMode: true });
+      useProjectStore.setState({ customSnapPoints: snapPoints([1]) });
+
+      const screen = await render(<Harness />);
+      await expect.poll(() => layerOf(screen.container)?.style.transform).toBe(transformAt(0));
+      await quiesce();
+
+      await settleFrames(() => frames);
+      expect(frames).toBe(0);
+    });
+  });
+});

--- a/src/views/timeline/snap-markers-overlay.frame-loop.browser.test.tsx
+++ b/src/views/timeline/snap-markers-overlay.frame-loop.browser.test.tsx
@@ -1,9 +1,9 @@
 import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { subscribeFrame } from "@/lib/frame-loop";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import { snapPoints } from "@/test/factories";
+import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
 import { settleFrames } from "@/test/frame-steps";
 import { render } from "@/test/render";
 import { SnapMarkersOverlay } from "@/views/timeline/snap-markers-overlay";
@@ -43,8 +43,7 @@ const Harness: React.FC<HarnessProps> = ({ wakeSources = true }) => {
   );
 };
 
-let unsubscribeProbe: (() => void) | null = null;
-let frames = 0;
+let probe: FrameProbe;
 
 function seedNothingToShow(): void {
   useSettingsStore.setState({ vocalOnsetSnap: false });
@@ -66,21 +65,12 @@ function transformAt(scrollLeft: number): string {
   return `translate3d(${GUTTER_WIDTH - scrollLeft}px, 0px, 0px)`;
 }
 
-async function quiesce(): Promise<void> {
-  await settleFrames(() => frames);
-  frames = 0;
-}
-
 beforeEach(() => {
-  frames = 0;
-  unsubscribeProbe = subscribeFrame(() => {
-    frames += 1;
-  });
+  probe = createFrameProbe();
 });
 
 afterEach(() => {
-  unsubscribeProbe?.();
-  unsubscribeProbe = null;
+  probe.dispose();
 });
 
 // -- Tests ---------------------------------------------------------------------
@@ -126,12 +116,12 @@ describe("SnapMarkersOverlay on the frame loop", () => {
   describe("invariants", () => {
     it("regression #174: never subscribes while there is nothing to show", async () => {
       seedNothingToShow();
-      await quiesce();
+      await probe.quiesce();
 
       await render(<Harness wakeSources={false} />);
 
-      await settleFrames(() => frames);
-      expect(frames).toBe(0);
+      await settleFrames(probe.count);
+      expect(probe.count()).toBe(0);
     });
 
     it("regression #174: stops running frames once the overlay settles", async () => {
@@ -141,10 +131,10 @@ describe("SnapMarkersOverlay on the frame loop", () => {
 
       const screen = await render(<Harness />);
       await expect.poll(() => layerOf(screen.container)?.style.transform).toBe(transformAt(0));
-      await quiesce();
+      await probe.quiesce();
 
-      await settleFrames(() => frames);
-      expect(frames).toBe(0);
+      await settleFrames(probe.count);
+      expect(probe.count()).toBe(0);
     });
   });
 });

--- a/src/views/timeline/snap-markers-overlay.tsx
+++ b/src/views/timeline/snap-markers-overlay.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence } from "motion/react";
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo, useRef } from "react";
 import { snapPointTimes } from "@/domain/snap-point/model";
+import { useFrameLoop } from "@/hooks/use-frame-loop";
 import { useProjectStore } from "@/stores/project";
 import { useSettingsStore } from "@/stores/settings";
 import { SnapMarkerPin } from "@/views/timeline/snap-marker-pin";
@@ -51,26 +52,19 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
   }, [showOnsets, vocalOnsetSnapPoints, customSnapPoints, draggingTime, zoom, thresholdPx]);
 
   const layerRef = useRef<HTMLDivElement>(null);
-  const rafRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    const applyTransform = () => {
-      const layer = layerRef.current;
-      if (layer) {
-        const scrollLeft = scrollContainerRef.current?.scrollLeft ?? useTimelineStore.getState().scrollLeft;
-        layer.style.transform = `translate3d(${GUTTER_WIDTH - scrollLeft}px, 0, 0)`;
-      }
-      rafRef.current = requestAnimationFrame(applyTransform);
-    };
-
-    applyTransform();
-    return () => {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
-    };
-  }, [scrollContainerRef]);
 
   const visibleOnsetCount = showOnsets ? vocalOnsetSnapPoints.length : 0;
-  if (visibleOnsetCount === 0 && customSnapPoints.length === 0 && !markerMode) return null;
+  const isVisible = visibleOnsetCount > 0 || customSnapPoints.length > 0 || markerMode;
+
+  useFrameLoop(() => {
+    const layer = layerRef.current;
+    if (layer) {
+      const scrollLeft = scrollContainerRef.current?.scrollLeft ?? useTimelineStore.getState().scrollLeft;
+      layer.style.transform = `translate3d(${GUTTER_WIDTH - scrollLeft}px, 0, 0)`;
+    }
+  }, isVisible);
+
+  if (!isVisible) return null;
 
   return (
     <div

--- a/src/views/timeline/snap-markers-overlay.tsx
+++ b/src/views/timeline/snap-markers-overlay.tsx
@@ -56,13 +56,17 @@ const SnapMarkersOverlay: React.FC<SnapMarkersOverlayProps> = ({ scrollContainer
   const visibleOnsetCount = showOnsets ? vocalOnsetSnapPoints.length : 0;
   const isVisible = visibleOnsetCount > 0 || customSnapPoints.length > 0 || markerMode;
 
-  useFrameLoop(() => {
-    const layer = layerRef.current;
-    if (layer) {
-      const scrollLeft = scrollContainerRef.current?.scrollLeft ?? useTimelineStore.getState().scrollLeft;
-      layer.style.transform = `translate3d(${GUTTER_WIDTH - scrollLeft}px, 0, 0)`;
-    }
-  }, isVisible);
+  useFrameLoop(
+    () => {
+      const layer = layerRef.current;
+      if (layer) {
+        const scrollLeft = scrollContainerRef.current?.scrollLeft ?? useTimelineStore.getState().scrollLeft;
+        layer.style.transform = `translate3d(${GUTTER_WIDTH - scrollLeft}px, 0, 0)`;
+      }
+    },
+    "snap-markers-overlay",
+    isVisible,
+  );
 
   if (!isVisible) return null;
 

--- a/src/views/timeline/timeline-idle-cost.browser.test.tsx
+++ b/src/views/timeline/timeline-idle-cost.browser.test.tsx
@@ -1,0 +1,181 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { wireFrameLoop } from "@/lib/frame-loop-wiring";
+import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
+import { bufferToBlobUrl, createAudioFile, makeSineBuffer } from "@/test/audio-fixtures";
+import { installStyleSheet, POSITION_UTILITIES_CSS, WAVEFORM_SWEEP_CSS } from "@/test/browser-css";
+import { createLine, createWord } from "@/test/factories";
+import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
+import { settleFrames, stepFrames } from "@/test/frame-steps";
+import { render } from "@/test/render";
+import { TimelinePanel } from "@/views/timeline/timeline-panel";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+
+// The user-visible property behind issue #174: an idle, paused timeline costs nothing. Every other
+// guard in this PR names one known cause. This one watches the cost itself, so it also catches the
+// causes nobody has thought of yet, whatever mechanism they arrive by.
+
+// -- Constants -----------------------------------------------------------------
+
+const AUDIO_DURATION_S = 2;
+const PROJECT_DURATION_S = 60;
+const LINE_COUNT = 12;
+const IDLE_FRAMES = 30;
+const PLAYBACK_FRAMES = 12;
+const SCROLL_VIEWPORT_HEIGHT = 300;
+const SETTLE_TIMEOUT_MS = 5000;
+
+// -- Harness -------------------------------------------------------------------
+
+let disposeWiring: (() => void) | null = null;
+let probe: FrameProbe;
+let styles: HTMLStyleElement[] = [];
+
+function seedTimeline(): void {
+  const audio = new Audio();
+  audio.src = bufferToBlobUrl(makeSineBuffer(AUDIO_DURATION_S));
+  useAudioStore.setState({
+    source: { type: "file", file: createAudioFile() },
+    duration: PROJECT_DURATION_S,
+    currentTime: 0,
+    isPlaying: false,
+    audioElement: audio,
+  });
+  useTimelineStore.setState({ zoom: 100 });
+  useProjectStore.setState({
+    activeTab: "timeline",
+    lines: Array.from({ length: LINE_COUNT }, (_, i) =>
+      createLine({
+        id: `line-${i}`,
+        text: `lyric line ${i}`,
+        words: [
+          createWord({ text: "lyric ", begin: i * 2, end: i * 2 + 0.5 }),
+          createWord({ text: "line ", begin: i * 2 + 0.5, end: i * 2 + 1 }),
+          createWord({ text: `${i}`, begin: i * 2 + 1, end: i * 2 + 1.5 }),
+        ],
+        backgroundText: i % 4 === 0 ? "ooh" : undefined,
+        backgroundWords: i % 4 === 0 ? [createWord({ text: "ooh", begin: i * 2 + 0.2, end: i * 2 + 1.2 })] : undefined,
+      }),
+    ),
+  });
+}
+
+function scrollContainer(): HTMLElement {
+  const container = document.querySelector<HTMLElement>("[data-scroll-container]");
+  if (!container) throw new Error("scroll container missing");
+  return container;
+}
+
+function loadingDots(): HTMLElement {
+  const dots = document.querySelector<HTMLElement>("[data-waveform-loading-dots]");
+  if (!dots) throw new Error("waveform loading layer missing");
+  return dots;
+}
+
+async function renderIdleTimeline(): Promise<void> {
+  seedTimeline();
+  await render(<TimelinePanel />);
+  const container = scrollContainer();
+  container.style.height = `${SCROLL_VIEWPORT_HEIGHT}px`;
+  container.style.overflow = "auto";
+
+  await expect.poll(() => scrollContainer().querySelectorAll("[data-word-block]").length).toBeGreaterThan(0);
+  await expect.poll(() => loadingDots().hasAttribute("data-sweeping"), { timeout: SETTLE_TIMEOUT_MS }).toBe(false);
+
+  await probe.quiesce();
+  await settleFrames(probe.count);
+  expect(probe.count()).toBe(0);
+}
+
+// The shared loop routes its stepping through window.requestAnimationFrame too, so the frames the
+// measurement itself needs have to come off a reference captured before the global is watched.
+function stepCapturedFrames(raf: typeof window.requestAnimationFrame, count: number): Promise<void> {
+  let chain = Promise.resolve();
+  for (let stepped = 0; stepped < count; stepped++) {
+    chain = chain.then(() => new Promise<void>((resolve) => raf.call(window, () => resolve())));
+  }
+  return chain;
+}
+
+function describeTarget(effect: AnimationEffect | null): string {
+  if (!(effect instanceof KeyframeEffect) || !effect.target) return "(no target)";
+  const classes = effect.target.getAttribute("class");
+  return `<${effect.target.tagName.toLowerCase()}${classes ? ` class="${classes}"` : ""}>${effect.pseudoElement ?? ""}`;
+}
+
+function describeAnimation(animation: Animation): string {
+  const name = animation instanceof CSSAnimation ? animation.animationName : animation.id || "(unnamed)";
+  return `${name} on ${describeTarget(animation.effect)}`;
+}
+
+function runningInfiniteAnimations(): string[] {
+  return document
+    .getAnimations()
+    .filter(
+      (animation) =>
+        animation.playState === "running" && animation.effect?.getTiming().iterations === Number.POSITIVE_INFINITY,
+    )
+    .map(describeAnimation);
+}
+
+beforeAll(() => {
+  styles = [installStyleSheet(POSITION_UTILITIES_CSS), installStyleSheet(WAVEFORM_SWEEP_CSS)];
+  for (const style of styles) expect(style.sheet?.cssRules.length).toBeGreaterThan(0);
+});
+
+afterAll(() => {
+  for (const style of styles) style.remove();
+  styles = [];
+});
+
+beforeEach(() => {
+  disposeWiring = wireFrameLoop();
+  probe = createFrameProbe();
+});
+
+afterEach(() => {
+  probe.dispose();
+  disposeWiring?.();
+  disposeWiring = null;
+});
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("timeline idle cost", () => {
+  it("regression #174: schedules no animation frames while idle and paused", async () => {
+    await renderIdleTimeline();
+
+    const nativeRequestAnimationFrame = window.requestAnimationFrame;
+    const schedulers: string[] = [];
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      schedulers.push(new Error("frame scheduled while idle").stack ?? "unknown scheduler");
+      return nativeRequestAnimationFrame.call(window, callback);
+    };
+
+    try {
+      await stepCapturedFrames(nativeRequestAnimationFrame, IDLE_FRAMES);
+    } finally {
+      window.requestAnimationFrame = nativeRequestAnimationFrame;
+    }
+
+    expect(schedulers.join("\n\n")).toBe("");
+  });
+
+  it("regression #174: runs no infinite animations while idle and paused", async () => {
+    // A reduced-motion environment forces animation-iteration-count: 1 globally (src/index.css),
+    // which would make the assertion below vacuous.
+    expect(window.matchMedia("(prefers-reduced-motion: reduce)").matches).toBe(false);
+    await renderIdleTimeline();
+
+    expect(runningInfiniteAnimations().join("\n")).toBe("");
+  });
+
+  it("still runs frames during playback", async () => {
+    await renderIdleTimeline();
+
+    useAudioStore.getState().setIsPlaying(true);
+    await stepFrames(PLAYBACK_FRAMES);
+
+    expect(probe.count()).toBeGreaterThan(PLAYBACK_FRAMES - 2);
+  });
+});

--- a/src/views/timeline/timeline-panel.frame-wake.browser.test.tsx
+++ b/src/views/timeline/timeline-panel.frame-wake.browser.test.tsx
@@ -1,17 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { subscribeFrame } from "@/lib/frame-loop";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { createAudioFile } from "@/test/audio-fixtures";
 import { createLine, createWord } from "@/test/factories";
+import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
 import { settleFrames } from "@/test/frame-steps";
 import { render } from "@/test/render";
 import { TimelinePanel } from "@/views/timeline/timeline-panel";
 
 // -- Harness -------------------------------------------------------------------
 
-let unsubscribeProbe: (() => void) | null = null;
-let frames = 0;
+let probe: FrameProbe;
 
 function seedTimeline(): void {
   useAudioStore.setState({ source: { type: "file", file: createAudioFile() }, duration: 60 });
@@ -39,28 +38,12 @@ function scrollHost(): HTMLDivElement {
   return host;
 }
 
-async function quiesce(): Promise<void> {
-  await settleFrames(() => frames);
-  frames = 0;
-}
-
-async function wokeAfter(trigger: () => void): Promise<boolean> {
-  await quiesce();
-  trigger();
-  await settleFrames(() => frames);
-  return frames > 0;
-}
-
 beforeEach(() => {
-  frames = 0;
-  unsubscribeProbe = subscribeFrame(() => {
-    frames += 1;
-  });
+  probe = createFrameProbe();
 });
 
 afterEach(() => {
-  unsubscribeProbe?.();
-  unsubscribeProbe = null;
+  probe.dispose();
 });
 
 // -- Tests ---------------------------------------------------------------------
@@ -73,7 +56,7 @@ describe("TimelinePanel frame wake sources", () => {
     container.style.height = "200px";
 
     expect(
-      await wokeAfter(() => {
+      await probe.wokeAfter(() => {
         container.scrollTop = 240;
       }),
     ).toBe(true);
@@ -85,7 +68,7 @@ describe("TimelinePanel frame wake sources", () => {
     const host = scrollHost();
 
     expect(
-      await wokeAfter(() => {
+      await probe.wokeAfter(() => {
         host.style.flex = "none";
         host.style.height = "180px";
       }),
@@ -96,10 +79,10 @@ describe("TimelinePanel frame wake sources", () => {
     it("regression #174: an idle paused timeline stops running frames", async () => {
       seedTimeline();
       await render(<TimelinePanel />);
-      await quiesce();
+      await probe.quiesce();
 
-      await settleFrames(() => frames);
-      expect(frames).toBe(0);
+      await settleFrames(probe.count);
+      expect(probe.count()).toBe(0);
     });
   });
 });

--- a/src/views/timeline/timeline-panel.frame-wake.browser.test.tsx
+++ b/src/views/timeline/timeline-panel.frame-wake.browser.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { subscribeFrame } from "@/lib/frame-loop";
+import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
+import { createAudioFile } from "@/test/audio-fixtures";
+import { createLine, createWord } from "@/test/factories";
+import { settleFrames } from "@/test/frame-steps";
+import { render } from "@/test/render";
+import { TimelinePanel } from "@/views/timeline/timeline-panel";
+
+// -- Harness -------------------------------------------------------------------
+
+let unsubscribeProbe: (() => void) | null = null;
+let frames = 0;
+
+function seedTimeline(): void {
+  useAudioStore.setState({ source: { type: "file", file: createAudioFile() }, duration: 60 });
+  useProjectStore.setState({
+    activeTab: "timeline",
+    lines: Array.from({ length: 12 }, (_, i) =>
+      createLine({
+        id: `line-${i}`,
+        text: `lyric ${i}`,
+        words: [createWord({ text: `lyric${i}`, begin: i, end: i + 0.5 })],
+      }),
+    ),
+  });
+}
+
+function scrollContainer(): HTMLDivElement {
+  const container = document.querySelector<HTMLDivElement>("[data-scroll-container]");
+  if (!container) throw new Error("scroll container missing");
+  return container;
+}
+
+function scrollHost(): HTMLDivElement {
+  const host = document.querySelector<HTMLDivElement>("[data-timeline-scroll-host]");
+  if (!host) throw new Error("scroll host missing");
+  return host;
+}
+
+async function quiesce(): Promise<void> {
+  await settleFrames(() => frames);
+  frames = 0;
+}
+
+async function wokeAfter(trigger: () => void): Promise<boolean> {
+  await quiesce();
+  trigger();
+  await settleFrames(() => frames);
+  return frames > 0;
+}
+
+beforeEach(() => {
+  frames = 0;
+  unsubscribeProbe = subscribeFrame(() => {
+    frames += 1;
+  });
+});
+
+afterEach(() => {
+  unsubscribeProbe?.();
+  unsubscribeProbe = null;
+});
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("TimelinePanel frame wake sources", () => {
+  it("wakes the loop when the timeline scrolls vertically", async () => {
+    seedTimeline();
+    await render(<TimelinePanel />);
+    const container = scrollContainer();
+    container.style.height = "200px";
+
+    expect(
+      await wokeAfter(() => {
+        container.scrollTop = 240;
+      }),
+    ).toBe(true);
+  });
+
+  it("wakes the loop when the scroll host resizes", async () => {
+    seedTimeline();
+    await render(<TimelinePanel />);
+    const host = scrollHost();
+
+    expect(
+      await wokeAfter(() => {
+        host.style.flex = "none";
+        host.style.height = "180px";
+      }),
+    ).toBe(true);
+  });
+
+  describe("invariants", () => {
+    it("regression #174: an idle paused timeline stops running frames", async () => {
+      seedTimeline();
+      await render(<TimelinePanel />);
+      await quiesce();
+
+      await settleFrames(() => frames);
+      expect(frames).toBe(0);
+    });
+  });
+});

--- a/src/views/timeline/timeline-panel.mask-root.browser.test.tsx
+++ b/src/views/timeline/timeline-panel.mask-root.browser.test.tsx
@@ -1,0 +1,164 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { useAudioStore } from "@/stores/audio";
+import { installStyleSheet, POSITION_UTILITIES_CSS } from "@/test/browser-css";
+import { allowConsole } from "@/test/console-guard";
+import { useProjectStore } from "@/stores/project";
+import { createAudioFile } from "@/test/audio-fixtures";
+import { createLine, createWord } from "@/test/factories";
+import { render } from "@/test/render";
+import { TimelinePanel } from "@/views/timeline/timeline-panel";
+import { playheadMaskRoot } from "@/views/timeline/timeline-playhead-mask";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+
+// -- Constants -----------------------------------------------------------------
+
+const DRAG_ACTIVATION_PX = 8;
+const DRAG_DISTANCE_PX = 40;
+const SCROLL_VIEWPORT_HEIGHT = 300;
+
+// -- Harness -------------------------------------------------------------------
+
+let positionUtilities: HTMLStyleElement;
+
+function seedTimeline(): void {
+  useAudioStore.setState({ source: { type: "file", file: createAudioFile() }, duration: 60 });
+  useTimelineStore.setState({ zoom: 100 });
+  useProjectStore.setState({
+    activeTab: "timeline",
+    lines: Array.from({ length: 4 }, (_, i) =>
+      createLine({
+        id: `line-${i}`,
+        text: `lyric ${i}`,
+        words: [createWord({ text: `lyric${i}`, begin: i * 2, end: i * 2 + 1.5 })],
+      }),
+    ),
+  });
+}
+
+function maskRootElement(): HTMLElement {
+  const root = document.querySelector<HTMLElement>("[data-timeline-mask-root]");
+  if (!root) throw new Error("mask root missing");
+  return root;
+}
+
+function scrollContainer(): HTMLElement {
+  const container = document.querySelector<HTMLElement>("[data-scroll-container]");
+  if (!container) throw new Error("scroll container missing");
+  return container;
+}
+
+function makeScrollable(): void {
+  const container = scrollContainer();
+  container.style.height = `${SCROLL_VIEWPORT_HEIGHT}px`;
+  container.style.overflow = "auto";
+}
+
+async function firstWordBlock(): Promise<HTMLElement> {
+  await expect.poll(() => scrollContainer().querySelectorAll("[data-word-block]").length).toBeGreaterThan(0);
+  const block = scrollContainer().querySelector<HTMLElement>("[data-word-block]");
+  if (!block) throw new Error("no word block rendered");
+  return block;
+}
+
+function dragGhostBlocks(): HTMLElement[] {
+  const inScrollContainer = new Set(scrollContainer().querySelectorAll("[data-word-block]"));
+  return [...document.querySelectorAll<HTMLElement>("[data-word-block]")].filter(
+    (block) => !inScrollContainer.has(block),
+  );
+}
+
+function pressAndDrag(block: HTMLElement): void {
+  const rect = block.getBoundingClientRect();
+  const startX = rect.left + rect.width / 2;
+  const startY = rect.top + rect.height / 2;
+  block.dispatchEvent(
+    new PointerEvent("pointerdown", {
+      bubbles: true,
+      button: 0,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: "mouse",
+      clientX: startX,
+      clientY: startY,
+    }),
+  );
+  document.dispatchEvent(
+    new PointerEvent("pointermove", {
+      bubbles: true,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: "mouse",
+      clientX: startX + DRAG_ACTIVATION_PX + DRAG_DISTANCE_PX,
+      clientY: startY,
+    }),
+  );
+}
+
+function releasePointer(): void {
+  document.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+}
+
+beforeAll(() => {
+  positionUtilities = installStyleSheet(POSITION_UTILITIES_CSS);
+});
+
+afterAll(() => positionUtilities.remove());
+
+afterEach(() => releasePointer());
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("TimelinePanel mask root", () => {
+  it("marks a root that contains the timeline scroll container", async () => {
+    seedTimeline();
+    await render(<TimelinePanel />);
+
+    expect(maskRootElement().contains(scrollContainer())).toBe(true);
+    expect(playheadMaskRoot(scrollContainer())).toBe(maskRootElement());
+  });
+
+  it("marks a root that also contains the drag overlay's ghost", async () => {
+    // Pre-existing: dnd-kit applies modifiers during render, and useTimelineSnap writes the
+    // snapped leader to the timeline store from inside one. Unrelated to the mask root.
+    allowConsole(/while rendering a different component/);
+    seedTimeline();
+    await render(<TimelinePanel />);
+    makeScrollable();
+    pressAndDrag(await firstWordBlock());
+
+    await expect.poll(() => dragGhostBlocks().length).toBeGreaterThan(0);
+    const root = playheadMaskRoot(scrollContainer());
+    for (const ghost of dragGhostBlocks()) {
+      expect(root.contains(ghost)).toBe(true);
+      expect(scrollContainer().contains(ghost)).toBe(false);
+    }
+  });
+
+  it("resolves without the product tour anchor, which names an unrelated concept", async () => {
+    seedTimeline();
+    await render(<TimelinePanel />);
+    for (const anchor of document.querySelectorAll("[data-tour='timeline-panel']")) {
+      anchor.removeAttribute("data-tour");
+    }
+
+    expect(playheadMaskRoot(scrollContainer())).toBe(maskRootElement());
+  });
+
+  describe("invariants", () => {
+    // Tailwind utility CSS is not loaded here, so the class is the only witness to display: contents.
+    it("generates no layout box of its own", async () => {
+      seedTimeline();
+      await render(<TimelinePanel />);
+
+      expect(maskRootElement().classList.contains("contents")).toBe(true);
+    });
+
+    it("falls back to the document for a scroll container outside any marked root", async () => {
+      const orphan = document.createElement("div");
+      document.body.appendChild(orphan);
+
+      expect(playheadMaskRoot(orphan)).toBe(document);
+      orphan.remove();
+    });
+  });
+});

--- a/src/views/timeline/timeline-panel.tsx
+++ b/src/views/timeline/timeline-panel.tsx
@@ -34,6 +34,7 @@ import {
   type SyllablePosition,
 } from "@/domain/word/syllable-groups";
 import { useTimelineDnd } from "@/views/timeline/use-timeline-dnd";
+import { useTimelineFrameWake } from "@/views/timeline/use-timeline-frame-wake";
 import { useTimelineKeyboard } from "@/views/timeline/use-timeline-keyboard";
 import { useTimelinePan } from "@/views/timeline/use-timeline-pan";
 import { useTimelineWheel } from "@/views/timeline/use-timeline-wheel";
@@ -176,6 +177,7 @@ const TimelinePanel: React.FC = () => {
   const openLyricsModal = useCallback(() => openImportModal(), [openImportModal]);
   useTimelineKeyboard(scrollContainerRef, effectiveLines, duration, openLyricsModal);
   useTimelineWheel(scrollContainerRef, !!source && lines.length > 0);
+  useTimelineFrameWake(scrollContainerRef, contentRef, !!source && lines.length > 0);
 
   const lastDistributedDurationRef = useRef<number | null>(null);
 

--- a/src/views/timeline/timeline-panel.tsx
+++ b/src/views/timeline/timeline-panel.tsx
@@ -433,89 +433,92 @@ const TimelinePanel: React.FC = () => {
         handleDragCancel();
       }}
     >
-      <div data-tour="timeline-panel" className="flex flex-col flex-1 overflow-hidden select-none">
-        <TimelineHeader onImportLyrics={openLyricsModal} scrollContainerRef={scrollContainerRef} />
-        <GroupingSuggestionsBanner />
-        <ExplicitSuggestionsBanner />
+      {/* display: contents so the mask root adds a query anchor without a layout box. */}
+      <div data-timeline-mask-root className="contents">
+        <div data-tour="timeline-panel" className="flex flex-col flex-1 overflow-hidden select-none">
+          <TimelineHeader onImportLyrics={openLyricsModal} scrollContainerRef={scrollContainerRef} />
+          <GroupingSuggestionsBanner />
+          <ExplicitSuggestionsBanner />
 
-        <div className="flex flex-1 overflow-hidden">
-          <div className="flex flex-col flex-1 overflow-hidden">
-            <div
-              ref={contentRef}
-              data-timeline-scroll-host
-              className="relative flex-1 flex flex-col overflow-hidden isolate"
-            >
+          <div className="flex flex-1 overflow-hidden">
+            <div className="flex flex-col flex-1 overflow-hidden">
               <div
-                ref={scrollContainerRef}
-                role="application"
-                aria-label="Timeline"
-                data-scroll-container
-                className="flex-1 overflow-auto overscroll-none static! z-[unset] overflow-anchor-none"
-                onScroll={handleScroll}
-                onMouseDown={handleMouseDown}
-                onAuxClick={(e) => e.preventDefault()}
-                onKeyDown={(e) => {
-                  if (e.key === " " || e.key === "Enter") {
-                    e.preventDefault();
-                  }
-                }}
+                ref={contentRef}
+                data-timeline-scroll-host
+                className="relative flex-1 flex flex-col overflow-hidden isolate"
               >
-                <div className="absolute grid place-items-center text-xs text-composer-text-muted top-0 left-0 z-100 w-12 h-20 border-b border-r-2 border-composer-border bg-composer-bg shadow-lg">
-                  <svg xmlns="http://www.w3.org/2000/svg" className="size-4" viewBox="0 0 24 24">
-                    <title>Music Icon</title>
-                    <path
-                      fill="currentColor"
-                      d="M10 21q-1.65 0-2.825-1.175T6 17t1.175-2.825T10 13q.575 0 1.063.138t.937.412V4q0-.425.288-.712T13 3h4q.425 0 .713.288T18 4v2q0 .425-.288.713T17 7h-3v10q0 1.65-1.175 2.825T10 21"
-                    />
-                  </svg>
-                </div>
-                <TimelineWaveform />
+                <div
+                  ref={scrollContainerRef}
+                  role="application"
+                  aria-label="Timeline"
+                  data-scroll-container
+                  className="flex-1 overflow-auto overscroll-none static! z-[unset] overflow-anchor-none"
+                  onScroll={handleScroll}
+                  onMouseDown={handleMouseDown}
+                  onAuxClick={(e) => e.preventDefault()}
+                  onKeyDown={(e) => {
+                    if (e.key === " " || e.key === "Enter") {
+                      e.preventDefault();
+                    }
+                  }}
+                >
+                  <div className="absolute grid place-items-center text-xs text-composer-text-muted top-0 left-0 z-100 w-12 h-20 border-b border-r-2 border-composer-border bg-composer-bg shadow-lg">
+                    <svg xmlns="http://www.w3.org/2000/svg" className="size-4" viewBox="0 0 24 24">
+                      <title>Music Icon</title>
+                      <path
+                        fill="currentColor"
+                        d="M10 21q-1.65 0-2.825-1.175T6 17t1.175-2.825T10 13q.575 0 1.063.138t.937.412V4q0-.425.288-.712T13 3h4q.425 0 .713.288T18 4v2q0 .425-.288.713T17 7h-3v10q0 1.65-1.175 2.825T10 21"
+                      />
+                    </svg>
+                  </div>
+                  <TimelineWaveform />
 
-                <TimelineRows scrollContainerRef={scrollContainerRef} />
+                  <TimelineRows scrollContainerRef={scrollContainerRef} />
+                </div>
+
+                <TimelinePlayhead containerHeight={contentHeight} scrollContainerRef={scrollContainerRef} />
+
+                <SnapGuideline />
+
+                <SnapMarkersOverlay scrollContainerRef={scrollContainerRef} />
+
+                {marqueeRect && <MarqueeSelection rect={marqueeRect} scrollContainerRef={scrollContainerRef} />}
+
+                {pasteMode.status === "preview" && (
+                  <PastePreview clipboard={pasteMode.clipboard} scrollContainerRef={scrollContainerRef} />
+                )}
+
+                {editingWord && (
+                  <WordEditOverlay
+                    lineId={editingWord.lineId}
+                    wordIndex={editingWord.wordIndex}
+                    type={editingWord.type}
+                    scrollContainerRef={scrollContainerRef}
+                  />
+                )}
               </div>
 
-              <TimelinePlayhead containerHeight={contentHeight} scrollContainerRef={scrollContainerRef} />
-
-              <SnapGuideline />
-
-              <SnapMarkersOverlay scrollContainerRef={scrollContainerRef} />
-
-              {marqueeRect && <MarqueeSelection rect={marqueeRect} scrollContainerRef={scrollContainerRef} />}
-
-              {pasteMode.status === "preview" && (
-                <PastePreview clipboard={pasteMode.clipboard} scrollContainerRef={scrollContainerRef} />
-              )}
-
-              {editingWord && (
-                <WordEditOverlay
-                  lineId={editingWord.lineId}
-                  wordIndex={editingWord.wordIndex}
-                  type={editingWord.type}
-                  scrollContainerRef={scrollContainerRef}
-                />
-              )}
+              <TimelineInfoPanel />
             </div>
 
-            <TimelineInfoPanel />
+            <Activity mode={previewSidebarOpen ? "visible" : "hidden"}>
+              <TimelinePreviewSidebar />
+            </Activity>
           </div>
-
-          <Activity mode={previewSidebarOpen ? "visible" : "hidden"}>
-            <TimelinePreviewSidebar />
-          </Activity>
         </div>
-      </div>
 
-      <DragOverlay dropAnimation={null}>
-        {activeDrag && dragCells && (
-          <DragGhost
-            cells={dragCells.cells}
-            anchorWidth={dragCells.anchorWidth}
-            anchorHeight={dragCells.anchorHeight}
-            color={dragColor}
-            isSnapped={ghostSnapped}
-          />
-        )}
-      </DragOverlay>
+        <DragOverlay dropAnimation={null}>
+          {activeDrag && dragCells && (
+            <DragGhost
+              cells={dragCells.cells}
+              anchorWidth={dragCells.anchorWidth}
+              anchorHeight={dragCells.anchorHeight}
+              color={dragColor}
+              isSnapped={ghostSnapped}
+            />
+          )}
+        </DragOverlay>
+      </div>
 
       <TimelineContextMenu />
       <TimelineSyllableSplitter />

--- a/src/views/timeline/timeline-playhead-mask.test.ts
+++ b/src/views/timeline/timeline-playhead-mask.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildPlayheadMask } from "@/views/timeline/timeline-playhead-mask";
+
+// -- Constants -----------------------------------------------------------------
+
+const PLAYHEAD_X = 300;
+const CONTAINER_TOP = 100;
+
+// -- Helpers -------------------------------------------------------------------
+
+interface BlockRect {
+  top: number;
+  height: number;
+  left: number;
+  width: number;
+}
+
+function addWordBlock(parent: HTMLElement, rect: BlockRect, syllablePosition?: string): HTMLElement {
+  const block = document.createElement("div");
+  block.setAttribute("data-word-block", "");
+  if (syllablePosition) block.dataset.syllablePosition = syllablePosition;
+  block.getBoundingClientRect = () => new DOMRect(rect.left, rect.top, rect.width, rect.height);
+  parent.appendChild(block);
+  return block;
+}
+
+function addRoot(): HTMLElement {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  return root;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("buildPlayheadMask", () => {
+  it("returns an empty mask when the root holds no word block", () => {
+    expect(buildPlayheadMask(addRoot(), PLAYHEAD_X, CONTAINER_TOP)).toBe("");
+  });
+
+  it("returns an empty mask when no word block spans the playhead", () => {
+    const root = addRoot();
+    addWordBlock(root, { top: 200, height: 40, left: 400, width: 100 });
+    expect(buildPlayheadMask(root, PLAYHEAD_X, CONTAINER_TOP)).toBe("");
+  });
+
+  it("dims the band covered by a word block under the playhead", () => {
+    const root = addRoot();
+    addWordBlock(root, { top: 200, height: 40, left: 100, width: 400 });
+    expect(buildPlayheadMask(root, PLAYHEAD_X, CONTAINER_TOP)).toBe(
+      "linear-gradient(to bottom, black 0, black 100px, rgba(0,0,0,0.5) 100px, rgba(0,0,0,0.5) 140px, black 140px, black 100%)",
+    );
+  });
+
+  it("merges word blocks whose bands touch", () => {
+    const root = addRoot();
+    addWordBlock(root, { top: 200, height: 40, left: 100, width: 400 });
+    addWordBlock(root, { top: 230, height: 40, left: 100, width: 400 });
+    expect(buildPlayheadMask(root, PLAYHEAD_X, CONTAINER_TOP)).toBe(
+      "linear-gradient(to bottom, black 0, black 100px, rgba(0,0,0,0.5) 100px, rgba(0,0,0,0.5) 170px, black 170px, black 100%)",
+    );
+  });
+
+  it("insets the band near a rounded corner", () => {
+    const root = addRoot();
+    addWordBlock(root, { top: 200, height: 40, left: PLAYHEAD_X - 2, width: 400 });
+    const mask = buildPlayheadMask(root, PLAYHEAD_X, CONTAINER_TOP);
+    expect(mask).not.toBe("");
+    expect(mask).not.toContain("rgba(0,0,0,0.5) 100px");
+  });
+
+  it("keeps a joined syllable edge square", () => {
+    const root = addRoot();
+    addWordBlock(root, { top: 200, height: 40, left: PLAYHEAD_X - 2, width: 400 }, "last");
+    expect(buildPlayheadMask(root, PLAYHEAD_X, CONTAINER_TOP)).toBe(
+      "linear-gradient(to bottom, black 0, black 100px, rgba(0,0,0,0.5) 100px, rgba(0,0,0,0.5) 140px, black 140px, black 100%)",
+    );
+  });
+
+  describe("root scoping", () => {
+    it("matches a document-scoped query when every word block sits inside the root", () => {
+      const root = addRoot();
+      addWordBlock(root, { top: 200, height: 40, left: 100, width: 400 }, "first");
+      addWordBlock(root, { top: 260, height: 40, left: 280, width: 60 }, "middle");
+      addWordBlock(root, { top: 400, height: 40, left: 100, width: 400 });
+      addWordBlock(root, { top: 500, height: 40, left: 900, width: 100 });
+
+      expect(buildPlayheadMask(root, PLAYHEAD_X, CONTAINER_TOP)).toBe(
+        buildPlayheadMask(document, PLAYHEAD_X, CONTAINER_TOP),
+      );
+    });
+
+    it("excludes a word block rendered outside the root", () => {
+      const root = addRoot();
+      addWordBlock(root, { top: 200, height: 40, left: 100, width: 400 });
+      const outsideRoot = addRoot();
+      addWordBlock(outsideRoot, { top: 600, height: 40, left: 100, width: 400 });
+
+      const scoped = buildPlayheadMask(root, PLAYHEAD_X, CONTAINER_TOP);
+      const documentScoped = buildPlayheadMask(document, PLAYHEAD_X, CONTAINER_TOP);
+
+      expect(scoped).not.toContain("500px");
+      expect(documentScoped).toContain("500px");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("treats the left edge of a block as covered", () => {
+      const root = addRoot();
+      addWordBlock(root, { top: 200, height: 40, left: PLAYHEAD_X, width: 100 }, "middle");
+      expect(buildPlayheadMask(root, PLAYHEAD_X, CONTAINER_TOP)).toContain("rgba(0,0,0,0.5) 100px");
+    });
+
+    it("treats the right edge of a block as covered", () => {
+      const root = addRoot();
+      addWordBlock(root, { top: 200, height: 40, left: PLAYHEAD_X - 100, width: 100 }, "middle");
+      expect(buildPlayheadMask(root, PLAYHEAD_X, CONTAINER_TOP)).toContain("rgba(0,0,0,0.5) 100px");
+    });
+
+    it("orders bands top to bottom regardless of DOM order", () => {
+      const root = addRoot();
+      addWordBlock(root, { top: 400, height: 40, left: 100, width: 400 });
+      addWordBlock(root, { top: 200, height: 40, left: 100, width: 400 });
+      expect(buildPlayheadMask(root, PLAYHEAD_X, CONTAINER_TOP)).toBe(
+        "linear-gradient(to bottom, black 0, black 100px, rgba(0,0,0,0.5) 100px, rgba(0,0,0,0.5) 140px, black 140px, black 300px, rgba(0,0,0,0.5) 300px, rgba(0,0,0,0.5) 340px, black 340px, black 100%)",
+      );
+    });
+  });
+
+  describe("invariants", () => {
+    it("leaves the document untouched", () => {
+      const root = addRoot();
+      addWordBlock(root, { top: 200, height: 40, left: 100, width: 400 });
+      const before = document.body.childElementCount;
+      buildPlayheadMask(root, PLAYHEAD_X, CONTAINER_TOP);
+      expect(document.body.childElementCount).toBe(before);
+    });
+
+    it("is idempotent for an unchanged root", () => {
+      const root = addRoot();
+      addWordBlock(root, { top: 200, height: 40, left: 100, width: 400 });
+      expect(buildPlayheadMask(root, PLAYHEAD_X, CONTAINER_TOP)).toBe(
+        buildPlayheadMask(root, PLAYHEAD_X, CONTAINER_TOP),
+      );
+    });
+  });
+});

--- a/src/views/timeline/timeline-playhead-mask.test.ts
+++ b/src/views/timeline/timeline-playhead-mask.test.ts
@@ -31,24 +31,25 @@ function addRoot(): HTMLElement {
 }
 
 interface TimelineFixture {
-  host: HTMLElement;
+  maskRoot: HTMLElement;
   scrollContainer: HTMLElement;
 }
 
 function addTimelineFixture(): TimelineFixture {
-  const host = addRoot();
+  const maskRoot = addRoot();
+  maskRoot.dataset.timelineMaskRoot = "";
   const panel = document.createElement("div");
   panel.dataset.tour = "timeline-panel";
-  host.appendChild(panel);
+  maskRoot.appendChild(panel);
   const scrollContainer = document.createElement("div");
   panel.appendChild(scrollContainer);
   addWordBlock(scrollContainer, { top: 200, height: 40, left: 100, width: 400 });
-  return { host, scrollContainer };
+  return { maskRoot, scrollContainer };
 }
 
-function addDragGhost(host: HTMLElement, rect: BlockRect): HTMLElement {
+function addDragGhost(maskRoot: HTMLElement, rect: BlockRect): HTMLElement {
   const overlay = document.createElement("div");
-  host.appendChild(overlay);
+  maskRoot.appendChild(overlay);
   addWordBlock(overlay, rect);
   return overlay;
 }
@@ -140,32 +141,43 @@ describe("buildPlayheadMask", () => {
     });
 
     it("matches a document-scoped query while a word is being dragged", () => {
-      const { host, scrollContainer } = addTimelineFixture();
-      addDragGhost(host, { top: 600, height: 40, left: 100, width: 400 });
+      const { maskRoot, scrollContainer } = addTimelineFixture();
+      addDragGhost(maskRoot, { top: 600, height: 40, left: 100, width: 400 });
 
       expect(buildPlayheadMask(playheadMaskRoot(scrollContainer), PLAYHEAD_X, CONTAINER_TOP)).toBe(
         buildPlayheadMask(document, PLAYHEAD_X, CONTAINER_TOP),
       );
     });
 
+    it("regression: resolves the root without the product tour anchor", () => {
+      const { maskRoot, scrollContainer } = addTimelineFixture();
+      maskRoot.querySelector("[data-tour='timeline-panel']")?.removeAttribute("data-tour");
+      addDragGhost(maskRoot, { top: 600, height: 40, left: 100, width: 400 });
+
+      expect(playheadMaskRoot(scrollContainer)).toBe(maskRoot);
+      expect(buildPlayheadMask(playheadMaskRoot(scrollContainer), PLAYHEAD_X, CONTAINER_TOP)).toBe(
+        buildPlayheadMask(document, PLAYHEAD_X, CONTAINER_TOP),
+      );
+    });
+
     it("regression: the scroll container alone drops the drag ghost's band", () => {
-      const { host, scrollContainer } = addTimelineFixture();
-      addDragGhost(host, { top: 600, height: 40, left: 100, width: 400 });
+      const { maskRoot, scrollContainer } = addTimelineFixture();
+      addDragGhost(maskRoot, { top: 600, height: 40, left: 100, width: 400 });
 
       expect(buildPlayheadMask(scrollContainer, PLAYHEAD_X, CONTAINER_TOP)).not.toContain("500px");
       expect(buildPlayheadMask(playheadMaskRoot(scrollContainer), PLAYHEAD_X, CONTAINER_TOP)).toContain("500px");
     });
 
     it("counts a drag ghost overlapping the dragged word once", () => {
-      const { host, scrollContainer } = addTimelineFixture();
-      addDragGhost(host, { top: 210, height: 40, left: 100, width: 400 });
+      const { maskRoot, scrollContainer } = addTimelineFixture();
+      addDragGhost(maskRoot, { top: 210, height: 40, left: 100, width: 400 });
 
       expect(buildPlayheadMask(playheadMaskRoot(scrollContainer), PLAYHEAD_X, CONTAINER_TOP)).toBe(
         "linear-gradient(to bottom, black 0, black 100px, rgba(0,0,0,0.5) 100px, rgba(0,0,0,0.5) 150px, black 150px, black 100%)",
       );
     });
 
-    it("falls back to the document when the panel root is missing", () => {
+    it("falls back to the document when the mask root is missing", () => {
       const scrollContainer = addRoot();
       addWordBlock(scrollContainer, { top: 200, height: 40, left: 100, width: 400 });
       const outsideRoot = addRoot();

--- a/src/views/timeline/timeline-playhead-mask.test.ts
+++ b/src/views/timeline/timeline-playhead-mask.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { buildPlayheadMask } from "@/views/timeline/timeline-playhead-mask";
+import { buildPlayheadMask, playheadMaskRoot } from "@/views/timeline/timeline-playhead-mask";
 
 // -- Constants -----------------------------------------------------------------
 
@@ -28,6 +28,29 @@ function addRoot(): HTMLElement {
   const root = document.createElement("div");
   document.body.appendChild(root);
   return root;
+}
+
+interface TimelineFixture {
+  host: HTMLElement;
+  scrollContainer: HTMLElement;
+}
+
+function addTimelineFixture(): TimelineFixture {
+  const host = addRoot();
+  const panel = document.createElement("div");
+  panel.dataset.tour = "timeline-panel";
+  host.appendChild(panel);
+  const scrollContainer = document.createElement("div");
+  panel.appendChild(scrollContainer);
+  addWordBlock(scrollContainer, { top: 200, height: 40, left: 100, width: 400 });
+  return { host, scrollContainer };
+}
+
+function addDragGhost(host: HTMLElement, rect: BlockRect): HTMLElement {
+  const overlay = document.createElement("div");
+  host.appendChild(overlay);
+  addWordBlock(overlay, rect);
+  return overlay;
 }
 
 afterEach(() => {
@@ -104,6 +127,53 @@ describe("buildPlayheadMask", () => {
 
       expect(scoped).not.toContain("500px");
       expect(documentScoped).toContain("500px");
+    });
+  });
+
+  describe("playheadMaskRoot", () => {
+    it("matches a document-scoped query while no word is being dragged", () => {
+      const { scrollContainer } = addTimelineFixture();
+
+      expect(buildPlayheadMask(playheadMaskRoot(scrollContainer), PLAYHEAD_X, CONTAINER_TOP)).toBe(
+        buildPlayheadMask(document, PLAYHEAD_X, CONTAINER_TOP),
+      );
+    });
+
+    it("matches a document-scoped query while a word is being dragged", () => {
+      const { host, scrollContainer } = addTimelineFixture();
+      addDragGhost(host, { top: 600, height: 40, left: 100, width: 400 });
+
+      expect(buildPlayheadMask(playheadMaskRoot(scrollContainer), PLAYHEAD_X, CONTAINER_TOP)).toBe(
+        buildPlayheadMask(document, PLAYHEAD_X, CONTAINER_TOP),
+      );
+    });
+
+    it("regression: the scroll container alone drops the drag ghost's band", () => {
+      const { host, scrollContainer } = addTimelineFixture();
+      addDragGhost(host, { top: 600, height: 40, left: 100, width: 400 });
+
+      expect(buildPlayheadMask(scrollContainer, PLAYHEAD_X, CONTAINER_TOP)).not.toContain("500px");
+      expect(buildPlayheadMask(playheadMaskRoot(scrollContainer), PLAYHEAD_X, CONTAINER_TOP)).toContain("500px");
+    });
+
+    it("counts a drag ghost overlapping the dragged word once", () => {
+      const { host, scrollContainer } = addTimelineFixture();
+      addDragGhost(host, { top: 210, height: 40, left: 100, width: 400 });
+
+      expect(buildPlayheadMask(playheadMaskRoot(scrollContainer), PLAYHEAD_X, CONTAINER_TOP)).toBe(
+        "linear-gradient(to bottom, black 0, black 100px, rgba(0,0,0,0.5) 100px, rgba(0,0,0,0.5) 150px, black 150px, black 100%)",
+      );
+    });
+
+    it("falls back to the document when the panel root is missing", () => {
+      const scrollContainer = addRoot();
+      addWordBlock(scrollContainer, { top: 200, height: 40, left: 100, width: 400 });
+      const outsideRoot = addRoot();
+      addWordBlock(outsideRoot, { top: 600, height: 40, left: 100, width: 400 });
+
+      expect(buildPlayheadMask(playheadMaskRoot(scrollContainer), PLAYHEAD_X, CONTAINER_TOP)).toBe(
+        buildPlayheadMask(document, PLAYHEAD_X, CONTAINER_TOP),
+      );
     });
   });
 

--- a/src/views/timeline/timeline-playhead-mask.ts
+++ b/src/views/timeline/timeline-playhead-mask.ts
@@ -2,8 +2,16 @@
 
 const MASK_DIM_ALPHA = 0.5;
 const WORD_CORNER_RADIUS_PX = 12;
+const TIMELINE_PANEL_SELECTOR = "[data-tour='timeline-panel']";
 
 // -- Helpers -------------------------------------------------------------------
+
+// dnd-kit renders the drag ghost's word blocks into a DragOverlay that does not portal
+// and sits beside the panel root, so the panel's parent is the smallest root that still
+// holds every word block the document-scoped query used to find.
+function playheadMaskRoot(scrollContainer: Element): ParentNode {
+  return scrollContainer.closest(TIMELINE_PANEL_SELECTOR)?.parentElement ?? scrollContainer.ownerDocument;
+}
 
 function cornerYInset(distFromEdge: number, radius: number): number {
   if (distFromEdge >= radius || distFromEdge < 0) return 0;
@@ -50,4 +58,4 @@ function buildPlayheadMask(root: ParentNode, playheadCenterXViewport: number, co
 
 // -- Exports -------------------------------------------------------------------
 
-export { buildPlayheadMask };
+export { buildPlayheadMask, playheadMaskRoot };

--- a/src/views/timeline/timeline-playhead-mask.ts
+++ b/src/views/timeline/timeline-playhead-mask.ts
@@ -11,8 +11,8 @@ function cornerYInset(distFromEdge: number, radius: number): number {
   return radius - Math.sqrt(radius * radius - d * d);
 }
 
-function buildPlayheadMask(playheadCenterXViewport: number, containerTopViewport: number): string {
-  const wordBlocks = document.querySelectorAll("[data-word-block]");
+function buildPlayheadMask(root: ParentNode, playheadCenterXViewport: number, containerTopViewport: number): string {
+  const wordBlocks = root.querySelectorAll("[data-word-block]");
   const ranges: { top: number; bottom: number }[] = [];
   for (const wb of wordBlocks) {
     const el = wb as HTMLElement;

--- a/src/views/timeline/timeline-playhead-mask.ts
+++ b/src/views/timeline/timeline-playhead-mask.ts
@@ -2,15 +2,15 @@
 
 const MASK_DIM_ALPHA = 0.5;
 const WORD_CORNER_RADIUS_PX = 12;
-const TIMELINE_PANEL_SELECTOR = "[data-tour='timeline-panel']";
+const MASK_ROOT_SELECTOR = "[data-timeline-mask-root]";
 
 // -- Helpers -------------------------------------------------------------------
 
-// dnd-kit renders the drag ghost's word blocks into a DragOverlay that does not portal
-// and sits beside the panel root, so the panel's parent is the smallest root that still
+// dnd-kit renders the drag ghost's word blocks into a DragOverlay that does not portal,
+// so the marked root wraps both it and the scroll container: the smallest root that still
 // holds every word block the document-scoped query used to find.
 function playheadMaskRoot(scrollContainer: Element): ParentNode {
-  return scrollContainer.closest(TIMELINE_PANEL_SELECTOR)?.parentElement ?? scrollContainer.ownerDocument;
+  return scrollContainer.closest(MASK_ROOT_SELECTOR) ?? scrollContainer.ownerDocument;
 }
 
 function cornerYInset(distFromEdge: number, radius: number): number {

--- a/src/views/timeline/timeline-playhead.frame-loop.browser.test.tsx
+++ b/src/views/timeline/timeline-playhead.frame-loop.browser.test.tsx
@@ -1,0 +1,262 @@
+import { useEffect, useRef, useState } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { subscribeFrame } from "@/lib/frame-loop";
+import { wireFrameLoop } from "@/lib/frame-loop-wiring";
+import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
+import { createLine, createWord } from "@/test/factories";
+import { settleFrames, stepFrames } from "@/test/frame-steps";
+import { render } from "@/test/render";
+import { TimelinePlayhead } from "@/views/timeline/timeline-playhead";
+import { GUTTER_WIDTH, useTimelineStore } from "@/views/timeline/timeline-store";
+import { useTimelineFrameWake } from "@/views/timeline/use-timeline-frame-wake";
+
+// -- Constants -----------------------------------------------------------------
+
+const ROW_ID = "content-row";
+const VIEWPORT_WIDTH = 600;
+const VIEWPORT_HEIGHT = 200;
+const CONTENT_WIDTH = 2000;
+const ROW_COUNT = 10;
+const DEFAULT_ROW_HEIGHT = 80;
+const RESIZED_ROW_HEIGHT = 120;
+const DEFAULT_CONTENT_HEIGHT = DEFAULT_ROW_HEIGHT * ROW_COUNT;
+const WORD_BLOCK_TOP = 200;
+const WORD_BLOCK_HEIGHT = 100;
+const WORD_BLOCK_WIDTH = 1200;
+const LIVE_FRAMES = 12;
+
+// -- Harness -------------------------------------------------------------------
+
+const Harness: React.FC = () => {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const rowHeight = useTimelineStore((s) => s.rowHeights[ROW_ID] ?? DEFAULT_ROW_HEIGHT);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useTimelineFrameWake(scrollContainerRef, hostRef, true);
+
+  return (
+    <div ref={hostRef} style={{ position: "relative", width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT }}>
+      <div
+        ref={scrollContainerRef}
+        data-test="scroll-container"
+        style={{ position: "absolute", inset: 0, overflow: "auto" }}
+      >
+        <div style={{ position: "relative", width: CONTENT_WIDTH, height: rowHeight * ROW_COUNT }}>
+          <div
+            data-word-block
+            style={{
+              position: "absolute",
+              left: 0,
+              top: WORD_BLOCK_TOP,
+              width: WORD_BLOCK_WIDTH,
+              height: WORD_BLOCK_HEIGHT,
+            }}
+          />
+        </div>
+      </div>
+      {mounted && <TimelinePlayhead containerHeight={VIEWPORT_HEIGHT} scrollContainerRef={scrollContainerRef} />}
+    </div>
+  );
+};
+
+let disposeWiring: (() => void) | null = null;
+let unsubscribeProbe: (() => void) | null = null;
+let frames = 0;
+
+function seedPaused(zoom: number, currentTime: number): void {
+  useAudioStore.setState({ duration: 60, currentTime, isPlaying: false });
+  useTimelineStore.setState({ zoom, scrollLeft: 0, isDraggingPlayhead: false, followEnabled: false });
+}
+
+function playheadBar(root: HTMLElement): HTMLElement {
+  const bar = root.querySelector<HTMLElement>("[role='separator']");
+  if (!bar) throw new Error("playhead bar missing");
+  return bar;
+}
+
+function scrollContainerOf(root: HTMLElement): HTMLDivElement {
+  const container = root.querySelector<HTMLDivElement>("[data-test='scroll-container']");
+  if (!container) throw new Error("scroll container missing");
+  return container;
+}
+
+function transformAt(time: number, zoom: number, scrollLeft: number): string {
+  return `translate3d(${time * zoom - scrollLeft + GUTTER_WIDTH - 1}px, 0px, 0px)`;
+}
+
+async function quiesce(): Promise<void> {
+  await settleFrames(() => frames);
+  frames = 0;
+}
+
+async function wokeAfter(trigger: () => void): Promise<boolean> {
+  await quiesce();
+  trigger();
+  await settleFrames(() => frames);
+  return frames > 0;
+}
+
+beforeEach(() => {
+  frames = 0;
+  disposeWiring = wireFrameLoop();
+  unsubscribeProbe = subscribeFrame(() => {
+    frames += 1;
+  });
+});
+
+afterEach(() => {
+  unsubscribeProbe?.();
+  disposeWiring?.();
+  unsubscribeProbe = null;
+  disposeWiring = null;
+});
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("TimelinePlayhead on the frame loop", () => {
+  it("keeps translating while the audio plays and after it pauses", async () => {
+    seedPaused(50, 0);
+    const screen = await render(<Harness />);
+    const bar = playheadBar(screen.container);
+
+    useAudioStore.getState().setIsPlaying(true);
+    useAudioStore.getState().setCurrentTime(2);
+    await expect.poll(() => bar.style.transform).toBe(transformAt(2, 50, 0));
+
+    useAudioStore.getState().setIsPlaying(false);
+    useAudioStore.getState().setCurrentTime(4);
+    await expect.poll(() => bar.style.transform).toBe(transformAt(4, 50, 0));
+  });
+
+  it("follows a seek while paused", async () => {
+    seedPaused(50, 5);
+    const screen = await render(<Harness />);
+    const bar = playheadBar(screen.container);
+    await expect.poll(() => bar.style.transform).toBe(transformAt(5, 50, 0));
+
+    useAudioStore.getState().seekTo(21);
+    await expect.poll(() => bar.style.transform).toBe(transformAt(21, 50, 0));
+  });
+
+  it("re-lays out after a zoom change while paused", async () => {
+    seedPaused(50, 5);
+    const screen = await render(<Harness />);
+    const bar = playheadBar(screen.container);
+    await expect.poll(() => bar.style.transform).toBe(transformAt(5, 50, 0));
+
+    useTimelineStore.getState().setZoom(120);
+    await expect.poll(() => bar.style.transform).toBe(transformAt(5, 120, 0));
+  });
+
+  it("follows horizontal scroll while paused", async () => {
+    seedPaused(50, 5);
+    const screen = await render(<Harness />);
+    const bar = playheadBar(screen.container);
+    const container = scrollContainerOf(screen.container);
+    await expect.poll(() => bar.style.transform).toBe(transformAt(5, 50, 0));
+
+    container.scrollLeft = 120;
+    await expect.poll(() => bar.style.transform).toBe(transformAt(5, 50, 120));
+  });
+
+  it("re-masks after vertical scroll while paused", async () => {
+    seedPaused(50, 5);
+    const screen = await render(<Harness />);
+    const bar = playheadBar(screen.container);
+    const container = scrollContainerOf(screen.container);
+    await expect.poll(() => bar.style.maskImage).toContain(`${WORD_BLOCK_TOP}px`);
+
+    container.scrollTop = 50;
+    await expect.poll(() => bar.style.maskImage).toContain(`${WORD_BLOCK_TOP - 50}px`);
+  });
+
+  it("grows with the scroll content when a row is resized", async () => {
+    seedPaused(50, 5);
+    const screen = await render(<Harness />);
+    const bar = playheadBar(screen.container);
+    await expect.poll(() => bar.style.height).toBe(`${DEFAULT_CONTENT_HEIGHT}px`);
+
+    useTimelineStore.getState().setRowHeight(ROW_ID, RESIZED_ROW_HEIGHT);
+    await expect.poll(() => bar.style.height).toBe(`${RESIZED_ROW_HEIGHT * ROW_COUNT}px`);
+  });
+
+  it("tracks the pointer while the playhead is dragged", async () => {
+    seedPaused(50, 5);
+    const screen = await render(<Harness />);
+    const bar = playheadBar(screen.container);
+    const container = scrollContainerOf(screen.container);
+    await expect.poll(() => bar.style.transform).toBe(transformAt(5, 50, 0));
+
+    const rect = container.getBoundingClientRect();
+    bar.dispatchEvent(new MouseEvent("mousedown", { button: 0, clientX: rect.left + 298, bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mousemove", { clientX: rect.left + GUTTER_WIDTH + 400, bubbles: true }));
+
+    await expect.poll(() => bar.style.transform).toBe(transformAt(8, 50, 0));
+    expect(useTimelineStore.getState().dragTime).toBe(8);
+
+    document.dispatchEvent(new MouseEvent("mouseup", { clientX: rect.left + GUTTER_WIDTH + 400, bubbles: true }));
+  });
+
+  describe("wake sources", () => {
+    it("keeps updating after a line text edit", async () => {
+      seedPaused(50, 5);
+      await render(<Harness />);
+
+      const woke = await wokeAfter(() => {
+        useProjectStore
+          .getState()
+          .setLines([
+            createLine({ id: "edited", text: "new", words: [createWord({ text: "new", begin: 1, end: 2 })] }),
+          ]);
+      });
+      expect(woke).toBe(true);
+    });
+
+    it("keeps updating after follow mode is toggled", async () => {
+      seedPaused(50, 5);
+      await render(<Harness />);
+
+      expect(await wokeAfter(() => useTimelineStore.getState().toggleFollow())).toBe(true);
+    });
+
+    it("keeps updating after an instance is collapsed and expanded", async () => {
+      seedPaused(50, 5);
+      await render(<Harness />);
+
+      expect(await wokeAfter(() => useTimelineStore.getState().setInstanceCollapsed("group-1:0", true))).toBe(true);
+      expect(await wokeAfter(() => useTimelineStore.getState().setInstanceCollapsed("group-1:0", false))).toBe(true);
+    });
+  });
+
+  describe("invariants", () => {
+    it("regression #174: stops running frames once the audio is paused and idle", async () => {
+      seedPaused(50, 5);
+      await render(<Harness />);
+
+      useAudioStore.getState().setIsPlaying(true);
+      await stepFrames(LIVE_FRAMES);
+      expect(frames).toBeGreaterThan(LIVE_FRAMES - 2);
+
+      useAudioStore.getState().setIsPlaying(false);
+      const settled = await settleFrames(() => frames);
+      await stepFrames(30);
+      expect(frames).toBe(settled);
+    });
+
+    it("regression #174: follow mode does not keep the loop awake while paused", async () => {
+      seedPaused(50, 5);
+      useTimelineStore.setState({ followEnabled: true });
+      await render(<Harness />);
+      await quiesce();
+
+      await settleFrames(() => frames);
+      expect(frames).toBe(0);
+    });
+  });
+});

--- a/src/views/timeline/timeline-playhead.frame-loop.browser.test.tsx
+++ b/src/views/timeline/timeline-playhead.frame-loop.browser.test.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { subscribeFrame } from "@/lib/frame-loop";
 import { wireFrameLoop } from "@/lib/frame-loop-wiring";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { createLine, createWord } from "@/test/factories";
+import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
 import { settleFrames, stepFrames } from "@/test/frame-steps";
 import { render } from "@/test/render";
 import { TimelinePlayhead } from "@/views/timeline/timeline-playhead";
@@ -66,8 +66,7 @@ const Harness: React.FC = () => {
 };
 
 let disposeWiring: (() => void) | null = null;
-let unsubscribeProbe: (() => void) | null = null;
-let frames = 0;
+let probe: FrameProbe;
 
 function seedPaused(zoom: number, currentTime: number): void {
   useAudioStore.setState({ duration: 60, currentTime, isPlaying: false });
@@ -90,30 +89,14 @@ function transformAt(time: number, zoom: number, scrollLeft: number): string {
   return `translate3d(${time * zoom - scrollLeft + GUTTER_WIDTH - 1}px, 0px, 0px)`;
 }
 
-async function quiesce(): Promise<void> {
-  await settleFrames(() => frames);
-  frames = 0;
-}
-
-async function wokeAfter(trigger: () => void): Promise<boolean> {
-  await quiesce();
-  trigger();
-  await settleFrames(() => frames);
-  return frames > 0;
-}
-
 beforeEach(() => {
-  frames = 0;
   disposeWiring = wireFrameLoop();
-  unsubscribeProbe = subscribeFrame(() => {
-    frames += 1;
-  });
+  probe = createFrameProbe();
 });
 
 afterEach(() => {
-  unsubscribeProbe?.();
+  probe.dispose();
   disposeWiring?.();
-  unsubscribeProbe = null;
   disposeWiring = null;
 });
 
@@ -208,7 +191,7 @@ describe("TimelinePlayhead on the frame loop", () => {
       seedPaused(50, 5);
       await render(<Harness />);
 
-      const woke = await wokeAfter(() => {
+      const woke = await probe.wokeAfter(() => {
         useProjectStore
           .getState()
           .setLines([
@@ -222,15 +205,19 @@ describe("TimelinePlayhead on the frame loop", () => {
       seedPaused(50, 5);
       await render(<Harness />);
 
-      expect(await wokeAfter(() => useTimelineStore.getState().toggleFollow())).toBe(true);
+      expect(await probe.wokeAfter(() => useTimelineStore.getState().toggleFollow())).toBe(true);
     });
 
     it("keeps updating after an instance is collapsed and expanded", async () => {
       seedPaused(50, 5);
       await render(<Harness />);
 
-      expect(await wokeAfter(() => useTimelineStore.getState().setInstanceCollapsed("group-1:0", true))).toBe(true);
-      expect(await wokeAfter(() => useTimelineStore.getState().setInstanceCollapsed("group-1:0", false))).toBe(true);
+      expect(await probe.wokeAfter(() => useTimelineStore.getState().setInstanceCollapsed("group-1:0", true))).toBe(
+        true,
+      );
+      expect(await probe.wokeAfter(() => useTimelineStore.getState().setInstanceCollapsed("group-1:0", false))).toBe(
+        true,
+      );
     });
   });
 
@@ -241,22 +228,22 @@ describe("TimelinePlayhead on the frame loop", () => {
 
       useAudioStore.getState().setIsPlaying(true);
       await stepFrames(LIVE_FRAMES);
-      expect(frames).toBeGreaterThan(LIVE_FRAMES - 2);
+      expect(probe.count()).toBeGreaterThan(LIVE_FRAMES - 2);
 
       useAudioStore.getState().setIsPlaying(false);
-      const settled = await settleFrames(() => frames);
+      const settled = await settleFrames(probe.count);
       await stepFrames(30);
-      expect(frames).toBe(settled);
+      expect(probe.count()).toBe(settled);
     });
 
     it("regression #174: follow mode does not keep the loop awake while paused", async () => {
       seedPaused(50, 5);
       useTimelineStore.setState({ followEnabled: true });
       await render(<Harness />);
-      await quiesce();
+      await probe.quiesce();
 
-      await settleFrames(() => frames);
-      expect(frames).toBe(0);
+      await settleFrames(probe.count);
+      expect(probe.count()).toBe(0);
     });
   });
 });

--- a/src/views/timeline/timeline-playhead.tsx
+++ b/src/views/timeline/timeline-playhead.tsx
@@ -136,7 +136,7 @@ const TimelinePlayhead: React.FC<TimelinePlayheadProps> = ({ containerHeight, sc
       const playheadCenterXViewport = playheadCenterXLocal + containerRect.left;
       playheadCenterXLocalRef.current = playheadCenterXLocal;
       containerLeftRef.current = containerRect.left;
-      const mask = buildPlayheadMask(playheadCenterXViewport, containerRect.top);
+      const mask = container ? buildPlayheadMask(container, playheadCenterXViewport, containerRect.top) : "";
       if (mask !== lastMaskRef.current) {
         lastMaskRef.current = mask;
         const style = playheadRef.current.style;

--- a/src/views/timeline/timeline-playhead.tsx
+++ b/src/views/timeline/timeline-playhead.tsx
@@ -3,7 +3,7 @@ import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { getBannerNodes } from "@/views/timeline/banner-progress-registry";
 import { GROUP_HEADER_HEIGHT } from "@/views/timeline/group-header-row";
-import { buildPlayheadMask } from "@/views/timeline/timeline-playhead-mask";
+import { buildPlayheadMask, playheadMaskRoot } from "@/views/timeline/timeline-playhead-mask";
 import { createPlayheadDrag } from "@/views/timeline/playhead-drag";
 import { snapPlayheadTime } from "@/views/timeline/playhead-snap";
 import { GUTTER_WIDTH, timeToX } from "@/views/timeline/coords";
@@ -136,7 +136,9 @@ const TimelinePlayhead: React.FC<TimelinePlayheadProps> = ({ containerHeight, sc
       const playheadCenterXViewport = playheadCenterXLocal + containerRect.left;
       playheadCenterXLocalRef.current = playheadCenterXLocal;
       containerLeftRef.current = containerRect.left;
-      const mask = container ? buildPlayheadMask(container, playheadCenterXViewport, containerRect.top) : "";
+      const mask = container
+        ? buildPlayheadMask(playheadMaskRoot(container), playheadCenterXViewport, containerRect.top)
+        : "";
       if (mask !== lastMaskRef.current) {
         lastMaskRef.current = mask;
         const style = playheadRef.current.style;

--- a/src/views/timeline/timeline-playhead.tsx
+++ b/src/views/timeline/timeline-playhead.tsx
@@ -162,7 +162,7 @@ const TimelinePlayhead: React.FC<TimelinePlayheadProps> = ({ containerHeight, sc
       const clamped = Math.max(0, Math.min(1, ratio));
       banner.style.setProperty("--progress-fill", `${(clamped * 100).toFixed(2)}%`);
     }
-  });
+  }, "timeline-playhead");
 
   useEffect(() => {
     let yielded = false;

--- a/src/views/timeline/timeline-playhead.tsx
+++ b/src/views/timeline/timeline-playhead.tsx
@@ -1,3 +1,4 @@
+import { useFrameLoop } from "@/hooks/use-frame-loop";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { getBannerNodes } from "@/views/timeline/banner-progress-registry";
@@ -35,147 +36,133 @@ const TimelinePlayhead: React.FC<TimelinePlayheadProps> = ({ containerHeight, sc
 
   const containerRef = useRef<HTMLDivElement>(null);
   const playheadRef = useRef<HTMLDivElement>(null);
-  const rafRef = useRef<number | null>(null);
   const lastFollowedLineRef = useRef<number>(-1);
   const verticalTargetRef = useRef<number | null>(null);
   const lastMaskRef = useRef<string>("");
   const playheadCenterXLocalRef = useRef<number>(0);
   const containerLeftRef = useRef<number>(0);
 
-  // RAF loop - always runs, reads directly from audio element and stores
-  useEffect(() => {
-    const update = () => {
-      if (!playheadRef.current) {
-        rafRef.current = requestAnimationFrame(update);
-        return;
-      }
+  useFrameLoop(() => {
+    if (!playheadRef.current) return;
 
-      // Read directly from audio element for smooth updates
-      const audioEl = useAudioStore.getState().audioElement;
-      const isPlaying = useAudioStore.getState().isPlaying;
-      const currentTime = audioEl?.currentTime ?? useAudioStore.getState().currentTime;
-      const { zoom, scrollLeft, isDraggingPlayhead, dragTime, followEnabled } = useTimelineStore.getState();
+    // Read directly from audio element for smooth updates
+    const audioEl = useAudioStore.getState().audioElement;
+    const isPlaying = useAudioStore.getState().isPlaying;
+    const currentTime = audioEl?.currentTime ?? useAudioStore.getState().currentTime;
+    const { zoom, scrollLeft, isDraggingPlayhead, dragTime, followEnabled } = useTimelineStore.getState();
 
-      // Auto-scroll to keep playhead centered when follow is enabled
-      const container = scrollContainerRef.current;
-      if (followEnabled && isPlaying && container && !isDraggingPlayhead) {
-        const viewportWidth = container.clientWidth;
-        const centerOffset = viewportWidth / 2 - GUTTER_WIDTH;
-        const targetScrollLeft = Math.max(0, currentTime * zoom - centerOffset);
-        container.scrollLeft = targetScrollLeft;
+    // Auto-scroll to keep playhead centered when follow is enabled
+    const container = scrollContainerRef.current;
+    if (followEnabled && isPlaying && container && !isDraggingPlayhead) {
+      const viewportWidth = container.clientWidth;
+      const centerOffset = viewportWidth / 2 - GUTTER_WIDTH;
+      const targetScrollLeft = Math.max(0, currentTime * zoom - centerOffset);
+      container.scrollLeft = targetScrollLeft;
 
-        const lines = useProjectStore.getState().lines;
-        let activeLineIndex = -1;
-        for (let i = 0; i < lines.length; i++) {
-          const timing = effectiveBounds(lines[i]);
-          if (timing && currentTime >= timing.begin && currentTime < timing.end) {
-            activeLineIndex = i;
-            break;
-          }
-        }
-
-        if (activeLineIndex >= 0 && activeLineIndex !== lastFollowedLineRef.current) {
-          lastFollowedLineRef.current = activeLineIndex;
-          const BG_DROP_ZONE_HEIGHT = 24;
-          const { rowHeights, defaultRowHeight, collapsedInstances } = useTimelineStore.getState();
-
-          const layout = computeRowLayout({
-            lines,
-            rowHeights,
-            defaultRowHeight,
-            collapsedInstances,
-            waveformHeight: WAVEFORM_HEIGHT,
-            bgDropZoneHeight: BG_DROP_ZONE_HEIGHT,
-            groupHeaderHeight: GROUP_HEADER_HEIGHT,
-          });
-
-          const activeLine = lines[activeLineIndex];
-          const activeInstanceKey = isLinked(activeLine) ? `${activeLine.groupId}:${activeLine.instanceIdx}` : null;
-          const isActiveCollapsed = activeInstanceKey !== null && collapsedInstances[activeInstanceKey];
-
-          const target =
-            isActiveCollapsed && activeInstanceKey !== null
-              ? layout.headerTops.get(activeInstanceKey)
-              : layout.lineTops.get(activeLine.id);
-
-          if (target) {
-            const viewportHeight = container.clientHeight;
-            const rowCenter = target.top + target.height / 2;
-            verticalTargetRef.current = Math.max(
-              0,
-              Math.min(container.scrollHeight - viewportHeight, rowCenter - viewportHeight / 2),
-            );
-          }
-        }
-
-        // Lerp vertical scroll only while animating toward target
-        if (verticalTargetRef.current !== null) {
-          const diff = verticalTargetRef.current - container.scrollTop;
-          if (Math.abs(diff) > 0.5) {
-            container.scrollTop += diff * 0.15;
-          } else {
-            container.scrollTop = verticalTargetRef.current;
-            verticalTargetRef.current = null;
-          }
-        }
-      } else {
-        lastFollowedLineRef.current = -1;
-        verticalTargetRef.current = null;
-      }
-
-      container?.parentElement?.classList.toggle("scrollbar-hidden", isPlaying && followEnabled);
-
-      const displayTime = isDraggingPlayhead ? dragTime : currentTime;
-      const actualScrollLeft = container?.scrollLeft ?? scrollLeft;
-      const position = timeToX(displayTime, zoom, actualScrollLeft) - 1; // -1 to center the 2px wide playhead
-      playheadRef.current.style.transform = `translate3d(${position}px, 0, 0)`;
-
-      // Update height to match full scrollable content
-      if (container) {
-        playheadRef.current.style.height = `${container.scrollHeight}px`;
-      }
-
-      const containerRect = containerRef.current?.getBoundingClientRect();
-      if (containerRect) {
-        const playheadCenterXLocal = timeToX(displayTime, zoom, actualScrollLeft);
-        const playheadCenterXViewport = playheadCenterXLocal + containerRect.left;
-        playheadCenterXLocalRef.current = playheadCenterXLocal;
-        containerLeftRef.current = containerRect.left;
-        const mask = buildPlayheadMask(playheadCenterXViewport, containerRect.top);
-        if (mask !== lastMaskRef.current) {
-          lastMaskRef.current = mask;
-          const style = playheadRef.current.style;
-          style.maskImage = mask;
-          style.webkitMaskImage = mask;
+      const lines = useProjectStore.getState().lines;
+      let activeLineIndex = -1;
+      for (let i = 0; i < lines.length; i++) {
+        const timing = effectiveBounds(lines[i]);
+        if (timing && currentTime >= timing.begin && currentTime < timing.end) {
+          activeLineIndex = i;
+          break;
         }
       }
 
-      // Update progress fill on collapsed banner DOM nodes (registered via mount)
-      const banners = getBannerNodes();
-      for (const banner of banners) {
-        const startStr = banner.dataset.instanceStart;
-        const endStr = banner.dataset.instanceEnd;
-        if (!startStr || !endStr) continue;
-        const startNum = Number.parseFloat(startStr);
-        const endNum = Number.parseFloat(endStr);
-        const span = endNum - startNum;
-        if (!Number.isFinite(span) || span <= 0) {
-          banner.style.setProperty("--progress-fill", "0%");
-          continue;
+      if (activeLineIndex >= 0 && activeLineIndex !== lastFollowedLineRef.current) {
+        lastFollowedLineRef.current = activeLineIndex;
+        const BG_DROP_ZONE_HEIGHT = 24;
+        const { rowHeights, defaultRowHeight, collapsedInstances } = useTimelineStore.getState();
+
+        const layout = computeRowLayout({
+          lines,
+          rowHeights,
+          defaultRowHeight,
+          collapsedInstances,
+          waveformHeight: WAVEFORM_HEIGHT,
+          bgDropZoneHeight: BG_DROP_ZONE_HEIGHT,
+          groupHeaderHeight: GROUP_HEADER_HEIGHT,
+        });
+
+        const activeLine = lines[activeLineIndex];
+        const activeInstanceKey = isLinked(activeLine) ? `${activeLine.groupId}:${activeLine.instanceIdx}` : null;
+        const isActiveCollapsed = activeInstanceKey !== null && collapsedInstances[activeInstanceKey];
+
+        const target =
+          isActiveCollapsed && activeInstanceKey !== null
+            ? layout.headerTops.get(activeInstanceKey)
+            : layout.lineTops.get(activeLine.id);
+
+        if (target) {
+          const viewportHeight = container.clientHeight;
+          const rowCenter = target.top + target.height / 2;
+          verticalTargetRef.current = Math.max(
+            0,
+            Math.min(container.scrollHeight - viewportHeight, rowCenter - viewportHeight / 2),
+          );
         }
-        const ratio = (currentTime - startNum) / span;
-        const clamped = Math.max(0, Math.min(1, ratio));
-        banner.style.setProperty("--progress-fill", `${(clamped * 100).toFixed(2)}%`);
       }
 
-      rafRef.current = requestAnimationFrame(update);
-    };
+      // Lerp vertical scroll only while animating toward target
+      if (verticalTargetRef.current !== null) {
+        const diff = verticalTargetRef.current - container.scrollTop;
+        if (Math.abs(diff) > 0.5) {
+          container.scrollTop += diff * 0.15;
+        } else {
+          container.scrollTop = verticalTargetRef.current;
+          verticalTargetRef.current = null;
+        }
+      }
+    } else {
+      lastFollowedLineRef.current = -1;
+      verticalTargetRef.current = null;
+    }
 
-    rafRef.current = requestAnimationFrame(update);
-    return () => {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
-    };
-  }, [scrollContainerRef]);
+    container?.parentElement?.classList.toggle("scrollbar-hidden", isPlaying && followEnabled);
+
+    const displayTime = isDraggingPlayhead ? dragTime : currentTime;
+    const actualScrollLeft = container?.scrollLeft ?? scrollLeft;
+    const position = timeToX(displayTime, zoom, actualScrollLeft) - 1; // -1 to center the 2px wide playhead
+    playheadRef.current.style.transform = `translate3d(${position}px, 0, 0)`;
+
+    // Update height to match full scrollable content
+    if (container) {
+      playheadRef.current.style.height = `${container.scrollHeight}px`;
+    }
+
+    const containerRect = containerRef.current?.getBoundingClientRect();
+    if (containerRect) {
+      const playheadCenterXLocal = timeToX(displayTime, zoom, actualScrollLeft);
+      const playheadCenterXViewport = playheadCenterXLocal + containerRect.left;
+      playheadCenterXLocalRef.current = playheadCenterXLocal;
+      containerLeftRef.current = containerRect.left;
+      const mask = buildPlayheadMask(playheadCenterXViewport, containerRect.top);
+      if (mask !== lastMaskRef.current) {
+        lastMaskRef.current = mask;
+        const style = playheadRef.current.style;
+        style.maskImage = mask;
+        style.webkitMaskImage = mask;
+      }
+    }
+
+    // Update progress fill on collapsed banner DOM nodes (registered via mount)
+    const banners = getBannerNodes();
+    for (const banner of banners) {
+      const startStr = banner.dataset.instanceStart;
+      const endStr = banner.dataset.instanceEnd;
+      if (!startStr || !endStr) continue;
+      const startNum = Number.parseFloat(startStr);
+      const endNum = Number.parseFloat(endStr);
+      const span = endNum - startNum;
+      if (!Number.isFinite(span) || span <= 0) {
+        banner.style.setProperty("--progress-fill", "0%");
+        continue;
+      }
+      const ratio = (currentTime - startNum) / span;
+      const clamped = Math.max(0, Math.min(1, ratio));
+      banner.style.setProperty("--progress-fill", `${(clamped * 100).toFixed(2)}%`);
+    }
+  });
 
   useEffect(() => {
     let yielded = false;

--- a/src/views/timeline/timeline-preview-sidebar.frame-loop.browser.test.tsx
+++ b/src/views/timeline/timeline-preview-sidebar.frame-loop.browser.test.tsx
@@ -3,6 +3,8 @@ import { wireFrameLoop } from "@/lib/frame-loop-wiring";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { createLine } from "@/test/factories";
+import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
+import { settleFrames } from "@/test/frame-steps";
 import { render } from "@/test/render";
 import { TimelinePreviewSidebar } from "@/views/timeline/timeline-preview-sidebar";
 
@@ -24,6 +26,7 @@ const Harness: React.FC = () => (
 );
 
 let disposeWiring: (() => void) | null = null;
+let probe: FrameProbe;
 
 function seedLines(): void {
   useProjectStore.setState({
@@ -64,9 +67,11 @@ function viewportOf(root: HTMLElement): HTMLElement {
 
 beforeEach(() => {
   disposeWiring = wireFrameLoop();
+  probe = createFrameProbe();
 });
 
 afterEach(() => {
+  probe.dispose();
   disposeWiring?.();
   disposeWiring = null;
 });
@@ -122,5 +127,27 @@ describe("TimelinePreviewSidebar on the frame loop", () => {
     useAudioStore.getState().seekTo(25);
 
     await expect.poll(() => viewport.scrollTop).toBeGreaterThan(0);
+  });
+
+  describe("invariants", () => {
+    it("regression #174: stops running frames once the audio is paused and idle", async () => {
+      seedLines();
+      attachAudio();
+      const screen = await render(<Harness />);
+      await expect.poll(() => lineOpacity(screen.container, 0)).toBe("1");
+      await probe.quiesce();
+
+      await settleFrames(probe.count);
+      expect(probe.count()).toBe(0);
+    });
+
+    it("regression #174: stops running frames when there is nothing synced to preview", async () => {
+      useProjectStore.setState({ lines: [] });
+      await render(<Harness />);
+      await probe.quiesce();
+
+      await settleFrames(probe.count);
+      expect(probe.count()).toBe(0);
+    });
   });
 });

--- a/src/views/timeline/timeline-preview-sidebar.frame-loop.browser.test.tsx
+++ b/src/views/timeline/timeline-preview-sidebar.frame-loop.browser.test.tsx
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { wireFrameLoop } from "@/lib/frame-loop-wiring";
+import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
+import { createLine } from "@/test/factories";
+import { render } from "@/test/render";
+import { TimelinePreviewSidebar } from "@/views/timeline/timeline-preview-sidebar";
+
+// -- Constants -----------------------------------------------------------------
+
+const LINE_COUNT = 15;
+const WORD_SECONDS = 2;
+const VIEWPORT_HEIGHT = 200;
+
+// -- Harness -------------------------------------------------------------------
+
+// Tailwind never reaches the test document, so the scroll box the sidebar's own
+// classes would create has to come from the harness for scrollIntoView to have a
+// scrollable ancestor to move.
+const Harness: React.FC = () => (
+  <div data-test="viewport" style={{ height: VIEWPORT_HEIGHT, overflow: "auto" }}>
+    <TimelinePreviewSidebar />
+  </div>
+);
+
+let disposeWiring: (() => void) | null = null;
+
+function seedLines(): void {
+  useProjectStore.setState({
+    granularity: "word",
+    lines: Array.from({ length: LINE_COUNT }, (_, index) =>
+      createLine({
+        id: `line-${index}`,
+        text: `line ${index}`,
+        words: [{ text: `line ${index}`, begin: index * WORD_SECONDS, end: (index + 1) * WORD_SECONDS }],
+      }),
+    ),
+  });
+}
+
+function attachAudio(): HTMLAudioElement {
+  const audioElement = document.createElement("audio");
+  useAudioStore.getState().registerAudioElement(audioElement);
+  return audioElement;
+}
+
+function wordSweep(root: HTMLElement, lineIndex: number): string | undefined {
+  return root.querySelector<HTMLElement>(`[data-word-begin='${lineIndex * WORD_SECONDS}']`)?.style.clipPath;
+}
+
+function sweptTo(progress: number): string {
+  return `inset(0px ${(1 - progress) * 100}% 0px 0px)`;
+}
+
+function lineOpacity(root: HTMLElement, lineIndex: number): string | undefined {
+  return root.querySelector<HTMLElement>(`[data-line-idx='${lineIndex}'][data-line-begin]`)?.style.opacity;
+}
+
+function viewportOf(root: HTMLElement): HTMLElement {
+  const viewport = root.querySelector<HTMLElement>("[data-test='viewport']");
+  if (!viewport) throw new Error("viewport missing");
+  return viewport;
+}
+
+beforeEach(() => {
+  disposeWiring = wireFrameLoop();
+});
+
+afterEach(() => {
+  disposeWiring?.();
+  disposeWiring = null;
+});
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("TimelinePreviewSidebar on the frame loop", () => {
+  it("sweeps the word clip path while the audio plays", async () => {
+    seedLines();
+    const audioElement = attachAudio();
+    const screen = await render(<Harness />);
+    await expect.poll(() => wordSweep(screen.container, 0)).toBe(sweptTo(0));
+
+    useAudioStore.getState().setIsPlaying(true);
+    audioElement.currentTime = 1;
+
+    await expect.poll(() => wordSweep(screen.container, 0)).toBe(sweptTo(0.5));
+  });
+
+  it("sweeps the word clip path after a seek while paused", async () => {
+    seedLines();
+    attachAudio();
+    const screen = await render(<Harness />);
+    await expect.poll(() => wordSweep(screen.container, 0)).toBe(sweptTo(0));
+
+    useAudioStore.getState().seekTo(3);
+
+    await expect.poll(() => wordSweep(screen.container, 1)).toBe(sweptTo(0.5));
+    expect(wordSweep(screen.container, 0)).toBe(sweptTo(1));
+  });
+
+  it("moves a line through the upcoming, active and complete opacities", async () => {
+    seedLines();
+    attachAudio();
+    const screen = await render(<Harness />);
+    await expect.poll(() => lineOpacity(screen.container, 2)).toBe("0.3");
+
+    useAudioStore.getState().seekTo(5);
+    await expect.poll(() => lineOpacity(screen.container, 2)).toBe("1");
+
+    useAudioStore.getState().seekTo(9);
+    await expect.poll(() => lineOpacity(screen.container, 2)).toBe("0.6");
+  });
+
+  it("scrolls the active line into view", async () => {
+    seedLines();
+    attachAudio();
+    const screen = await render(<Harness />);
+    const viewport = viewportOf(screen.container);
+    await expect.poll(() => lineOpacity(screen.container, 0)).toBe("1");
+    expect(viewport.scrollTop).toBe(0);
+
+    useAudioStore.getState().seekTo(25);
+
+    await expect.poll(() => viewport.scrollTop).toBeGreaterThan(0);
+  });
+});

--- a/src/views/timeline/timeline-preview-sidebar.tsx
+++ b/src/views/timeline/timeline-preview-sidebar.tsx
@@ -1,3 +1,4 @@
+import { useFrameLoop } from "@/hooks/use-frame-loop";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { getAgentColor } from "@/domain/agent/colors";
@@ -7,7 +8,7 @@ import { stripSplitCharacter } from "@/utils/split-character";
 import { splitIntoWords } from "@/utils/sync-helpers";
 import { getTimingState } from "@/views/timeline/timeline-preview-sidebar-activity";
 import { effectiveBounds } from "@/domain/line/bounds";
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 // -- Helpers ------------------------------------------------------------------
 
@@ -155,72 +156,59 @@ const TimelinePreviewSidebar: React.FC = () => {
   const lines = useProjectStore((s) => s.lines);
   const granularity = useProjectStore((s) => s.granularity);
   const containerRef = useRef<HTMLDivElement>(null);
-  const rafRef = useRef<number | null>(null);
   const lastScrolledLineRef = useRef<number>(-1);
 
-  // Animation loop - queries DOM directly on each frame for reliability
-  useEffect(() => {
-    const update = () => {
-      const container = containerRef.current;
-      if (!container) {
-        rafRef.current = requestAnimationFrame(update);
-        return;
+  // Queries DOM directly on each frame for reliability
+  useFrameLoop(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const audioEl = useAudioStore.getState().audioElement;
+    const currentTime = audioEl?.currentTime ?? useAudioStore.getState().currentTime;
+    let currentLineIdx = -1;
+
+    const wordEls = container.querySelectorAll<HTMLElement>("[data-word-begin]");
+    for (const el of wordEls) {
+      const begin = Number.parseFloat(el.dataset.wordBegin ?? "0");
+      const end = Number.parseFloat(el.dataset.wordEnd ?? "0");
+      const lineIdx = Number.parseInt(el.dataset.lineIdx ?? "-1", 10);
+
+      const { isActive, progress } = getTimingState(begin, end, currentTime);
+      el.style.clipPath = `inset(0 ${(1 - progress) * 100}% 0 0)`;
+
+      if (isActive && lineIdx > currentLineIdx) {
+        currentLineIdx = lineIdx;
       }
+    }
 
-      const audioEl = useAudioStore.getState().audioElement;
-      const currentTime = audioEl?.currentTime ?? useAudioStore.getState().currentTime;
-      let currentLineIdx = -1;
+    const lineEls = container.querySelectorAll<HTMLElement>("[data-line-begin]");
+    for (const el of lineEls) {
+      const begin = Number.parseFloat(el.dataset.lineBegin ?? "0");
+      const end = Number.parseFloat(el.dataset.lineEnd ?? "0");
+      const { isActive, isComplete } = getTimingState(begin, end, currentTime);
+      const style = el.style;
 
-      const wordEls = container.querySelectorAll<HTMLElement>("[data-word-begin]");
-      for (const el of wordEls) {
-        const begin = Number.parseFloat(el.dataset.wordBegin ?? "0");
-        const end = Number.parseFloat(el.dataset.wordEnd ?? "0");
-        const lineIdx = Number.parseInt(el.dataset.lineIdx ?? "-1", 10);
-
-        const { isActive, progress } = getTimingState(begin, end, currentTime);
-        el.style.clipPath = `inset(0 ${(1 - progress) * 100}% 0 0)`;
-
-        if (isActive && lineIdx > currentLineIdx) {
-          currentLineIdx = lineIdx;
-        }
+      if (isActive) {
+        style.opacity = "1";
+      } else if (isComplete) {
+        style.opacity = "0.6";
+      } else {
+        style.opacity = "0.3";
       }
+    }
 
-      const lineEls = container.querySelectorAll<HTMLElement>("[data-line-begin]");
+    // Auto-scroll to current line
+    if (currentLineIdx !== -1 && currentLineIdx !== lastScrolledLineRef.current) {
       for (const el of lineEls) {
-        const begin = Number.parseFloat(el.dataset.lineBegin ?? "0");
-        const end = Number.parseFloat(el.dataset.lineEnd ?? "0");
-        const { isActive, isComplete } = getTimingState(begin, end, currentTime);
-        const style = el.style;
-
-        if (isActive) {
-          style.opacity = "1";
-        } else if (isComplete) {
-          style.opacity = "0.6";
-        } else {
-          style.opacity = "0.3";
+        const idx = Number.parseInt(el.dataset.lineIdx ?? "-1", 10);
+        if (idx === currentLineIdx) {
+          el.scrollIntoView({ behavior: "smooth", block: "center" });
+          lastScrolledLineRef.current = currentLineIdx;
+          break;
         }
       }
-
-      // Auto-scroll to current line
-      if (currentLineIdx !== -1 && currentLineIdx !== lastScrolledLineRef.current) {
-        for (const el of lineEls) {
-          const idx = Number.parseInt(el.dataset.lineIdx ?? "-1", 10);
-          if (idx === currentLineIdx) {
-            el.scrollIntoView({ behavior: "smooth", block: "center" });
-            lastScrolledLineRef.current = currentLineIdx;
-            break;
-          }
-        }
-      }
-
-      rafRef.current = requestAnimationFrame(update);
-    };
-
-    rafRef.current = requestAnimationFrame(update);
-    return () => {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
-    };
-  }, []);
+    }
+  }, "timeline-preview-sidebar");
 
   const hasSyncedContent = lines.some((line) => effectiveBounds(line) !== null);
 
@@ -233,11 +221,14 @@ const TimelinePreviewSidebar: React.FC = () => {
   }
 
   return (
-    <div className="w-64 border-l border-composer-border bg-composer-bg-dark flex flex-col overflow-hidden">
+    <div
+      ref={containerRef}
+      className="w-64 border-l border-composer-border bg-composer-bg-dark flex flex-col overflow-hidden"
+    >
       <div className="px-3 py-2 border-b border-composer-border text-xs font-medium text-composer-text-muted">
         Preview
       </div>
-      <Scroll viewportRef={containerRef} className="flex-1 py-2">
+      <Scroll className="flex-1 py-2">
         {lines.map((line, index) => (
           <MiniPreviewLine key={line.id} line={line} lineIndex={index} granularity={granularity} />
         ))}

--- a/src/views/timeline/timeline-waveform.browser.test.tsx
+++ b/src/views/timeline/timeline-waveform.browser.test.tsx
@@ -1,8 +1,9 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import indexCss from "@/index.css?raw";
 import { TimelineWaveform } from "@/views/timeline/timeline-waveform";
 import { useAudioStore } from "@/stores/audio";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
-import { createAudioFile } from "@/test/audio-fixtures";
+import { bufferToBlobUrl, createAudioFile, makeSineBuffer } from "@/test/audio-fixtures";
 import { render } from "@/test/render";
 import { readToken } from "@/utils/theme/read-token";
 import { TOKEN_VAR } from "@/domain/theme/model";
@@ -13,6 +14,27 @@ function setupWaveformAudio(duration = 30) {
     duration,
   });
 }
+
+// The browser project registers no Tailwind plugin and imports no stylesheet, so
+// the sweep rules are lifted out of the real src/index.css rather than restated.
+function extractCssBlock(css: string, header: RegExp): string {
+  const match = header.exec(css);
+  if (!match) throw new Error(`no CSS block matching ${header} in src/index.css`);
+  const bodyStart = match.index + match[0].length;
+  let depth = 1;
+  for (let i = bodyStart; i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}" && --depth === 0) return css.slice(bodyStart, i);
+  }
+  throw new Error(`unbalanced CSS block matching ${header} in src/index.css`);
+}
+
+const SWEEP_ANIMATION_NAME = "waveform-loading-sweep";
+
+const WAVEFORM_SWEEP_CSS = [
+  `.waveform-loading-dots {${extractCssBlock(indexCss, /@utility\s+waveform-loading-dots\s*\{/)}}`,
+  `@keyframes ${SWEEP_ANIMATION_NAME} {${extractCssBlock(indexCss, /@keyframes\s+waveform-loading-sweep\s*\{/)}}`,
+].join("\n");
 
 describe("TimelineWaveform", () => {
   it("renders nothing when there is no audio source", async () => {
@@ -338,5 +360,106 @@ describe("TimelineWaveform loading dots", () => {
     setupWaveformAudio(30);
     await render(<TimelineWaveform />);
     expect(getDots()?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  describe("sweep lifecycle", () => {
+    let sweepStyles: HTMLStyleElement;
+
+    beforeAll(() => {
+      sweepStyles = document.createElement("style");
+      sweepStyles.textContent = WAVEFORM_SWEEP_CSS;
+      document.head.appendChild(sweepStyles);
+    });
+
+    afterAll(() => sweepStyles.remove());
+
+    function requireDots(): HTMLElement {
+      const dots = getDots();
+      if (!dots) throw new Error("loading dots layer not found");
+      return dots;
+    }
+
+    function sweepAnimationName(): string {
+      return getComputedStyle(requireDots(), "::before").animationName;
+    }
+
+    function nextFrame(): Promise<void> {
+      return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+    }
+
+    function playableAudio(durationSeconds: number): HTMLAudioElement {
+      const audio = new Audio();
+      audio.src = bufferToBlobUrl(makeSineBuffer(durationSeconds));
+      setupWaveformAudio(durationSeconds);
+      useAudioStore.setState({ audioElement: audio });
+      return audio;
+    }
+
+    it("sweeps while the loading layer is still visible", async () => {
+      setupWaveformAudio(30);
+      await render(<TimelineWaveform />);
+      expect(requireDots().style.opacity).toBe("1");
+      expect(sweepAnimationName()).toBe(SWEEP_ANIMATION_NAME);
+    });
+
+    it("keeps sweeping right after WaveSurfer becomes ready, because the layer is still fading out", async () => {
+      playableAudio(2);
+      await render(<TimelineWaveform />);
+      await expect.poll(() => requireDots().style.opacity, { timeout: 5000 }).toBe("0");
+      expect(sweepAnimationName()).toBe(SWEEP_ANIMATION_NAME);
+    });
+
+    it("stops sweeping once the fade-out has finished", async () => {
+      playableAudio(2);
+      await render(<TimelineWaveform />);
+      await expect.poll(() => sweepAnimationName(), { timeout: 5000 }).toBe("none");
+      expect(requireDots().style.opacity).toBe("0");
+    });
+
+    it("regression #174: never sweeps once settled and invisible", async () => {
+      playableAudio(2);
+      await render(<TimelineWaveform />);
+      await expect.poll(() => sweepAnimationName(), { timeout: 5000 }).toBe("none");
+
+      const sweptWhileSettled: number[] = [];
+      for (let frame = 0; frame < 30; frame++) {
+        await nextFrame();
+        if (sweepAnimationName() !== "none") sweptWhileSettled.push(frame);
+      }
+      expect(sweptWhileSettled).toEqual([]);
+      expect(requireDots().style.opacity).toBe("0");
+    });
+
+    it("regression: the loading layer is never unmounted across the whole ready-then-settle cycle", async () => {
+      playableAudio(2);
+      await render(<TimelineWaveform />);
+      const layer = requireDots();
+      await expect.poll(() => sweepAnimationName(), { timeout: 5000 }).toBe("none");
+      expect(requireDots()).toBe(layer);
+    });
+
+    it("regression #174: sweep is already active in the frame the source changes", async () => {
+      const audio = playableAudio(2);
+      await render(<TimelineWaveform />);
+      const layer = requireDots();
+      await expect.poll(() => sweepAnimationName(), { timeout: 5000 }).toBe("none");
+
+      audio.src = bufferToBlobUrl(makeSineBuffer(3));
+      useAudioStore.setState({ duration: 3 });
+
+      let becameVisibleAgain = false;
+      const visibleButNotSweeping: number[] = [];
+      for (let frame = 0; frame < 60; frame++) {
+        if (layer.style.opacity === "1") {
+          becameVisibleAgain = true;
+          if (sweepAnimationName() !== SWEEP_ANIMATION_NAME) visibleButNotSweeping.push(frame);
+        }
+        await nextFrame();
+      }
+
+      expect(becameVisibleAgain).toBe(true);
+      expect(visibleButNotSweeping).toEqual([]);
+      expect(requireDots()).toBe(layer);
+    });
   });
 });

--- a/src/views/timeline/timeline-waveform.browser.test.tsx
+++ b/src/views/timeline/timeline-waveform.browser.test.tsx
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import indexCss from "@/index.css?raw";
+import { installStyleSheet, WAVEFORM_SWEEP_ANIMATION, WAVEFORM_SWEEP_CSS } from "@/test/browser-css";
 import { FADE_SETTLE_MS, TimelineWaveform } from "@/views/timeline/timeline-waveform";
 import { useAudioStore } from "@/stores/audio";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
@@ -14,26 +14,6 @@ function setupWaveformAudio(duration = 30) {
     duration,
   });
 }
-
-// The browser project has no Tailwind plugin, so sweep rules come from the real src/index.css.
-function extractCssBlock(css: string, header: RegExp): string {
-  const match = header.exec(css);
-  if (!match) throw new Error(`no CSS block matching ${header} in src/index.css`);
-  const bodyStart = match.index + match[0].length;
-  let depth = 1;
-  for (let i = bodyStart; i < css.length; i++) {
-    if (css[i] === "{") depth++;
-    else if (css[i] === "}" && --depth === 0) return css.slice(bodyStart, i);
-  }
-  throw new Error(`unbalanced CSS block matching ${header} in src/index.css`);
-}
-
-const SWEEP_ANIMATION_NAME = "waveform-loading-sweep";
-
-const WAVEFORM_SWEEP_CSS = [
-  `.waveform-loading-dots {${extractCssBlock(indexCss, /@utility\s+waveform-loading-dots\s*\{/)}}`,
-  `@keyframes ${SWEEP_ANIMATION_NAME} {${extractCssBlock(indexCss, /@keyframes\s+waveform-loading-sweep\s*\{/)}}`,
-].join("\n");
 
 describe("TimelineWaveform", () => {
   it("renders nothing when there is no audio source", async () => {
@@ -365,9 +345,7 @@ describe("TimelineWaveform loading dots", () => {
     let sweepStyles: HTMLStyleElement;
 
     beforeAll(() => {
-      sweepStyles = document.createElement("style");
-      sweepStyles.textContent = WAVEFORM_SWEEP_CSS;
-      document.head.appendChild(sweepStyles);
+      sweepStyles = installStyleSheet(WAVEFORM_SWEEP_CSS);
       expect(sweepStyles.sheet?.cssRules.length).toBeGreaterThan(1);
     });
 
@@ -399,7 +377,7 @@ describe("TimelineWaveform loading dots", () => {
       setupWaveformAudio(30);
       await render(<TimelineWaveform />);
       expect(requireDots().style.opacity).toBe("1");
-      expect(sweepAnimationName()).toBe(SWEEP_ANIMATION_NAME);
+      expect(sweepAnimationName()).toBe(WAVEFORM_SWEEP_ANIMATION);
     });
 
     it("keeps sweeping right after WaveSurfer becomes ready, because the layer is still fading out", async () => {
@@ -407,7 +385,7 @@ describe("TimelineWaveform loading dots", () => {
       await render(<TimelineWaveform />);
       await expect
         .poll(() => ({ opacity: requireDots().style.opacity, animation: sweepAnimationName() }), { timeout: 5000 })
-        .toEqual({ opacity: "0", animation: SWEEP_ANIMATION_NAME });
+        .toEqual({ opacity: "0", animation: WAVEFORM_SWEEP_ANIMATION });
     });
 
     it("stops sweeping once the fade-out has finished", async () => {

--- a/src/views/timeline/timeline-waveform.browser.test.tsx
+++ b/src/views/timeline/timeline-waveform.browser.test.tsx
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import indexCss from "@/index.css?raw";
-import { TimelineWaveform } from "@/views/timeline/timeline-waveform";
+import { FADE_SETTLE_MS, TimelineWaveform } from "@/views/timeline/timeline-waveform";
 import { useAudioStore } from "@/stores/audio";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { bufferToBlobUrl, createAudioFile, makeSineBuffer } from "@/test/audio-fixtures";
@@ -438,28 +438,40 @@ describe("TimelineWaveform loading dots", () => {
       expect(requireDots()).toBe(layer);
     });
 
+    // Sampled per committed DOM mutation rather than per animation frame: a passive
+    // effect's lag is sub-frame, so a rAF sampler only catches it when a vsync
+    // boundary happens to fall between the two commits.
     it("regression #174: sweep is already active in the frame the source changes", async () => {
       const audio = playableAudio(2);
       await render(<TimelineWaveform />);
       const layer = requireDots();
       await expect.poll(() => sweepAnimationName(), { timeout: 5000 }).toBe("none");
 
+      const commits: { opacity: string; sweeping: boolean }[] = [];
+      const observer = new MutationObserver(() => {
+        commits.push({ opacity: layer.style.opacity, sweeping: layer.hasAttribute("data-sweeping") });
+      });
+      observer.observe(layer, { attributes: true, attributeFilter: ["style", "data-sweeping"] });
+
       audio.src = bufferToBlobUrl(makeSineBuffer(3));
       useAudioStore.setState({ duration: 3 });
 
-      let becameVisibleAgain = false;
-      const visibleButNotSweeping: number[] = [];
-      for (let frame = 0; frame < 60; frame++) {
-        if (layer.style.opacity === "1") {
-          becameVisibleAgain = true;
-          if (sweepAnimationName() !== SWEEP_ANIMATION_NAME) visibleButNotSweeping.push(frame);
-        }
-        await nextFrame();
+      try {
+        await expect.poll(() => commits.some((c) => c.opacity === "1"), { timeout: 5000 }).toBe(true);
+        for (let frame = 0; frame < 5; frame++) await nextFrame();
+      } finally {
+        observer.disconnect();
       }
 
-      expect(becameVisibleAgain).toBe(true);
-      expect(visibleButNotSweeping).toEqual([]);
+      expect(commits.filter((c) => c.opacity === "1" && !c.sweeping)).toEqual([]);
       expect(requireDots()).toBe(layer);
+    });
+
+    it("settle delay outlasts the fade-out transition it is paired with", async () => {
+      setupWaveformAudio(30);
+      await render(<TimelineWaveform />);
+      expect(requireDots().className).toContain("duration-200");
+      expect(FADE_SETTLE_MS).toBeGreaterThan(200);
     });
   });
 });

--- a/src/views/timeline/timeline-waveform.browser.test.tsx
+++ b/src/views/timeline/timeline-waveform.browser.test.tsx
@@ -15,8 +15,7 @@ function setupWaveformAudio(duration = 30) {
   });
 }
 
-// The browser project registers no Tailwind plugin and imports no stylesheet, so
-// the sweep rules are lifted out of the real src/index.css rather than restated.
+// The browser project has no Tailwind plugin, so sweep rules come from the real src/index.css.
 function extractCssBlock(css: string, header: RegExp): string {
   const match = header.exec(css);
   if (!match) throw new Error(`no CSS block matching ${header} in src/index.css`);
@@ -369,6 +368,7 @@ describe("TimelineWaveform loading dots", () => {
       sweepStyles = document.createElement("style");
       sweepStyles.textContent = WAVEFORM_SWEEP_CSS;
       document.head.appendChild(sweepStyles);
+      expect(sweepStyles.sheet?.cssRules.length).toBeGreaterThan(1);
     });
 
     afterAll(() => sweepStyles.remove());
@@ -387,7 +387,7 @@ describe("TimelineWaveform loading dots", () => {
       return new Promise((resolve) => requestAnimationFrame(() => resolve()));
     }
 
-    function playableAudio(durationSeconds: number): HTMLAudioElement {
+    function setupPlayableAudio(durationSeconds: number): HTMLAudioElement {
       const audio = new Audio();
       audio.src = bufferToBlobUrl(makeSineBuffer(durationSeconds));
       setupWaveformAudio(durationSeconds);
@@ -403,21 +403,22 @@ describe("TimelineWaveform loading dots", () => {
     });
 
     it("keeps sweeping right after WaveSurfer becomes ready, because the layer is still fading out", async () => {
-      playableAudio(2);
+      setupPlayableAudio(2);
       await render(<TimelineWaveform />);
-      await expect.poll(() => requireDots().style.opacity, { timeout: 5000 }).toBe("0");
-      expect(sweepAnimationName()).toBe(SWEEP_ANIMATION_NAME);
+      await expect
+        .poll(() => ({ opacity: requireDots().style.opacity, animation: sweepAnimationName() }), { timeout: 5000 })
+        .toEqual({ opacity: "0", animation: SWEEP_ANIMATION_NAME });
     });
 
     it("stops sweeping once the fade-out has finished", async () => {
-      playableAudio(2);
+      setupPlayableAudio(2);
       await render(<TimelineWaveform />);
       await expect.poll(() => sweepAnimationName(), { timeout: 5000 }).toBe("none");
       expect(requireDots().style.opacity).toBe("0");
     });
 
     it("regression #174: never sweeps once settled and invisible", async () => {
-      playableAudio(2);
+      setupPlayableAudio(2);
       await render(<TimelineWaveform />);
       await expect.poll(() => sweepAnimationName(), { timeout: 5000 }).toBe("none");
 
@@ -431,18 +432,16 @@ describe("TimelineWaveform loading dots", () => {
     });
 
     it("regression: the loading layer is never unmounted across the whole ready-then-settle cycle", async () => {
-      playableAudio(2);
+      setupPlayableAudio(2);
       await render(<TimelineWaveform />);
       const layer = requireDots();
       await expect.poll(() => sweepAnimationName(), { timeout: 5000 }).toBe("none");
       expect(requireDots()).toBe(layer);
     });
 
-    // Sampled per committed DOM mutation rather than per animation frame: a passive
-    // effect's lag is sub-frame, so a rAF sampler only catches it when a vsync
-    // boundary happens to fall between the two commits.
-    it("regression #174: sweep is already active in the frame the source changes", async () => {
-      const audio = playableAudio(2);
+    // A passive effect's lag is sub-frame, so a rAF sampler would miss it; sample per committed mutation.
+    it("regression #174: sweep is active in the commit the source changes, then stops again once resettled", async () => {
+      const audio = setupPlayableAudio(2);
       await render(<TimelineWaveform />);
       const layer = requireDots();
       await expect.poll(() => sweepAnimationName(), { timeout: 5000 }).toBe("none");
@@ -465,13 +464,17 @@ describe("TimelineWaveform loading dots", () => {
 
       expect(commits.filter((c) => c.opacity === "1" && !c.sweeping)).toEqual([]);
       expect(requireDots()).toBe(layer);
+
+      await expect.poll(() => sweepAnimationName(), { timeout: 5000 }).toBe("none");
+      expect(requireDots().style.opacity).toBe("0");
     });
 
     it("settle delay outlasts the fade-out transition it is paired with", async () => {
       setupWaveformAudio(30);
       await render(<TimelineWaveform />);
-      expect(requireDots().className).toContain("duration-200");
-      expect(FADE_SETTLE_MS).toBeGreaterThan(200);
+      const fadeMs = Number(/duration-(\d+)/.exec(requireDots().className)?.[1]);
+      expect(fadeMs).toBeGreaterThan(0);
+      expect(FADE_SETTLE_MS).toBeGreaterThan(fadeMs);
     });
   });
 });

--- a/src/views/timeline/timeline-waveform.tsx
+++ b/src/views/timeline/timeline-waveform.tsx
@@ -11,6 +11,10 @@ import WavesurferPlayer from "@wavesurfer/react";
 import { useCallback, useEffect, useState } from "react";
 import type WaveSurfer from "wavesurfer.js";
 
+// -- Constants -----------------------------------------------------------------
+
+const FADE_SETTLE_MS = 260;
+
 // -- Component -----------------------------------------------------------------
 
 const TimelineWaveform: React.FC = () => {
@@ -24,7 +28,11 @@ const TimelineWaveform: React.FC = () => {
   const markerMode = useTimelineStore((s) => s.markerMode);
 
   const [ws, setWs] = useState<WaveSurfer | null>(null);
+  const [settledFor, setSettledFor] = useState<WaveSurfer | null>(null);
   const [altHeld, setAltHeld] = useState(false);
+
+  // Never move this into an effect: opacity and the sweep gate must land in the same commit.
+  const sweeping = ws === null || settledFor !== ws;
 
   const totalWidth = duration > 0 ? duration * zoom : 0;
   const waveformKey = audioElement?.src ?? "no-audio";
@@ -53,6 +61,12 @@ const TimelineWaveform: React.FC = () => {
     if (!ws) return;
     ws.zoom(zoom);
   }, [ws, zoom]);
+
+  useEffect(() => {
+    if (!ws) return;
+    const timer = setTimeout(() => setSettledFor(ws), FADE_SETTLE_MS);
+    return () => clearTimeout(timer);
+  }, [ws]);
 
   const timeFromClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -110,6 +124,7 @@ const TimelineWaveform: React.FC = () => {
       />
       <div
         data-waveform-loading-dots
+        data-sweeping={sweeping ? "" : undefined}
         aria-hidden="true"
         className="absolute top-0 left-0 waveform-loading-dots pointer-events-none transition-opacity duration-200 ease-out"
         style={{ width: totalWidth, height: WAVEFORM_HEIGHT - 1, opacity: ws ? 0 : 1 }}

--- a/src/views/timeline/timeline-waveform.tsx
+++ b/src/views/timeline/timeline-waveform.tsx
@@ -102,7 +102,10 @@ const TimelineWaveform: React.FC = () => {
     [duration, totalWidth, timeFromClick, addSnappedPoint, seekTo],
   );
 
-  const onDestroy = useCallback(() => setWs(null), []);
+  const onDestroy = useCallback(() => {
+    setWs(null);
+    setSettledFor(null);
+  }, []);
 
   const onReady = useCallback((wavesurfer: WaveSurfer) => {
     setWs(wavesurfer);

--- a/src/views/timeline/timeline-waveform.tsx
+++ b/src/views/timeline/timeline-waveform.tsx
@@ -173,4 +173,4 @@ const TimelineWaveform: React.FC = () => {
 
 // -- Exports -------------------------------------------------------------------
 
-export { TimelineWaveform };
+export { FADE_SETTLE_MS, TimelineWaveform };

--- a/src/views/timeline/use-marquee.browser.test.tsx
+++ b/src/views/timeline/use-marquee.browser.test.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { subscribeFrame } from "@/lib/frame-loop";
 import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
 import { settleFrames, stepFrames } from "@/test/frame-steps";
 import { render } from "@/test/render";
@@ -58,6 +59,35 @@ function releaseDrag(): void {
   document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
 }
 
+function marqueeIn(root: HTMLElement): HTMLElement | null {
+  return root.querySelector<HTMLElement>("[data-test='marquee']");
+}
+
+interface FrameRelease {
+  releaseWithinFrame: () => Promise<void>;
+  dispose: () => void;
+}
+
+// Subscribed before the hook's own tick so the mouseup lands in the same task, ahead of it.
+function createFrameRelease(): FrameRelease {
+  let pendingRelease: (() => void) | null = null;
+  const unsubscribe = subscribeFrame(() => {
+    const resolveRelease = pendingRelease;
+    if (!resolveRelease) return;
+    pendingRelease = null;
+    releaseDrag();
+    resolveRelease();
+  }, "marquee-release-gate");
+
+  return {
+    releaseWithinFrame: () =>
+      new Promise<void>((resolve) => {
+        pendingRelease = resolve;
+      }),
+    dispose: unsubscribe,
+  };
+}
+
 async function dragToEdgeAndScroll(root: HTMLElement): Promise<{ container: HTMLDivElement; rect: DOMRect }> {
   const container = scrollContainerOf(root);
   const rect = pressInside(container);
@@ -67,13 +97,16 @@ async function dragToEdgeAndScroll(root: HTMLElement): Promise<{ container: HTML
 }
 
 let probe: FrameProbe;
+let frameRelease: FrameRelease;
 
 beforeEach(() => {
   probe = createFrameProbe();
+  frameRelease = createFrameRelease();
 });
 
 afterEach(() => {
   releaseDrag();
+  frameRelease.dispose();
   probe.dispose();
 });
 
@@ -129,6 +162,17 @@ describe("useMarquee auto-scroll", () => {
       const settled = await settleFrames(probe.count);
       await stepFrames(IDLE_FRAMES);
       expect(probe.count()).toBe(settled);
+    });
+
+    it("regression: a mouseup that lands in the auto-scroll frame does not re-show the marquee", async () => {
+      const screen = await render(<Harness />);
+      await dragToEdgeAndScroll(screen.container);
+      expect(marqueeIn(screen.container)).not.toBeNull();
+
+      await frameRelease.releaseWithinFrame();
+      await settleFrames(probe.count);
+
+      expect(marqueeIn(screen.container)).toBeNull();
     });
 
     it("regression #174: a released drag leaves no stale hold, so a second drag scrolls and quiesces too", async () => {

--- a/src/views/timeline/use-marquee.browser.test.tsx
+++ b/src/views/timeline/use-marquee.browser.test.tsx
@@ -1,0 +1,152 @@
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
+import { settleFrames, stepFrames } from "@/test/frame-steps";
+import { render } from "@/test/render";
+import { useMarquee } from "@/views/timeline/use-marquee";
+
+// -- Constants -----------------------------------------------------------------
+
+const VIEWPORT_WIDTH = 400;
+const VIEWPORT_HEIGHT = 300;
+const CONTENT_SIZE = 4000;
+const RELEASE_FRAMES = 6;
+const IDLE_FRAMES = 30;
+
+// -- Harness -------------------------------------------------------------------
+
+const Harness: React.FC = () => {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const { marqueeRect, handleMarqueeMouseDown } = useMarquee(scrollContainerRef);
+
+  return (
+    <div
+      ref={scrollContainerRef}
+      data-test="scroll-container"
+      onMouseDown={handleMarqueeMouseDown}
+      style={{ position: "relative", width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT, overflow: "auto" }}
+    >
+      <div style={{ width: CONTENT_SIZE, height: CONTENT_SIZE }} />
+      {marqueeRect && <div data-test="marquee" style={{ position: "absolute", top: 0, left: 0 }} />}
+    </div>
+  );
+};
+
+// -- Helpers -------------------------------------------------------------------
+
+function scrollContainerOf(root: HTMLElement): HTMLDivElement {
+  const container = root.querySelector<HTMLDivElement>("[data-test='scroll-container']");
+  if (!container) throw new Error("scroll container missing");
+  return container;
+}
+
+function pressInside(container: HTMLElement): DOMRect {
+  const rect = container.getBoundingClientRect();
+  container.dispatchEvent(
+    new MouseEvent("mousedown", { button: 0, clientX: rect.left + 60, clientY: rect.top + 60, bubbles: true }),
+  );
+  return rect;
+}
+
+function dragToBottomEdge(rect: DOMRect): void {
+  document.dispatchEvent(
+    new MouseEvent("mousemove", { clientX: rect.left + 70, clientY: rect.top + VIEWPORT_HEIGHT - 10, bubbles: true }),
+  );
+}
+
+function releaseDrag(): void {
+  document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+}
+
+async function dragToEdgeAndScroll(root: HTMLElement): Promise<{ container: HTMLDivElement; rect: DOMRect }> {
+  const container = scrollContainerOf(root);
+  const rect = pressInside(container);
+  dragToBottomEdge(rect);
+  await expect.poll(() => container.scrollTop).toBeGreaterThan(0);
+  return { container, rect };
+}
+
+let probe: FrameProbe;
+
+beforeEach(() => {
+  probe = createFrameProbe();
+});
+
+afterEach(() => {
+  releaseDrag();
+  probe.dispose();
+});
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("useMarquee auto-scroll", () => {
+  it("scrolls the container when the pointer reaches the bottom edge zone", async () => {
+    const screen = await render(<Harness />);
+    await dragToEdgeAndScroll(screen.container);
+  });
+
+  it("keeps scrolling while the pointer is held still at the edge", async () => {
+    const screen = await render(<Harness />);
+    const { container } = await dragToEdgeAndScroll(screen.container);
+
+    const before = container.scrollTop;
+    await stepFrames(IDLE_FRAMES);
+    expect(container.scrollTop).toBeGreaterThan(before);
+  });
+
+  it("stops scrolling once the drag is released", async () => {
+    const screen = await render(<Harness />);
+    const { container } = await dragToEdgeAndScroll(screen.container);
+
+    releaseDrag();
+    await stepFrames(RELEASE_FRAMES);
+    const parked = container.scrollTop;
+
+    await stepFrames(IDLE_FRAMES);
+    expect(container.scrollTop).toBe(parked);
+  });
+
+  describe("regressions", () => {
+    it("regression #174: the hold is released on unmount mid-drag", async () => {
+      const screen = await render(<Harness />);
+      const { container } = await dragToEdgeAndScroll(screen.container);
+
+      screen.unmount();
+      await stepFrames(RELEASE_FRAMES);
+      const parked = container.scrollTop;
+
+      const settled = await settleFrames(probe.count);
+      await stepFrames(IDLE_FRAMES);
+      expect(probe.count()).toBe(settled);
+      expect(container.scrollTop).toBe(parked);
+    });
+
+    it("regression #174: the loop quiesces after the drag ends", async () => {
+      const screen = await render(<Harness />);
+      await dragToEdgeAndScroll(screen.container);
+
+      releaseDrag();
+      const settled = await settleFrames(probe.count);
+      await stepFrames(IDLE_FRAMES);
+      expect(probe.count()).toBe(settled);
+    });
+
+    it("regression #174: a released drag leaves no stale hold, so a second drag scrolls and quiesces too", async () => {
+      const screen = await render(<Harness />);
+      const { container } = await dragToEdgeAndScroll(screen.container);
+
+      releaseDrag();
+      await settleFrames(probe.count);
+
+      const rect = pressInside(container);
+      const resumedFrom = container.scrollTop;
+      dragToBottomEdge(rect);
+      await expect.poll(() => container.scrollTop).toBeGreaterThan(resumedFrom);
+
+      releaseDrag();
+      const settled = await settleFrames(probe.count);
+      await stepFrames(IDLE_FRAMES);
+      expect(probe.count()).toBe(settled);
+    });
+  });
+});

--- a/src/views/timeline/use-marquee.browser.test.tsx
+++ b/src/views/timeline/use-marquee.browser.test.tsx
@@ -68,15 +68,17 @@ interface FrameRelease {
   dispose: () => void;
 }
 
-// Subscribed before the hook's own tick so the mouseup lands in the same task, ahead of it.
 function createFrameRelease(): FrameRelease {
   let pendingRelease: (() => void) | null = null;
   const unsubscribe = subscribeFrame(() => {
     const resolveRelease = pendingRelease;
     if (!resolveRelease) return;
     pendingRelease = null;
-    releaseDrag();
-    resolveRelease();
+    try {
+      releaseDrag();
+    } finally {
+      resolveRelease();
+    }
   }, "marquee-release-gate");
 
   return {
@@ -101,6 +103,7 @@ let frameRelease: FrameRelease;
 
 beforeEach(() => {
   probe = createFrameProbe();
+  // Subscribed before the hook's autoScroll subscriber so the mouseup lands in the same task, ahead of it.
   frameRelease = createFrameRelease();
 });
 

--- a/src/views/timeline/use-marquee.browser.test.tsx
+++ b/src/views/timeline/use-marquee.browser.test.tsx
@@ -99,17 +99,13 @@ async function dragToEdgeAndScroll(root: HTMLElement): Promise<{ container: HTML
 }
 
 let probe: FrameProbe;
-let frameRelease: FrameRelease;
 
 beforeEach(() => {
   probe = createFrameProbe();
-  // Subscribed before the hook's autoScroll subscriber so the mouseup lands in the same task, ahead of it.
-  frameRelease = createFrameRelease();
 });
 
 afterEach(() => {
   releaseDrag();
-  frameRelease.dispose();
   probe.dispose();
 });
 
@@ -168,14 +164,20 @@ describe("useMarquee auto-scroll", () => {
     });
 
     it("regression: a mouseup that lands in the auto-scroll frame does not re-show the marquee", async () => {
-      const screen = await render(<Harness />);
-      await dragToEdgeAndScroll(screen.container);
-      expect(marqueeIn(screen.container)).not.toBeNull();
+      // Subscribed here, ahead of the hook's autoScroll subscriber, so the mouseup runs first in the same frame.
+      const frameRelease = createFrameRelease();
+      try {
+        const screen = await render(<Harness />);
+        await dragToEdgeAndScroll(screen.container);
+        expect(marqueeIn(screen.container)).not.toBeNull();
 
-      await frameRelease.releaseWithinFrame();
-      await settleFrames(probe.count);
+        await frameRelease.releaseWithinFrame();
+        await settleFrames(probe.count);
 
-      expect(marqueeIn(screen.container)).toBeNull();
+        expect(marqueeIn(screen.container)).toBeNull();
+      } finally {
+        frameRelease.dispose();
+      }
     });
 
     it("regression #174: a released drag leaves no stale hold, so a second drag scrolls and quiesces too", async () => {

--- a/src/views/timeline/use-marquee.ts
+++ b/src/views/timeline/use-marquee.ts
@@ -1,3 +1,5 @@
+import { useFrameLoop } from "@/hooks/use-frame-loop";
+import { holdFrames } from "@/lib/frame-loop";
 import { useProjectStore } from "@/stores/project";
 import { GROUP_HEADER_HEIGHT } from "@/views/timeline/group-header-row";
 import type { WordSelection } from "@/domain/selection/model";
@@ -24,15 +26,16 @@ const ACTIVATION_THRESHOLD = 5;
 const BG_DROP_ZONE_HEIGHT = 24;
 const AUTO_SCROLL_ZONE = 40;
 const AUTO_SCROLL_SPEED = 8;
+const AUTO_SCROLL_LABEL = "marquee-scroll";
 
 // -- Hook ----------------------------------------------------------------------
 
 function useMarquee(scrollContainerRef: RefObject<HTMLDivElement | null>) {
   const [marqueeRect, setMarqueeRect] = useState<MarqueeRect | null>(null);
+  const [autoScrolling, setAutoScrolling] = useState(false);
   const stateRef = useRef<MarqueeState>("idle");
   const startRef = useRef({ clientX: 0, clientY: 0, scrollLeft: 0, scrollTop: 0 });
   const currentRef = useRef({ clientX: 0, clientY: 0 });
-  const rafRef = useRef<number | null>(null);
   const shiftRef = useRef(false);
 
   const computeRect = useCallback((): MarqueeRect | null => {
@@ -55,6 +58,42 @@ function useMarquee(scrollContainerRef: RefObject<HTMLDivElement | null>) {
 
     return { x, y, width, height };
   }, [scrollContainerRef]);
+
+  const autoScroll = useCallback(() => {
+    const c = scrollContainerRef.current;
+    if (!c) return;
+
+    const cRect = c.getBoundingClientRect();
+    const cy = currentRef.current.clientY - cRect.top;
+    const cx = currentRef.current.clientX - cRect.left;
+
+    let scrolled = false;
+    if (cy < AUTO_SCROLL_ZONE) {
+      c.scrollTop -= AUTO_SCROLL_SPEED;
+      scrolled = true;
+    } else if (cy > cRect.height - AUTO_SCROLL_ZONE) {
+      c.scrollTop += AUTO_SCROLL_SPEED;
+      scrolled = true;
+    }
+    if (cx < AUTO_SCROLL_ZONE) {
+      c.scrollLeft -= AUTO_SCROLL_SPEED;
+      scrolled = true;
+    } else if (cx > cRect.width - AUTO_SCROLL_ZONE) {
+      c.scrollLeft += AUTO_SCROLL_SPEED;
+      scrolled = true;
+    }
+
+    if (scrolled) {
+      const updatedRect = computeRect();
+      if (updatedRect) setMarqueeRect(updatedRect);
+    }
+  }, [scrollContainerRef, computeRect]);
+
+  useFrameLoop(autoScroll, AUTO_SCROLL_LABEL, autoScrolling);
+
+  // Edge auto-scroll must keep running while the pointer is held still, so hold
+  // the loop awake and let effect cleanup guarantee the release.
+  useEffect(() => (autoScrolling ? holdFrames(AUTO_SCROLL_LABEL) : undefined), [autoScrolling]);
 
   const computeSelection = useCallback((rect: MarqueeRect): WordSelection[] => {
     const lines = getEffectiveLines(useProjectStore.getState().lines);
@@ -155,50 +194,11 @@ function useMarquee(scrollContainerRef: RefObject<HTMLDivElement | null>) {
         setMarqueeRect(rect);
       }
 
-      if (rafRef.current === null) {
-        const autoScroll = () => {
-          const c = scrollContainerRef.current;
-          if (!c || stateRef.current !== "active") {
-            rafRef.current = null;
-            return;
-          }
-
-          const cRect = c.getBoundingClientRect();
-          const cy = currentRef.current.clientY - cRect.top;
-          const cx = currentRef.current.clientX - cRect.left;
-
-          let scrolled = false;
-          if (cy < AUTO_SCROLL_ZONE) {
-            c.scrollTop -= AUTO_SCROLL_SPEED;
-            scrolled = true;
-          } else if (cy > cRect.height - AUTO_SCROLL_ZONE) {
-            c.scrollTop += AUTO_SCROLL_SPEED;
-            scrolled = true;
-          }
-          if (cx < AUTO_SCROLL_ZONE) {
-            c.scrollLeft -= AUTO_SCROLL_SPEED;
-            scrolled = true;
-          } else if (cx > cRect.width - AUTO_SCROLL_ZONE) {
-            c.scrollLeft += AUTO_SCROLL_SPEED;
-            scrolled = true;
-          }
-
-          if (scrolled) {
-            const updatedRect = computeRect();
-            if (updatedRect) setMarqueeRect(updatedRect);
-          }
-
-          rafRef.current = requestAnimationFrame(autoScroll);
-        };
-        rafRef.current = requestAnimationFrame(autoScroll);
-      }
+      setAutoScrolling(true);
     };
 
     const handleMouseUp = () => {
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
-        rafRef.current = null;
-      }
+      setAutoScrolling(false);
 
       if (stateRef.current === "active") {
         const rect = computeRect();
@@ -226,11 +226,8 @@ function useMarquee(scrollContainerRef: RefObject<HTMLDivElement | null>) {
     return () => {
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("mouseup", handleMouseUp);
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
-      }
     };
-  }, [scrollContainerRef, computeRect, computeSelection]);
+  }, [computeRect, computeSelection]);
 
   return { marqueeRect, handleMarqueeMouseDown };
 }

--- a/src/views/timeline/use-marquee.ts
+++ b/src/views/timeline/use-marquee.ts
@@ -61,7 +61,7 @@ function useMarquee(scrollContainerRef: RefObject<HTMLDivElement | null>) {
 
   const autoScroll = useCallback(() => {
     const c = scrollContainerRef.current;
-    if (!c) return;
+    if (!c || stateRef.current !== "active") return;
 
     const cRect = c.getBoundingClientRect();
     const cy = currentRef.current.clientY - cRect.top;

--- a/src/views/timeline/use-timeline-frame-wake.browser.test.tsx
+++ b/src/views/timeline/use-timeline-frame-wake.browser.test.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { subscribeFrame } from "@/lib/frame-loop";
+import { createFrameProbe, type FrameProbe } from "@/test/frame-probe";
 import { settleFrames } from "@/test/frame-steps";
 import { render } from "@/test/render";
 import { useTimelineFrameWake } from "@/views/timeline/use-timeline-frame-wake";
@@ -26,20 +26,7 @@ const WakeProbe: React.FC<WakeProbeProps> = ({ enabled = true }) => {
   );
 };
 
-let unsubscribeProbe: (() => void) | null = null;
-let frames = 0;
-
-async function quiesce(): Promise<void> {
-  await settleFrames(() => frames);
-  frames = 0;
-}
-
-async function wokeAfter(trigger: () => void): Promise<boolean> {
-  await quiesce();
-  trigger();
-  await settleFrames(() => frames);
-  return frames > 0;
-}
+let probe: FrameProbe;
 
 function scrollContainer(root: HTMLElement): HTMLDivElement {
   const container = root.querySelector<HTMLDivElement>("[data-test='scroll']");
@@ -54,15 +41,11 @@ function contentElement(root: HTMLElement): HTMLDivElement {
 }
 
 beforeEach(() => {
-  frames = 0;
-  unsubscribeProbe = subscribeFrame(() => {
-    frames += 1;
-  });
+  probe = createFrameProbe();
 });
 
 afterEach(() => {
-  unsubscribeProbe?.();
-  unsubscribeProbe = null;
+  probe.dispose();
 });
 
 // -- Tests ---------------------------------------------------------------------
@@ -72,7 +55,7 @@ describe("useTimelineFrameWake", () => {
     const screen = await render(<WakeProbe />);
     const container = scrollContainer(screen.container);
     expect(
-      await wokeAfter(() => {
+      await probe.wokeAfter(() => {
         container.scrollTop = 300;
       }),
     ).toBe(true);
@@ -82,7 +65,7 @@ describe("useTimelineFrameWake", () => {
     const screen = await render(<WakeProbe />);
     const container = scrollContainer(screen.container);
     expect(
-      await wokeAfter(() => {
+      await probe.wokeAfter(() => {
         container.scrollLeft = 300;
       }),
     ).toBe(true);
@@ -92,7 +75,7 @@ describe("useTimelineFrameWake", () => {
     const screen = await render(<WakeProbe />);
     const content = contentElement(screen.container);
     expect(
-      await wokeAfter(() => {
+      await probe.wokeAfter(() => {
         content.style.height = "320px";
       }),
     ).toBe(true);
@@ -104,7 +87,7 @@ describe("useTimelineFrameWake", () => {
       const container = scrollContainer(screen.container);
       const content = contentElement(screen.container);
       expect(
-        await wokeAfter(() => {
+        await probe.wokeAfter(() => {
           container.scrollTop = 300;
           content.style.height = "320px";
         }),
@@ -115,14 +98,14 @@ describe("useTimelineFrameWake", () => {
       const screen = await render(<WakeProbe enabled={false} />);
       const container = scrollContainer(screen.container);
       expect(
-        await wokeAfter(() => {
+        await probe.wokeAfter(() => {
           container.scrollTop = 300;
         }),
       ).toBe(false);
 
       await screen.rerender(<WakeProbe enabled={true} />);
       expect(
-        await wokeAfter(() => {
+        await probe.wokeAfter(() => {
           container.scrollTop = 600;
         }),
       ).toBe(true);
@@ -135,14 +118,14 @@ describe("useTimelineFrameWake", () => {
       const container = scrollContainer(screen.container);
       const content = contentElement(screen.container);
       expect(
-        await wokeAfter(() => {
+        await probe.wokeAfter(() => {
           container.scrollTop = 300;
         }),
       ).toBe(true);
 
       await screen.unmount();
       expect(
-        await wokeAfter(() => {
+        await probe.wokeAfter(() => {
           container.scrollTop = 600;
           content.style.height = "320px";
         }),
@@ -153,9 +136,9 @@ describe("useTimelineFrameWake", () => {
   describe("invariants", () => {
     it("leaves the loop quiescent when nothing moves", async () => {
       await render(<WakeProbe />);
-      await quiesce();
-      await settleFrames(() => frames);
-      expect(frames).toBe(0);
+      await probe.quiesce();
+      await settleFrames(probe.count);
+      expect(probe.count()).toBe(0);
     });
   });
 });

--- a/src/views/timeline/use-timeline-frame-wake.browser.test.tsx
+++ b/src/views/timeline/use-timeline-frame-wake.browser.test.tsx
@@ -1,0 +1,161 @@
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { subscribeFrame } from "@/lib/frame-loop";
+import { settleFrames } from "@/test/frame-steps";
+import { render } from "@/test/render";
+import { useTimelineFrameWake } from "@/views/timeline/use-timeline-frame-wake";
+
+// -- Interfaces ----------------------------------------------------------------
+
+interface WakeProbeProps {
+  enabled?: boolean;
+}
+
+// -- Harness -------------------------------------------------------------------
+
+const WakeProbe: React.FC<WakeProbeProps> = ({ enabled = true }) => {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  useTimelineFrameWake(scrollContainerRef, contentRef, enabled);
+  return (
+    <div ref={contentRef} data-test="content" style={{ position: "relative", width: 400, height: 200 }}>
+      <div ref={scrollContainerRef} data-test="scroll" style={{ position: "absolute", inset: 0, overflow: "auto" }}>
+        <div style={{ width: 2000, height: 1200 }} />
+      </div>
+    </div>
+  );
+};
+
+let unsubscribeProbe: (() => void) | null = null;
+let frames = 0;
+
+async function quiesce(): Promise<void> {
+  await settleFrames(() => frames);
+  frames = 0;
+}
+
+async function wokeAfter(trigger: () => void): Promise<boolean> {
+  await quiesce();
+  trigger();
+  await settleFrames(() => frames);
+  return frames > 0;
+}
+
+function scrollContainer(root: HTMLElement): HTMLDivElement {
+  const container = root.querySelector<HTMLDivElement>("[data-test='scroll']");
+  if (!container) throw new Error("scroll container missing");
+  return container;
+}
+
+function contentElement(root: HTMLElement): HTMLDivElement {
+  const content = root.querySelector<HTMLDivElement>("[data-test='content']");
+  if (!content) throw new Error("content element missing");
+  return content;
+}
+
+beforeEach(() => {
+  frames = 0;
+  unsubscribeProbe = subscribeFrame(() => {
+    frames += 1;
+  });
+});
+
+afterEach(() => {
+  unsubscribeProbe?.();
+  unsubscribeProbe = null;
+});
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("useTimelineFrameWake", () => {
+  it("wakes the loop on vertical scroll", async () => {
+    const screen = await render(<WakeProbe />);
+    const container = scrollContainer(screen.container);
+    expect(
+      await wokeAfter(() => {
+        container.scrollTop = 300;
+      }),
+    ).toBe(true);
+  });
+
+  it("wakes the loop on horizontal scroll", async () => {
+    const screen = await render(<WakeProbe />);
+    const container = scrollContainer(screen.container);
+    expect(
+      await wokeAfter(() => {
+        container.scrollLeft = 300;
+      }),
+    ).toBe(true);
+  });
+
+  it("wakes the loop when the content element resizes", async () => {
+    const screen = await render(<WakeProbe />);
+    const content = contentElement(screen.container);
+    expect(
+      await wokeAfter(() => {
+        content.style.height = "320px";
+      }),
+    ).toBe(true);
+  });
+
+  describe("enabled gate", () => {
+    it("attaches no wake source while disabled", async () => {
+      const screen = await render(<WakeProbe enabled={false} />);
+      const container = scrollContainer(screen.container);
+      const content = contentElement(screen.container);
+      expect(
+        await wokeAfter(() => {
+          container.scrollTop = 300;
+          content.style.height = "320px";
+        }),
+      ).toBe(false);
+    });
+
+    it("attaches once enabled turns on", async () => {
+      const screen = await render(<WakeProbe enabled={false} />);
+      const container = scrollContainer(screen.container);
+      expect(
+        await wokeAfter(() => {
+          container.scrollTop = 300;
+        }),
+      ).toBe(false);
+
+      await screen.rerender(<WakeProbe enabled={true} />);
+      expect(
+        await wokeAfter(() => {
+          container.scrollTop = 600;
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("stops waking after the tree unmounts", async () => {
+      const screen = await render(<WakeProbe />);
+      const container = scrollContainer(screen.container);
+      const content = contentElement(screen.container);
+      expect(
+        await wokeAfter(() => {
+          container.scrollTop = 300;
+        }),
+      ).toBe(true);
+
+      await screen.unmount();
+      expect(
+        await wokeAfter(() => {
+          container.scrollTop = 600;
+          content.style.height = "320px";
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("invariants", () => {
+    it("leaves the loop quiescent when nothing moves", async () => {
+      await render(<WakeProbe />);
+      await quiesce();
+      await settleFrames(() => frames);
+      expect(frames).toBe(0);
+    });
+  });
+});

--- a/src/views/timeline/use-timeline-frame-wake.ts
+++ b/src/views/timeline/use-timeline-frame-wake.ts
@@ -1,0 +1,29 @@
+import { wake } from "@/lib/frame-loop";
+import { type RefObject, useEffect } from "react";
+
+// -- Hook ----------------------------------------------------------------------
+
+function useTimelineFrameWake(
+  scrollContainerRef: RefObject<HTMLElement | null>,
+  contentRef: RefObject<HTMLElement | null>,
+  enabled: boolean,
+): void {
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    const content = contentRef.current;
+    if (!enabled || !container || !content) return;
+
+    container.addEventListener("scroll", wake, { passive: true });
+    const observer = new ResizeObserver(wake);
+    observer.observe(content);
+
+    return () => {
+      container.removeEventListener("scroll", wake);
+      observer.disconnect();
+    };
+  }, [enabled, scrollContainerRef, contentRef]);
+}
+
+// -- Exports -------------------------------------------------------------------
+
+export { useTimelineFrameWake };

--- a/src/views/timeline/word-edit-overlay.tsx
+++ b/src/views/timeline/word-edit-overlay.tsx
@@ -1,3 +1,4 @@
+import { cancelNextFrame, nextFrame } from "@/lib/frame-loop";
 import { useProjectStore } from "@/stores/project";
 import { useTimelineStore } from "@/views/timeline/timeline-store";
 import { manualBackgroundWordEdit } from "@/domain/line/background";
@@ -50,19 +51,19 @@ const WordEditOverlay: React.FC<WordEditOverlayProps> = ({ lineId, wordIndex, ty
 
     if (findAndPosition()) return;
 
-    const raf = requestAnimationFrame(() => {
+    const frame = nextFrame(() => {
       if (!findAndPosition()) clearEditingWord();
     });
-    return () => cancelAnimationFrame(raf);
+    return () => cancelNextFrame(frame);
   }, [lineId, wordIndex, type, word, scrollContainerRef, clearEditingWord]);
 
   useEffect(() => {
     if (!pos) return;
-    const raf = requestAnimationFrame(() => {
+    const frame = nextFrame(() => {
       inputRef.current?.focus();
       inputRef.current?.select();
     });
-    return () => cancelAnimationFrame(raf);
+    return () => cancelNextFrame(frame);
   }, [pos]);
 
   const handleCommit = useCallback(

--- a/src/views/timeline/word-track.tsx
+++ b/src/views/timeline/word-track.tsx
@@ -1,5 +1,6 @@
 import { isWordSelected } from "@/domain/selection/identity";
 import { manualBackgroundWordEdit } from "@/domain/line/background";
+import { nextFrame } from "@/lib/frame-loop";
 import { useAudioStore } from "@/stores/audio";
 import type { WordTiming } from "@/domain/word/timing";
 import { useProjectStore } from "@/stores/project";
@@ -201,7 +202,7 @@ const WordTrack: React.FC<WordTrackProps> = ({
 
         if (dragged) {
           justResizedRef.current = true;
-          requestAnimationFrame(() => {
+          nextFrame(() => {
             justResizedRef.current = false;
           });
         }


### PR DESCRIPTION
## Overview

Fixes #174. The page never stopped rendering, even sitting untouched with audio paused. Eight animation loops rescheduled themselves every frame whether anything had changed or not, and the waveform's loading shimmer carried on animating behind a layer that had already faded to invisible. Frame scheduling now has one owner that runs only while something is actually moving, and the shimmer stops once it's gone. Idle CPU drops from about 17% of a core to under 1%.
