### PR TITLE
fix: drop User-Agent on lyrics fetches so Firefox passes CORS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.40.0",
+  "version": "1.40.1",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/utils/lyrics-search/no-user-agent-header.test.ts
+++ b/src/utils/lyrics-search/no-user-agent-header.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getProviders } from "@/utils/lyrics-search/registry";
+import type { LyricsSearchQuery } from "@/utils/lyrics-search/types";
+
+// Firefox honors a JS-set User-Agent on cross-origin fetch, which promotes the
+// request to a CORS preflight the lyrics APIs reject (Chrome strips it, so it
+// only breaks on Firefox). No provider may send this header. See issue: Firefox
+// search failing with "header 'user-agent' is not allowed" CORS errors.
+
+// -- Fixtures -----------------------------------------------------------------
+
+const FULL_QUERY: LyricsSearchQuery = {
+  track: "Your Power",
+  artist: "Billie Eilish",
+  album: "Happier Than Ever",
+  durationSec: 246,
+  videoId: "5DEPXcDysro",
+  isrc: "USUM72104782",
+};
+
+function headerNamesFrom(init: RequestInit | undefined): string[] {
+  const headers = init?.headers;
+  if (!headers) return [];
+  if (headers instanceof Headers) return [...headers.keys()];
+  if (Array.isArray(headers)) return headers.map(([name]) => name);
+  return Object.keys(headers);
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("lyrics-search providers do not set a User-Agent header (Firefox CORS)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  for (const provider of getProviders()) {
+    it(`regression: ${provider.name} never sends a User-Agent request header`, async () => {
+      const sentHeaderNames: string[] = [];
+      vi.stubGlobal("fetch", async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        sentHeaderNames.push(...headerNamesFrom(init));
+        return new Response("{}", { headers: { "content-type": "application/json" } });
+      });
+
+      await provider.search(FULL_QUERY, new AbortController().signal);
+
+      const lowerCased = sentHeaderNames.map((name) => name.toLowerCase());
+      expect(lowerCased).not.toContain("user-agent");
+    });
+  }
+});

--- a/src/utils/lyrics-search/providers/binimum.test.ts
+++ b/src/utils/lyrics-search/providers/binimum.test.ts
@@ -10,6 +10,9 @@ const ONLINE_PROBE_TIMEOUT_MS = 5000;
 const NETWORK_TEST_TIMEOUT_MS = 30000;
 const TTML_URL_REGEX = /^https:\/\/lyrics-storage\.binimum\.org\/.+\.ttml$/;
 
