### PR TITLE
fix: treat 4xx lyrics search responses as no results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.40.1",
+  "version": "1.40.2",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.40.0",
+  "version": "1.40.1",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/utils/lyrics-search/http-status.test.ts
+++ b/src/utils/lyrics-search/http-status.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isClientError } from "@/utils/lyrics-search/http-status";
+
+describe("isClientError", () => {
+  it("is true across the whole 4xx range", () => {
+    expect(isClientError(400)).toBe(true);
+    expect(isClientError(401)).toBe(true);
+    expect(isClientError(429)).toBe(true);
+    expect(isClientError(499)).toBe(true);
+  });
+
+  it("is false below 400 and at/above 500", () => {
+    expect(isClientError(399)).toBe(false);
+    expect(isClientError(200)).toBe(false);
+    expect(isClientError(304)).toBe(false);
+    expect(isClientError(500)).toBe(false);
+    expect(isClientError(503)).toBe(false);
+  });
+});

--- a/src/utils/lyrics-search/http-status.ts
+++ b/src/utils/lyrics-search/http-status.ts
@@ -1,0 +1,9 @@
+// -- Guards -------------------------------------------------------------------
+
+function isClientError(status: number): boolean {
+  return status >= 400 && status < 500;
+}
+
+// -- Exports ------------------------------------------------------------------
+
+export { isClientError };

--- a/src/utils/lyrics-search/providers/binimum.test.ts
+++ b/src/utils/lyrics-search/providers/binimum.test.ts
@@ -327,3 +327,44 @@ describe("binimumProvider duration mapping", () => {
     expect(await searchWithDuration({ ...SEARCH_HIT, duration: 0 })).toBeUndefined();
   });
 });
+
+// -- 4xx status handling (stubbed transport) ----------------------------------
+
+describe("binimumProvider 4xx handling", () => {
+  const QUERY = { track: "Bohemian Rhapsody", artist: "Queen" } as const;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubStatus(status: number): void {
+    vi.stubGlobal("fetch", async (): Promise<Response> => new Response("body", { status }));
+  }
+
+  it.each([400, 401, 403, 422, 429])("returns [] without throwing on %i", async (status) => {
+    stubStatus(status);
+    const results = await binimumProvider.search(QUERY, new AbortController().signal);
+    expect(results).toEqual([]);
+  });
+
+  it("logs a warning on a non-404 4xx instead of surfacing an error", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    stubStatus(403);
+    await binimumProvider.search(QUERY, new AbortController().signal);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("stays silent on a plain 404 miss", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    stubStatus(404);
+    const results = await binimumProvider.search(QUERY, new AbortController().signal);
+    expect(results).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("still throws a LyricsSearchError on 5xx", async () => {
+    stubStatus(503);
+    await expect(binimumProvider.search(QUERY, new AbortController().signal)).rejects.toBeInstanceOf(LyricsSearchError);
+  });
+});

--- a/src/utils/lyrics-search/providers/binimum.ts
+++ b/src/utils/lyrics-search/providers/binimum.ts
@@ -2,6 +2,7 @@ import { toUsableDurationSec } from "@/domain/lyrics-search/duration";
 import type { LyricsSearchPayload, LyricsSearchResult } from "@/domain/lyrics-search/result";
 import type { SyncType } from "@/domain/lyrics-search/sync-type";
 import { isAbortError } from "@/utils/abort-error";
+import { isClientError } from "@/utils/lyrics-search/http-status";
 import { isValidIsrc, normalizeIsrc } from "@/utils/isrc";
 import { hasNonEmptyString } from "@/utils/lyrics-search/query-guards";
 import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } from "@/utils/lyrics-search/types";
@@ -11,6 +12,7 @@ import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } 
 const BINIMUM_BASE_URL = "https://lyrics-api.binimum.org/";
 const ID_PREFIX = "binimum-";
 const USER_AGENT = "Better Lyrics Composer (https://composer.betterlyrics.org)";
