### PR TITLE
fix: bump am-lyrics to 1.6.1 so line mode keeps the main lyric line

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@lit/react": "^1.0.8",
     "@tabler/icons-react": "^3.46.0",
     "@tanstack/react-query": "^5.101.4",
-    "@uimaxbai/am-lyrics": "^1.5.6",
+    "@uimaxbai/am-lyrics": "^1.6.1",
     "@wavesurfer/react": "^1.0.12",
     "clsx": "^2.1.1",
     "diff": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
       '@uimaxbai/am-lyrics':
-        specifier: ^1.5.6
-        version: 1.5.6(@lit/react@1.0.8(@types/react@19.2.18))(react@19.2.8)
+        specifier: ^1.6.1
+        version: 1.6.1(@lit/react@1.0.8(@types/react@19.2.18))(react@19.2.8)
       '@wavesurfer/react':
         specifier: ^1.0.12
         version: 1.0.12(react@19.2.8)(wavesurfer.js@7.12.11)
@@ -1422,8 +1422,8 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
-  '@uimaxbai/am-lyrics@1.5.6':
-    resolution: {integrity: sha512-dRSGA+pfms7Ryngwlpzf+QQ2JPJvYSDVKgtsDWcdiUwYtroxMe0E1+2WoUIrX9tjihBJCY+Cy9jMHRs7ysJf0Q==}
+  '@uimaxbai/am-lyrics@1.6.1':
+    resolution: {integrity: sha512-v6QPDnzzXWOCISfznuA1Zbxv7DXD1K22pL53TuII5LWf8hp8GhoI6QglqhufniwkoupeVi1FJAhGTtpPPriQ6Q==}
     peerDependencies:
       '@lit/react': ^1.0.0
       react: '>=17.0.0'
@@ -3706,7 +3706,7 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
-  '@uimaxbai/am-lyrics@1.5.6(@lit/react@1.0.8(@types/react@19.2.18))(react@19.2.8)':
+  '@uimaxbai/am-lyrics@1.6.1(@lit/react@1.0.8(@types/react@19.2.18))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
       lit: 3.3.3


### PR DESCRIPTION
Composer's lockfile pinned @uimaxbai/am-lyrics at 1.5.6, which drops the main lyric line in line-by-line preview whenever the line also has background vocals, so only the word-synced backing vocals show. 1.6.1 parses that case correctly, so bump the dependency and refresh the lock.