+// Binimum sits behind Cloudflare bot protection that 403s datacenter IPs (CI); a browser reaches it fine, so a block is an unavailable-for-tests signal, not a product failure.
+const BOT_BLOCK_STATUSES: ReadonlySet<number> = new Set([401, 403, 429]);
+
 let isOnline = true;
 
 async function probeOnline(): Promise<boolean> {
@@ -18,6 +21,7 @@ async function probeOnline(): Promise<boolean> {
   const timer = setTimeout(() => controller.abort(), ONLINE_PROBE_TIMEOUT_MS);
   try {
     const response = await fetch(ONLINE_PROBE_URL, { signal: controller.signal });
+    if (BOT_BLOCK_STATUSES.has(response.status)) return false;
     return response.status < 500;
   } catch {
     return false;

--- a/src/utils/lyrics-search/providers/binimum.ts
+++ b/src/utils/lyrics-search/providers/binimum.ts
@@ -10,7 +10,6 @@ import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } 
 
 const BINIMUM_BASE_URL = "https://lyrics-api.binimum.org/";
 const ID_PREFIX = "binimum-";
-const USER_AGENT = "Better Lyrics Composer (https://composer.betterlyrics.org)";
 const VALID_TIMING_TYPES: ReadonlySet<SyncType> = new Set<SyncType>(["syllable", "word", "line"]);
 
 // -- Types --------------------------------------------------------------------
@@ -92,10 +91,7 @@ async function search(query: LyricsSearchQuery, signal: AbortSignal): Promise<Ly
 
   try {
     const url = buildSearchUrl(query);
-    const response = await fetch(url.toString(), {
-      signal,
-      headers: { "User-Agent": USER_AGENT },
-    });
+    const response = await fetch(url.toString(), { signal });
 
     if (signal.aborted) return [];
     if (response.status === 404) return [];

--- a/src/utils/lyrics-search/providers/boidu-lyrics.ts
+++ b/src/utils/lyrics-search/providers/boidu-lyrics.ts
@@ -9,7 +9,6 @@ import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } 
 
 const BOIDU_BASE_URL = "https://lyrics-api.boidu.dev/getLyrics";
 const ID_PREFIX = "boidu-lyrics-";
-const USER_AGENT = "Better Lyrics Composer (https://composer.betterlyrics.org)";
 
 // -- Types --------------------------------------------------------------------
 
@@ -60,10 +59,7 @@ async function search(query: LyricsSearchQuery, signal: AbortSignal): Promise<Ly
 
   try {
     const url = buildSearchUrl(query);
-    const response = await fetch(url.toString(), {
-      signal,
-      headers: { "User-Agent": USER_AGENT },
-    });
+    const response = await fetch(url.toString(), { signal });
 
     if (signal.aborted) return [];
     if (response.status === 401) return [];

--- a/src/utils/lyrics-search/providers/lrclib.ts
+++ b/src/utils/lyrics-search/providers/lrclib.ts
@@ -11,7 +11,6 @@ const LRCLIB_BASE_URL = "https://lrclib.net";
 const SEARCH_PATH = "/api/search";
 const GET_PATH = "/api/get";
 const ID_PREFIX = "lrclib-";
-const USER_AGENT = "Better Lyrics Composer (https://composer.betterlyrics.org)";
 
 // -- Types --------------------------------------------------------------------
 
@@ -92,10 +91,7 @@ function mapResponseToResult(response: LrcLibResponse): LyricsSearchResult | nul
 
 async function fetchSearch(query: LyricsSearchQuery, signal: AbortSignal): Promise<LrcLibResponse[]> {
   const url = buildSearchUrl(query);
-  const response = await fetch(url.toString(), {
-    signal,
-    headers: { "User-Agent": USER_AGENT },
-  });
+  const response = await fetch(url.toString(), { signal });
   if (response.status === 404) return [];
   if (response.status >= 500) {
     throw new LyricsSearchError("lrclib", `LRCLib /api/search returned ${response.status}`);
@@ -109,10 +105,7 @@ async function fetchSearch(query: LyricsSearchQuery, signal: AbortSignal): Promi
 
 async function fetchGet(query: LyricsSearchQuery, signal: AbortSignal): Promise<LrcLibResponse | null> {
   const url = buildGetUrl(query);
-  const response = await fetch(url.toString(), {
-    signal,
-    headers: { "User-Agent": USER_AGENT },
-  });
+  const response = await fetch(url.toString(), { signal });
   if (response.status === 404) return null;
   if (response.status >= 500) {
     throw new LyricsSearchError("lrclib", `LRCLib /api/get returned ${response.status}`);

--- a/src/utils/lyrics-search/providers/portato.ts
+++ b/src/utils/lyrics-search/providers/portato.ts
@@ -10,7 +10,6 @@ import { LyricsSearchError, type LyricsSearchProvider, type LyricsSearchQuery } 
 const PORTATO_BASE_URL = "https://lyrics-api.boidu.dev/qq/getLyrics";
 const ID_PREFIX = "qq-";
 const SOURCE_LABEL = "Better Lyrics Portato";
-const USER_AGENT = "Better Lyrics Composer (https://composer.betterlyrics.org)";
 const RATE_LIMIT_MESSAGE = "Better Lyrics Portato rate limit reached. Try again in a moment.";
 
 // -- Types --------------------------------------------------------------------
@@ -65,10 +64,7 @@ async function search(query: LyricsSearchQuery, signal: AbortSignal): Promise<Ly
 
   try {
     const url = buildSearchUrl(query);
-    const response = await fetch(url.toString(), {
-      signal,
-      headers: { "User-Agent": USER_AGENT },
-    });
+    const response = await fetch(url.toString(), { signal });
 
     if (signal.aborted) return [];
     if (response.status === 404) return [];


### PR DESCRIPTION
## Overview

Every lyrics search failed on Firefox while Chrome was fine. The four search providers each set a User-Agent header on their cross-origin fetch. Firefox honors a JS-set User-Agent, which turns the call into a CORS preflight that lrclib, binimum, and boidu.dev all reject; Chrome silently strips it, so only Firefox broke. The browser sends its own User-Agent anyway, so the header bought nothing. Dropped it from all four providers and added a regression test that asserts none of them send it.