+const LOG_PREFIX = "[Binimum]";
 const VALID_TIMING_TYPES: ReadonlySet<SyncType> = new Set<SyncType>(["syllable", "word", "line"]);
 
 // -- Types --------------------------------------------------------------------
@@ -99,9 +101,9 @@ async function search(query: LyricsSearchQuery, signal: AbortSignal): Promise<Ly
 
     if (signal.aborted) return [];
     if (response.status === 404) return [];
-    if (response.status === 400) return [];
-    if (response.status >= 500) {
-      throw new LyricsSearchError("binimum", `Binimum search returned ${response.status}`);
+    if (isClientError(response.status)) {
+      console.warn(LOG_PREFIX, `search returned ${response.status}, treating as no results`);
+      return [];
     }
     if (!response.ok) {
       throw new LyricsSearchError("binimum", `Binimum search returned ${response.status}`);

--- a/src/utils/lyrics-search/providers/boidu-lyrics.test.ts
+++ b/src/utils/lyrics-search/providers/boidu-lyrics.test.ts
@@ -314,3 +314,44 @@ describe("boiduLyricsProvider result mapping", () => {
     expect(results[0].durationSec).toBeUndefined();
   });
 });
+
+// -- 4xx status handling (stubbed transport) ----------------------------------
+
+describe("boiduLyricsProvider 4xx handling", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubStatus(status: number): void {
+    vi.stubGlobal("fetch", async (): Promise<Response> => new Response("body", { status }));
+  }
+
+  it.each([400, 401, 403, 422, 429])("returns [] without throwing on %i", async (status) => {
+    stubStatus(status);
+    const results = await boiduLyricsProvider.search(CACHED_QUERY, new AbortController().signal);
+    expect(results).toEqual([]);
+  });
+
+  it("logs a warning on a non-404 4xx instead of surfacing an error", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    stubStatus(403);
+    await boiduLyricsProvider.search(CACHED_QUERY, new AbortController().signal);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("stays silent on a plain 404 miss", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    stubStatus(404);
+    const results = await boiduLyricsProvider.search(CACHED_QUERY, new AbortController().signal);
+    expect(results).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("still throws a LyricsSearchError on 5xx", async () => {
+    stubStatus(503);
+    await expect(boiduLyricsProvider.search(CACHED_QUERY, new AbortController().signal)).rejects.toBeInstanceOf(
+      LyricsSearchError,
+    );
+  });
+});

--- a/src/utils/lyrics-search/providers/boidu-lyrics.ts
+++ b/src/utils/lyrics-search/providers/boidu-lyrics.ts
@@ -2,6 +2,7 @@ import { hasUsableDuration } from "@/domain/lyrics-search/duration";
 import type { LyricsSearchPayload, LyricsSearchResult } from "@/domain/lyrics-search/result";
 import { detectTtmlSyncType } from "@/domain/lyrics-search/sync-type";
 import { isAbortError } from "@/utils/abort-error";
+import { isClientError } from "@/utils/lyrics-search/http-status";
 import { hasNonEmptyString } from "@/utils/lyrics-search/query-guards";
 import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } from "@/utils/lyrics-search/types";
 
@@ -10,6 +11,7 @@ import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } 
 const BOIDU_BASE_URL = "https://lyrics-api.boidu.dev/getLyrics";
 const ID_PREFIX = "boidu-lyrics-";
 const USER_AGENT = "Better Lyrics Composer (https://composer.betterlyrics.org)";
+const LOG_PREFIX = "[BetterLyrics]";
 
 // -- Types --------------------------------------------------------------------
 
@@ -66,10 +68,10 @@ async function search(query: LyricsSearchQuery, signal: AbortSignal): Promise<Ly
     });
 
     if (signal.aborted) return [];
-    if (response.status === 401) return [];
     if (response.status === 404) return [];
