### PR TITLE
Add pitch preservation toggle to playback speed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer",
   "private": true,
-  "version": "1.40.4",
+  "version": "1.41.0",
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",

--- a/src/audio/audio-engine.browser.test.tsx
+++ b/src/audio/audio-engine.browser.test.tsx
@@ -4,6 +4,7 @@ import { scrubStemRouter } from "@/audio/scrub-stem-router";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useSeparationStore } from "@/stores/separation";
+import { useSettingsStore } from "@/stores/settings";
 import { createAudioFile, createMp3File } from "@/test/audio-fixtures";
 import { allowConsole } from "@/test/console-guard";
 import { render } from "@/test/render";
@@ -52,6 +53,10 @@ describe("AudioEngine", () => {
     useAudioStore.setState({ playbackRate: 1.5 });
     await waitFor(() => audio.playbackRate === 1.5);
     expect(audio.playbackRate).toBe(1.5);
+
+    useSettingsStore.getState().set("preservePitch", false);
+    await waitFor(() => audio.preservesPitch === false);
+    expect(audio.preservesPitch).toBe(false);
 
     useAudioStore.setState({ volume: 0.25 });
     await waitFor(() => audio.volume === 0.25);

--- a/src/audio/audio-engine.tsx
+++ b/src/audio/audio-engine.tsx
@@ -5,6 +5,7 @@ import { scrubStemRouter } from "@/audio/scrub-stem-router";
 import { useAudioStore } from "@/stores/audio";
 import { useProjectStore } from "@/stores/project";
 import { useSeparationStore } from "@/stores/separation";
+import { useSettingsStore } from "@/stores/settings";
 import { useEffect, useRef } from "react";
 
 // -- Constants -----------------------------------------------------------------
@@ -21,6 +22,7 @@ const AudioEngine: React.FC = () => {
   const source = useAudioStore((s) => s.source);
   const isPlaying = useAudioStore((s) => s.isPlaying);
   const playbackRate = useAudioStore((s) => s.playbackRate);
+  const preservePitch = useSettingsStore((s) => s.preservePitch);
   const volume = useAudioStore((s) => s.volume);
   const isMuted = useAudioStore((s) => s.isMuted);
   const audioElement = useAudioStore((s) => s.audioElement);
@@ -123,6 +125,7 @@ const AudioEngine: React.FC = () => {
         isPlaying: initialIsPlaying,
       } = useAudioStore.getState();
       audio.playbackRate = initialPlaybackRate;
+      audio.preservesPitch = useSettingsStore.getState().preservePitch;
       audio.volume = initialVolume;
       audio.muted = initialIsMuted;
       audio.style.display = "none";
@@ -187,9 +190,10 @@ const AudioEngine: React.FC = () => {
     const audio = audioRef.current;
     if (!audio) return;
     audio.playbackRate = playbackRate;
+    audio.preservesPitch = preservePitch;
     audio.volume = volume;
     audio.muted = isMuted;
-  }, [playbackRate, volume, isMuted]);
+  }, [playbackRate, preservePitch, volume, isMuted]);
 
   useEffect(() => {
     const audio = audioElement;

--- a/src/audio/audio-engine.tsx
+++ b/src/audio/audio-engine.tsx
@@ -35,6 +35,7 @@ const AudioEngine: React.FC = () => {
   const currentStem = useSeparationStore((s) => s.currentStem);
   const stemUrls = useSeparationStore((s) => s.stemUrls);
 
+  // react-doctor-disable-next-line react-doctor/effect-needs-cleanup -- teardown/clearSlowLoading run from the returned cleanup and revoke every listener, timer and object URL; the async setup() indirection hides that from static analysis
   useEffect(() => {
     if (!source) {
       registerAudioElement(null);

--- a/src/audio/audio-player.browser.test.tsx
+++ b/src/audio/audio-player.browser.test.tsx
@@ -56,9 +56,9 @@ describe("AudioPlayer", () => {
     const screen = await render(<AudioPlayer />);
     await screen.getByRole("button", { name: /1\.00x/ }).click();
 
-    const checkbox = screen.getByRole("checkbox", { name: "Preserve pitch" });
-    await expect.element(checkbox).toBeChecked();
-    await checkbox.click();
+    const toggle = screen.getByRole("switch", { name: "Preserve pitch" });
+    await expect.element(toggle).toBeChecked();
+    await toggle.click();
 
     expect(useSettingsStore.getState().preservePitch).toBe(false);
     const persisted = JSON.parse(localStorage.getItem("composer-settings") ?? "{}") as {

--- a/src/audio/audio-player.browser.test.tsx
+++ b/src/audio/audio-player.browser.test.tsx
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
 import { AudioPlayer } from "@/audio/audio-player";
 import { useAudioStore } from "@/stores/audio";
+import { useSettingsStore } from "@/stores/settings";
 import { createAudioFile } from "@/test/audio-fixtures";
 import { render } from "@/test/render";
+import { describe, expect, it } from "vitest";
 
 function setupAudioSource() {
   const file = createAudioFile("track.wav");
@@ -15,6 +16,7 @@ function setupAudioSource() {
     volume: 0.8,
     isMuted: false,
   });
+  useSettingsStore.setState({ preservePitch: true });
 }
 
 describe("AudioPlayer", () => {
@@ -47,6 +49,22 @@ describe("AudioPlayer", () => {
     await screen.getByRole("button", { name: /1\.00x/ }).click();
     await screen.getByRole("button", { name: "1.5x" }).click();
     expect(useAudioStore.getState().playbackRate).toBeCloseTo(1.5, 5);
+  });
+
+  it("remembers whether pitch is preserved when playback speed changes", async () => {
+    setupAudioSource();
+    const screen = await render(<AudioPlayer />);
+    await screen.getByRole("button", { name: /1\.00x/ }).click();
+
+    const checkbox = screen.getByRole("checkbox", { name: "Preserve pitch" });
+    await expect.element(checkbox).toBeChecked();
+    await checkbox.click();
+
+    expect(useSettingsStore.getState().preservePitch).toBe(false);
+    const persisted = JSON.parse(localStorage.getItem("composer-settings") ?? "{}") as {
+      state?: { preservePitch?: boolean };
+    };
+    expect(persisted.state?.preservePitch).toBe(false);
   });
 
   it("opens the volume popover and toggles mute", async () => {

--- a/src/audio/audio-player.tsx
+++ b/src/audio/audio-player.tsx
@@ -1,4 +1,5 @@
 import { useAudioStore } from "@/stores/audio";
+import { useSettingsStore } from "@/stores/settings";
 import { Button } from "@/ui/button";
 import { Popover } from "@/ui/popover";
 import { Slider } from "@/ui/slider";
@@ -29,7 +30,9 @@ const RATE_STEP = 0.05;
 const PlaybackRateControl: React.FC<{
   rate: number;
   onChangeRate: (rate: number) => void;
-}> = ({ rate, onChangeRate }) => {
+  preservePitch: boolean;
+  onChangePreservePitch: (preservePitch: boolean) => void;
+}> = ({ rate, onChangeRate, preservePitch, onChangePreservePitch }) => {
   const handleSliderChange = useCallback(
     (value: number) => {
       onChangeRate(Math.round(value * 100) / 100);
@@ -75,6 +78,18 @@ const PlaybackRateControl: React.FC<{
           />
           <span className="font-mono text-xs text-composer-text-muted">{RATE_MAX}x</span>
         </div>
+        <label className="flex items-start gap-2.5 mt-3 pt-3 border-t cursor-pointer border-composer-border">
+          <input
+            type="checkbox"
+            checked={preservePitch}
+            onChange={(event) => onChangePreservePitch(event.target.checked)}
+            className="mt-0.5 size-3.5 rounded cursor-pointer accent-composer-accent"
+          />
+          <span className="flex flex-col gap-0.5">
+            <span className="text-xs font-medium text-composer-text">Preserve pitch</span>
+            <span className="text-xs text-composer-text-muted">Prevents pitch from changing with speed.</span>
+          </span>
+        </label>
       </div>
     </Popover>
   );
@@ -138,12 +153,14 @@ const AudioPlayer: React.FC = () => {
   const currentTime = useAudioStore((s) => s.currentTime);
   const duration = useAudioStore((s) => s.duration);
   const playbackRate = useAudioStore((s) => s.playbackRate);
+  const preservePitch = useSettingsStore((s) => s.preservePitch);
   const volume = useAudioStore((s) => s.volume);
   const isMuted = useAudioStore((s) => s.isMuted);
   const setIsPlaying = useAudioStore((s) => s.setIsPlaying);
   const setPlaybackRate = useAudioStore((s) => s.setPlaybackRate);
   const setVolume = useAudioStore((s) => s.setVolume);
   const toggleMute = useAudioStore((s) => s.toggleMute);
+  const setSetting = useSettingsStore((s) => s.set);
 
   if (!source) return null;
 
@@ -160,7 +177,12 @@ const AudioPlayer: React.FC = () => {
       />
       <TimeDisplay current={currentTime} duration={duration} />
       <VolumeControl volume={volume} isMuted={isMuted} onChangeVolume={setVolume} onToggleMute={toggleMute} />
-      <PlaybackRateControl rate={playbackRate} onChangeRate={setPlaybackRate} />
+      <PlaybackRateControl
+        rate={playbackRate}
+        onChangeRate={setPlaybackRate}
+        preservePitch={preservePitch}
+        onChangePreservePitch={(value) => setSetting("preservePitch", value)}
+      />
       <VocalSeparationDropdown />
     </div>
   );

--- a/src/audio/audio-player.tsx
+++ b/src/audio/audio-player.tsx
@@ -6,14 +6,7 @@ import { Slider } from "@/ui/slider";
 import { VocalSeparationDropdown } from "@/ui/vocal-separation-dropdown";
 import { cn } from "@/utils/cn";
 import { formatTime } from "@/utils/format-time";
-import {
-  IconMusic,
-  IconPlayerPauseFilled,
-  IconPlayerPlayFilled,
-  IconVolume,
-  IconVolume2,
-  IconVolume3,
-} from "@tabler/icons-react";
+import { IconPlayerPauseFilled, IconPlayerPlayFilled, IconVolume, IconVolume2, IconVolume3 } from "@tabler/icons-react";
 import { useCallback } from "react";
 
 // -- Components ---------------------------------------------------------------
@@ -86,14 +79,8 @@ const PlaybackRateControl: React.FC<{
           />
           <span className="font-mono text-xs text-composer-text-muted">{RATE_MAX}x</span>
         </div>
-        <div className="flex items-center gap-2.5 mt-3 pt-3 border-t border-composer-border">
-          <IconMusic
-            className={cn(
-              "size-4 shrink-0",
-              preservePitch ? "text-composer-accent-text" : "text-composer-text opacity-55",
-            )}
-          />
-          <div className="flex flex-1 flex-col gap-0.5 min-w-0">
+        <div className="flex items-center justify-between gap-2.5 mt-3 pt-3 border-t border-composer-border">
+          <div className="flex flex-col gap-0.5 min-w-0">
             <span className="text-sm text-composer-text">Preserve pitch</span>
             <span className="text-xs text-composer-text-muted">Keeps pitch steady when speed changes.</span>
           </div>

--- a/src/audio/audio-player.tsx
+++ b/src/audio/audio-player.tsx
@@ -4,8 +4,16 @@ import { Button } from "@/ui/button";
 import { Popover } from "@/ui/popover";
 import { Slider } from "@/ui/slider";
 import { VocalSeparationDropdown } from "@/ui/vocal-separation-dropdown";
+import { cn } from "@/utils/cn";
 import { formatTime } from "@/utils/format-time";
-import { IconPlayerPauseFilled, IconPlayerPlayFilled, IconVolume, IconVolume2, IconVolume3 } from "@tabler/icons-react";
+import {
+  IconMusic,
+  IconPlayerPauseFilled,
+  IconPlayerPlayFilled,
+  IconVolume,
+  IconVolume2,
+  IconVolume3,
+} from "@tabler/icons-react";
 import { useCallback } from "react";
 
 // -- Components ---------------------------------------------------------------
@@ -78,18 +86,36 @@ const PlaybackRateControl: React.FC<{
           />
           <span className="font-mono text-xs text-composer-text-muted">{RATE_MAX}x</span>
         </div>
-        <label className="flex items-start gap-2.5 mt-3 pt-3 border-t cursor-pointer border-composer-border">
-          <input
-            type="checkbox"
-            checked={preservePitch}
-            onChange={(event) => onChangePreservePitch(event.target.checked)}
-            className="mt-0.5 size-3.5 rounded cursor-pointer accent-composer-accent"
+        <div className="flex items-center gap-2.5 mt-3 pt-3 border-t border-composer-border">
+          <IconMusic
+            className={cn(
+              "size-4 shrink-0",
+              preservePitch ? "text-composer-accent-text" : "text-composer-text opacity-55",
+            )}
           />
-          <span className="flex flex-col gap-0.5">
-            <span className="text-xs font-medium text-composer-text">Preserve pitch</span>
-            <span className="text-xs text-composer-text-muted">Prevents pitch from changing with speed.</span>
-          </span>
-        </label>
+          <div className="flex flex-1 flex-col gap-0.5 min-w-0">
+            <span className="text-sm text-composer-text">Preserve pitch</span>
+            <span className="text-xs text-composer-text-muted">Keeps pitch steady when speed changes.</span>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={preservePitch}
+            aria-label="Preserve pitch"
+            onClick={() => onChangePreservePitch(!preservePitch)}
+            className={cn(
+              "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors",
+              preservePitch ? "bg-composer-accent" : "bg-composer-button",
+            )}
+          >
+            <span
+              className={cn(
+                "pointer-events-none inline-block size-4 rounded-full bg-white shadow transform transition-transform mt-0.5",
+                preservePitch ? "translate-x-4.5" : "translate-x-0.5",
+              )}
+            />
+          </button>
+        </div>
       </div>
     </Popover>
   );

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -33,6 +33,19 @@ describe("preview renderer settings", () => {
   });
 });
 
+describe("audio pitch settings", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ ...DEFAULTS });
+  });
+
+  it("preserves pitch by default and restores that default on reset", () => {
+    expect(useSettingsStore.getState().preservePitch).toBe(true);
+    useSettingsStore.getState().set("preservePitch", false);
+    useSettingsStore.getState().resetToDefaults();
+    expect(useSettingsStore.getState().preservePitch).toBe(true);
+  });
+});
+
 describe("vocal model settings", () => {
   beforeEach(() => {
     useSettingsStore.setState({ ...DEFAULTS });

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,7 +1,7 @@
-import { create } from "zustand";
-import { persist } from "zustand/middleware";
 import { DEFAULT_BRIDGE_URL } from "@/utils/composer-bridge-api";
 import { DEFAULT_MIN_WORD_DURATION } from "@/utils/word-spaces";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 // -- Types --------------------------------------------------------------------
 
@@ -30,6 +30,7 @@ const DEFAULT_COBALT_INSTANCE_ID = "default";
 
 interface SettingsState {
   defaultPlaybackRate: number;
+  preservePitch: boolean;
   rememberVolume: boolean;
   lastVolume: number;
   audioScrubPreview: boolean;
@@ -98,6 +99,7 @@ interface SettingsActions {
 
 const DEFAULTS: SettingsState = {
   defaultPlaybackRate: 0.75,
+  preservePitch: true,
   rememberVolume: true,
   lastVolume: 1,
   audioScrubPreview: true,

--- a/src/ui/settings/playback-section.browser.test.tsx
+++ b/src/ui/settings/playback-section.browser.test.tsx
@@ -1,8 +1,8 @@
-import { describe, expect, it } from "vitest";
 import { useAudioStore } from "@/stores/audio";
 import { useSettingsStore } from "@/stores/settings";
 import { render } from "@/test/render";
 import { PlaybackSection } from "@/ui/settings/playback-section";
+import { describe, expect, it } from "vitest";
 
 describe("PlaybackSection", () => {
   it("shows the formatted default playback rate", async () => {
@@ -29,6 +29,19 @@ describe("PlaybackSection", () => {
     const screen = await render(<PlaybackSection />);
     await screen.getByRole("switch", { name: "Audio scrub preview" }).click();
     await expect.poll(() => useSettingsStore.getState().audioScrubPreview).toBe(false);
+  });
+
+  it("renders the Preserve pitch toggle on by default", async () => {
+    const screen = await render(<PlaybackSection />);
+    const toggle = screen.getByRole("switch", { name: "Preserve pitch" });
+    await expect.element(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("flips Preserve pitch when its toggle is clicked", async () => {
+    useSettingsStore.setState({ preservePitch: true });
+    const screen = await render(<PlaybackSection />);
+    await screen.getByRole("switch", { name: "Preserve pitch" }).click();
+    await expect.poll(() => useSettingsStore.getState().preservePitch).toBe(false);
   });
 
   it("hides the Use current action when no audio is loaded", async () => {

--- a/src/ui/settings/playback-section.tsx
+++ b/src/ui/settings/playback-section.tsx
@@ -28,6 +28,11 @@ const PlaybackSection: React.FC = () => {
         }
       />
       <ToggleSetting
+        label="Preserve pitch"
+        description="Keep pitch steady when the playback speed changes."
+        settingKey="preservePitch"
+      />
+      <ToggleSetting
         label="Remember volume"
         description="Keep your volume level between sessions."
         settingKey="rememberVolume"


### PR DESCRIPTION
## Summary

- add a remembered Preserve pitch checkbox to the playback-speed popover
- apply the preference immediately to the active HTML audio element
- keep pitch preservation enabled by default
- cover persistence, reset behavior, and audio-engine propagation

## Validation

- `pnpm typecheck`
- `pnpm exec biome check` on changed files
- 58 focused unit tests
- 24 focused browser tests