### PR TITLE
fix: land cross-line word drops on the line under the cursor at any scale

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.40.3",
+  "version": "1.40.4",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/views/timeline/drag-end-resolution.ts
+++ b/src/views/timeline/drag-end-resolution.ts
@@ -1,6 +1,6 @@
 import type { LyricLine } from "@/domain/line/model";
 import { GROUP_HEADER_HEIGHT } from "@/views/timeline/group-header-row";
-import { GUTTER_WIDTH, useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
+import { useTimelineStore, WAVEFORM_HEIGHT } from "@/views/timeline/timeline-store";
 import { computeRowLayout, getLineAndTrackAtY } from "@/views/timeline/utils";
 
 // -- Constants -----------------------------------------------------------------
@@ -14,7 +14,6 @@ const BG_DROP_ZONE_HEIGHT = 24;
 interface DropTarget {
   targetLineIndex: number;
   targetTrack: "word" | "bg";
-  cursorTime: number;
 }
 
 interface ResolveDropTargetInput {
@@ -25,21 +24,34 @@ interface ResolveDropTargetInput {
 
 // -- Helpers -------------------------------------------------------------------
 
-// clientX/Y are viewport-relative live pointer coordinates (from a pointermove
-// listener), not derived from dnd-kit's delta. dnd-kit's delta is already
-// scroll-adjusted, so combining it with scrollTop double-counts auto-scroll.
-// Live pointer coordinates already reflect any scroll-during-drag, so adding
-// container.scrollTop here cleanly converts viewport to container-content
-// coordinates without double-counting.
-function resolveDropTarget({ clientX, clientY, lines }: ResolveDropTargetInput): DropTarget | null {
+// The rendered rows are the single source of truth for row geometry, and they
+// live in the same coordinate frame as the pointer, so hit-testing them is
+// correct under any browser/OS scale. Each track tags itself with
+// data-line-index + data-track (line-row.tsx). Walking up from whatever paints
+// under the cursor finds the row the user is visually over.
+function hitTestRow(clientX: number, clientY: number): { lineIndex: number; track: "word" | "bg" } | null {
+  const el = document.elementFromPoint(clientX, clientY)?.closest<HTMLElement>("[data-line-index][data-track]");
+  if (!el) return null;
+  const lineIndex = Number(el.dataset.lineIndex);
+  const track = el.dataset.track;
+  if (!Number.isInteger(lineIndex) || (track !== "word" && track !== "bg")) return null;
+  return { lineIndex, track };
+}
+
+// Fallback for environments where the tagged rows are not in the DOM (unit
+// harness). Reconstructs row geometry from the layout constants; because those
+// are unscaled CSS px, this path drifts under a scaled frame, which is why the
+// DOM hit-test above is preferred whenever a row is under the cursor.
+function resolveViaLayoutModel(
+  clientY: number,
+  lines: LyricLine[],
+): { lineIndex: number; track: "word" | "bg" } | null {
   const container = document.querySelector<HTMLDivElement>("[data-scroll-container]");
   if (!container) return null;
-
   const rect = container.getBoundingClientRect();
-  const cursorX = clientX - rect.left + container.scrollLeft;
   const cursorY = clientY - rect.top + container.scrollTop;
 
-  const { zoom, rowHeights, defaultRowHeight, collapsedInstances } = useTimelineStore.getState();
+  const { rowHeights, defaultRowHeight, collapsedInstances } = useTimelineStore.getState();
   const layout = computeRowLayout({
     lines,
     rowHeights,
@@ -49,12 +61,13 @@ function resolveDropTarget({ clientX, clientY, lines }: ResolveDropTargetInput):
     bgDropZoneHeight: BG_DROP_ZONE_HEIGHT,
     groupHeaderHeight: GROUP_HEADER_HEIGHT,
   });
+  return getLineAndTrackAtY(cursorY, lines, layout);
+}
 
-  const hit = getLineAndTrackAtY(cursorY, lines, layout);
-  if (!hit) return null;
-
-  const cursorTime = (cursorX - GUTTER_WIDTH) / zoom;
-  return { targetLineIndex: hit.lineIndex, targetTrack: hit.track, cursorTime };
+function resolveDropTarget({ clientX, clientY, lines }: ResolveDropTargetInput): DropTarget | null {
+  const hit = hitTestRow(clientX, clientY) ?? resolveViaLayoutModel(clientY, lines);
+  if (!hit || hit.lineIndex < 0 || hit.lineIndex >= lines.length) return null;
+  return { targetLineIndex: hit.lineIndex, targetTrack: hit.track };
 }
 
 // -- Exports -------------------------------------------------------------------

--- a/src/views/timeline/line-row.tsx
+++ b/src/views/timeline/line-row.tsx
@@ -169,6 +169,8 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
         </div>
         <div
           ref={setMainDropRef}
+          data-line-index={lineIndex}
+          data-track="word"
           className={cn(
             "transition-colors relative",
             !hasMainWords && "opacity-50",
@@ -241,6 +243,8 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
         {hasBgWords ? (
           <div
             ref={setBgDropRef}
+            data-line-index={lineIndex}
+            data-track="bg"
             className={cn(
               "relative opacity-70 transition-colors border-t border-composer-border/50",
               isOverBg ? "bg-composer-accent/10" : "bg-composer-bg-elevated/25",
@@ -261,6 +265,8 @@ const LineRow: React.FC<LineRowProps> = ({ line, lineIndex, duration, onUpdateWo
         ) : (
           <div
             ref={setBgDropRef}
+            data-line-index={lineIndex}
+            data-track="bg"
             className={cn(
               "flex items-center px-2 text-xs font-mono truncate transition-colors border-t border-composer-border/30 cursor-pointer",
               isOverBg

--- a/src/views/timeline/use-timeline-dnd.scaled-frame.browser.test.tsx
+++ b/src/views/timeline/use-timeline-dnd.scaled-frame.browser.test.tsx
@@ -1,0 +1,120 @@
+import type { LyricLine } from "@/domain/line/model";
+import { useAudioStore } from "@/stores/audio";
+import { useProjectStore } from "@/stores/project";
+import { LineRow } from "@/views/timeline/line-row";
+import { useTimelineDnd } from "@/views/timeline/use-timeline-dnd";
+import {
+  makeCursorTargetingEvent,
+  makeCursorTargetingStartEvent,
+} from "@/views/timeline/use-timeline-dnd.test-helpers";
+import { useTimelineStore } from "@/views/timeline/timeline-store";
+import { render } from "@/test/render";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// -- Harness -------------------------------------------------------------------
+
+interface Handlers {
+  handleDragStart: ReturnType<typeof useTimelineDnd>["handleDragStart"];
+  handleDragEnd: ReturnType<typeof useTimelineDnd>["handleDragEnd"];
+}
+
+// A scaled ancestor (how a browser/OS page-zoom scales the coordinate frame)
+// makes getBoundingClientRect/clientY diverge from the timeline's unscaled row
+// layout. The drop must still land on the row the cursor is visually over.
+const ScaledRows: React.FC<{ lines: LyricLine[]; sink: Handlers }> = ({ lines, sink }) => {
+  const dnd = useTimelineDnd(lines);
+  sink.handleDragStart = dnd.handleDragStart;
+  sink.handleDragEnd = dnd.handleDragEnd;
+  return (
+    <div style={{ transform: "scale(1.3)", transformOrigin: "top left" }}>
+      <div data-scroll-container style={{ position: "relative" }}>
+        <div style={{ height: 81 }} />
+        {lines.map((line, index) => (
+          <LineRow
+            key={line.id}
+            line={line}
+            lineIndex={index}
+            duration={30}
+            onUpdateWord={() => {}}
+            onUpdateBgWord={() => {}}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+function centerOfWord(text: string): { x: number; y: number } {
+  const el = [...document.querySelectorAll<HTMLElement>("[data-word-block]")].find(
+    (b) => b.textContent?.trim() === text,
+  );
+  if (!el) throw new Error(`no rendered word block "${text}"`);
+  const r = el.getBoundingClientRect();
+  return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+}
+
+// -- Tests ---------------------------------------------------------------------
+
+describe("useTimelineDnd · drop target under a scaled frame", () => {
+  beforeEach(() => {
+    useAudioStore.setState({ duration: 30 });
+    useTimelineStore.setState({ zoom: 100, rowHeights: {}, defaultRowHeight: 44, collapsedInstances: {} });
+  });
+
+  it("drops a word onto the line the cursor is visually over, not the one the unscaled model predicts", async () => {
+    const lines: LyricLine[] = [
+      {
+        id: "l0",
+        text: "alpha beta",
+        agentId: "v1",
+        words: [
+          { text: "alpha ", begin: 0.1, end: 0.4 },
+          { text: "beta", begin: 0.4, end: 0.7 },
+        ],
+      },
+      { id: "l1", text: "gamma", agentId: "v1", words: [{ text: "gamma", begin: 5.0, end: 5.3 }] },
+      { id: "l2", text: "delta", agentId: "v1", words: [{ text: "delta", begin: 10.0, end: 10.3 }] },
+      { id: "l3", text: "epsilon", agentId: "v1", words: [{ text: "epsilon", begin: 15.0, end: 15.3 }] },
+    ];
+    useProjectStore.setState({ lines });
+
+    const sink = {} as Handlers;
+    await render(<ScaledRows lines={lines} sink={sink} />, { dndContext: true });
+
+    const target = centerOfWord("delta");
+
+    sink.handleDragStart(
+      makeCursorTargetingStartEvent({
+        lineId: "l0",
+        lineIndex: 0,
+        wordIndex: 0,
+        trackType: "word",
+        text: "alpha",
+        begin: 0.1,
+        end: 0.4,
+        pointerX: target.x,
+        pointerY: target.y,
+      }),
+    );
+    window.dispatchEvent(new PointerEvent("pointermove", { clientX: target.x, clientY: target.y }));
+    sink.handleDragEnd(
+      makeCursorTargetingEvent({
+        lineId: "l0",
+        lineIndex: 0,
+        wordIndex: 0,
+        trackType: "word",
+        text: "alpha",
+        begin: 0.1,
+        end: 0.4,
+        pointerX: target.x,
+        pointerY: target.y,
+        deltaX: 0,
+        deltaY: 0,
+      }),
+    );
+
+    const after = useProjectStore.getState().lines;
+    expect(after.find((l) => l.id === "l2")?.words?.some((w) => w.text.trim() === "alpha")).toBe(true);
+    expect(after.find((l) => l.id === "l0")?.words?.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Overview

Dropping a word onto another line reconstructed each row's position from fixed pixel constants, so at any non-100% browser or system scale that math drifted from the real layout and the word landed on the wrong line, worse the further down you dropped. Now the drop hit-tests the row actually under the cursor with elementFromPoint, which lives in the pointer's own coordinate frame, so the word lands where you drop it at any scale.