-    if (response.status >= 500) {
-      throw new LyricsSearchError("boidu-lyrics", `Better Lyrics returned ${response.status}`);
+    if (isClientError(response.status)) {
+      console.warn(LOG_PREFIX, `getLyrics returned ${response.status}, treating as no results`);
+      return [];
     }
     if (!response.ok) {
       throw new LyricsSearchError("boidu-lyrics", `Better Lyrics returned ${response.status}`);

--- a/src/utils/lyrics-search/providers/lrclib.test.ts
+++ b/src/utils/lyrics-search/providers/lrclib.test.ts
@@ -361,3 +361,44 @@ describe("lrclibProvider duration mapping", () => {
     expect(await searchWithDuration({ ...SEARCH_HIT, duration: 0 })).toBeUndefined();
   });
 });
+
+// -- 4xx status handling (stubbed transport) ----------------------------------
+
+describe("lrclibProvider 4xx handling", () => {
+  const QUERY = { track: "Bohemian Rhapsody", artist: "Queen" } as const;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubStatus(status: number): void {
+    vi.stubGlobal("fetch", async (): Promise<Response> => new Response("body", { status }));
+  }
+
+  it.each([400, 401, 403, 422, 429])("returns [] without throwing on %i", async (status) => {
+    stubStatus(status);
+    const results = await lrclibProvider.search(QUERY, new AbortController().signal);
+    expect(results).toEqual([]);
+  });
+
+  it("logs a warning on a non-404 4xx instead of surfacing an error", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    stubStatus(403);
+    await lrclibProvider.search(QUERY, new AbortController().signal);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("stays silent on a plain 404 miss", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    stubStatus(404);
+    const results = await lrclibProvider.search(QUERY, new AbortController().signal);
+    expect(results).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("still throws a LyricsSearchError on 5xx", async () => {
+    stubStatus(503);
+    await expect(lrclibProvider.search(QUERY, new AbortController().signal)).rejects.toBeInstanceOf(LyricsSearchError);
+  });
+});

--- a/src/utils/lyrics-search/providers/lrclib.ts
+++ b/src/utils/lyrics-search/providers/lrclib.ts
@@ -2,6 +2,7 @@ import { toUsableDurationSec } from "@/domain/lyrics-search/duration";
 import type { LyricsSearchPayload, LyricsSearchResult } from "@/domain/lyrics-search/result";
 import { detectLrcSyncType, type SyncType } from "@/domain/lyrics-search/sync-type";
 import { isAbortError } from "@/utils/abort-error";
+import { isClientError } from "@/utils/lyrics-search/http-status";
 import { hasNonEmptyString } from "@/utils/lyrics-search/query-guards";
 import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } from "@/utils/lyrics-search/types";
 
@@ -12,6 +13,7 @@ const SEARCH_PATH = "/api/search";
 const GET_PATH = "/api/get";
 const ID_PREFIX = "lrclib-";
 const USER_AGENT = "Better Lyrics Composer (https://composer.betterlyrics.org)";
+const LOG_PREFIX = "[LRCLib]";
 
 // -- Types --------------------------------------------------------------------
 
@@ -97,8 +99,9 @@ async function fetchSearch(query: LyricsSearchQuery, signal: AbortSignal): Promi
     headers: { "User-Agent": USER_AGENT },
   });
   if (response.status === 404) return [];
-  if (response.status >= 500) {
-    throw new LyricsSearchError("lrclib", `LRCLib /api/search returned ${response.status}`);
+  if (isClientError(response.status)) {
+    console.warn(LOG_PREFIX, `/api/search returned ${response.status}, treating as no results`);
+    return [];
   }
   if (!response.ok) {
     throw new LyricsSearchError("lrclib", `LRCLib /api/search returned ${response.status}`);
@@ -114,8 +117,9 @@ async function fetchGet(query: LyricsSearchQuery, signal: AbortSignal): Promise<
     headers: { "User-Agent": USER_AGENT },
   });
   if (response.status === 404) return null;
-  if (response.status >= 500) {
-    throw new LyricsSearchError("lrclib", `LRCLib /api/get returned ${response.status}`);
+  if (isClientError(response.status)) {
+    console.warn(LOG_PREFIX, `/api/get returned ${response.status}, treating as no results`);
+    return null;
   }
   if (!response.ok) {
     throw new LyricsSearchError("lrclib", `LRCLib /api/get returned ${response.status}`);

--- a/src/utils/lyrics-search/providers/portato.test.ts
+++ b/src/utils/lyrics-search/providers/portato.test.ts
@@ -366,3 +366,49 @@ describe("portatoProvider result mapping", () => {
     expect(results[0].durationSec).toBeUndefined();
   });
 });
+
+// -- 4xx status handling (stubbed transport) ----------------------------------
+
+describe("portatoProvider 4xx handling", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubStatus(status: number): void {
+    vi.stubGlobal("fetch", async (): Promise<Response> => new Response("body", { status }));
+  }
+
+  it.each([400, 401, 403, 422])("returns [] without throwing on %i", async (status) => {
+    stubStatus(status);
+    const results = await portatoProvider.search(CACHED_QUERY, new AbortController().signal);
+    expect(results).toEqual([]);
+  });
+
+  it("logs a warning on a non-404 4xx instead of surfacing an error", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    stubStatus(403);
+    await portatoProvider.search(CACHED_QUERY, new AbortController().signal);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("stays silent on a plain 404 miss", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    stubStatus(404);
+    const results = await portatoProvider.search(CACHED_QUERY, new AbortController().signal);
+    expect(results).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("still throws a rate-limit error on 429, not treated as no results", async () => {
+    stubStatus(429);
+    await expect(portatoProvider.search(CACHED_QUERY, new AbortController().signal)).rejects.toThrow(/rate limit/i);
+  });
+
+  it("still throws a LyricsSearchError on 5xx", async () => {
+    stubStatus(503);
+    await expect(portatoProvider.search(CACHED_QUERY, new AbortController().signal)).rejects.toBeInstanceOf(
+      LyricsSearchError,
+    );
+  });
+});

--- a/src/utils/lyrics-search/providers/portato.ts
+++ b/src/utils/lyrics-search/providers/portato.ts
@@ -2,6 +2,7 @@ import { hasUsableDuration } from "@/domain/lyrics-search/duration";
 import type { LyricsSearchPayload, LyricsSearchResult } from "@/domain/lyrics-search/result";
 import { detectQrcSyncType } from "@/domain/lyrics-search/sync-type";
 import { isAbortError } from "@/utils/abort-error";
+import { isClientError } from "@/utils/lyrics-search/http-status";
 import { hasNonEmptyString } from "@/utils/lyrics-search/query-guards";
 import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } from "@/utils/lyrics-search/types";
 
@@ -10,6 +11,7 @@ import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } 
 const PORTATO_BASE_URL = "https://lyrics-api.boidu.dev/qq/getLyrics";
 const ID_PREFIX = "qq-";
 const SOURCE_LABEL = "Better Lyrics Portato";
+const LOG_PREFIX = "[Portato]";
 const USER_AGENT = "Better Lyrics Composer (https://composer.betterlyrics.org)";
 const RATE_LIMIT_MESSAGE = "Better Lyrics Portato rate limit reached. Try again in a moment.";
 
@@ -75,6 +77,10 @@ async function search(query: LyricsSearchQuery, signal: AbortSignal): Promise<Ly
     // A rate limit is not a miss: reporting it as "no results" would tell the user the lyrics do not exist.
     if (response.status === 429) {
       throw new LyricsSearchError("portato", RATE_LIMIT_MESSAGE);
+    }
+    if (isClientError(response.status)) {
+      console.warn(LOG_PREFIX, `getLyrics returned ${response.status}, treating as no results`);
+      return [];
     }
     if (!response.ok) {
       throw new LyricsSearchError("portato", `${SOURCE_LABEL} returned ${response.status}`);


### PR DESCRIPTION
## Overview

A stray 4xx from any lyrics provider (an uncached Better Lyrics 401, a 403, a 422) used to throw, so the search panel showed "Search failed" when it really just had nothing to show. Treat any 4xx as a miss now: return no results and log the status to the console instead of surfacing an error. 5xx and dropped connections still fail loudly. Portato's 429 stays a rate-limit signal, because throttled isn't the same as missing.
